### PR TITLE
`Programming exercises`: Fix code editor read only state after due date

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.html
@@ -41,7 +41,7 @@
             #editor
             id="ace-code-editor"
             [mode]="editorMode ? editorMode : 'java'"
-            [readOnly]="isLoading"
+            [readOnly]="isLoading || disableActions"
             [hidden]="!selectedFile || isLoading"
             [autoUpdateContent]="true"
             [durationBeforeCallback]="200"

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
@@ -67,6 +67,8 @@ export class CodeEditorAceComponent implements AfterViewInit, OnChanges, OnDestr
     highlightDifferences: boolean;
     @Input()
     course?: Course;
+    @Input()
+    disableActions = false;
 
     @Output()
     onFileContentChange = new EventEmitter<{ file: string; fileContent: string }>();

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.html
@@ -35,15 +35,16 @@
     <jhi-code-editor-ace
         editorCenter
         [selectedFile]="selectedFile!"
-        [sessionId]="participation ? participation.id! : 'test'"
+        [sessionId]="participation?.id ?? 'test'"
         [annotations]="annotations"
         [commitState]="commitState"
         [editorState]="editorState"
-        [feedbacks]="(participation?.results && participation.results!.length > 0 && participation.results!.first()!.feedbacks) || []"
+        [feedbacks]="participation?.results?.[0]?.feedbacks ?? []"
         [readOnlyManualFeedback]="readOnlyManualFeedback"
         [isTutorAssessment]="isTutorAssessment"
         [highlightDifferences]="highlightDifferences"
         [course]="course"
+        [disableActions]="!editable"
         (onFileContentChange)="onFileContentChange($event)"
         (onUpdateFeedback)="updateFeedback($event!)"
         (onError)="onError($event)"

--- a/src/test/javascript/spec/component/code-editor/code-editor-ace.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-ace.component.spec.ts
@@ -74,6 +74,15 @@ describe('CodeEditorAceComponent', () => {
         expect(comp.editor.getEditor().getReadOnly()).toBeFalse();
     });
 
+    it('if actions are disabled, it should show the editor in a readonly state', () => {
+        comp.selectedFile = 'dummy';
+        comp.disableActions = true;
+        fixture.detectChanges();
+        const aceEditor = debugElement.query(By.css('#ace-code-editor'));
+        expect(aceEditor.nativeElement.hasAttribute('hidden')).toBeFalse();
+        expect(comp.editor.getEditor().getReadOnly()).toBeTrue();
+    });
+
     it('if a file is selected and the component is not loading a file from server, the editor should be usable', () => {
         comp.selectedFile = 'dummy';
         comp.isLoading = false;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix #6124

### Description
<!-- Describe your changes in detail -->
The text field of the code editor is now also in read only mode (i.e. you cannot write), when the code editor does not allow writing, e.g. after the exercise due date.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise with a due date

1. Log in to Artemis
2. Participate in the exercise
3. Wait until after the due date
4. Open the code editor of the participation before the due date
5. Try to edit any text in the code editor and hopefully fail

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 1 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Wait until the working time is over
4. Try to edit any text in the code editor and hopefully fail

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [x] Test

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->