### PR TITLE
`Development`: Improve build plan relationship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,10 @@ repos-download/
 /src/main/generated
 /coverage
 /exports
+/src/main/docker/.env
 /src/main/resources/config/application-local*.yml
+/src/main/resources/id_*
+/src/main/resources/known_hosts
 /src/test/cypress/screenshots/
 /src/test/cypress/videos/
 /src/test/cypress/build

--- a/src/main/java/de/tum/in/www1/artemis/domain/BuildPlan.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/BuildPlan.java
@@ -27,11 +27,12 @@ public class BuildPlan extends DomainObject {
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<ProgrammingExercise> programmingExercises = new HashSet<>();
 
+    @Nullable
     public String getBuildPlan() {
         return buildPlan;
     }
 
-    public void setBuildPlan(String buildPlan) {
+    public void setBuildPlan(@Nullable String buildPlan) {
         this.buildPlan = buildPlan;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/BuildPlan.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/BuildPlan.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.domain;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -38,5 +39,9 @@ public class BuildPlan extends DomainObject {
 
     public void addProgrammingExercise(ProgrammingExercise exercise) {
         programmingExercises.add(exercise);
+    }
+
+    public Optional<ProgrammingExercise> getProgrammingExerciseById(Long exerciseId) {
+        return programmingExercises.stream().filter(programmingExercise -> programmingExercise.getId() == exerciseId).findFirst();
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/BuildPlan.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/BuildPlan.java
@@ -1,10 +1,10 @@
 package de.tum.in.www1.artemis.domain;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.annotation.Nullable;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
+import javax.persistence.*;
 import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -19,13 +19,8 @@ public class BuildPlan extends DomainObject {
     @Column(name = "build_plan", table = "build_plan", length = 10_000)
     private String buildPlan;
 
-    public BuildPlan() {
-        // explicit constructor needed for Jackson
-    }
-
-    public BuildPlan(String buildPlan) {
-        this.buildPlan = buildPlan;
-    }
+    @OneToMany
+    private Set<ProgrammingExercise> programmingExercises = new HashSet<>();
 
     public String getBuildPlan() {
         return buildPlan;
@@ -33,5 +28,9 @@ public class BuildPlan extends DomainObject {
 
     public void setBuildPlan(String buildPlan) {
         this.buildPlan = buildPlan;
+    }
+
+    public void addProgrammingExercise(ProgrammingExercise exercise) {
+        programmingExercises.add(exercise);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/BuildPlan.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/BuildPlan.java
@@ -7,6 +7,9 @@ import javax.annotation.Nullable;
 import javax.persistence.*;
 import javax.validation.constraints.Size;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @Entity
@@ -20,6 +23,8 @@ public class BuildPlan extends DomainObject {
     private String buildPlan;
 
     @OneToMany
+    @JoinColumn(name = "build_plan_id")
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<ProgrammingExercise> programmingExercises = new HashSet<>();
 
     public String getBuildPlan() {

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
@@ -93,10 +93,6 @@ public class ProgrammingExercise extends Exercise {
     @Column(name = "build_plan_access_secret", table = "programming_exercise_details", length = 36)
     private String buildPlanAccessSecret;
 
-    @ManyToOne
-    @JoinColumn(name = "build_plan_id", table = "programming_exercise_details")
-    private BuildPlan buildPlan;
-
     @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JoinColumn(unique = true, name = "template_participation_id")
     @JsonIgnoreProperties("programmingExercise")
@@ -820,15 +816,6 @@ public class ProgrammingExercise extends Exercise {
 
     public void setExerciseHints(Set<ExerciseHint> exerciseHints) {
         this.exerciseHints = exerciseHints;
-    }
-
-    public void setBuildPlan(BuildPlan buildPlan) {
-        this.buildPlan = buildPlan;
-    }
-
-    // TODO: Save build plan when exercise is created
-    public BuildPlan getBuildPlan() {
-        return buildPlan;
     }
 
     public void setBuildPlanAccessSecret(String buildPlanAccessSecret) {

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
@@ -818,14 +818,11 @@ public class ProgrammingExercise extends Exercise {
         this.exerciseHints = exerciseHints;
     }
 
-    public void setBuildPlanAccessSecret(String buildPlanAccessSecret) {
-        this.buildPlanAccessSecret = buildPlanAccessSecret;
-    }
-
     public boolean hasBuildPlanAccessSecretSet() {
         return buildPlanAccessSecret != null && !buildPlanAccessSecret.isEmpty();
     }
 
+    @Nullable
     public String getBuildPlanAccessSecret() {
         return buildPlanAccessSecret;
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/BuildLogStatisticsEntryRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/BuildLogStatisticsEntryRepository.java
@@ -53,7 +53,7 @@ public interface BuildLogStatisticsEntryRepository extends JpaRepository<BuildLo
 
         BuildLogStatisticsEntry buildLogStatisticsEntry = new BuildLogStatisticsEntry(programmingSubmission, agentSetupDuration.durationInSeconds(),
                 testDuration.durationInSeconds(), scaDuration.durationInSeconds(), totalJobDuration.durationInSeconds(), dependenciesDownloadedCount);
-        return this.save(buildLogStatisticsEntry);
+        return save(buildLogStatisticsEntry);
     }
 
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
@@ -15,12 +15,12 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 public interface BuildPlanRepository extends JpaRepository<BuildPlan, Long> {
 
     @Query("""
-            SELECT b
-            FROM BuildPlan b
-                INNER join b.programmingExercises programmingExercises
+            SELECT buildPlan
+            FROM BuildPlan buildPlan
+                INNER JOIN FETCH buildPlan.programmingExercises programmingExercises
             WHERE programmingExercises.id = :exerciseId
             """)
-    Optional<BuildPlan> findByProgrammingExercises_Id(@Param("exerciseId") long exerciseId);
+    Optional<BuildPlan> findByProgrammingExercises_IdWithProgrammingExercises(@Param("exerciseId") long exerciseId);
 
     @EntityGraph(type = LOAD, attributePaths = { "programmingExercises" })
     Optional<BuildPlan> findByBuildPlan(String buildPlan);

--- a/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
@@ -5,8 +5,17 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import de.tum.in.www1.artemis.domain.BuildPlan;
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 
 public interface BuildPlanRepository extends JpaRepository<BuildPlan, Long> {
 
+    Optional<BuildPlan> findByProgrammingExercises_Id(long programmingExerciseId);
+
     Optional<BuildPlan> findByBuildPlan(String buildPlan);
+
+    default void updateBuildPlan(ProgrammingExercise exercise, String buildPlan, BuildPlanRepository buildPlanRepository) {
+        BuildPlan buildPlanWrapper = findByBuildPlan(buildPlan).orElse(new BuildPlan());
+        buildPlanWrapper.addProgrammingExercise(exercise);
+        save(buildPlanWrapper);
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.repository;
 
+import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphType.LOAD;
+
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,6 +22,7 @@ public interface BuildPlanRepository extends JpaRepository<BuildPlan, Long> {
             """)
     Optional<BuildPlan> findByProgrammingExercises_Id(@Param("exerciseId") long exerciseId);
 
+    @EntityGraph(type = LOAD, attributePaths = { "programmingExercises" })
     Optional<BuildPlan> findByBuildPlan(String buildPlan);
 
     default void updateBuildPlan(ProgrammingExercise exercise, String buildPlan) {

--- a/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
@@ -3,18 +3,27 @@ package de.tum.in.www1.artemis.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import de.tum.in.www1.artemis.domain.BuildPlan;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 
 public interface BuildPlanRepository extends JpaRepository<BuildPlan, Long> {
 
-    Optional<BuildPlan> findByProgrammingExercises_Id(long programmingExerciseId);
+    @Query("""
+            SELECT b
+            FROM BuildPlan b
+                INNER join b.programmingExercises programmingExercises
+            WHERE programmingExercises.id = :exerciseId
+            """)
+    Optional<BuildPlan> findByProgrammingExercises_Id(@Param("exerciseId") long exerciseId);
 
     Optional<BuildPlan> findByBuildPlan(String buildPlan);
 
-    default void updateBuildPlan(ProgrammingExercise exercise, String buildPlan, BuildPlanRepository buildPlanRepository) {
+    default void updateBuildPlan(ProgrammingExercise exercise, String buildPlan) {
         BuildPlan buildPlanWrapper = findByBuildPlan(buildPlan).orElse(new BuildPlan());
+        buildPlanWrapper.setBuildPlan(buildPlan);
         buildPlanWrapper.addProgrammingExercise(exercise);
         save(buildPlanWrapper);
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
@@ -15,17 +15,17 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 public interface BuildPlanRepository extends JpaRepository<BuildPlan, Long> {
 
     @Query("""
-            SELECT b
-            FROM BuildPlan b
-                INNER join b.programmingExercises programmingExercises
-            WHERE programmingExercises.id = :exerciseId
+            SELECT buildPlan
+            FROM BuildPlan buildPlan
+                INNER join FETCH buildPlan.programmingExercises programmingExercises
+            WHERE programmingExercises.id = :#{#exerciseId}
             """)
     Optional<BuildPlan> findByProgrammingExercises_Id(@Param("exerciseId") long exerciseId);
 
     @EntityGraph(type = LOAD, attributePaths = { "programmingExercises" })
     Optional<BuildPlan> findByBuildPlan(String buildPlan);
 
-    default void updateBuildPlan(ProgrammingExercise exercise, String buildPlan) {
+    default void setBuildPlanForExercise(String buildPlan, ProgrammingExercise exercise) {
         BuildPlan buildPlanWrapper = findByBuildPlan(buildPlan).orElse(new BuildPlan());
         buildPlanWrapper.setBuildPlan(buildPlan);
         buildPlanWrapper.addProgrammingExercise(exercise);

--- a/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/BuildPlanRepository.java
@@ -15,10 +15,10 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 public interface BuildPlanRepository extends JpaRepository<BuildPlan, Long> {
 
     @Query("""
-            SELECT buildPlan
-            FROM BuildPlan buildPlan
-                INNER join FETCH buildPlan.programmingExercises programmingExercises
-            WHERE programmingExercises.id = :#{#exerciseId}
+            SELECT b
+            FROM BuildPlan b
+                INNER join b.programmingExercises programmingExercises
+            WHERE programmingExercises.id = :exerciseId
             """)
     Optional<BuildPlan> findByProgrammingExercises_Id(@Param("exerciseId") long exerciseId);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/ParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ParticipationRepository.java
@@ -31,7 +31,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             LEFT JOIN FETCH p.submissions s
             LEFT JOIN FETCH s.results r
             WHERE p.id = :participationId
-                AND (s.id = (SELECT max(id) FROM p.submissions) OR s.id = NULL)
+                AND (s.id = (SELECT max(s2.id) FROM p.submissions s2) OR s.id = NULL)
             """)
     Optional<Participation> findByIdWithLatestSubmissionAndResult(@Param("participationId") Long participationId);
 
@@ -40,7 +40,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             FROM Participation p
                 LEFT JOIN FETCH p.submissions s
             WHERE p.id = :participationId
-                AND (s.id = (SELECT max(id) FROM p.submissions) OR s.id = NULL)
+                AND (s.id = (SELECT max(s2.id) FROM p.submissions s2) OR s.id = NULL)
             """)
     Optional<Participation> findByIdWithLatestSubmission(@Param("participationId") Long participationId);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -22,7 +22,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import de.tum.in.www1.artemis.domain.BuildPlan;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry;
@@ -733,11 +732,5 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
             exercise.generateAndSetBuildPlanAccessSecret();
             save(exercise);
         }
-    }
-
-    default void updateBuildPlan(ProgrammingExercise exercise, String buildPlan, BuildPlanRepository buildPlanRepository) {
-        BuildPlan buildPlanWrapper = buildPlanRepository.findByBuildPlan(buildPlan).orElseGet(() -> buildPlanRepository.save(new BuildPlan(buildPlan)));
-        exercise.setBuildPlan(buildPlanWrapper);
-        save(exercise);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIBuildPlanService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIBuildPlanService.java
@@ -19,7 +19,7 @@ import de.tum.in.www1.artemis.service.ResourceLoaderService;
 @Profile("gitlabci")
 public class GitLabCIBuildPlanService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(GitLabCIBuildPlanService.class);
+    private static final Logger log = LoggerFactory.getLogger(GitLabCIBuildPlanService.class);
 
     private static final String FILE_NAME = ".gitlab-ci.yml";
 
@@ -53,10 +53,9 @@ public class GitLabCIBuildPlanService {
         try {
             return StreamUtils.copyToString(resource.getInputStream(), Charset.defaultCharset());
         }
-        catch (IOException e) {
-            final var errorMessage = "Error loading template GitLab CI build configuration " + e.getMessage();
-            LOG.error(errorMessage, e);
-            throw new IllegalStateException(errorMessage, e);
+        catch (IOException ex) {
+            log.error("Error loading template GitLab CI build configuration", ex);
+            throw new IllegalStateException("Error loading template GitLab CI build configuration", ex);
         }
 
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIBuildPlanService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIBuildPlanService.java
@@ -30,12 +30,12 @@ public class GitLabCIBuildPlanService {
     }
 
     /**
-     * Get the default build plan for the project type of the given programming exercise.
+     * Generate the default build plan for the project type of the given programming exercise.
      *
      * @param programmingExercise the programming exercise for which to get the build plan
      * @return the default build plan
      */
-    public String getBuildPlan(ProgrammingExercise programmingExercise) {
+    public String generateDefaultBuildPlan(ProgrammingExercise programmingExercise) {
         Optional<String> projectTypeName;
         if (programmingExercise.getProgrammingLanguage().equals(ProgrammingLanguage.JAVA)) {
             projectTypeName = Optional.of("maven");

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
@@ -368,22 +368,16 @@ public class GitLabCIService extends AbstractContinuousIntegrationService {
             return;
         }
 
-        ZonedDateTime jobStarted = getTimestampForLogEntry(buildLogEntries, ""); // First entry;
-        ZonedDateTime testsStarted;
-        ZonedDateTime testsFinished;
-        ZonedDateTime jobFinished = buildLogEntries.get(buildLogEntries.size() - 1).getTime(); // Last entry
-        Integer dependenciesDownloadedCount;
-
-        if (ProjectType.isMavenProject(projectType)) {
-            testsStarted = getTimestampForLogEntry(buildLogEntries, "Scanning for projects...");
-            testsFinished = getTimestampForLogEntry(buildLogEntries, "Total time:");
-            dependenciesDownloadedCount = countMatchingLogs(buildLogEntries, "Downloaded from");
-        }
-        else {
+        if (!ProjectType.isMavenProject(projectType)) {
             // A new, unsupported project type was used -> Log it but don't store it since it would only contain null-values
             log.warn("Received unsupported project type {} for GitLabCIService.extractAndPersistBuildLogStatistics, will not store any build log statistics.", projectType);
             return;
         }
+        ZonedDateTime jobStarted = getTimestampForLogEntry(buildLogEntries, ""); // First entry;
+        ZonedDateTime jobFinished = buildLogEntries.get(buildLogEntries.size() - 1).getTime(); // Last entry
+        ZonedDateTime testsStarted = getTimestampForLogEntry(buildLogEntries, "Scanning for projects...");
+        ZonedDateTime testsFinished = getTimestampForLogEntry(buildLogEntries, "Total time:");
+        Integer dependenciesDownloadedCount = countMatchingLogs(buildLogEntries, "Downloaded from");
 
         var testDuration = new BuildLogStatisticsEntry.BuildJobPartDuration(testsStarted, testsFinished);
         var totalJobDuration = new BuildLogStatisticsEntry.BuildJobPartDuration(jobStarted, jobFinished);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
@@ -176,7 +176,8 @@ public class GitLabCIService extends AbstractContinuousIntegrationService {
     private void addBuildPlanToProgrammingExerciseIfUnset(ProgrammingExercise programmingExercise) {
         Optional<BuildPlan> optionalBuildPlan = buildPlanRepository.findByProgrammingExercises_Id(programmingExercise.getId());
         if (optionalBuildPlan.isEmpty()) {
-            buildPlanRepository.updateBuildPlan(programmingExercise, buildPlanService.getBuildPlan(programmingExercise));
+            var defaultBuildPlan = buildPlanService.generateDefaultBuildPlan(programmingExercise);
+            buildPlanRepository.setBuildPlanForExercise(defaultBuildPlan, programmingExercise);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
@@ -383,7 +383,7 @@ public class GitLabCIService extends AbstractContinuousIntegrationService {
         var totalJobDuration = new BuildLogStatisticsEntry.BuildJobPartDuration(jobStarted, jobFinished);
 
         // Set the duration to 0 for the durations, we cannot extract.
-        var time = ZonedDateTime.now();
+        var time = ZonedDateTime.now(); // TODO: this needs to be properly implemented
         var agentSetupDuration = new BuildLogStatisticsEntry.BuildJobPartDuration(time, time);
         var scaDuration = new BuildLogStatisticsEntry.BuildJobPartDuration(time, time);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
@@ -174,7 +174,7 @@ public class GitLabCIService extends AbstractContinuousIntegrationService {
     }
 
     private void addBuildPlanToProgrammingExerciseIfUnset(ProgrammingExercise programmingExercise) {
-        Optional<BuildPlan> optionalBuildPlan = buildPlanRepository.findByProgrammingExercises_Id(programmingExercise.getId());
+        Optional<BuildPlan> optionalBuildPlan = buildPlanRepository.findByProgrammingExercises_IdWithProgrammingExercises(programmingExercise.getId());
         if (optionalBuildPlan.isEmpty()) {
             var defaultBuildPlan = buildPlanService.generateDefaultBuildPlan(programmingExercise);
             buildPlanRepository.setBuildPlanForExercise(defaultBuildPlan, programmingExercise);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
@@ -174,8 +174,9 @@ public class GitLabCIService extends AbstractContinuousIntegrationService {
     }
 
     private void addBuildPlanToProgrammingExerciseIfUnset(ProgrammingExercise programmingExercise) {
-        if (programmingExercise.getBuildPlan() == null) {
-            programmingExerciseRepository.updateBuildPlan(programmingExercise, buildPlanService.getBuildPlan(programmingExercise), buildPlanRepository);
+        Optional<BuildPlan> optionalBuildPlan = buildPlanRepository.findByProgrammingExercises_Id(programmingExercise.getId());
+        if (optionalBuildPlan.isEmpty()) {
+            buildPlanRepository.updateBuildPlan(programmingExercise, buildPlanService.getBuildPlan(programmingExercise), buildPlanRepository);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
@@ -176,7 +176,7 @@ public class GitLabCIService extends AbstractContinuousIntegrationService {
     private void addBuildPlanToProgrammingExerciseIfUnset(ProgrammingExercise programmingExercise) {
         Optional<BuildPlan> optionalBuildPlan = buildPlanRepository.findByProgrammingExercises_Id(programmingExercise.getId());
         if (optionalBuildPlan.isEmpty()) {
-            buildPlanRepository.updateBuildPlan(programmingExercise, buildPlanService.getBuildPlan(programmingExercise), buildPlanRepository);
+            buildPlanRepository.updateBuildPlan(programmingExercise, buildPlanService.getBuildPlan(programmingExercise));
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
@@ -30,7 +30,7 @@ import de.tum.in.www1.artemis.service.util.XmlFileUtils;
 @Component
 public class JenkinsBuildPlanCreator implements JenkinsXmlConfigBuilder {
 
-    private static final Logger LOG = LoggerFactory.getLogger(JenkinsBuildPlanCreator.class);
+    private static final Logger log = LoggerFactory.getLogger(JenkinsBuildPlanCreator.class);
 
     private static final String STATIC_CODE_ANALYSIS_REPORT_DIR = "staticCodeAnalysisReports";
 
@@ -209,7 +209,7 @@ public class JenkinsBuildPlanCreator implements JenkinsXmlConfigBuilder {
         }
         catch (IOException e) {
             final var errorMessage = "Error loading template Jenkins build XML: " + e.getMessage();
-            LOG.error(errorMessage, e);
+            log.error(errorMessage, e);
             throw new IllegalStateException(errorMessage, e);
         }
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsService.java
@@ -173,10 +173,10 @@ public class JenkinsService extends AbstractContinuousIntegrationService {
 
         ZonedDateTime jobStarted = getTimestampForLogEntry(buildLogEntries, ""); // First entry;
         ZonedDateTime agentSetupCompleted = null;
-        ZonedDateTime testsStarted = null;
-        ZonedDateTime testsFinished = null;
-        ZonedDateTime scaStarted = null;
-        ZonedDateTime scaFinished = null;
+        ZonedDateTime testsStarted;
+        ZonedDateTime testsFinished;
+        ZonedDateTime scaStarted;
+        ZonedDateTime scaFinished;
         ZonedDateTime jobFinished = buildLogEntries.get(buildLogEntries.size() - 1).getTime(); // Last entry
         Integer dependenciesDownloadedCount = null;
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/BuildPlanResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/BuildPlanResource.java
@@ -1,0 +1,54 @@
+package de.tum.in.www1.artemis.web.rest;
+
+import static de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResourceEndpoints.BUILD_PLAN;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import de.tum.in.www1.artemis.domain.BuildPlan;
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.repository.BuildPlanRepository;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
+
+@Profile("gitlabci")
+@RestController
+@RequestMapping("api/")
+public class BuildPlanResource {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final ProgrammingExerciseRepository programmingExerciseRepository;
+
+    private final BuildPlanRepository buildPlanRepository;
+
+    public BuildPlanResource(ProgrammingExerciseRepository programmingExerciseRepository, BuildPlanRepository buildPlanRepository) {
+        this.programmingExerciseRepository = programmingExerciseRepository;
+        this.buildPlanRepository = buildPlanRepository;
+    }
+
+    /**
+     * Returns the build plan for a given programming exercise.
+     *
+     * @param exerciseId the exercise for which the build plan should be retrieved
+     * @param secret the secret to authenticate the request
+     * @return the build plan stored in the database
+     */
+    @GetMapping(BUILD_PLAN)
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<String> getBuildPlan(@PathVariable Long exerciseId, @RequestParam("secret") String secret) {
+        log.debug("REST request to get build plan for programming exercise with id {}", exerciseId);
+        ProgrammingExercise programmingExercise = programmingExerciseRepository.findByIdElseThrow(exerciseId);
+        if (!programmingExercise.hasBuildPlanAccessSecretSet() || !secret.equals(programmingExercise.getBuildPlanAccessSecret())) {
+            throw new AccessForbiddenException();
+        }
+        Optional<BuildPlan> buildPlanOptional = buildPlanRepository.findByProgrammingExercises_Id(exerciseId);
+        return ResponseEntity.ok().body(buildPlanOptional.map(BuildPlan::getBuildPlan).orElse(null));
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/BuildPlanResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/BuildPlanResource.java
@@ -2,8 +2,6 @@ package de.tum.in.www1.artemis.web.rest;
 
 import static de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResourceEndpoints.BUILD_PLAN;
 
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
@@ -14,7 +12,6 @@ import org.springframework.web.bind.annotation.*;
 import de.tum.in.www1.artemis.domain.BuildPlan;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.repository.BuildPlanRepository;
-import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 
 @Profile("gitlabci")
@@ -24,12 +21,9 @@ public class BuildPlanResource {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    private final ProgrammingExerciseRepository programmingExerciseRepository;
-
     private final BuildPlanRepository buildPlanRepository;
 
-    public BuildPlanResource(ProgrammingExerciseRepository programmingExerciseRepository, BuildPlanRepository buildPlanRepository) {
-        this.programmingExerciseRepository = programmingExerciseRepository;
+    public BuildPlanResource(BuildPlanRepository buildPlanRepository) {
         this.buildPlanRepository = buildPlanRepository;
     }
 
@@ -44,11 +38,11 @@ public class BuildPlanResource {
     @PreAuthorize("permitAll()")
     public ResponseEntity<String> getBuildPlan(@PathVariable Long exerciseId, @RequestParam("secret") String secret) {
         log.debug("REST request to get build plan for programming exercise with id {}", exerciseId);
-        ProgrammingExercise programmingExercise = programmingExerciseRepository.findByIdElseThrow(exerciseId);
+        BuildPlan buildPlan = buildPlanRepository.findByProgrammingExercises_Id(exerciseId).orElseThrow();
+        ProgrammingExercise programmingExercise = buildPlan.getProgrammingExerciseById(exerciseId).orElseThrow();
         if (!programmingExercise.hasBuildPlanAccessSecretSet() || !secret.equals(programmingExercise.getBuildPlanAccessSecret())) {
             throw new AccessForbiddenException();
         }
-        Optional<BuildPlan> buildPlanOptional = buildPlanRepository.findByProgrammingExercises_Id(exerciseId);
-        return ResponseEntity.ok().body(buildPlanOptional.map(BuildPlan::getBuildPlan).orElse(null));
+        return ResponseEntity.ok().body(buildPlan.getBuildPlan());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/BuildPlanResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/BuildPlanResource.java
@@ -38,7 +38,7 @@ public class BuildPlanResource {
     @PreAuthorize("permitAll()")
     public ResponseEntity<String> getBuildPlan(@PathVariable Long exerciseId, @RequestParam("secret") String secret) {
         log.debug("REST request to get build plan for programming exercise with id {}", exerciseId);
-        BuildPlan buildPlan = buildPlanRepository.findByProgrammingExercises_Id(exerciseId).orElseThrow();
+        BuildPlan buildPlan = buildPlanRepository.findByProgrammingExercises_IdWithProgrammingExercises(exerciseId).orElseThrow();
         ProgrammingExercise programmingExercise = buildPlan.getProgrammingExerciseById(exerciseId).orElseThrow();
         if (!programmingExercise.hasBuildPlanAccessSecretSet() || !secret.equals(programmingExercise.getBuildPlanAccessSecret())) {
             throw new AccessForbiddenException();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -118,6 +118,8 @@ public class ProgrammingExerciseResource {
 
     private final Pattern packageNamePatternForSwift = Pattern.compile(packageNameRegexForSwift);
 
+    private final BuildPlanRepository buildPlanRepository;
+
     public ProgrammingExerciseResource(ProgrammingExerciseRepository programmingExerciseRepository, ProgrammingExerciseTestCaseRepository programmingExerciseTestCaseRepository,
             UserRepository userRepository, AuthorizationCheckService authCheckService, CourseService courseService,
             Optional<ContinuousIntegrationService> continuousIntegrationService, Optional<VersionControlService> versionControlService, ExerciseService exerciseService,
@@ -127,7 +129,7 @@ public class ProgrammingExerciseResource {
             AuxiliaryRepositoryService auxiliaryRepositoryService, SubmissionPolicyService submissionPolicyService,
             SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository,
             TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository,
-            BuildLogStatisticsEntryRepository buildLogStatisticsEntryRepository) {
+            BuildLogStatisticsEntryRepository buildLogStatisticsEntryRepository, BuildPlanRepository buildPlanRepository) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.programmingExerciseTestCaseRepository = programmingExerciseTestCaseRepository;
         this.userRepository = userRepository;
@@ -149,6 +151,7 @@ public class ProgrammingExerciseResource {
         this.solutionProgrammingExerciseParticipationRepository = solutionProgrammingExerciseParticipationRepository;
         this.templateProgrammingExerciseParticipationRepository = templateProgrammingExerciseParticipationRepository;
         this.buildLogStatisticsEntryRepository = buildLogStatisticsEntryRepository;
+        this.buildPlanRepository = buildPlanRepository;
     }
 
     /**
@@ -823,7 +826,8 @@ public class ProgrammingExerciseResource {
         if (!programmingExercise.hasBuildPlanAccessSecretSet() || !secret.equals(programmingExercise.getBuildPlanAccessSecret())) {
             throw new AccessForbiddenException();
         }
-        return ResponseEntity.ok().body(programmingExercise.getBuildPlan().getBuildPlan());
+        Optional<BuildPlan> buildPlanOptional = buildPlanRepository.findByProgrammingExercises_Id(exerciseId);
+        return ResponseEntity.ok().body(buildPlanOptional.map(BuildPlan::getBuildPlan).orElse(null));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
@@ -196,7 +196,7 @@ public class ProgrammingSubmissionResource {
     @PreAuthorize("hasRole('USER')")
     @FeatureToggle(Feature.ProgrammingExercises)
     public ResponseEntity<Void> triggerFailedBuild(@PathVariable Long participationId, @RequestParam(defaultValue = "false") boolean lastGraded) {
-        final Participation participation = participationRepository.findByIdWithLatestSubmissionElseThrow(participationId);
+        final Participation participation = participationRepository.findByIdElseThrow(participationId);
         if (!(participation instanceof ProgrammingExerciseParticipation programmingExerciseParticipation)) {
             throw new EntityNotFoundException("Participation is not a ProgrammingExerciseParticipation");
         }

--- a/src/main/resources/config/liquibase/changelog/20220905125330_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20220905125330_changelog.xml
@@ -15,12 +15,14 @@
 
         <addColumn tableName="programming_exercise_details">
             <column name="build_plan_access_secret" type="VARCHAR(36)"/>
+        </addColumn>
+        <addColumn tableName="exercise">
             <column name="build_plan_id" type="BIGINT">
                 <constraints nullable="true"/>
             </column>
         </addColumn>
 
-        <addForeignKeyConstraint baseColumnNames="build_plan_id" baseTableName="programming_exercise_details"
+        <addForeignKeyConstraint baseColumnNames="build_plan_id" baseTableName="exercise"
                                  constraintName="FK_EXERCISE_ON_BUILDPLAN"
                                  referencedColumnNames="id" referencedTableName="build_plan"/>
         <!-- TODO: Column can't be unique because it is too long (Specified key was too long; max key length is 3072 bytes)

--- a/src/test/java/de/tum/in/www1/artemis/domain/ObjectMethodTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/domain/ObjectMethodTest.java
@@ -25,7 +25,7 @@ import io.github.classgraph.ClassInfo;
  */
 class ObjectMethodTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ObjectMethodTest.class);
+    private static final Logger log = LoggerFactory.getLogger(ObjectMethodTest.class);
 
     private static final String GENERATE_TESTS = "Generate tests";
 
@@ -137,7 +137,7 @@ class ObjectMethodTest {
             }
         }
         else {
-            LOG.warn("{} does not have a no-args constructor", domainClass);
+            log.warn("{} does not have a no-args constructor", domainClass);
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBuildPlanTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBuildPlanTest.java
@@ -33,7 +33,7 @@ class ProgrammingExerciseBuildPlanTest extends AbstractSpringIntegrationGitlabCI
 
     @BeforeEach
     void init() {
-        database.addUsers(TEST_PREFIX, 2, 2, 0, 2);
+        // no users needed for this test
         var course = database.addCourseWithOneProgrammingExercise();
         programmingExerciseId = database.getFirstExerciseWithType(course, ProgrammingExercise.class).getId();
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
@@ -24,6 +24,7 @@ import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.exception.GitLabCIException;
+import de.tum.in.www1.artemis.repository.BuildPlanRepository;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
@@ -40,6 +41,9 @@ class GitlabCIServiceTest extends AbstractSpringIntegrationGitlabCIGitlabSamlTes
 
     @Autowired
     private ParticipationRepository participationRepository;
+
+    @Autowired
+    private BuildPlanRepository buildPlanRepository;
 
     private Long programmingExerciseId;
 
@@ -175,7 +179,9 @@ class GitlabCIServiceTest extends AbstractSpringIntegrationGitlabCIGitlabSamlTes
         verify(gitlab.getProjectApi(), atLeastOnce()).getProject(eq(repositoryPath));
         verify(gitlab.getProjectApi(), atLeastOnce()).updateProject(any(Project.class));
         verify(gitlab.getProjectApi(), atLeastOnce()).createVariable(anyString(), anyString(), anyString(), any(), anyBoolean(), anyBoolean());
-        assertThat(exercise.getBuildPlan()).isNotNull();
+        var buildPlanOptional = buildPlanRepository.findByProgrammingExercises_Id(exercise.getId());
+        assertThat(buildPlanOptional).isPresent();
+        assertThat(buildPlanOptional.get().getBuildPlan()).isNotBlank();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
@@ -218,7 +218,7 @@ class GitlabCIServiceTest extends AbstractSpringIntegrationGitlabCIGitlabSamlTes
         verify(gitlab.getProjectApi(), atLeastOnce()).getProject(eq(repositoryPath));
         verify(gitlab.getProjectApi(), atLeastOnce()).updateProject(any(Project.class));
         verify(gitlab.getProjectApi(), atLeastOnce()).createVariable(anyString(), anyString(), anyString(), any(), anyBoolean(), anyBoolean());
-        var buildPlanOptional = buildPlanRepository.findByProgrammingExercises_Id(exercise.getId());
+        var buildPlanOptional = buildPlanRepository.findByProgrammingExercises_IdWithProgrammingExercises(exercise.getId());
         assertThat(buildPlanOptional).isPresent();
         assertThat(buildPlanOptional.get().getBuildPlan()).isNotBlank();
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
@@ -50,7 +50,7 @@ class GitlabCIServiceTest extends AbstractSpringIntegrationGitlabCIGitlabSamlTes
     @BeforeEach
     void initTestCase() throws Exception {
         gitlabRequestMockProvider.enableMockingOfRequests();
-        database.addUsers(TEST_PREFIX, 2, 2, 0, 2);
+        database.addUsers(TEST_PREFIX, 1, 0, 0, 1);
         var course = database.addCourseWithOneProgrammingExercise();
         programmingExerciseId = database.getFirstExerciseWithType(course, ProgrammingExercise.class).getId();
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
@@ -143,7 +143,7 @@ class GitlabCIServiceTest extends AbstractSpringIntegrationGitlabCIGitlabSamlTes
         gitlabCIService.extractAndPersistBuildLogStatistics(submission, ProgrammingLanguage.JAVA, ProjectType.MAVEN_MAVEN, buildLogEntries);
         var buildLogStatisticSizeAfterSuccessfulSave = buildLogStatisticsEntryRepository.count();
         assertThat(buildLogStatisticSizeAfterSuccessfulSave).isEqualTo(buildLogStatisticSizeBefore + 1);
-        // TODO: add an assertion on the average data and add more realisitc build log entries
+        // TODO: add an assertion on the average data and add more realistic build log entries
 
         // should not work
         gitlabCIService.extractAndPersistBuildLogStatistics(submission, ProgrammingLanguage.JAVA, ProjectType.GRADLE_GRADLE, buildLogEntries);

--- a/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 import java.net.URL;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.gitlab4j.api.GitLabApiException;
@@ -19,15 +22,20 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationGitlabCIGitlabSamlTest;
+import de.tum.in.www1.artemis.domain.BuildLogEntry;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
+import de.tum.in.www1.artemis.domain.enumeration.ProjectType;
 import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.exception.GitLabCIException;
+import de.tum.in.www1.artemis.repository.BuildLogStatisticsEntryRepository;
 import de.tum.in.www1.artemis.repository.BuildPlanRepository;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
+import de.tum.in.www1.artemis.service.connectors.gitlabci.GitLabCIService;
 
 class GitlabCIServiceTest extends AbstractSpringIntegrationGitlabCIGitlabSamlTest {
 
@@ -44,6 +52,12 @@ class GitlabCIServiceTest extends AbstractSpringIntegrationGitlabCIGitlabSamlTes
 
     @Autowired
     private BuildPlanRepository buildPlanRepository;
+
+    @Autowired
+    private GitLabCIService gitlabCIService;
+
+    @Autowired
+    private BuildLogStatisticsEntryRepository buildLogStatisticsEntryRepository;
 
     private Long programmingExerciseId;
 
@@ -112,6 +126,31 @@ class GitlabCIServiceTest extends AbstractSpringIntegrationGitlabCIGitlabSamlTes
         var result = continuousIntegrationService.getBuildStatus(participation);
 
         assertThat(result).isEqualTo(ContinuousIntegrationService.BuildStatus.INACTIVE);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testExtractAndPersistBuildLogStatistics() {
+        final var exercise = programmingExerciseRepository.findByIdElseThrow(programmingExerciseId);
+        final var participation = database.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
+        final var submission = database.createProgrammingSubmission(participation, false, "hash");
+
+        var buildLogStatisticSizeBefore = buildLogStatisticsEntryRepository.count();
+        List<BuildLogEntry> buildLogEntries = new ArrayList<>();
+        buildLogEntries.add(new BuildLogEntry(ZonedDateTime.now(), "Scanning for projects...", submission));
+        buildLogEntries.add(new BuildLogEntry(ZonedDateTime.now(), "LogEntry", submission));
+        buildLogEntries.add(new BuildLogEntry(ZonedDateTime.now(), "Total time:", submission));
+        gitlabCIService.extractAndPersistBuildLogStatistics(submission, ProgrammingLanguage.JAVA, ProjectType.MAVEN_MAVEN, buildLogEntries);
+        var buildLogStatisticSizeAfterSuccessfulSave = buildLogStatisticsEntryRepository.count();
+        assertThat(buildLogStatisticSizeAfterSuccessfulSave).isEqualTo(buildLogStatisticSizeBefore + 1);
+        // TODO: add an assertion on the average data and add more realisitc build log entries
+
+        // should not work
+        gitlabCIService.extractAndPersistBuildLogStatistics(submission, ProgrammingLanguage.JAVA, ProjectType.GRADLE_GRADLE, buildLogEntries);
+        gitlabCIService.extractAndPersistBuildLogStatistics(submission, ProgrammingLanguage.C, ProjectType.GCC, buildLogEntries);
+
+        var buildLogStatisticSizeAfterUnsuccessfulSave = buildLogStatisticsEntryRepository.count();
+        assertThat(buildLogStatisticSizeAfterUnsuccessfulSave).isEqualTo(buildLogStatisticSizeAfterUnsuccessfulSave);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -2717,7 +2717,7 @@ public class DatabaseUtilService {
     }
 
     public void addBuildPlanAndSecretToProgrammingExercise(ProgrammingExercise programmingExercise, String buildPlan) {
-        buildPlanRepository.updateBuildPlan(programmingExercise, buildPlan);
+        buildPlanRepository.setBuildPlanForExercise(buildPlan, programmingExercise);
         programmingExercise.generateAndSetBuildPlanAccessSecret();
         programmingExerciseRepository.save(programmingExercise);
 

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -2721,7 +2721,7 @@ public class DatabaseUtilService {
         programmingExercise.generateAndSetBuildPlanAccessSecret();
         programmingExerciseRepository.save(programmingExercise);
 
-        var buildPlanOptional = buildPlanRepository.findByProgrammingExercises_Id(programmingExercise.getId());
+        var buildPlanOptional = buildPlanRepository.findByProgrammingExercises_IdWithProgrammingExercises(programmingExercise.getId());
         assertThat(buildPlanOptional).isPresent();
         assertThat(buildPlanOptional.get().getBuildPlan()).as("build plan is set").isNotNull();
         assertThat(programmingExercise.getBuildPlanAccessSecret()).as("build plan access secret is set").isNotNull();

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -2717,7 +2717,7 @@ public class DatabaseUtilService {
     }
 
     public void addBuildPlanAndSecretToProgrammingExercise(ProgrammingExercise programmingExercise, String buildPlan) {
-        buildPlanRepository.updateBuildPlan(programmingExercise, buildPlan, buildPlanRepository);
+        buildPlanRepository.updateBuildPlan(programmingExercise, buildPlan);
         programmingExercise.generateAndSetBuildPlanAccessSecret();
         programmingExerciseRepository.save(programmingExercise);
 

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -334,6 +334,9 @@ public class DatabaseUtilService {
     @Value("${info.guided-tour.course-group-instructors:#{null}}")
     private Optional<String> tutorialGroupInstructors;
 
+    @Autowired
+    private BuildLogEntryRepository buildLogEntryRepository;
+
     // TODO: this should probably be moved into another service
     public void changeUser(String username) {
         User user = getUserByLogin(username);
@@ -2714,11 +2717,13 @@ public class DatabaseUtilService {
     }
 
     public void addBuildPlanAndSecretToProgrammingExercise(ProgrammingExercise programmingExercise, String buildPlan) {
-        programmingExerciseRepository.updateBuildPlan(programmingExercise, buildPlan, buildPlanRepository);
+        buildPlanRepository.updateBuildPlan(programmingExercise, buildPlan, buildPlanRepository);
         programmingExercise.generateAndSetBuildPlanAccessSecret();
         programmingExerciseRepository.save(programmingExercise);
 
-        assertThat(programmingExercise.getBuildPlan()).as("build plan is set").isNotNull();
+        var buildPlanOptional = buildPlanRepository.findByProgrammingExercises_Id(programmingExercise.getId());
+        assertThat(buildPlanOptional).isPresent();
+        assertThat(buildPlanOptional.get().getBuildPlan()).as("build plan is set").isNotNull();
         assertThat(programmingExercise.getBuildPlanAccessSecret()).as("build plan access secret is set").isNotNull();
     }
 


### PR DESCRIPTION
This PR affects setups with Gitlab CI (which is still experimental)

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
At the moment, the relationship between `ProgrammingExercise` -> `BuildPlan` is not ideal, because it leads to additional database queries / joins in many situation due to the nature of a `ManyToOne` relationship.

As the build plan is only needed in 2-3 situations, it is favorable to store the unidirectional relationship on the other side:  `BuildPlan` -> `ProgrammingExercise` as a `OneToMany` relationship

### Description


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Test that the Gitlab CI features are still working

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2