### PR TITLE
`Development`: Add server tests for starting participations in programming exercises

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
@@ -125,6 +125,24 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
         bitbucketRequestMockProvider.mockDefaultBranch(defaultBranch, exercise.getProjectKey());
     }
 
+    public void mockConnectorRequestsForStartPractice(ProgrammingExercise exercise, String username, Set<User> users, boolean ltiUserExists, HttpStatus status)
+            throws IOException, URISyntaxException {
+        // Step 1a)
+        bitbucketRequestMockProvider.mockCopyRepositoryForParticipation(exercise, username, true);
+        // Step 1b)
+        bitbucketRequestMockProvider.mockConfigureRepository(exercise, username, users, ltiUserExists, true);
+        // Step 2a)
+        bambooRequestMockProvider.mockCopyBuildPlanForParticipation(exercise, username, true);
+        // Step 2b)
+        // Note: no need to mock empty commit (Step 2c) because this is done on a git repository
+        mockUpdatePlanRepositoryForParticipation(exercise, username, true);
+        // Step 1c)
+        bitbucketRequestMockProvider.mockAddWebHooks(exercise);
+
+        // Mock Default Branch
+        bitbucketRequestMockProvider.mockDefaultBranch(defaultBranch, exercise.getProjectKey());
+    }
+
     @Override
     public void mockConnectorRequestsForResumeParticipation(ProgrammingExercise exercise, String username, Set<User> users, boolean ltiUserExists)
             throws IOException, URISyntaxException {
@@ -137,8 +155,12 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
 
     @Override
     public void mockUpdatePlanRepositoryForParticipation(ProgrammingExercise exercise, String username) throws IOException, URISyntaxException {
+        mockUpdatePlanRepositoryForParticipation(exercise, username, false);
+    }
+
+    public void mockUpdatePlanRepositoryForParticipation(ProgrammingExercise exercise, String username, boolean practiceMode) throws IOException, URISyntaxException {
         final var projectKey = exercise.getProjectKey();
-        final var bitbucketRepoName = projectKey.toLowerCase() + "-" + username;
+        final var bitbucketRepoName = projectKey.toLowerCase() + "-" + (practiceMode ? "practice-" : "") + username;
         mockUpdatePlanRepository(exercise, username, ASSIGNMENT_REPO_NAME, bitbucketRepoName, List.of());
         bambooRequestMockProvider.mockEnablePlan(exercise.getProjectKey(), username, true, false);
     }

--- a/src/test/java/de/tum/in/www1/artemis/connector/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/BambooRequestMockProvider.java
@@ -185,8 +185,12 @@ public class BambooRequestMockProvider {
     }
 
     public void mockCopyBuildPlanForParticipation(ProgrammingExercise exercise, String username) throws URISyntaxException, JsonProcessingException {
+        mockCopyBuildPlanForParticipation(exercise, username, false);
+    }
+
+    public void mockCopyBuildPlanForParticipation(ProgrammingExercise exercise, String username, boolean practiceMode) throws URISyntaxException, JsonProcessingException {
         final var projectKey = exercise.getProjectKey();
-        final var targetPlanName = username.toUpperCase();
+        final var targetPlanName = (practiceMode ? "practice" : "") + username.toUpperCase();
         mockCopyBuildPlan(projectKey, BuildPlanType.TEMPLATE.getName(), projectKey, targetPlanName, true);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
@@ -184,8 +184,12 @@ public class BitbucketRequestMockProvider {
     }
 
     public void mockCopyRepositoryForParticipation(ProgrammingExercise exercise, String username) throws URISyntaxException, IOException {
+        mockCopyRepositoryForParticipation(exercise, username, false);
+    }
+
+    public void mockCopyRepositoryForParticipation(ProgrammingExercise exercise, String username, boolean practiceMode) throws URISyntaxException, IOException {
         final var projectKey = exercise.getProjectKey();
-        final var clonedRepoName = projectKey.toLowerCase() + "-" + username.toLowerCase();
+        final var clonedRepoName = projectKey.toLowerCase() + "-" + (practiceMode ? "practice-" : "") + username.toLowerCase();
         mockCreateRepository(exercise, clonedRepoName);
     }
 
@@ -198,8 +202,13 @@ public class BitbucketRequestMockProvider {
     }
 
     public void mockConfigureRepository(ProgrammingExercise exercise, String username, Set<User> users, boolean userExists) throws URISyntaxException, IOException {
+        mockConfigureRepository(exercise, username, users, userExists, false);
+    }
+
+    public void mockConfigureRepository(ProgrammingExercise exercise, String username, Set<User> users, boolean userExists, boolean practiceMode)
+            throws URISyntaxException, IOException {
         final var projectKey = exercise.getProjectKey();
-        final var repoName = projectKey.toLowerCase() + "-" + username.toLowerCase();
+        final var repoName = projectKey.toLowerCase() + "-" + (practiceMode ? "practice-" : "") + username.toLowerCase();
         for (User user : users) {
             if (userExists) {
                 mockUserExists(user.getLogin());

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -331,8 +331,12 @@ public class ProgrammingExerciseTestService {
      * can be invoked for teams and students
      */
     public void setupRepositoryMocksParticipant(ProgrammingExercise exercise, String participantName, LocalRepository studentRepo) throws Exception {
+        setupRepositoryMocksParticipant(exercise, participantName, studentRepo, false);
+    }
+
+    public void setupRepositoryMocksParticipant(ProgrammingExercise exercise, String participantName, LocalRepository studentRepo, boolean practiceMode) throws Exception {
         final var projectKey = exercise.getProjectKey();
-        String participantRepoName = projectKey.toLowerCase() + "-" + participantName;
+        String participantRepoName = projectKey.toLowerCase() + "-" + (practiceMode ? "practice-" : "") + participantName;
         var participantRepoTestUrl = ModelFactory.getMockFileRepositoryUrl(studentRepo);
         doReturn(participantRepoTestUrl).when(versionControlService).getCloneRepositoryUrl(projectKey, participantRepoName);
         doReturn(gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepo.localRepoFile.toPath(), null)).when(gitService).getOrCheckoutRepository(participantRepoTestUrl,


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Successfully starting the participation (normal and practice mode) were previously untested for programming exercise, which should not be the case.

### Description
<!-- Describe your changes in detail -->
This PR adds two new test cases for these scenarios together with the necessary mocking.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Only code review

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->