### PR TITLE
`Quiz exercises`: Fix an issue with the release date when resetting a quiz

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
@@ -413,7 +413,7 @@ public class QuizExerciseService {
         quizExercise.setIsOpenForPractice(Boolean.FALSE);
         if (!quizExercise.isExamExercise()) {
             // do not set the release date of exam exercises
-            quizExercise.setReleaseDate(ZonedDateTime.now().plusYears(1));
+            quizExercise.setReleaseDate(ZonedDateTime.now());
         }
         quizExercise.setDueDate(null);
         quizExercise.setQuizBatches(Set.of());

--- a/src/test/java/de/tum/in/www1/artemis/quiz/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/quiz/QuizExerciseIntegrationTest.java
@@ -1899,6 +1899,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
         quizExercise = quizExerciseRepository.findOneWithQuestionsAndStatistics(quizExercise.getId());
         assertThat(studentParticipationRepository.findByExerciseId(quizExercise.getId())).as("Student participations have been deleted").isEmpty();
         assertThat(quizExercise.isIsOpenForPractice()).as("Quiz Question is open for practice has been set to false").isFalse();
+        assertThat(ZonedDateTime.now().isAfter(quizExercise.getReleaseDate())).as("Quiz Question is released").isTrue();
         assertThat(quizExercise.getDueDate()).as("Quiz Question due date has been set to null").isNull();
         assertThat(quizExercise.getQuizBatches()).as("Quiz Question batches has been set to empty").isEmpty();
         for (QuizQuestion quizQuestion : quizExercise.getQuizQuestions()) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes: [5158](https://github.com/ls1intum/Artemis/issues/5158)

### Description
<!-- Describe your changes in detail -->

Remove plus 1 year of release date when resetting a quiz exercise.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course with 1 Quiz Exercise (e.g. **Test 6168** of [6.0 Testing Session Course 1](https://artemis-test1.artemis.in.tum.de/course-management/117/exercises))

1. Log in to Artemis
2. Navigate to Course Administration
3. Select the Course
4. Navigate to Exercises
5. Click Reset of the Quiz Exercise
6. Verify that the Release Date (Visible From) of the Quiz Exercise is set to the current timestamp (instead of 1 year later)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| QuizExerciseService | 86% | 96% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

https://user-images.githubusercontent.com/10885503/215498185-a548a760-cb3b-4a99-9231-1c0a5784faaa.mov
