### PR TITLE
Mostly working. liquibase does not migrate database tables yet. some tests fail.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionExportService.java
@@ -18,21 +18,21 @@ public class ModelingSubmissionExportService extends SubmissionExportService {
     }
 
     @Override
-    protected void saveSubmissionToFile(Exercise exercise, Submission submission, File file) throws IOException {
+    protected void saveSubmissionToFiles(Exercise exercise, Submission submission, File[] files) throws IOException {
         if (((ModelingSubmission) submission).getModel() == null) {
-            if (!file.exists()) {
-                file.createNewFile(); // create empty file if submission is empty
+            if (!files[0].exists()) {
+                files[0].createNewFile(); // create empty file if submission is empty
             }
         }
         else {
-            try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, StandardCharsets.UTF_8))) {
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(files[0], StandardCharsets.UTF_8))) {
                 writer.write(((ModelingSubmission) submission).getModel()); // TODO: save explanation text
             }
         }
     }
 
     @Override
-    protected String getFileEndingForSubmission(Submission submission) {
-        return ".json";
+    protected String[] getFileEndingsForSubmission(Submission submission) {
+        return new String[] { ".json" };
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionExportService.java
@@ -18,14 +18,14 @@ public class TextSubmissionExportService extends SubmissionExportService {
     }
 
     @Override
-    protected void saveSubmissionToFile(Exercise exercise, Submission submission, File file) throws IOException {
+    protected void saveSubmissionToFiles(Exercise exercise, Submission submission, File[] files) throws IOException {
         if (((TextSubmission) submission).getText() == null) {
-            if (!file.exists()) {
-                file.createNewFile(); // create empty file if submission is empty
+            if (!files[0].exists()) {
+                files[0].createNewFile(); // create empty file if submission is empty
             }
         }
         else {
-            try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, StandardCharsets.UTF_8))) {
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(files[0], StandardCharsets.UTF_8))) {
                 writer.write(((TextSubmission) submission).getText());
             }
         }
@@ -39,7 +39,7 @@ public class TextSubmissionExportService extends SubmissionExportService {
      * @param submissionsFolderName base folder name to save the file to
      */
     public void saveSubmissionToFile(TextSubmission submission, String studentLogin, String submissionsFolderName) throws IOException {
-        String submissionFileName = String.format("%s-%s%s", submission.getId(), studentLogin, this.getFileEndingForSubmission(submission));
+        String submissionFileName = String.format("%s-%s%s", submission.getId(), studentLogin, this.getFileEndingsForSubmission(submission)[0]);
 
         File submissionExportFile = new File(submissionsFolderName, submissionFileName);
 
@@ -53,7 +53,7 @@ public class TextSubmissionExportService extends SubmissionExportService {
     }
 
     @Override
-    protected String getFileEndingForSubmission(Submission submission) {
-        return ".txt";
+    protected String[] getFileEndingsForSubmission(Submission submission) {
+        return new String[] { ".txt" };
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -280,7 +280,6 @@ public class ExamService {
      *
      * @param examId the id of the exam
      * @return return ExamScoresDTO with students, scores, exerciseGroups, bonus and related plagiarism verdicts for the exam
-     *
      */
     public ExamScoresDTO calculateExamScores(Long examId) {
         Exam exam = examRepository.findWithExerciseGroupsAndExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam", examId));
@@ -360,7 +359,8 @@ public class ExamService {
     /**
      * Calculates max points, max bonus points and achieved points per exercise if the given studentExam is assessed.
      * Includes the corresponding grade and grade type as well if a GradingScale is set for the relevant exam.
-     * @param studentExam a StudentExam instance that will have its points and grades calculated if it is assessed
+     *
+     * @param studentExam             a StudentExam instance that will have its points and grades calculated if it is assessed
      * @param participationsOfStudent StudentParticipation list for the given studentExam
      * @return Student Exam results with exam grade calculated if applicable
      */
@@ -453,10 +453,10 @@ public class ExamService {
     /**
      * Return student exam result, aggregate points, assessment result for a student exam and grade calculations
      * if the exam is assessed.
-     *
+     * <p>
      * See {@link StudentExamWithGradeDTO} for more explanation.
      *
-     * @param targetUser the user who submitted the studentExam
+     * @param targetUser  the user who submitted the studentExam
      * @param studentExam the student exam to be evaluated
      * @return the student exam result with points and grade
      */
@@ -587,8 +587,9 @@ public class ExamService {
      * We also attach the result if the results are already published for the exam.
      * If no suitable Result is found for StudentParticipation, an empty Result set is assigned to prevent LazyInitializationException on future reads.
      * See {@link StudentExam#areResultsPublishedYet}
-     * @param studentExam the given studentExam
-     * @param participation the given participation of the student
+     *
+     * @param studentExam         the given studentExam
+     * @param participation       the given participation of the student
      * @param isAtLeastInstructor flag for instructor access privileges
      */
     private static void setResultIfNecessary(StudentExam studentExam, StudentParticipation participation, boolean isAtLeastInstructor) {
@@ -732,7 +733,7 @@ public class ExamService {
      * First rounds max points for each exercise according to their {@link IncludedInOverallScore} value and sums them up.
      *
      * @param exercises exercises to sum their max points, intended use case is passing all exercises in a {@link StudentExam}
-     * @param course supplies the rounding accuracy of scores
+     * @param course    supplies the rounding accuracy of scores
      * @return sum of rounded max points if exercises are given, else 0.0
      */
     private double calculateMaxPointsSum(List<Exercise> exercises, Course course) {
@@ -747,7 +748,7 @@ public class ExamService {
      * First rounds max bonus points for each exercise according to their {@link IncludedInOverallScore} value and sums them up.
      *
      * @param exercises exercises to sum their bonus points, intended use case is passing all exercises in a {@link StudentExam}
-     * @param course supplies the rounding accuracy of scores
+     * @param course    supplies the rounding accuracy of scores
      * @return sum of rounded max bonus points if exercises are given, else 0.0
      */
     private double calculateMaxBonusPointsSum(List<Exercise> exercises, Course course) {
@@ -783,9 +784,10 @@ public class ExamService {
      * In the client, these are now displayed rounded as 1.1 points.
      * If the student adds up the displayed points, they get a total of 5.5 points.
      * In order to get the same total result as the student, we have to round before summing.
+     *
      * @param exercise the relevant exercise
-     * @param result the result for the given exercise
-     * @param course course to specify number of decimal places to round
+     * @param result   the result for the given exercise
+     * @param course   course to specify number of decimal places to round
      * @return the rounded points according to the student's achieved score and max points of the exercise
      */
     private double calculateAchievedPoints(Exercise exercise, Result result, Course course, double plagiarismPointDeductionPercentage) {
@@ -821,7 +823,7 @@ public class ExamService {
         }
         else if (exercise instanceof FileUploadExercise) {
             FileUploadSubmission textSubmission = (FileUploadSubmission) submissions.iterator().next();
-            return textSubmission.getFilePath() != null && !textSubmission.getFilePath().isEmpty();
+            return textSubmission.getFilePaths() != null && !textSubmission.getFilePaths().isEmpty(); // nocheckin
         }
         else if (exercise instanceof TextExercise) {
             TextSubmission textSubmission = (TextSubmission) submissions.iterator().next();

--- a/src/main/resources/config/liquibase/changelog/20230103211700_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230103211700_changelog.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="erikstern" id="20230103211700">
+        <createTable tableName="file_upload_paths">
+            <column name="id" type="BIGINT"/>
+            <column name="path" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -194,6 +194,7 @@
     <include file="classpath:config/liquibase/changelog/20221122111500_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20221201110000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20221216184800_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20230103211700_changelog.xml" relativeToChangelogFile="false"/>
 
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->

--- a/src/main/webapp/app/entities/file-upload-submission.model.ts
+++ b/src/main/webapp/app/entities/file-upload-submission.model.ts
@@ -1,7 +1,7 @@
 import { Submission, SubmissionExerciseType } from 'app/entities/submission.model';
 
 export class FileUploadSubmission extends Submission {
-    public filePath?: string;
+    public filePaths?: string[];
 
     constructor() {
         super(SubmissionExerciseType.FILE_UPLOAD);

--- a/src/main/webapp/app/exam/participate/exercises/file-upload/file-upload-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/file-upload/file-upload-exam-submission.component.html
@@ -16,7 +16,7 @@
                     <label for="fileUploadInput" class="form-control-label" jhiTranslate="artemisApp.fileUploadSubmission.selectFile">Please select </label>
                     <div class="input-group background-file">
                         <div class="custom-file overflow-ellipsis">
-                            <input #fileInput id="fileUploadInput" type="file" class="custom-file-input" (change)="setFileSubmissionForExercise($event)" />
+                            <input #fileInput id="fileUploadInput" type="file" class="custom-file-input" (change)="addFileSubmissionForExercise($event)" />
                         </div>
                         <div class="col-4">
                             <button class="btn btn-primary" (click)="saveUploadedFile()">
@@ -34,14 +34,16 @@
             </div>
         </div>
 
-        <div *ngIf="submittedFileName && studentSubmission?.filePath" class="card-text">
+        <div *ngIf="submittedFileNames && studentSubmission?.filePaths" class="card-text">
             <h6>
-                {{ 'artemisApp.fileUploadSubmission.submittedFile' | artemisTranslate : { filename: submittedFileName } }}
+                {{ 'artemisApp.fileUploadSubmission.submittedFile' | artemisTranslate : { filename: submittedFileNames } }}
             </h6>
-            <a class="text-primary" (click)="downloadFile(studentSubmission!.filePath!)" jhiTranslate="artemisApp.fileUploadSubmission.download">Download file</a>
-            <span class="ms-2 badge bg-info" *ngIf="submittedFileExtension">
-                {{ submittedFileExtension | uppercase }}
-            </span>
+            <div *ngFor="let filePath of studentSubmission!.filePaths!; index as i" class="col-12 card-text">
+                {{ 'artemisApp.fileUploadSubmission.download' | artemisTranslate : { fileName: submittedFileNames![i] } }}
+                <span class="ms-2 badge bg-info" *ngIf="submittedFileExtensions">
+                    {{ submittedFileExtensions[i] | uppercase }}
+                </span>
+            </div>
         </div>
     </div>
     <!--endregion-->

--- a/src/main/webapp/app/exam/participate/summary/exercises/file-upload-exam-summary/file-upload-exam-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exercises/file-upload-exam-summary/file-upload-exam-summary.component.html
@@ -1,9 +1,12 @@
-<div *ngIf="submission && submission.filePath; else noSubmission">
-    <a id="downloadFileButton" (click)="downloadFile(submission.filePath!)">{{ 'artemisApp.fileUploadAssessment.submissionFile' | artemisTranslate }}</a>
-    <span class="ms-2 badge bg-info">
-        {{ attachmentExtension(submission.filePath!) | uppercase }}
-    </span>
+<div *ngIf="submission && submission.filePaths; else noSubmission">
+    <div *ngFor="let filePath of submission!.filePaths!; index as i" class="col-12 card-text">
+        <a id="downloadFileButton" (click)="downloadFile(filePath)">{{ 'artemisApp.fileUploadAssessment.submissionFile' | artemisTranslate : { fileName: filePath } }}</a>
+        <span class="ms-2 badge bg-info">
+            {{ attachmentExtension(filePath) | uppercase }}
+        </span>
+    </div>
 </div>
+
 <ng-template #noSubmission>
     <div>No submission</div>
 </ng-template>

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.html
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.html
@@ -28,10 +28,12 @@
         <span *ngIf="exercise.title" left-header>{{ exercise.title }}</span>
         <jhi-score-display left-header [score]="totalScore" [maxPoints]="exercise.maxPoints!" [maxBonusPoints]="exercise.bonusPoints!" [course]="course"></jhi-score-display>
         <div left-body>
-            <div class="row">
-                <div *ngIf="submission.filePath" class="col-12 card-text">
-                    <a class="text-primary" (click)="downloadFile(submission.filePath)">{{ 'artemisApp.fileUploadAssessment.submissionFile' | artemisTranslate }}</a>
-                    <span class="ms-2 badge bg-info">{{ attachmentExtension(submission.filePath!) | uppercase }}</span>
+            <div class="row" *ngIf="submission.filePaths">
+                <div *ngFor="let filePath of submission!.filePaths!; index as i" class="col-12 card-text">
+                    <a class="text-primary" (click)="downloadFile(filePath)">{{
+                        'artemisApp.fileUploadAssessment.submissionFile' | artemisTranslate : { fileName: submissionFileNames[i] }
+                    }}</a>
+                    <span class="ms-2 badge bg-info">{{ attachmentExtension(filePath) | uppercase }}</span>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.ts
@@ -42,6 +42,7 @@ export class FileUploadAssessmentComponent implements OnInit, OnDestroy {
     text: string;
     participation: StudentParticipation;
     submission: FileUploadSubmission;
+    submissionFileNames: string[];
     unassessedSubmission: FileUploadSubmission;
     result?: Result;
     unreferencedFeedback: Feedback[] = [];
@@ -193,9 +194,21 @@ export class FileUploadAssessmentComponent implements OnInit, OnDestroy {
             });
     }
 
+    private filePathToNames(filePaths: string[]) {
+        const fileNames: string[] = [];
+
+        for (const filePath of filePaths) {
+            const submittedFileName = filePath.split('/').last()!;
+            fileNames.push(submittedFileName);
+        }
+
+        return fileNames;
+    }
+
     private initializePropertiesFromSubmission(submission: FileUploadSubmission): void {
         this.loadingInitialSubmission = false;
         this.submission = submission;
+        this.submissionFileNames = this.filePathToNames(this.submission!.filePaths!);
         this.participation = this.submission.participation as StudentParticipation;
         this.exercise = this.participation.exercise as FileUploadExercise;
         /**

--- a/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.html
+++ b/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.html
@@ -5,7 +5,7 @@
     <jhi-button
         submitbutton
         *ngIf="isOwnerOfParticipation"
-        [disabled]="(!isActive && !isLate) || !submission || !submissionFile || !!result"
+        [disabled]="(!isActive && !isLate) || !submission || !submissionFiles || !!result"
         [title]="!isLate ? 'entity.action.submit' : 'entity.action.submitDeadlineMissed'"
         (onClick)="submitExercise()"
         [btnType]="!isLate ? ButtonType.PRIMARY : ButtonType.WARNING"
@@ -24,7 +24,7 @@
                     <label for="fileUploadInput" class="form-control-label" jhiTranslate="artemisApp.fileUploadSubmission.selectFile">Please select </label>
                     <div class="input-group background-file">
                         <div class="custom-file overflow-ellipsis">
-                            <input #fileInput id="fileUploadInput" type="file" class="custom-file-input" (change)="setFileSubmissionForExercise($event)" />
+                            <input #fileInput id="fileUploadInput" type="file" class="custom-file-input" (change)="addFileSubmissionForExercise($event)" />
                         </div>
                     </div>
                     <p class="d-inline-block" jhiTranslate="artemisApp.fileUploadExercise.supportedFileExtensions">Supported file extensions:</p>
@@ -37,15 +37,33 @@
             </div>
         </div>
 
-        <div *ngIf="submittedFileName && submission?.filePath" class="card-text">
+        <div *ngIf="submissionFiles" class="card-text pb-2">
             <h6>
-                {{ 'artemisApp.fileUploadSubmission.submittedFile' | artemisTranslate : { filename: submittedFileName } }}
+                {{ 'artemisApp.fileUploadSubmission.submissionFile' | artemisTranslate }}
+            </h6>
+            <div *ngFor="let submissionFile of submissionFiles; index as i">
+                <a class="text-primary" (click)="openFile(submissionFile)">
+                    {{ 'artemisApp.fileUploadSubmission.open' | artemisTranslate : { fileName: submissionFileNames![i] } }}
+                </a>
+                <span class="ms-2 badge bg-info" *ngIf="submissionFileExtensions">
+                    {{ submissionFileExtensions![i] | uppercase }}
+                </span>
+            </div>
+        </div>
+
+        <div *ngIf="submittedFileNames && submission?.filePaths" class="card-text">
+            <h6>
+                {{ 'artemisApp.fileUploadSubmission.submittedFile' | artemisTranslate }}
                 <span> {{ submission!.submissionDate! | artemisTimeAgo }}</span>
             </h6>
-            <a class="text-primary" (click)="downloadFile(submission!.filePath!)" jhiTranslate="artemisApp.fileUploadSubmission.download">Download file</a>
-            <span class="ms-2 badge bg-info" *ngIf="submittedFileExtension">
-                {{ submittedFileExtension | uppercase }}
-            </span>
+            <div *ngFor="let filePath of submission!.filePaths; index as i">
+                <a class="text-primary" (click)="downloadFile(filePath)">
+                    {{ 'artemisApp.fileUploadSubmission.download' | artemisTranslate : { fileName: submittedFileNames![i] } }}
+                </a>
+                <span class="ms-2 badge bg-info" *ngIf="submittedFileExtensions">
+                    {{ submittedFileExtensions![i] | uppercase }}
+                </span>
+            </div>
         </div>
         <div *ngIf="result && result.feedbacks && result.feedbacks.length && result.feedbacks.length > 0">
             <br />

--- a/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.service.ts
+++ b/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.service.ts
@@ -18,13 +18,17 @@ export class FileUploadSubmissionService {
      * Updates File Upload submission on the server
      * @param fileUploadSubmission that will be updated on the server
      * @param exerciseId id of the exercise
-     * @param submissionFile the file submitted that will for the exercise
+     * @param submissionFiles the files submitted that will for the exercise
      */
-    update(fileUploadSubmission: FileUploadSubmission, exerciseId: number, submissionFile: File): Observable<HttpResponse<FileUploadSubmission>> {
+    update(fileUploadSubmission: FileUploadSubmission, exerciseId: number, submissionFiles: File[]): Observable<HttpResponse<FileUploadSubmission>> {
         const copy = this.submissionService.convert(fileUploadSubmission);
         const formData = new FormData();
         const submissionBlob = new Blob([stringifyCircular(copy)], { type: 'application/json' });
-        formData.append('file', submissionFile);
+
+        for (const submissionFile of submissionFiles) {
+            formData.append('file[]', submissionFile);
+        }
+
         formData.append('submission', submissionBlob);
         return this.http
             .post<FileUploadSubmission>(`api/exercises/${exerciseId}/file-upload-submissions`, formData, {

--- a/src/main/webapp/i18n/de/fileUploadAssessment.json
+++ b/src/main/webapp/i18n/de/fileUploadAssessment.json
@@ -2,7 +2,7 @@
     "artemisApp": {
         "fileUploadAssessment": {
             "editorTitle": "Bewertungseditor für Datei-Upload-Übung {{ title }}",
-            "submissionFile": "Abgabedatei herunterladen",
+            "submissionFile": "Abgabedatei herunterladen {{ fileName }}",
             "notFound": "Wir haben keine neue Datei-Upload-Abgabe ohne Bewertung gefunden, bitte gehe zurück.",
             "addFeedback": "Neues Feedback hinzufügen",
             "assessInstruction": "Bitte klicke auf \"Neues Feedback hinzufügen\".",

--- a/src/main/webapp/i18n/de/fileUploadSubmission.json
+++ b/src/main/webapp/i18n/de/fileUploadSubmission.json
@@ -25,9 +25,11 @@
             "fileExtensionError": "Falsche Dateierweiterung. Bitte lade eine Datei mit einer der unten aufgeführten zulässigen Dateierweiterungen hoch.",
             "fileUploadError": "Deine Einreichung der Datei {{ fileName }} ist fehlgeschlagen!",
             "submitted": "Abgegeben",
-            "submittedFile": "Die Datei {{ filename }} wurde als Lösung für die Übung eingereicht",
-            "download": "Datei herunterladen",
-            "selectFile": "Bitte wähle zuerst eine Datei aus und sende sie dann ab.",
+            "submissionFile": "Dateien als Lösung eingereicht werden",
+            "submittedFile": "Dateien wurden als Lösung für die Übung eingereicht",
+            "download": "Datei herunterladen {{ fileName }}",
+            "open": "Datei öffnen {{ fileName }}",
+            "selectFile": "Bitte wähle zuerst Dateien aus und sende sie dann ab.",
             "fileUpload": "Datei hochladen",
             "forExercise": "für Übung"
         }

--- a/src/main/webapp/i18n/en/fileUploadAssessment.json
+++ b/src/main/webapp/i18n/en/fileUploadAssessment.json
@@ -2,7 +2,7 @@
     "artemisApp": {
         "fileUploadAssessment": {
             "editorTitle": "Assessment Editor for File Upload Exercise {{ title }}",
-            "submissionFile": "Download Submission File",
+            "submissionFile": "Download Submission File {{ fileName }}",
             "notFound": "We couldn't find any unassessed file upload submissions, please go back.",
             "addFeedback": "Add new Feedback",
             "assessInstruction": "Please click the \"Add new Feedback\" button.",

--- a/src/main/webapp/i18n/en/fileUploadSubmission.json
+++ b/src/main/webapp/i18n/en/fileUploadSubmission.json
@@ -25,9 +25,11 @@
             "fileExtensionError": "Unsupported file extension. Please upload a file with one of the allowed file extensions listed below.",
             "fileUploadError": "Your submission of file {{ fileName }} failed!",
             "submitted": "Submitted",
-            "submittedFile": "Submitted file {{ filename }} as a solution for the exercise",
-            "download": "Download file",
-            "selectFile": "Please first select a file and then submit it.",
+            "submissionFile": "Files to be submitted",
+            "submittedFile": "Submitted files as a solution for the exercise",
+            "download": "Download file {{ fileName }}",
+            "open": "Open file {{ fileName }}",
+            "selectFile": "Please first select files and then submit them.",
             "fileUpload": "File Upload",
             "forExercise": "for Exercise"
         }

--- a/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
@@ -154,11 +154,11 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         FileUploadSubmission fileUploadSubmission = createFileUploadSubmissionWithRealFile();
 
         // get access token
-        String accessToken = request.get(fileUploadSubmission.getFilePath() + "/access-token", HttpStatus.OK, String.class);
+        String accessToken = request.get(fileUploadSubmission.getFilePaths().get(0) + "/access-token", HttpStatus.OK, String.class);
 
-        String receivedFile = request.get(fileUploadSubmission.getFilePath() + "?access_token=" + accessToken, HttpStatus.OK, String.class);
+        String receivedFile = request.get(fileUploadSubmission.getFilePaths().get(0) + "?access_token=" + accessToken, HttpStatus.OK, String.class);
         assertThat(receivedFile).isEqualTo("some data");
-        request.get(fileUploadSubmission.getFilePath() + "?access_token=random_non_valid_token", HttpStatus.FORBIDDEN, String.class);
+        request.get(fileUploadSubmission.getFilePaths().get(0) + "?access_token=random_non_valid_token", HttpStatus.FORBIDDEN, String.class);
     }
 
     @Test
@@ -167,11 +167,11 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         FileUploadSubmission fileUploadSubmission = createFileUploadSubmissionWithRealFile();
 
         // get access token
-        String accessToken = request.get(fileUploadSubmission.getFilePath() + "/access-token", HttpStatus.OK, String.class);
+        String accessToken = request.get(fileUploadSubmission.getFilePaths().get(0) + "/access-token", HttpStatus.OK, String.class);
 
-        String receivedFile = request.get(fileUploadSubmission.getFilePath() + "?access_token=" + accessToken, HttpStatus.OK, String.class);
+        String receivedFile = request.get(fileUploadSubmission.getFilePaths().get(0) + "?access_token=" + accessToken, HttpStatus.OK, String.class);
         assertThat(receivedFile).isEqualTo("some data");
-        request.get(fileUploadSubmission.getFilePath() + "?access_token=random_non_valid_token", HttpStatus.FORBIDDEN, String.class);
+        request.get(fileUploadSubmission.getFilePaths().get(0) + "?access_token=random_non_valid_token", HttpStatus.FORBIDDEN, String.class);
     }
 
     @Test
@@ -188,7 +188,7 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         String filePath = fileService.manageFilesForUpdatedFilePath(null, responsePath,
                 FileUploadSubmission.buildFilePath(fileUploadExercise.getId(), fileUploadSubmission.getId()), fileUploadSubmission.getId(), true);
 
-        fileUploadSubmission.setFilePath(filePath);
+        fileUploadSubmission.setFilePaths(new String[] { filePath });
 
         // invalid exercise id
         request.get("/api/files/file-upload-exercises/" + 999999999 + "/submissions/" + fileUploadSubmission.getId() + "/file.png/access-token", HttpStatus.NOT_FOUND,
@@ -207,7 +207,7 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         // create tutor that is not in the course
         database.addTeachingAssistant("other-tutors", "other-ta");
 
-        request.get(fileUploadSubmission.getFilePath() + "/access-token", HttpStatus.FORBIDDEN, String.class);
+        request.get(fileUploadSubmission.getFilePaths().get(0) + "/access-token", HttpStatus.FORBIDDEN, String.class);
     }
 
     @Test
@@ -216,7 +216,7 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         FileUploadSubmission fileUploadSubmission = createFileUploadSubmissionWithoutUploadPermissions();
 
         // get access token
-        request.get(fileUploadSubmission.getFilePath() + "/access-token", HttpStatus.OK, String.class);
+        request.get(fileUploadSubmission.getFilePaths().get(0) + "/access-token", HttpStatus.OK, String.class);
     }
 
     @Test
@@ -224,7 +224,7 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
     void testGetAccessTokenForOtherStudentsFileUploadSubmissionAsStudent_forbidden() throws Exception {
         FileUploadSubmission fileUploadSubmission = createFileUploadSubmissionWithoutUploadPermissions();
 
-        request.get(fileUploadSubmission.getFilePath() + "/access-token", HttpStatus.FORBIDDEN, String.class);
+        request.get(fileUploadSubmission.getFilePaths().get(0) + "/access-token", HttpStatus.FORBIDDEN, String.class);
     }
 
     private FileUploadSubmission createFileUploadSubmissionWithRealFile() throws Exception {
@@ -239,7 +239,7 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         String filePath = fileService.manageFilesForUpdatedFilePath(null, responsePath,
                 FileUploadSubmission.buildFilePath(fileUploadExercise.getId(), fileUploadSubmission.getId()), fileUploadSubmission.getId(), true);
 
-        fileUploadSubmission.setFilePath(filePath);
+        fileUploadSubmission.setFilePaths(new String[] { filePath });
         return fileUploadSubmission;
     }
 
@@ -249,7 +249,7 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         FileUploadSubmission fileUploadSubmission = ModelFactory.generateFileUploadSubmission(true);
         fileUploadSubmission = database.addFileUploadSubmission(fileUploadExercise, fileUploadSubmission, "student1");
         String path = "/api/files/file-upload-exercises/" + fileUploadExercise.getId() + "/submissions/" + fileUploadSubmission.getId() + "/test.png";
-        fileUploadSubmission.setFilePath(path);
+        fileUploadSubmission.setFilePaths(new String[] { path });
 
         return fileUploadSubmission;
     }

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -1281,7 +1281,8 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
             assertThat("Model: " + modelingSubmission.getModel() + "; Explanation: " + modelingSubmission.getExplanationText()).isEqualTo(versionedSubmission.get().getContent());
         }
         else if (submission instanceof FileUploadSubmission) {
-            assertThat(((FileUploadSubmission) submission).getFilePath()).isEqualTo(versionedSubmission.get().getContent());
+            // nocheckin: commenting this assert out is obviously wrong but i dont understand it yet.
+            assertThat(((FileUploadSubmission) submission).getFilePaths()).isEqualTo(versionedSubmission.get().getContent());
         }
         else {
             assert submission instanceof QuizSubmission;

--- a/src/test/java/de/tum/in/www1/artemis/SubmissionExportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/SubmissionExportIntegrationTest.java
@@ -88,9 +88,12 @@ class SubmissionExportIntegrationTest extends AbstractSpringIntegrationBambooBit
             else if (exercise instanceof FileUploadExercise) {
                 fileUploadExercise = (FileUploadExercise) exercise;
 
-                fileUploadSubmission1 = database.addFileUploadSubmission(fileUploadExercise, ModelFactory.generateFileUploadSubmissionWithFile(true, "test1.pdf"), "student1");
-                fileUploadSubmission2 = database.addFileUploadSubmission(fileUploadExercise, ModelFactory.generateFileUploadSubmissionWithFile(true, "test2.pdf"), "student2");
-                fileUploadSubmission3 = database.addFileUploadSubmission(fileUploadExercise, ModelFactory.generateFileUploadSubmissionWithFile(true, "test3.pdf"), "student3");
+                fileUploadSubmission1 = database.addFileUploadSubmission(fileUploadExercise, ModelFactory.generateFileUploadSubmissionWithFiles(true, new String[] { "test1.pdf" }),
+                        "student1");
+                fileUploadSubmission2 = database.addFileUploadSubmission(fileUploadExercise, ModelFactory.generateFileUploadSubmissionWithFiles(true, new String[] { "test2.pdf" }),
+                        "student2");
+                fileUploadSubmission3 = database.addFileUploadSubmission(fileUploadExercise, ModelFactory.generateFileUploadSubmissionWithFiles(true, new String[] { "test3.pdf" }),
+                        "student3");
 
                 try {
                     saveEmptySubmissionFile(fileUploadExercise, fileUploadSubmission1);
@@ -110,8 +113,7 @@ class SubmissionExportIntegrationTest extends AbstractSpringIntegrationBambooBit
     }
 
     private void saveEmptySubmissionFile(Exercise exercise, FileUploadSubmission submission) throws IOException {
-
-        String[] parts = submission.getFilePath().split(Pattern.quote(File.separator));
+        String[] parts = submission.getFilePaths().get(0).split(Pattern.quote(File.separator));
         String fileName = parts[parts.length - 1];
         File file = Path.of(FileUploadSubmission.buildFilePath(exercise.getId(), submission.getId()), fileName).toFile();
 
@@ -242,13 +244,13 @@ class SubmissionExportIntegrationTest extends AbstractSpringIntegrationBambooBit
 
     private String getSubmissionFileName(Submission submission) {
         if (submission instanceof TextSubmission) {
-            return textExercise.getTitle() + "-" + ((StudentParticipation) submission.getParticipation()).getParticipantIdentifier() + "-" + submission.getId() + ".txt";
+            return textExercise.getTitle() + "-" + ((StudentParticipation) submission.getParticipation()).getParticipantIdentifier() + "-" + submission.getId() + "-0.txt";
         }
         else if (submission instanceof ModelingSubmission) {
-            return modelingExercise.getTitle() + "-" + ((StudentParticipation) submission.getParticipation()).getParticipantIdentifier() + "-" + submission.getId() + ".json";
+            return modelingExercise.getTitle() + "-" + ((StudentParticipation) submission.getParticipation()).getParticipantIdentifier() + "-" + submission.getId() + "-0.json";
         }
         else if (submission instanceof FileUploadSubmission) {
-            return fileUploadExercise.getTitle() + "-" + ((StudentParticipation) submission.getParticipation()).getParticipantIdentifier() + "-" + submission.getId() + ".pdf";
+            return fileUploadExercise.getTitle() + "-" + ((StudentParticipation) submission.getParticipation()).getParticipantIdentifier() + "-" + submission.getId() + "-0.pdf";
         }
         else {
             fail("Unknown submission type");

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -2667,7 +2667,7 @@ public class DatabaseUtilService {
                 exercise = exerciseRepo.findAllExercisesByCourseId(course.getId()).iterator().next();
 
                 for (int j = 1; j <= numberOfSubmissions; j++) {
-                    FileUploadSubmission submission = ModelFactory.generateFileUploadSubmissionWithFile(true, "path/to/file.pdf");
+                    FileUploadSubmission submission = ModelFactory.generateFileUploadSubmissionWithFiles(true, new String[] { "path/to/file.pdf" });
                     saveFileUploadSubmission((FileUploadExercise) exercise, submission, "student" + j);
                 }
                 return course;
@@ -2799,7 +2799,7 @@ public class DatabaseUtilService {
                 course = courseRepo.save(course);
                 exerciseRepo.save(fileUploadExercise);
                 for (int j = 1; j <= numberOfSubmissionPerExercise; j++) {
-                    FileUploadSubmission submission = ModelFactory.generateFileUploadSubmissionWithFile(true, "path/to/file.pdf");
+                    FileUploadSubmission submission = ModelFactory.generateFileUploadSubmissionWithFiles(true, new String[] { "path/to/file.pdf" });
                     saveFileUploadSubmission(fileUploadExercise, submission, "student" + j);
                     if (numberOfAssessments >= j) {
                         Result result = generateResult(submission, currentUser);
@@ -4100,7 +4100,7 @@ public class DatabaseUtilService {
             Files.createDirectories(uploadedFileDir);
             Files.createFile(uploadedFilePath);
         }
-        fileUploadSubmission.setFilePath(uploadedFilePath.toString());
+        fileUploadSubmission.setFilePaths(new String[] { uploadedFilePath.toString() });
         fileUploadSubmissionRepo.save(fileUploadSubmission);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
@@ -489,9 +489,9 @@ public class ModelFactory {
         return fileUploadSubmission;
     }
 
-    public static FileUploadSubmission generateFileUploadSubmissionWithFile(boolean submitted, String filePath) {
+    public static FileUploadSubmission generateFileUploadSubmissionWithFiles(boolean submitted, String[] filePaths) {
         FileUploadSubmission fileUploadSubmission = generateFileUploadSubmission(submitted);
-        fileUploadSubmission.setFilePath(filePath);
+        fileUploadSubmission.setFilePaths(filePaths);
         if (submitted) {
             fileUploadSubmission.setSubmissionDate(now().minusDays(1));
         }

--- a/src/test/javascript/spec/component/exam/participate/exercises/file-upload-exam-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exercises/file-upload-exam-submission.component.spec.ts
@@ -220,7 +220,7 @@ describe('FileUploadExamSubmissionComponent', () => {
         comp.studentSubmission = createFileUploadSubmission();
         const jhiErrorSpy = jest.spyOn(alertService, 'error');
         const event = { target: { files: [submissionFile] } };
-        comp.setFileSubmissionForExercise(event);
+        comp.addFileSubmissionForExercise(event); // nocheckin
         fixture.detectChanges();
 
         // check that properties are set properly
@@ -248,7 +248,7 @@ describe('FileUploadExamSubmissionComponent', () => {
         comp.studentSubmission = createFileUploadSubmission();
         const jhiErrorSpy = jest.spyOn(alertService, 'error');
         const event = { target: { files: [submissionFile] } };
-        comp.setFileSubmissionForExercise(event);
+        comp.addFileSubmissionForExercise(event); // nocheckin
         fixture.detectChanges();
 
         // check that properties are set properly

--- a/src/test/javascript/spec/component/file-upload-submission/file-upload-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-submission/file-upload-submission.component.spec.ts
@@ -160,7 +160,7 @@ describe('FileUploadSubmissionComponent', () => {
         comp.submission = createFileUploadSubmission();
         const jhiErrorSpy = jest.spyOn(alertService, 'error');
         const event = { target: { files: [submissionFile] } };
-        comp.setFileSubmissionForExercise(event);
+        comp.addFileSubmissionForExercise(event); // nocheckin
         fixture.detectChanges();
 
         // check that properties are set properly
@@ -187,7 +187,7 @@ describe('FileUploadSubmissionComponent', () => {
         comp.submission = createFileUploadSubmission();
         const jhiErrorSpy = jest.spyOn(alertService, 'error');
         const event = { target: { files: [submissionFile] } };
-        comp.setFileSubmissionForExercise(event);
+        comp.addFileSubmissionForExercise(event); // nocheckin
         fixture.detectChanges();
 
         // check that properties are set properly


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [ ] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I implemented the changes with a good performance and prevented too many database calls.
- [ ] I documented the Java code using JavaDoc style.
#### Client
- [ ] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://docs.artemis.cit.tum.de/user/exam_mode/) as reference.
4. ...

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
