### PR TITLE
`Exam mode`: Trim whitespace in exam title and exercise group names

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
@@ -153,7 +153,7 @@ public class Exam extends DomainObject {
     }
 
     public void setTitle(String title) {
-        this.title = title;
+        this.title = title != null ? title.strip() : null;
     }
 
     public boolean isTestExam() {

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/ExerciseGroup.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/ExerciseGroup.java
@@ -43,7 +43,7 @@ public class ExerciseGroup extends DomainObject {
     }
 
     public void setTitle(String title) {
-        this.title = title;
+        this.title = title != null ? title.strip() : null;
     }
 
     public Boolean getIsMandatory() {

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -842,7 +843,10 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         request.post("/api/courses/" + course1.getId() + "/exams", examD, HttpStatus.CONFLICT);
         // Test examAccessService.
         Exam examE = ModelFactory.generateExam(course1);
-        request.post("/api/courses/" + course1.getId() + "/exams", examE, HttpStatus.CREATED);
+        examE.setTitle("          Exam 123              ");
+        URI examUri = request.post("/api/courses/" + course1.getId() + "/exams", examE, HttpStatus.CREATED);
+        Exam savedExam = request.get(String.valueOf(examUri), HttpStatus.OK, Exam.class);
+        assertThat(savedExam.getTitle()).isEqualTo("Exam 123");
         verify(examAccessService, times(1)).checkCourseAccessForInstructorElseThrow(course1.getId());
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExerciseGroupIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExerciseGroupIntegrationTest.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.artemis.exam;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -98,8 +99,12 @@ class ExerciseGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         exerciseGroup.setExam(null);
         request.post("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exerciseGroups", exerciseGroup, HttpStatus.CONFLICT);
         exerciseGroup = ModelFactory.generateExerciseGroup(true, exam2);
-        request.post("/api/courses/" + course1.getId() + "/exams/" + exam2.getId() + "/exerciseGroups", exerciseGroup, HttpStatus.CREATED);
+        exerciseGroup.setTitle("      ExerciseGroup 123       ");
+        URI exerciseGroupUri = request.post("/api/courses/" + course1.getId() + "/exams/" + exam2.getId() + "/exerciseGroups", exerciseGroup, HttpStatus.CREATED);
         verify(examAccessService, times(1)).checkCourseAndExamAccessForEditorElseThrow(course1.getId(), exam2.getId());
+        ExerciseGroup savedExerciseGroup = request.get(String.valueOf(exerciseGroupUri), HttpStatus.OK, ExerciseGroup.class);
+        assertThat(savedExerciseGroup.getTitle()).isEqualTo("ExerciseGroup 123");
+
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
(https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
### Motivation and Context
Closes #6154 
### Description
Exam titles and exercise group names are now trimmend when set on the server. 
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course

1. Log in to Artemis
2. Navigate to Course Management
3. Navigate to Exam
4. Create a new exam and enter a title containing leading and/or trailing whitespace.
5. Create an exercise group and enter a name containing leading and/or trailing whitespace.
6. Delete the exercise group. When asked to enter the name, the delete button should be enabled, once you enter the name without leading or trailing whitespace
7. Delete the exam. When asked to enter the title, the delete button should be enabled, once you enter the name without leading or trailing whitespace.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| Exam.java | 85% | 77% |
| ExerciseGroup.java | 13% | 95% |
-->
