### PR TITLE
`Exam mode`: Improve dates in exam mode

### DIFF
--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.html
@@ -155,16 +155,8 @@
             <div *ngIf="!exam.testExam">
                 <hr />
                 <h5 class="pb-1" jhiTranslate="artemisApp.examManagement.sections.assessment">Exam Assessment</h5>
+                <h6 class="pb-1" jhiTranslate="artemisApp.examManagement.sections.assessment">Exam Assessment</h6>
                 <div class="row mb-3" *ngIf="!exam.testExam">
-                    <div class="col-sm-6">
-                        <jhi-date-time-picker
-                            labelName="{{ 'artemisApp.examManagement.publishResultsDate' | artemisTranslate }}"
-                            [(ngModel)]="exam.publishResultsDate"
-                            [error]="!isValidPublishResultsDate"
-                            name="publishResultsDate"
-                            id="publishResultsDate"
-                        ></jhi-date-time-picker>
-                    </div>
                     <div class="col-sm-6">
                         <label class="form-check-label" for="numberOfCorrectionRoundsInExam" jhiTranslate="artemisApp.examManagement.numberOfCorrectionRoundsInExam">
                             Number of correction rounds in Exam
@@ -178,6 +170,15 @@
                             max="2"
                             [(ngModel)]="exam.numberOfCorrectionRoundsInExam"
                         />
+                    </div>
+                    <div class="col-sm-6">
+                        <jhi-date-time-picker
+                            labelName="{{ 'artemisApp.examManagement.publishResultsDate' | artemisTranslate }}"
+                            [(ngModel)]="exam.publishResultsDate"
+                            [error]="!isValidPublishResultsDate"
+                            name="publishResultsDate"
+                            id="publishResultsDate"
+                        ></jhi-date-time-picker>
                     </div>
                 </div>
                 <div class="row mb-3">

--- a/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.html
@@ -119,7 +119,7 @@
             class="form-check-input"
             name="allowComplaintsForAutomaticAssessment"
             [checked]="exercise.allowComplaintsForAutomaticAssessments"
-            [disabled]="exercise.assessmentType !== assessmentType.AUTOMATIC"
+            [disabled]="exercise.assessmentType !== assessmentType.AUTOMATIC || readOnly"
             id="allowComplaintsForAutomaticAssessment"
             (change)="toggleComplaintsType()"
         />
@@ -137,7 +137,7 @@
             class="form-check-input"
             name="allowManualFeedbackRequests"
             [checked]="exercise.allowManualFeedbackRequests"
-            [disabled]="exercise.assessmentType !== assessmentType.SEMI_AUTOMATIC"
+            [disabled]="exercise.assessmentType !== assessmentType.SEMI_AUTOMATIC || readOnly"
             id="allowManualFeedbackRequests"
             (change)="toggleManualFeedbackRequests()"
         />
@@ -157,7 +157,7 @@
             class="form-check-input"
             name="releaseTestsWithExampleSolution"
             [checked]="exercise.releaseTestsWithExampleSolution"
-            [disabled]="!exercise.exampleSolutionPublicationDate"
+            [disabled]="!exercise.exampleSolutionPublicationDate || readOnly"
             id="releaseTestsWithExampleSolution"
             (change)="toggleReleaseTests()"
         />

--- a/src/main/webapp/app/exercises/shared/exercise/exercise-details/exercise-details.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise-details/exercise-details.component.html
@@ -53,7 +53,12 @@
         <span jhiTranslate="artemisApp.exercise.teamAssignmentConfig.participants">Participants</span>
     </dd>
 </ng-container>
-<ng-container *ngIf="exercise.type !== ExerciseType.PROGRAMMING">
+<ng-container *ngIf="exercise.type !== ExerciseType.PROGRAMMING && exercise.course">
+    <dt><span jhiTranslate="artemisApp.exercise.startDate">Start Date</span></dt>
+    <dd>
+        <span *ngIf="exercise.startDate">{{ exercise.startDate | artemisDate }}</span>
+        <span *ngIf="!exercise.startDate" jhiTranslate="artemisApp.exercise.dateNotSet"></span>
+    </dd>
     <dt><span jhiTranslate="artemisApp.exercise.releaseDate">Release Date</span></dt>
     <dd>
         <span *ngIf="exercise.releaseDate">{{ exercise.releaseDate | artemisDate }}</span>

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -328,6 +328,7 @@
                 "configuration": "Klausurkonfiguration",
                 "conduction": "Klausurdurchführung",
                 "assessment": "Klausurbewertung und Klausureinsicht",
+                "assessmentEmptyDates": "Wenn du ein Datum leer lässt, wird dieser Schritt nicht stattfinden.",
                 "exercises": "Klausuraufgaben",
                 "text": "Klausurtexte",
                 "examSolutions": "Klausurlösungen"

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -331,6 +331,7 @@
                 "configuration": "Exam Configuration",
                 "conduction": "Exam Conduction",
                 "assessment": "Exam Assessment and Student Review",
+                "assessmentEmptyDates": "If you leave a date blank, this exam step will not take place.",
                 "exercises": "Exam Exercises",
                 "text": "Exam Texts",
                 "examSolutions": "Exam Solutions"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The behavior of dates in the exam wasn't as clear as they should be.

### Description
<!-- Describe your changes in detail -->
This PR improves the following small things:
- When creating/editing an exam it should be clear now that leaving out optional dates will lead to that step never be available to students
- When viewing the detail page of exercises in an exam, they no longer show undefined dates that would be used in courses
- The checkboxes below the programming exercise time line are now also in readOnly when viewing the programming exercise details page

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://docs.artemis.cit.tum.de/user/exam_mode/) as reference.
4. ...

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
