### PR TITLE
`Development`: Add test exam management e2e tests

### DIFF
--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -16,7 +16,7 @@
 <div class="mt-3 text-end" id="number-groups" style="font-size: 0.85rem">
     {{ 'artemisApp.examManagement.numberOfExerciseGroups' | artemisTranslate }} {{ exerciseGroups ? exerciseGroups.length : 0 }}
 </div>
-<div *ngFor="let exerciseGroup of exerciseGroups; let i = index" class="exercise-group mt-3" id="{{ 'group-' + i }}">
+<div *ngFor="let exerciseGroup of exerciseGroups; let i = index" class="exercise-group mt-3" id="{{ 'group-' + exerciseGroup.id }}">
     <div class="d-flex p-3 header flex-wrap">
         <div class="me-3 d-flex justify-content-center" style="align-items: center">
             <a (click)="moveUp(i)" [class.disabled]="i === 0" class="border-0 p-0 me-1 bg-transparent">
@@ -62,8 +62,7 @@
                         <a
                             *ngIf="course?.isAtLeastEditor"
                             [routerLink]="[exerciseGroup.id, 'quiz-exercises', 'new']"
-                            class="btn btn-info btn-sm me-1 mb-1"
-                            [id]="'add-quiz-exercise-group-' + i"
+                            class="add-quiz-exercise btn btn-info btn-sm me-1 mb-1"
                             style="max-height: 44%"
                         >
                             <fa-icon [icon]="faPlus"></fa-icon>
@@ -77,12 +76,7 @@
                             <fa-icon class="d-xl-none" [icon]="faFont"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.textExercise.home.importLabel' | artemisTranslate }}</span>
                         </a>
-                        <a
-                            *ngIf="course?.isAtLeastEditor"
-                            [routerLink]="[exerciseGroup.id, 'text-exercises', 'new']"
-                            class="btn btn-info btn-sm me-1 mb-1"
-                            [id]="'add-text-exercise-group-' + i"
-                        >
+                        <a *ngIf="course?.isAtLeastEditor" [routerLink]="[exerciseGroup.id, 'text-exercises', 'new']" class="add-text-exercise btn btn-info btn-sm me-1 mb-1">
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <fa-icon class="d-xl-none" [icon]="faFont"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.examManagement.exerciseGroup.addTextExercise' | artemisTranslate }}</span>
@@ -97,8 +91,7 @@
                         <a
                             *ngIf="course?.isAtLeastEditor"
                             [routerLink]="[exerciseGroup.id, 'modeling-exercises', 'new']"
-                            class="btn btn-info btn-sm me-1 mb-1"
-                            [id]="'add-modeling-exercise-group-' + i"
+                            class="add-modeling-exercise btn btn-info btn-sm me-1 mb-1"
                         >
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <fa-icon class="d-xl-none" [icon]="faProjectDiagram"></fa-icon>
@@ -114,8 +107,7 @@
                         <a
                             *ngIf="course?.isAtLeastEditor"
                             [routerLink]="[exerciseGroup.id, 'programming-exercises', 'new']"
-                            class="btn btn-info btn-sm me-1 mb-1"
-                            [id]="'add-programming-exercise-group-' + i"
+                            class="add-programming-exercise btn btn-info btn-sm me-1 mb-1"
                         >
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <fa-icon class="d-xl-none" [icon]="faKeyboard"></fa-icon>

--- a/src/test/cypress/e2e/exam/ExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamManagement.cy.ts
@@ -151,11 +151,12 @@ describe('Exam management', () => {
             courseManagement.openExamsOfCourse(course.shortName!);
             examManagement.openExerciseGroups(exam.id!);
             // If the group in the "Create group test" was created successfully, we delete it so there is no group with no exercise
+            let group = exerciseGroup;
             if (createdGroup) {
-                exerciseGroups.clickDeleteGroup(createdGroup.id!, createdGroup.title!);
-            } else {
-                exerciseGroups.clickDeleteGroup(exerciseGroup.id!, exerciseGroup.title!);
+                group = createdGroup;
             }
+            exerciseGroups.clickDeleteGroup(group.id!, group.title!);
+            exerciseGroups.shouldNotExist(group.id!);
         });
     });
 

--- a/src/test/cypress/e2e/exam/ExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamManagement.cy.ts
@@ -4,6 +4,7 @@ import { Course } from 'app/entities/course.model';
 import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import { artemis } from '../../support/ArtemisTesting';
 import { generateUUID } from '../../support/utils';
+import { ExerciseGroup } from 'app/entities/exercise-group.model';
 
 // Requests
 const courseManagementRequests = artemis.requests.courseManagement;
@@ -11,6 +12,8 @@ const courseManagementRequests = artemis.requests.courseManagement;
 // User management
 const users = artemis.users;
 const admin = users.getAdmin();
+const instructor = users.getInstructor();
+const studentOne = users.getStudentOne();
 
 // Pageobjects
 const navigationBar = artemis.pageobjects.navigationBar;
@@ -28,6 +31,7 @@ const studentExamManagement = artemis.pageobjects.exam.studentExamManagement;
 const uid = generateUUID();
 const examTitle = 'exam' + uid;
 let groupCount = 0;
+let createdGroup: ExerciseGroup;
 
 describe('Exam management', () => {
     let course: Course;
@@ -37,7 +41,7 @@ describe('Exam management', () => {
         cy.login(admin);
         courseManagementRequests.createCourse(true).then((response) => {
             course = convertCourseAfterMultiPart(response);
-            courseManagementRequests.addStudentToCourse(course, users.getStudentOne());
+            courseManagementRequests.addStudentToCourse(course, studentOne);
             const examConfig = new CypressExamBuilder(course).title(examTitle).build();
             courseManagementRequests.createExam(examConfig).then((examResponse) => {
                 exam = examResponse.body;
@@ -45,120 +49,137 @@ describe('Exam management', () => {
         });
     });
 
-    beforeEach(() => {
-        cy.login(admin);
-    });
+    describe('Manage Group', () => {
+        let exerciseGroup: ExerciseGroup;
 
-    it('Create exercise group', () => {
-        cy.visit('/');
-        navigationBar.openCourseManagement();
-        courseManagement.openExamsOfCourse(course.shortName!);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
-        exerciseGroups.clickAddExerciseGroup();
-        const groupName = 'Group 1';
-        exerciseGroupCreation.typeTitle(groupName);
-        exerciseGroupCreation.isMandatoryBoxShouldBeChecked();
-        exerciseGroupCreation.clickSave();
-        groupCount++;
-        exerciseGroups.shouldHaveTitle(groupCount - 1, groupName);
-        exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
-    });
-
-    it('Adds a text exercise', () => {
-        cy.visit(`/course-management/${course.id}/exams`);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.clickAddTextExercise(0);
-        const textExerciseTitle = 'text' + uid;
-        textCreation.typeTitle(textExerciseTitle);
-        textCreation.typeMaxPoints(10);
-        textCreation.create().its('response.statusCode').should('eq', 201);
-        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
-        exerciseGroups.shouldContainExerciseWithTitle(textExerciseTitle);
-    });
-
-    it('Adds a quiz exercise', () => {
-        cy.visit(`/course-management/${course.id}/exams`);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.clickAddQuizExercise(0);
-        const quizExerciseTitle = 'quiz' + uid;
-        quizCreation.setTitle(quizExerciseTitle);
-        quizCreation.addMultipleChoiceQuestion(quizExerciseTitle, 10);
-        quizCreation.saveQuiz().its('response.statusCode').should('eq', 201);
-        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
-        exerciseGroups.shouldContainExerciseWithTitle(quizExerciseTitle);
-    });
-
-    it('Adds a modeling exercise', () => {
-        cy.visit(`/course-management/${course.id}/exams`);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.clickAddModelingExercise(0);
-        const modelingExerciseTitle = 'modeling' + uid;
-        modelingCreation.setTitle(modelingExerciseTitle);
-        modelingCreation.setPoints(10);
-        modelingCreation.save().its('response.statusCode').should('eq', 201);
-        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
-        exerciseGroups.shouldContainExerciseWithTitle(modelingExerciseTitle);
-    });
-
-    it('Adds a programming exercise', () => {
-        cy.visit(`/course-management/${course.id}/exams`);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.clickAddProgrammingExercise(0);
-        const programmingExerciseTitle = 'programming' + uid;
-        programmingCreation.setTitle(programmingExerciseTitle);
-        programmingCreation.setShortName(programmingExerciseTitle);
-        programmingCreation.setPackageName('de.test');
-        programmingCreation.setPoints(10);
-        programmingCreation.generate().its('response.statusCode').should('eq', 201);
-        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
-        exerciseGroups.shouldContainExerciseWithTitle(programmingExerciseTitle);
-    });
-
-    it('Edits an exercise group', () => {
-        cy.visit('/');
-        navigationBar.openCourseManagement();
-        courseManagement.openExamsOfCourse(course.shortName!);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
-        exerciseGroups.clickAddExerciseGroup();
-        const groupName = 'Group 2';
-        exerciseGroupCreation.typeTitle(groupName);
-        exerciseGroupCreation.isMandatoryBoxShouldBeChecked();
-        exerciseGroupCreation.clickSave();
-        groupCount++;
-
-        exerciseGroups.shouldHaveTitle(groupCount - 1, groupName);
-        exerciseGroups.clickEditGroup(groupCount - 1);
-        const newGroupName = 'Group 3';
-        exerciseGroupCreation.typeTitle(newGroupName);
-        exerciseGroupCreation.update();
-        exerciseGroups.shouldHaveTitle(groupCount - 1, newGroupName);
-    });
-
-    it('Delete an exercise group', () => {
-        cy.visit('/');
-        navigationBar.openCourseManagement();
-        courseManagement.openExamsOfCourse(course.shortName!);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.clickDeleteGroup(groupCount - 1, 'Group 3');
-    });
-
-    it('Registers the course students for the exam', () => {
-        // We already verified in the previous test that we can navigate here
-        cy.visit(`/course-management/${course.id}/exams`);
-        examManagement.openStudentRegistration(exam.id!);
-        studentExamManagement.clickRegisterCourseStudents().then((request: Interception) => {
-            expect(request.response!.statusCode).to.eq(200);
+        before(() => {
+            cy.login(instructor);
+            courseManagementRequests.addExerciseGroupForExam(exam).then((response) => {
+                exerciseGroup = response.body;
+                groupCount++;
+            });
         });
-        cy.get('#registered-students').contains(users.getStudentOne().username).should('be.visible');
+
+        beforeEach(() => {
+            cy.login(instructor);
+        });
+
+        it('Create exercise group', () => {
+            cy.visit('/');
+            navigationBar.openCourseManagement();
+            courseManagement.openExamsOfCourse(course.shortName!);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
+            exerciseGroups.clickAddExerciseGroup();
+            const groupName = 'Group 1';
+            exerciseGroupCreation.typeTitle(groupName);
+            exerciseGroupCreation.isMandatoryBoxShouldBeChecked();
+            exerciseGroupCreation.clickSave().then((interception) => {
+                const group = interception.response!.body;
+                groupCount++;
+                exerciseGroups.shouldHaveTitle(group.id, groupName);
+                exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
+                createdGroup = group;
+            });
+        });
+
+        it('Adds a text exercise', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.clickAddTextExercise(exerciseGroup.id!);
+            const textExerciseTitle = 'text' + uid;
+            textCreation.typeTitle(textExerciseTitle);
+            textCreation.typeMaxPoints(10);
+            textCreation.create().its('response.statusCode').should('eq', 201);
+            exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+            exerciseGroups.shouldContainExerciseWithTitle(exerciseGroup.id!, textExerciseTitle);
+        });
+
+        it('Adds a quiz exercise', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.clickAddQuizExercise(exerciseGroup.id!);
+            const quizExerciseTitle = 'quiz' + uid;
+            quizCreation.setTitle(quizExerciseTitle);
+            quizCreation.addMultipleChoiceQuestion(quizExerciseTitle, 10);
+            quizCreation.saveQuiz().its('response.statusCode').should('eq', 201);
+            exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+            exerciseGroups.shouldContainExerciseWithTitle(exerciseGroup.id!, quizExerciseTitle);
+        });
+
+        it('Adds a modeling exercise', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.clickAddModelingExercise(exerciseGroup.id!);
+            const modelingExerciseTitle = 'modeling' + uid;
+            modelingCreation.setTitle(modelingExerciseTitle);
+            modelingCreation.setPoints(10);
+            modelingCreation.save().its('response.statusCode').should('eq', 201);
+            exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+            exerciseGroups.shouldContainExerciseWithTitle(exerciseGroup.id!, modelingExerciseTitle);
+        });
+
+        it('Adds a programming exercise', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.clickAddProgrammingExercise(exerciseGroup.id!);
+            const programmingExerciseTitle = 'programming' + uid;
+            programmingCreation.setTitle(programmingExerciseTitle);
+            programmingCreation.setShortName(programmingExerciseTitle);
+            programmingCreation.setPackageName('de.test');
+            programmingCreation.setPoints(10);
+            programmingCreation.generate().its('response.statusCode').should('eq', 201);
+            exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+            exerciseGroups.shouldContainExerciseWithTitle(exerciseGroup.id!, programmingExerciseTitle);
+        });
+
+        it('Edits an exercise group', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.shouldHaveTitle(exerciseGroup.id!, exerciseGroup.title!);
+            exerciseGroups.clickEditGroup(exerciseGroup.id!);
+            const newGroupName = 'Group 3';
+            exerciseGroupCreation.typeTitle(newGroupName);
+            exerciseGroupCreation.update();
+            exerciseGroups.shouldHaveTitle(exerciseGroup.id!, newGroupName);
+            exerciseGroup.title = newGroupName;
+        });
+
+        it('Delete an exercise group', () => {
+            cy.visit('/');
+            navigationBar.openCourseManagement();
+            courseManagement.openExamsOfCourse(course.shortName!);
+            examManagement.openExerciseGroups(exam.id!);
+            // If the group in the "Create group test" was created successfully, we delete it so there is no group with no exercise
+            if (createdGroup) {
+                exerciseGroups.clickDeleteGroup(createdGroup.id!, createdGroup.title!);
+            } else {
+                exerciseGroups.clickDeleteGroup(exerciseGroup.id!, exerciseGroup.title!);
+            }
+        });
     });
 
-    it('Generates student exams', () => {
-        cy.visit(`/course-management/${course.id}/exams`);
-        examManagement.openStudentExams(exam.id!);
-        studentExamManagement.clickGenerateStudentExams();
-        cy.get('#generateMissingStudentExamsButton').should('be.disabled');
+    describe('Manage Students', () => {
+        beforeEach(() => {
+            cy.login(instructor);
+        });
+
+        it('Registers the course students for the exam', () => {
+            // We already verified in the previous test that we can navigate here
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openStudentRegistration(exam.id!);
+            studentExamManagement.clickRegisterCourseStudents().then((request: Interception) => {
+                expect(request.response!.statusCode).to.eq(200);
+            });
+            cy.get('#registered-students').contains(studentOne.username).should('be.visible');
+        });
+
+        it('Generates student exams', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openStudentExams(exam.id!);
+            studentExamManagement.clickGenerateStudentExams();
+            cy.get('#generateMissingStudentExamsButton').should('be.disabled');
+        });
     });
 
     after(() => {

--- a/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
@@ -1,0 +1,152 @@
+import { Exam } from 'app/entities/exam.model';
+import { Course } from 'app/entities/course.model';
+import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
+import { artemis } from '../../../support/ArtemisTesting';
+import { generateUUID } from '../../../support/utils';
+
+// Users
+const users = artemis.users;
+const admin = users.getAdmin();
+const studentOne = users.getStudentOne();
+
+// Requests
+const courseManagementRequests = artemis.requests.courseManagement;
+
+// PageObjects
+const navigationBar = artemis.pageobjects.navigationBar;
+const courseManagement = artemis.pageobjects.course.management;
+const examManagement = artemis.pageobjects.exam.management;
+const programmingCreation = artemis.pageobjects.exercise.programming.creation;
+const quizCreation = artemis.pageobjects.exercise.quiz.creation;
+const modelingCreation = artemis.pageobjects.exercise.modeling.creation;
+const textCreation = artemis.pageobjects.exercise.text.creation;
+const exerciseGroups = artemis.pageobjects.exam.exerciseGroups;
+const exerciseGroupCreation = artemis.pageobjects.exam.exerciseGroupCreation;
+
+// Common primitives
+const uid = generateUUID();
+const examTitle = 'test-exam' + uid;
+let groupCount = 0;
+
+describe('Test Exam management', () => {
+    let course: Course;
+    let exam: Exam;
+
+    before(() => {
+        cy.login(admin);
+        courseManagementRequests.createCourse(true).then((response) => {
+            course = convertCourseAfterMultiPart(response);
+            courseManagementRequests.addStudentToCourse(course, studentOne);
+            const examConfig = new CypressExamBuilder(course).title(examTitle).testExam().build();
+            courseManagementRequests.createExam(examConfig).then((examResponse) => {
+                exam = examResponse.body;
+            });
+        });
+    });
+
+    beforeEach(() => {
+        cy.login(admin);
+    });
+
+    it('Create exercise group', () => {
+        cy.visit('/');
+        navigationBar.openCourseManagement();
+        courseManagement.openExamsOfCourse(course.shortName!);
+        examManagement.openExerciseGroups(exam.id!);
+        exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
+        exerciseGroups.clickAddExerciseGroup();
+        const groupName = 'Group 1';
+        exerciseGroupCreation.typeTitle(groupName);
+        exerciseGroupCreation.isMandatoryBoxShouldBeChecked();
+        exerciseGroupCreation.clickSave();
+        groupCount++;
+        exerciseGroups.shouldHaveTitle(groupCount - 1, groupName);
+        exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
+    });
+
+    it('Adds a text exercise', () => {
+        cy.visit(`/course-management/${course.id}/exams`);
+        examManagement.openExerciseGroups(exam.id!);
+        exerciseGroups.clickAddTextExercise(0);
+        const textExerciseTitle = 'text' + uid;
+        textCreation.typeTitle(textExerciseTitle);
+        textCreation.typeMaxPoints(10);
+        textCreation.create().its('response.statusCode').should('eq', 201);
+        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+        exerciseGroups.shouldContainExerciseWithTitle(textExerciseTitle);
+    });
+
+    it('Adds a quiz exercise', () => {
+        cy.visit(`/course-management/${course.id}/exams`);
+        examManagement.openExerciseGroups(exam.id!);
+        exerciseGroups.clickAddQuizExercise(0);
+        const quizExerciseTitle = 'quiz' + uid;
+        quizCreation.setTitle(quizExerciseTitle);
+        quizCreation.addMultipleChoiceQuestion(quizExerciseTitle, 10);
+        quizCreation.saveQuiz().its('response.statusCode').should('eq', 201);
+        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+        exerciseGroups.shouldContainExerciseWithTitle(quizExerciseTitle);
+    });
+
+    it('Adds a modeling exercise', () => {
+        cy.visit(`/course-management/${course.id}/exams`);
+        examManagement.openExerciseGroups(exam.id!);
+        exerciseGroups.clickAddModelingExercise(0);
+        const modelingExerciseTitle = 'modeling' + uid;
+        modelingCreation.setTitle(modelingExerciseTitle);
+        modelingCreation.setPoints(10);
+        modelingCreation.save().its('response.statusCode').should('eq', 201);
+        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+        exerciseGroups.shouldContainExerciseWithTitle(modelingExerciseTitle);
+    });
+
+    it('Adds a programming exercise', () => {
+        cy.visit(`/course-management/${course.id}/exams`);
+        examManagement.openExerciseGroups(exam.id!);
+        exerciseGroups.clickAddProgrammingExercise(0);
+        const programmingExerciseTitle = 'programming' + uid;
+        programmingCreation.setTitle(programmingExerciseTitle);
+        programmingCreation.setShortName(programmingExerciseTitle);
+        programmingCreation.setPackageName('de.test');
+        programmingCreation.setPoints(10);
+        programmingCreation.generate().its('response.statusCode').should('eq', 201);
+        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+        exerciseGroups.shouldContainExerciseWithTitle(programmingExerciseTitle);
+    });
+
+    it('Edits an exercise group', () => {
+        cy.visit('/');
+        navigationBar.openCourseManagement();
+        courseManagement.openExamsOfCourse(course.shortName!);
+        examManagement.openExerciseGroups(exam.id!);
+        exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
+        exerciseGroups.clickAddExerciseGroup();
+        const groupName = 'Group 2';
+        exerciseGroupCreation.typeTitle(groupName);
+        exerciseGroupCreation.isMandatoryBoxShouldBeChecked();
+        exerciseGroupCreation.clickSave();
+        groupCount++;
+
+        exerciseGroups.shouldHaveTitle(groupCount - 1, groupName);
+        exerciseGroups.clickEditGroup(groupCount - 1);
+        const newGroupName = 'Group 3';
+        exerciseGroupCreation.typeTitle(newGroupName);
+        exerciseGroupCreation.update();
+        exerciseGroups.shouldHaveTitle(groupCount - 1, newGroupName);
+    });
+
+    it('Delete an exercise group', () => {
+        cy.visit('/');
+        navigationBar.openCourseManagement();
+        courseManagement.openExamsOfCourse(course.shortName!);
+        examManagement.openExerciseGroups(exam.id!);
+        exerciseGroups.clickDeleteGroup(groupCount - 1, 'Group 3');
+    });
+
+    after(() => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequests.deleteCourse(course.id!);
+        }
+    });
+});

--- a/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
@@ -149,11 +149,12 @@ describe('Test Exam management', () => {
             courseManagement.openExamsOfCourse(course.shortName!);
             examManagement.openExerciseGroups(exam.id!);
             // If the group in the "Create group test" was created successfully, we delete it so there is no group with no exercise
+            let group = exerciseGroup;
             if (createdGroup) {
-                exerciseGroups.clickDeleteGroup(createdGroup.id!, createdGroup.title!);
-            } else {
-                exerciseGroups.clickDeleteGroup(exerciseGroup.id!, exerciseGroup.title!);
+                group = createdGroup;
             }
+            exerciseGroups.clickDeleteGroup(group.id!, group.title!);
+            exerciseGroups.shouldNotExist(group.id!);
         });
     });
 

--- a/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
@@ -3,10 +3,12 @@ import { Course } from 'app/entities/course.model';
 import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import { artemis } from '../../../support/ArtemisTesting';
 import { generateUUID } from '../../../support/utils';
+import { ExerciseGroup } from 'app/entities/exercise-group.model';
 
 // Users
 const users = artemis.users;
 const admin = users.getAdmin();
+const instructor = users.getInstructor();
 const studentOne = users.getStudentOne();
 
 // Requests
@@ -27,6 +29,7 @@ const exerciseGroupCreation = artemis.pageobjects.exam.exerciseGroupCreation;
 const uid = generateUUID();
 const examTitle = 'test-exam' + uid;
 let groupCount = 0;
+let createdGroup: ExerciseGroup;
 
 describe('Test Exam management', () => {
     let course: Course;
@@ -44,103 +47,114 @@ describe('Test Exam management', () => {
         });
     });
 
-    beforeEach(() => {
-        cy.login(admin);
-    });
+    describe('Manage Group', () => {
+        let exerciseGroup: ExerciseGroup;
 
-    it('Create exercise group', () => {
-        cy.visit('/');
-        navigationBar.openCourseManagement();
-        courseManagement.openExamsOfCourse(course.shortName!);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
-        exerciseGroups.clickAddExerciseGroup();
-        const groupName = 'Group 1';
-        exerciseGroupCreation.typeTitle(groupName);
-        exerciseGroupCreation.isMandatoryBoxShouldBeChecked();
-        exerciseGroupCreation.clickSave();
-        groupCount++;
-        exerciseGroups.shouldHaveTitle(groupCount - 1, groupName);
-        exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
-    });
+        before(() => {
+            cy.login(instructor);
+            courseManagementRequests.addExerciseGroupForExam(exam).then((response) => {
+                exerciseGroup = response.body;
+                groupCount++;
+            });
+        });
 
-    it('Adds a text exercise', () => {
-        cy.visit(`/course-management/${course.id}/exams`);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.clickAddTextExercise(0);
-        const textExerciseTitle = 'text' + uid;
-        textCreation.typeTitle(textExerciseTitle);
-        textCreation.typeMaxPoints(10);
-        textCreation.create().its('response.statusCode').should('eq', 201);
-        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
-        exerciseGroups.shouldContainExerciseWithTitle(textExerciseTitle);
-    });
+        beforeEach(() => {
+            cy.login(instructor);
+        });
 
-    it('Adds a quiz exercise', () => {
-        cy.visit(`/course-management/${course.id}/exams`);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.clickAddQuizExercise(0);
-        const quizExerciseTitle = 'quiz' + uid;
-        quizCreation.setTitle(quizExerciseTitle);
-        quizCreation.addMultipleChoiceQuestion(quizExerciseTitle, 10);
-        quizCreation.saveQuiz().its('response.statusCode').should('eq', 201);
-        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
-        exerciseGroups.shouldContainExerciseWithTitle(quizExerciseTitle);
-    });
+        it('Create exercise group', () => {
+            cy.visit('/');
+            navigationBar.openCourseManagement();
+            courseManagement.openExamsOfCourse(course.shortName!);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
+            exerciseGroups.clickAddExerciseGroup();
+            const groupName = 'Group 1';
+            exerciseGroupCreation.typeTitle(groupName);
+            exerciseGroupCreation.isMandatoryBoxShouldBeChecked();
+            exerciseGroupCreation.clickSave().then((interception) => {
+                const group = interception.response!.body;
+                groupCount++;
+                exerciseGroups.shouldHaveTitle(group.id, groupName);
+                exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
+                createdGroup = group;
+            });
+        });
 
-    it('Adds a modeling exercise', () => {
-        cy.visit(`/course-management/${course.id}/exams`);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.clickAddModelingExercise(0);
-        const modelingExerciseTitle = 'modeling' + uid;
-        modelingCreation.setTitle(modelingExerciseTitle);
-        modelingCreation.setPoints(10);
-        modelingCreation.save().its('response.statusCode').should('eq', 201);
-        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
-        exerciseGroups.shouldContainExerciseWithTitle(modelingExerciseTitle);
-    });
+        it('Adds a text exercise', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.clickAddTextExercise(exerciseGroup.id!);
+            const textExerciseTitle = 'text' + uid;
+            textCreation.typeTitle(textExerciseTitle);
+            textCreation.typeMaxPoints(10);
+            textCreation.create().its('response.statusCode').should('eq', 201);
+            exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+            exerciseGroups.shouldContainExerciseWithTitle(exerciseGroup.id!, textExerciseTitle);
+        });
 
-    it('Adds a programming exercise', () => {
-        cy.visit(`/course-management/${course.id}/exams`);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.clickAddProgrammingExercise(0);
-        const programmingExerciseTitle = 'programming' + uid;
-        programmingCreation.setTitle(programmingExerciseTitle);
-        programmingCreation.setShortName(programmingExerciseTitle);
-        programmingCreation.setPackageName('de.test');
-        programmingCreation.setPoints(10);
-        programmingCreation.generate().its('response.statusCode').should('eq', 201);
-        exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
-        exerciseGroups.shouldContainExerciseWithTitle(programmingExerciseTitle);
-    });
+        it('Adds a quiz exercise', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.clickAddQuizExercise(exerciseGroup.id!);
+            const quizExerciseTitle = 'quiz' + uid;
+            quizCreation.setTitle(quizExerciseTitle);
+            quizCreation.addMultipleChoiceQuestion(quizExerciseTitle, 10);
+            quizCreation.saveQuiz().its('response.statusCode').should('eq', 201);
+            exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+            exerciseGroups.shouldContainExerciseWithTitle(exerciseGroup.id!, quizExerciseTitle);
+        });
 
-    it('Edits an exercise group', () => {
-        cy.visit('/');
-        navigationBar.openCourseManagement();
-        courseManagement.openExamsOfCourse(course.shortName!);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
-        exerciseGroups.clickAddExerciseGroup();
-        const groupName = 'Group 2';
-        exerciseGroupCreation.typeTitle(groupName);
-        exerciseGroupCreation.isMandatoryBoxShouldBeChecked();
-        exerciseGroupCreation.clickSave();
-        groupCount++;
+        it('Adds a modeling exercise', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.clickAddModelingExercise(exerciseGroup.id!);
+            const modelingExerciseTitle = 'modeling' + uid;
+            modelingCreation.setTitle(modelingExerciseTitle);
+            modelingCreation.setPoints(10);
+            modelingCreation.save().its('response.statusCode').should('eq', 201);
+            exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+            exerciseGroups.shouldContainExerciseWithTitle(exerciseGroup.id!, modelingExerciseTitle);
+        });
 
-        exerciseGroups.shouldHaveTitle(groupCount - 1, groupName);
-        exerciseGroups.clickEditGroup(groupCount - 1);
-        const newGroupName = 'Group 3';
-        exerciseGroupCreation.typeTitle(newGroupName);
-        exerciseGroupCreation.update();
-        exerciseGroups.shouldHaveTitle(groupCount - 1, newGroupName);
-    });
+        it('Adds a programming exercise', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.clickAddProgrammingExercise(exerciseGroup.id!);
+            const programmingExerciseTitle = 'programming' + uid;
+            programmingCreation.setTitle(programmingExerciseTitle);
+            programmingCreation.setShortName(programmingExerciseTitle);
+            programmingCreation.setPackageName('de.test');
+            programmingCreation.setPoints(10);
+            programmingCreation.generate().its('response.statusCode').should('eq', 201);
+            exerciseGroups.visitPageViaUrl(course.id!, exam.id!);
+            exerciseGroups.shouldContainExerciseWithTitle(exerciseGroup.id!, programmingExerciseTitle);
+        });
 
-    it('Delete an exercise group', () => {
-        cy.visit('/');
-        navigationBar.openCourseManagement();
-        courseManagement.openExamsOfCourse(course.shortName!);
-        examManagement.openExerciseGroups(exam.id!);
-        exerciseGroups.clickDeleteGroup(groupCount - 1, 'Group 3');
+        it('Edits an exercise group', () => {
+            cy.visit(`/course-management/${course.id}/exams`);
+            examManagement.openExerciseGroups(exam.id!);
+            exerciseGroups.shouldHaveTitle(exerciseGroup.id!, exerciseGroup.title!);
+            exerciseGroups.clickEditGroup(exerciseGroup.id!);
+            const newGroupName = 'Group 3';
+            exerciseGroupCreation.typeTitle(newGroupName);
+            exerciseGroupCreation.update();
+            exerciseGroups.shouldHaveTitle(exerciseGroup.id!, newGroupName);
+            exerciseGroup.title = newGroupName;
+        });
+
+        it('Delete an exercise group', () => {
+            cy.visit('/');
+            navigationBar.openCourseManagement();
+            courseManagement.openExamsOfCourse(course.shortName!);
+            examManagement.openExerciseGroups(exam.id!);
+            // If the group in the "Create group test" was created successfully, we delete it so there is no group with no exercise
+            if (createdGroup) {
+                exerciseGroups.clickDeleteGroup(createdGroup.id!, createdGroup.title!);
+            } else {
+                exerciseGroups.clickDeleteGroup(exerciseGroup.id!, exerciseGroup.title!);
+            }
+        });
     });
 
     after(() => {

--- a/src/test/cypress/support/pageobjects/exam/ExamExerciseGroupCreationPage.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamExerciseGroupCreationPage.ts
@@ -19,7 +19,7 @@ export class ExamExerciseGroupCreationPage {
     clickSave() {
         cy.intercept({ method: POST, url: `${BASE_API}courses/*/exams/*/exerciseGroups` }).as('createExerciseGroup');
         cy.get('#save-group').click();
-        cy.wait('@createExerciseGroup');
+        return cy.wait('@createExerciseGroup');
     }
 
     update() {

--- a/src/test/cypress/support/pageobjects/exam/ExamExerciseGroupsPage.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamExerciseGroupsPage.ts
@@ -6,16 +6,16 @@ export class ExamExerciseGroupsPage {
         cy.get('#create-new-group').click();
     }
 
-    shouldHaveTitle(groupIndex: number, groupTitle: string) {
-        cy.get(`#group-${groupIndex} .group-title`).contains(groupTitle);
+    shouldHaveTitle(groupID: number, groupTitle: string) {
+        cy.get(`#group-${groupID} .group-title`).contains(groupTitle);
     }
 
-    clickEditGroup(groupIndex: number) {
-        cy.get(`#group-${groupIndex} .edit-group`).click();
+    clickEditGroup(groupID: number) {
+        cy.get(`#group-${groupID} .edit-group`).click();
     }
 
-    clickDeleteGroup(groupIndex: number, groupName: string) {
-        cy.get(`#group-${groupIndex} .delete-group`).click();
+    clickDeleteGroup(groupID: number, groupName: string) {
+        cy.get(`#group-${groupID} .delete-group`).click();
         cy.get('#delete').should('be.disabled');
         cy.get('#confirm-exercise-name').type(groupName);
         cy.get('#delete').should('not.be.disabled').click();
@@ -29,27 +29,27 @@ export class ExamExerciseGroupsPage {
         cy.get('#create-new-group').click();
     }
 
-    clickAddTextExercise(groupIndex = 0) {
-        cy.get('#add-text-exercise-group-' + groupIndex).click();
+    clickAddTextExercise(groupID: number) {
+        cy.get(`#group-${groupID}`).find('.add-text-exercise').click();
     }
 
-    clickAddModelingExercise(groupIndex = 0) {
-        cy.get('#add-modeling-exercise-group-' + groupIndex).click();
+    clickAddModelingExercise(groupID: number) {
+        cy.get(`#group-${groupID}`).find('.add-modeling-exercise').click();
     }
 
-    clickAddQuizExercise(groupIndex = 0) {
-        cy.get('#add-quiz-exercise-group-' + groupIndex).click();
+    clickAddQuizExercise(groupID: number) {
+        cy.get(`#group-${groupID}`).find('.add-quiz-exercise').click();
     }
 
-    clickAddProgrammingExercise(groupIndex = 0) {
-        cy.get('#add-programming-exercise-group-' + groupIndex).click();
+    clickAddProgrammingExercise(groupID: number) {
+        cy.get(`#group-${groupID}`).find('.add-programming-exercise').click();
     }
 
     visitPageViaUrl(courseId: number, examId: number) {
         cy.visit(`course-management/${courseId}/exams/${examId}/exercise-groups`);
     }
 
-    shouldContainExerciseWithTitle(exerciseTitle: string) {
-        cy.get('#exercises').contains(exerciseTitle).scrollIntoView().should('be.visible');
+    shouldContainExerciseWithTitle(groupID: number, exerciseTitle: string) {
+        cy.get(`#group-${groupID}`).find('#exercises').contains(exerciseTitle).scrollIntoView().should('be.visible');
     }
 }

--- a/src/test/cypress/support/pageobjects/exam/ExamExerciseGroupsPage.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamExerciseGroupsPage.ts
@@ -10,6 +10,10 @@ export class ExamExerciseGroupsPage {
         cy.get(`#group-${groupID} .group-title`).contains(groupTitle);
     }
 
+    shouldNotExist(groupID: number) {
+        cy.get(`#group-${groupID}`).should('not.exist');
+    }
+
     clickEditGroup(groupID: number) {
         cy.get(`#group-${groupID} .edit-group`).click();
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently there are no E2E tests that test the creation of groups within a tetst exam and the edit of groups.

### Description
<!-- Describe your changes in detail -->
With this PR we add new test exam managment E2E tests. We add a exercise group and a text exercise. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test
