### PR TITLE
`Assessment`: Fix an issue with complaints

### DIFF
--- a/src/main/webapp/app/assessment/assessment-layout/assessment-layout.component.ts
+++ b/src/main/webapp/app/assessment/assessment-layout/assessment-layout.component.ts
@@ -1,9 +1,9 @@
 import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
 import { Result } from 'app/entities/result.model';
-import { ComplaintResponse } from 'app/entities/complaint-response.model';
 import { Complaint, ComplaintType } from 'app/entities/complaint.model';
 import { Exercise } from 'app/entities/exercise.model';
 import { Submission } from 'app/entities/submission.model';
+import { AssessmentAfterComplaint } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
 
 /**
  * The <jhi-assessment-layout> component provides the basic layout for an assessment page.
@@ -59,7 +59,7 @@ export class AssessmentLayoutComponent {
     @Output() submit = new EventEmitter<void>();
     @Output() cancel = new EventEmitter<void>();
     @Output() nextSubmission = new EventEmitter<void>();
-    @Output() updateAssessmentAfterComplaint = new EventEmitter<ComplaintResponse>();
+    @Output() updateAssessmentAfterComplaint = new EventEmitter<AssessmentAfterComplaint>();
     @Output() highlightDifferencesChange = new EventEmitter<boolean>();
     @Output() useAsExampleSubmission = new EventEmitter<void>();
 }

--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
@@ -13,6 +13,8 @@ import { Submission } from 'app/entities/submission.model';
 import { isAllowedToRespondToComplaintAction } from 'app/assessment/assessment.service';
 import { Course } from 'app/entities/course.model';
 
+export type AssessmentAfterComplaint = { complaintResponse: ComplaintResponse; onSuccess: () => void; onError: () => void };
+
 @Component({
     selector: 'jhi-complaints-for-tutor-form',
     templateUrl: './complaints-for-tutor.component.html',
@@ -27,7 +29,7 @@ export class ComplaintsForTutorComponent implements OnInit {
     @Input() submission: Submission | undefined;
     // Indicates that the assessment should be updated after a complaint. Includes the corresponding complaint
     // that should be sent to the server along with the assessment update.
-    @Output() updateAssessmentAfterComplaint = new EventEmitter<ComplaintResponse>();
+    @Output() updateAssessmentAfterComplaint = new EventEmitter<AssessmentAfterComplaint>();
     complaintText?: string;
     handled: boolean;
     complaintResponse: ComplaintResponse = new ComplaintResponse();
@@ -163,10 +165,19 @@ export class ComplaintsForTutorComponent implements OnInit {
         if (acceptComplaint && this.complaint.complaintType === ComplaintType.COMPLAINT) {
             // Tell the parent (assessment) component to update the corresponding result if the complaint was accepted.
             // The complaint is sent along with the assessment update by the parent to avoid additional requests.
-            this.updateAssessmentAfterComplaint.emit(this.complaintResponse);
-            this.handled = true;
-            this.showLockDuration = false;
-            this.lockedByCurrentUser = false;
+            this.isLoading = true;
+            this.updateAssessmentAfterComplaint.emit({
+                complaintResponse: this.complaintResponse,
+                onSuccess: () => {
+                    this.isLoading = false;
+                    this.handled = true;
+                    this.showLockDuration = false;
+                    this.lockedByCurrentUser = false;
+                },
+                onError: () => {
+                    this.isLoading = false;
+                },
+            });
         } else {
             // If the complaint was rejected or it was a more feedback request, just the complaint response is updated.
             this.resolveComplaint();

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.ts
@@ -11,7 +11,6 @@ import { ArtemisMarkdownService } from 'app/shared/markdown.service';
 import { filter, finalize } from 'rxjs/operators';
 import { AccountService } from 'app/core/auth/account.service';
 import { FileUploadExercise } from 'app/entities/file-upload-exercise.model';
-import { ComplaintResponse } from 'app/entities/complaint-response.model';
 import { FileUploadSubmissionService } from 'app/exercises/file-upload/participate/file-upload-submission.service';
 import { FileService } from 'app/shared/http/file.service';
 import { Complaint, ComplaintType } from 'app/entities/complaint.model';
@@ -31,6 +30,7 @@ import { onError } from 'app/shared/util/global.utils';
 import { Course } from 'app/entities/course.model';
 import { isAllowedToModifyFeedback } from 'app/assessment/assessment.service';
 import { faListAlt } from '@fortawesome/free-regular-svg-icons';
+import { AssessmentAfterComplaint } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
 
 @Component({
     providers: [FileUploadAssessmentService],
@@ -465,26 +465,29 @@ export class FileUploadAssessmentComponent implements OnInit, OnDestroy {
      * Sends the current (updated) assessment to the server to update the original assessment after a complaint was accepted.
      * The corresponding complaint response is sent along with the updated assessment to prevent additional requests.
      *
-     * @param complaintResponse the response to the complaint that is sent to the server along with the assessment update
+     * @param assessmentAfterComplaint the response to the complaint that is sent to the server along with the assessment update along with onSuccess and onError callbacks
      */
-    onUpdateAssessmentAfterComplaint(complaintResponse: ComplaintResponse): void {
+    onUpdateAssessmentAfterComplaint(assessmentAfterComplaint: AssessmentAfterComplaint): void {
         this.validateAssessment();
         if (!this.assessmentsAreValid) {
             this.alertService.error('artemisApp.fileUploadAssessment.error.invalidAssessments');
+            assessmentAfterComplaint.onError();
             return;
         }
         this.isLoading = true;
         this.fileUploadAssessmentService
-            .updateAssessmentAfterComplaint(this.assessments, complaintResponse, this.submission.id!)
+            .updateAssessmentAfterComplaint(this.assessments, assessmentAfterComplaint.complaintResponse, this.submission.id!)
             .pipe(finalize(() => (this.isLoading = false)))
             .subscribe({
                 next: (response) => {
+                    assessmentAfterComplaint.onSuccess();
                     this.result = response.body!;
                     this.updateParticipationWithResult();
                     this.alertService.closeAll();
                     this.alertService.success('artemisApp.assessment.messages.updateAfterComplaintSuccessful');
                 },
                 error: (httpErrorResponse: HttpErrorResponse) => {
+                    assessmentAfterComplaint.onError();
                     this.alertService.closeAll();
                     const error = httpErrorResponse.error;
                     if (error && error.errorKey && error.errorKey === 'complaintLock') {

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -379,6 +379,12 @@ export class ModelingAssessmentEditorComponent implements OnInit {
      * @param assessmentAfterComplaint the response to the complaint that is sent to the server along with the assessment update along with onSuccess and onError callbacks
      */
     onUpdateAssessmentAfterComplaint(assessmentAfterComplaint: AssessmentAfterComplaint): void {
+        this.validateFeedback();
+        if (!this.assessmentsAreValid) {
+            this.alertService.error('artemisApp.modelingAssessment.invalidAssessments');
+            assessmentAfterComplaint.onError();
+            return;
+        }
         this.modelingAssessmentService.updateAssessmentAfterComplaint(this.feedback, assessmentAfterComplaint.complaintResponse, this.submission!.id!).subscribe({
             next: (response) => {
                 assessmentAfterComplaint.onSuccess();

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -9,7 +9,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { TranslateService } from '@ngx-translate/core';
 import dayjs from 'dayjs/esm';
 import { ComplaintService } from 'app/complaints/complaint.service';
-import { ComplaintResponse } from 'app/entities/complaint-response.model';
 import { ModelingSubmission } from 'app/entities/modeling-submission.model';
 import { ResultService } from 'app/exercises/shared/result/result.service';
 import { ModelingExercise, UMLDiagramType } from 'app/entities/modeling-exercise.model';
@@ -30,6 +29,7 @@ import { ExampleSubmissionService } from 'app/exercises/shared/example-submissio
 import { onError } from 'app/shared/util/global.utils';
 import { Course } from 'app/entities/course.model';
 import { isAllowedToModifyFeedback } from 'app/assessment/assessment.service';
+import { AssessmentAfterComplaint } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
 
 @Component({
     selector: 'jhi-modeling-assessment-editor',
@@ -376,11 +376,12 @@ export class ModelingAssessmentEditorComponent implements OnInit {
      * Sends the current (updated) assessment to the server to update the original assessment after a complaint was accepted.
      * The corresponding complaint response is sent along with the updated assessment to prevent additional requests.
      *
-     * @param complaintResponse the response to the complaint that is sent to the server along with the assessment update
+     * @param assessmentAfterComplaint the response to the complaint that is sent to the server along with the assessment update along with onSuccess and onError callbacks
      */
-    onUpdateAssessmentAfterComplaint(complaintResponse: ComplaintResponse): void {
-        this.modelingAssessmentService.updateAssessmentAfterComplaint(this.feedback, complaintResponse, this.submission!.id!).subscribe({
+    onUpdateAssessmentAfterComplaint(assessmentAfterComplaint: AssessmentAfterComplaint): void {
+        this.modelingAssessmentService.updateAssessmentAfterComplaint(this.feedback, assessmentAfterComplaint.complaintResponse, this.submission!.id!).subscribe({
             next: (response) => {
+                assessmentAfterComplaint.onSuccess();
                 this.result = response.body!;
                 // reconnect
                 this.result.participation!.results = [this.result];
@@ -388,6 +389,7 @@ export class ModelingAssessmentEditorComponent implements OnInit {
                 this.alertService.success('artemisApp.modelingAssessmentEditor.messages.updateAfterComplaintSuccessful');
             },
             error: (httpErrorResponse: HttpErrorResponse) => {
+                assessmentAfterComplaint.onError();
                 this.alertService.closeAll();
                 const error = httpErrorResponse.error;
                 if (error && error.errorKey && error.errorKey === 'complaintLock') {

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -13,7 +13,6 @@ import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { DomainType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
 import { ProgrammingExerciseStudentParticipation } from 'app/entities/participation/programming-exercise-student-participation.model';
 import { Complaint } from 'app/entities/complaint.model';
-import { ComplaintResponse } from 'app/entities/complaint-response.model';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { ProgrammingAssessmentManualResultService } from 'app/exercises/programming/assess/manual-result/programming-assessment-manual-result.service';
 import { ProgrammingSubmission } from 'app/entities/programming-submission.model';
@@ -36,6 +35,7 @@ import { SubmissionType, getLatestSubmissionResult } from 'app/entities/submissi
 import { isAllowedToModifyFeedback } from 'app/assessment/assessment.service';
 import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 import { cloneDeep } from 'lodash-es';
+import { AssessmentAfterComplaint } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
 
 @Component({
     selector: 'jhi-code-editor-tutor-assessment',
@@ -388,17 +388,19 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
      * Sends the current (updated) assessment to the server to update the original assessment after a complaint was accepted.
      * The corresponding complaint response is sent along with the updated assessment to prevent additional requests.
      *
-     * @param complaintResponse the response to the complaint that is sent to the server along with the assessment update
+     * @param assessmentAfterComplaint the response to the complaint that is sent to the server along with the assessment update along with onSuccess and onError callbacks
      */
-    onUpdateAssessmentAfterComplaint(complaintResponse: ComplaintResponse): void {
+    onUpdateAssessmentAfterComplaint(assessmentAfterComplaint: AssessmentAfterComplaint): void {
         this.setFeedbacksForManualResult();
-        this.manualResultService.updateAfterComplaint(this.manualResult!.feedbacks!, complaintResponse, this.submission!.id!).subscribe({
+        this.manualResultService.updateAfterComplaint(this.manualResult!.feedbacks!, assessmentAfterComplaint.complaintResponse, this.submission!.id!).subscribe({
             next: (result: Result) => {
+                assessmentAfterComplaint.onSuccess();
                 this.participation.results![0] = this.manualResult = result;
                 this.alertService.closeAll();
                 this.alertService.success('artemisApp.assessment.messages.updateAfterComplaintSuccessful');
             },
             error: (httpErrorResponse: HttpErrorResponse) => {
+                assessmentAfterComplaint.onError();
                 this.alertService.closeAll();
                 const error = httpErrorResponse.error;
                 if (error && error.errorKey && error.errorKey === 'complaintLock') {

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -391,6 +391,12 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
      * @param assessmentAfterComplaint the response to the complaint that is sent to the server along with the assessment update along with onSuccess and onError callbacks
      */
     onUpdateAssessmentAfterComplaint(assessmentAfterComplaint: AssessmentAfterComplaint): void {
+        this.validateFeedback();
+        if (!this.assessmentsAreValid) {
+            this.alertService.error('artemisApp.programmingAssessment.invalidAssessments');
+            assessmentAfterComplaint.onError();
+            return;
+        }
         this.setFeedbacksForManualResult();
         this.manualResultService.updateAfterComplaint(this.manualResult!.feedbacks!, assessmentAfterComplaint.complaintResponse, this.submission!.id!).subscribe({
             next: (result: Result) => {

--- a/src/main/webapp/app/exercises/text/assess/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-submission-assessment.component.ts
@@ -362,13 +362,12 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
         }
 
         this.assessmentsService
-            // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
             .updateAssessmentAfterComplaint(
                 this.assessments,
                 this.textBlocksWithFeedback,
                 assessmentAfterComplaint.complaintResponse,
-                this.submission?.id!,
-                this.participation?.id!,
+                this.submission?.id!, // eslint-disable-line @typescript-eslint/no-non-null-asserted-optional-chain
+                this.participation?.id!, // eslint-disable-line @typescript-eslint/no-non-null-asserted-optional-chain
             )
             .subscribe({
                 next: (response) => {

--- a/src/main/webapp/app/exercises/text/assess/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-submission-assessment.component.ts
@@ -10,7 +10,6 @@ import { TextSubmission } from 'app/entities/text-submission.model';
 import { TextExercise } from 'app/entities/text-exercise.model';
 import { Result } from 'app/entities/result.model';
 import { Complaint } from 'app/entities/complaint.model';
-import { ComplaintResponse } from 'app/entities/complaint-response.model';
 import { ComplaintService } from 'app/complaints/complaint.service';
 import { TextAssessmentService } from 'app/exercises/text/assess/text-assessment.service';
 import { Feedback, FeedbackType } from 'app/entities/feedback.model';
@@ -34,6 +33,7 @@ import { ExampleSubmissionService } from 'app/exercises/shared/example-submissio
 import { Course } from 'app/entities/course.model';
 import { isAllowedToModifyFeedback } from 'app/assessment/assessment.service';
 import { faListAlt } from '@fortawesome/free-regular-svg-icons';
+import { AssessmentAfterComplaint } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
 
 @Component({
     selector: 'jhi-text-submission-assessment',
@@ -351,21 +351,32 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
      * Sends the current (updated) assessment to the server to update the original assessment after a complaint was accepted.
      * The corresponding complaint response is sent along with the updated assessment to prevent additional requests.
      *
-     * @param complaintResponse the response to the complaint that is sent to the server along with the assessment update
+     * @param assessmentAfterComplaint the response to the complaint that is sent to the server along with the assessment update along with onSuccess and onError callbacks
      */
-    updateAssessmentAfterComplaint(complaintResponse: ComplaintResponse): void {
+    updateAssessmentAfterComplaint(assessmentAfterComplaint: AssessmentAfterComplaint): void {
         this.validateFeedback();
         if (!this.assessmentsAreValid) {
             this.alertService.error('artemisApp.textAssessment.error.invalidAssessments');
+            assessmentAfterComplaint.onError();
             return;
         }
 
         this.assessmentsService
             // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-            .updateAssessmentAfterComplaint(this.assessments, this.textBlocksWithFeedback, complaintResponse, this.submission?.id!, this.participation?.id!)
+            .updateAssessmentAfterComplaint(
+                this.assessments,
+                this.textBlocksWithFeedback,
+                assessmentAfterComplaint.complaintResponse,
+                this.submission?.id!,
+                this.participation?.id!,
+            )
             .subscribe({
-                next: (response) => this.handleSaveOrSubmitSuccessWithAlert(response, 'artemisApp.textAssessment.updateAfterComplaintSuccessful'),
+                next: (response) => {
+                    assessmentAfterComplaint.onSuccess();
+                    this.handleSaveOrSubmitSuccessWithAlert(response, 'artemisApp.textAssessment.updateAfterComplaintSuccessful');
+                },
                 error: (httpErrorResponse: HttpErrorResponse) => {
+                    assessmentAfterComplaint.onError();
                     this.alertService.closeAll();
                     const error = httpErrorResponse.error;
                     if (error && error.errorKey && error.errorKey === 'complaintLock') {

--- a/src/main/webapp/i18n/de/programmingAssessment.json
+++ b/src/main/webapp/i18n/de/programmingAssessment.json
@@ -12,7 +12,8 @@
             "penaltyTooltip": "Penalty: {{ percentage }}% aller Penalties.",
             "issuesTooltip": "Issues: {{ percentage }}% aller gefundenen Issues.",
             "deductionsTooltip": "Punkte: {{ percentage }}% aller abgezogenen Punkte.",
-            "codeIssueNotApplied": "Dieses Issue zieht nicht die maximale Punktzahl ab, da bereits andere ähnliche Issues genug Punkte abziehen. Wenn dies das einzige Issue wäre, würde es {{points}} Punkte abziehen."
+            "codeIssueNotApplied": "Dieses Issue zieht nicht die maximale Punktzahl ab, da bereits andere ähnliche Issues genug Punkte abziehen. Wenn dies das einzige Issue wäre, würde es {{points}} Punkte abziehen.",
+            "invalidAssessments": "Deine Bewertung ist nicht gültig!"
         }
     }
 }

--- a/src/main/webapp/i18n/en/programmingAssessment.json
+++ b/src/main/webapp/i18n/en/programmingAssessment.json
@@ -12,7 +12,8 @@
             "penaltyTooltip": "Penalty: {{ percentage }}% of all penalties.",
             "issuesTooltip": "Issues: {{ percentage }}% of all detected issues.",
             "deductionsTooltip": "Deductions: {{ percentage }}% of all deducted points.",
-            "codeIssueNotApplied": "This issue does not deduct the maximum number of possible points, since similar code issues already deduct enough points. If this was the only issue, it would deduct {{points}} points."
+            "codeIssueNotApplied": "This issue does not deduct the maximum number of possible points, since similar code issues already deduct enough points. If this was the only issue, it would deduct {{points}} points.",
+            "invalidAssessments": "Your assessments are not valid!"
         }
     }
 }

--- a/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ComplaintService } from 'app/complaints/complaint.service';
 import { ComplaintResponseService } from 'app/complaints/complaint-response.service';
 import { ComplaintsForTutorComponent } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';

--- a/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ComplaintService } from 'app/complaints/complaint.service';
 import { ComplaintResponseService } from 'app/complaints/complaint-response.service';
 import { ComplaintsForTutorComponent } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
@@ -15,6 +15,7 @@ import { By } from '@angular/platform-browser';
 import { HttpResponse } from '@angular/common/http';
 import { of } from 'rxjs';
 import { Course } from 'app/entities/course.model';
+import { Exercise } from 'app/entities/exercise.model';
 
 // Mock getCourseFromExercise(exercise) to get a course even if there isn't a course.
 jest.mock('app/entities/exercise.model', () => ({
@@ -316,4 +317,60 @@ describe('ComplaintsForTutorComponent', () => {
         const responseTextArea = complaintForTutorComponentFixture.debugElement.query(By.css('#responseTextArea')).nativeElement;
         expect(responseTextArea.maxLength).toBe(26);
     }));
+
+    it.each(['success', 'failure'])(
+        'should handle %s after updating assessment after complaint',
+        fakeAsync((successOrFailure: string) => {
+            const isSuccess = successOrFailure === 'success';
+
+            const unhandledComplaint = new Complaint();
+            unhandledComplaint.id = 2;
+            unhandledComplaint.accepted = undefined;
+            unhandledComplaint.complaintText = 'please check again';
+            unhandledComplaint.complaintResponse = undefined;
+            unhandledComplaint.complaintType = ComplaintType.COMPLAINT;
+
+            const newComplaintResponse = new ComplaintResponse();
+            newComplaintResponse.id = 3;
+            newComplaintResponse.isCurrentlyLocked = true;
+            newComplaintResponse.complaint = unhandledComplaint;
+            newComplaintResponse.responseText = 'accepted';
+
+            complaintsForTutorComponent.complaint = unhandledComplaint;
+            complaintsForTutorComponent.complaintResponse = newComplaintResponse;
+            complaintsForTutorComponent.exercise = { id: 11, isAtLeastInstructor: true } as Exercise;
+
+            complaintsForTutorComponent.isLoading = false;
+            complaintsForTutorComponent.handled = false;
+            complaintsForTutorComponent.showLockDuration = true;
+            complaintsForTutorComponent.lockedByCurrentUser = true;
+
+            complaintsForTutorComponent.updateAssessmentAfterComplaint.subscribe((assessmentAfterComplaint) =>
+                // setTimeout is used so that the code below does not execute until tick() is called.
+                setTimeout(() => {
+                    expect(assessmentAfterComplaint.complaintResponse).toEqual(newComplaintResponse);
+                    if (isSuccess) {
+                        assessmentAfterComplaint.onSuccess();
+                    } else {
+                        assessmentAfterComplaint.onError();
+                    }
+                }),
+            );
+
+            complaintsForTutorComponent.respondToComplaint(true);
+
+            expect(complaintsForTutorComponent.isLoading).toBeTrue();
+            expect(complaintsForTutorComponent.handled).toBeFalse();
+            expect(complaintsForTutorComponent.showLockDuration).toBeTrue();
+            expect(complaintsForTutorComponent.lockedByCurrentUser).toBeTrue();
+
+            tick();
+
+            expect(complaintsForTutorComponent.isLoading).toBeFalse();
+
+            expect(complaintsForTutorComponent.handled).toBe(isSuccess);
+            expect(complaintsForTutorComponent.showLockDuration).toBe(!isSuccess);
+            expect(complaintsForTutorComponent.lockedByCurrentUser).toBe(!isSuccess);
+        }),
+    );
 });

--- a/src/test/javascript/spec/component/file-upload-assessment/file-upload-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-assessment/file-upload-assessment.component.spec.ts
@@ -498,6 +498,33 @@ describe('FileUploadAssessmentComponent', () => {
             expect(onSuccessCalled).toBeFalse();
             expect(onErrorCalled).toBeTrue();
         });
+
+        it('should not update assessment after complaint if assessments are invalid', () => {
+            const alertServiceErrorSpy = jest.spyOn(alertService, 'error');
+
+            let onSuccessCalled = false;
+            let onErrorCalled = false;
+            const assessmentAfterComplaint: AssessmentAfterComplaint = {
+                complaintResponse: new ComplaintResponse(),
+                onSuccess: () => (onSuccessCalled = true),
+                onError: () => (onErrorCalled = true),
+            };
+
+            const feedback = new Feedback();
+            feedback.credits = 10;
+            feedback.detailText = undefined;
+            feedback.type = FeedbackType.MANUAL_UNREFERENCED;
+            comp.unreferencedFeedback = [feedback];
+            comp.isLoading = false;
+
+            comp.onUpdateAssessmentAfterComplaint(assessmentAfterComplaint);
+
+            expect(comp.isLoading).toBeFalse();
+            expect(alertServiceErrorSpy).toHaveBeenCalledOnce();
+            expect(alertServiceErrorSpy).toHaveBeenCalledWith('artemisApp.fileUploadAssessment.error.invalidAssessments');
+            expect(onSuccessCalled).toBeFalse();
+            expect(onErrorCalled).toBeTrue();
+        });
     });
 
     describe('attachmentExtension', () => {

--- a/src/test/javascript/spec/component/file-upload-assessment/file-upload-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-assessment/file-upload-assessment.component.spec.ts
@@ -18,7 +18,7 @@ import { MockComplaintService } from '../../helpers/mocks/service/mock-complaint
 import { FileUploadExercise } from 'app/entities/file-upload-exercise.model';
 import { FileUploadSubmissionService } from 'app/exercises/file-upload/participate/file-upload-submission.service';
 import { FileUploadAssessmentService } from 'app/exercises/file-upload/assess/file-upload-assessment.service';
-import { ComplaintsForTutorComponent } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
+import { AssessmentAfterComplaint, ComplaintsForTutorComponent } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
 import { UpdatingResultComponent } from 'app/exercises/shared/result/updating-result.component';
 import { FileUploadSubmission } from 'app/entities/file-upload-submission.model';
 import { SubmissionExerciseType, SubmissionType, getFirstResult, setLatestSubmissionResult } from 'app/entities/submission.model';
@@ -395,11 +395,20 @@ describe('FileUploadAssessmentComponent', () => {
             setLatestSubmissionResult(comp.submission, initResult);
 
             fixture.detectChanges();
-            const complaintResponse = new ComplaintResponse();
-            comp.onUpdateAssessmentAfterComplaint(complaintResponse);
+            let onSuccessCalled = false;
+            let onErrorCalled = false;
+            const assessmentAfterComplaint: AssessmentAfterComplaint = {
+                complaintResponse: new ComplaintResponse(),
+                onSuccess: () => (onSuccessCalled = true),
+                onError: () => (onErrorCalled = true),
+            };
+
+            comp.onUpdateAssessmentAfterComplaint(assessmentAfterComplaint);
             expect(comp.isLoading).toBeFalse();
             expect(comp.result).toEqual(changedResult);
             expect(comp.participation.results![0]).toEqual(changedResult);
+            expect(onSuccessCalled).toBeTrue();
+            expect(onErrorCalled).toBeFalse();
         });
 
         it('should not update assessment after complaint if already locked', () => {
@@ -430,10 +439,20 @@ describe('FileUploadAssessmentComponent', () => {
             setLatestSubmissionResult(comp.submission, initResult);
 
             fixture.detectChanges();
-            const complaintResponse = new ComplaintResponse();
-            comp.onUpdateAssessmentAfterComplaint(complaintResponse);
+
+            let onSuccessCalled = false;
+            let onErrorCalled = false;
+            const assessmentAfterComplaint: AssessmentAfterComplaint = {
+                complaintResponse: new ComplaintResponse(),
+                onSuccess: () => (onSuccessCalled = true),
+                onError: () => (onErrorCalled = true),
+            };
+
+            comp.onUpdateAssessmentAfterComplaint(assessmentAfterComplaint);
             expect(comp.isLoading).toBeFalse();
             expect(alertServiceErrorSpy).toHaveBeenCalledWith('errormessage', []);
+            expect(onSuccessCalled).toBeFalse();
+            expect(onErrorCalled).toBeTrue();
         });
 
         it('should not update assessment after complaint', () => {
@@ -464,10 +483,20 @@ describe('FileUploadAssessmentComponent', () => {
             setLatestSubmissionResult(comp.submission, initResult);
 
             fixture.detectChanges();
-            const complaintResponse = new ComplaintResponse();
-            comp.onUpdateAssessmentAfterComplaint(complaintResponse);
+
+            let onSuccessCalled = false;
+            let onErrorCalled = false;
+            const assessmentAfterComplaint: AssessmentAfterComplaint = {
+                complaintResponse: new ComplaintResponse(),
+                onSuccess: () => (onSuccessCalled = true),
+                onError: () => (onErrorCalled = true),
+            };
+
+            comp.onUpdateAssessmentAfterComplaint(assessmentAfterComplaint);
             expect(comp.isLoading).toBeFalse();
             expect(alertServiceErrorSpy).toHaveBeenCalledWith('artemisApp.assessment.messages.updateAfterComplaintFailed');
+            expect(onSuccessCalled).toBeFalse();
+            expect(onErrorCalled).toBeTrue();
         });
     });
 

--- a/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -331,8 +331,9 @@ describe('ModelingAssessmentEditorComponent', () => {
                 onSuccess: () => (onSuccessCalled = true),
                 onError: () => (onErrorCalled = true),
             };
-
+            const validateSpy = jest.spyOn(component, 'validateFeedback').mockImplementation(() => (component.assessmentsAreValid = true));
             component.onUpdateAssessmentAfterComplaint(assessmentAfterComplaint);
+            expect(validateSpy).toHaveBeenCalledOnce();
             expect(serviceSpy).toHaveBeenCalledOnce();
             if (serverReturnsError) {
                 expect(component.result?.participation?.results).toBeUndefined();

--- a/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -41,6 +41,7 @@ import { UnreferencedFeedbackComponent } from 'app/exercises/shared/unreferenced
 import { ExampleSubmissionService } from 'app/exercises/shared/example-submission/example-submission.service';
 import { ExampleSubmission } from 'app/entities/example-submission.model';
 import dayjs from 'dayjs/esm';
+import { AssessmentAfterComplaint } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
 
 describe('ModelingAssessmentEditorComponent', () => {
     let component: ModelingAssessmentEditorComponent;
@@ -318,9 +319,19 @@ describe('ModelingAssessmentEditorComponent', () => {
         component.ngOnInit();
         tick(500);
 
-        component.onUpdateAssessmentAfterComplaint(complaintResponse);
+        let onSuccessCalled = false;
+        let onErrorCalled = false;
+        const assessmentAfterComplaint: AssessmentAfterComplaint = {
+            complaintResponse,
+            onSuccess: () => (onSuccessCalled = true),
+            onError: () => (onErrorCalled = true),
+        };
+
+        component.onUpdateAssessmentAfterComplaint(assessmentAfterComplaint);
         expect(serviceSpy).toHaveBeenCalledOnce();
         expect(component.result?.participation?.results).toEqual([changedResult]);
+        expect(onSuccessCalled).toBeTrue();
+        expect(onErrorCalled).toBeFalse();
     }));
 
     it('should cancel the current assessment', fakeAsync(() => {

--- a/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -42,6 +42,7 @@ import { ExampleSubmissionService } from 'app/exercises/shared/example-submissio
 import { ExampleSubmission } from 'app/entities/example-submission.model';
 import dayjs from 'dayjs/esm';
 import { AssessmentAfterComplaint } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
+import { AlertService } from 'app/core/util/alert.service';
 
 describe('ModelingAssessmentEditorComponent', () => {
     let component: ModelingAssessmentEditorComponent;
@@ -452,5 +453,26 @@ describe('ModelingAssessmentEditorComponent', () => {
 
         expect(importSpy).toHaveBeenCalledOnce();
         expect(importSpy).toHaveBeenCalledWith(component.submission.id, component.modelingExercise!.id);
+    });
+
+    it('should display error when complaint resolved but assessment invalid', () => {
+        let onSuccessCalled = false;
+        let onErrorCalled = false;
+        const assessmentAfterComplaint: AssessmentAfterComplaint = {
+            complaintResponse: new ComplaintResponse(),
+            onSuccess: () => (onSuccessCalled = true),
+            onError: () => (onErrorCalled = true),
+        };
+        const alertService = TestBed.inject(AlertService);
+        const errorSpy = jest.spyOn(alertService, 'error');
+
+        const validateSpy = jest.spyOn(component, 'validateFeedback').mockImplementation(() => (component.assessmentsAreValid = false));
+
+        component.onUpdateAssessmentAfterComplaint(assessmentAfterComplaint);
+        expect(validateSpy).toHaveBeenCalledOnce();
+        expect(errorSpy).toHaveBeenCalledOnce();
+        expect(errorSpy).toHaveBeenCalledWith('artemisApp.modelingAssessment.invalidAssessments');
+        expect(onSuccessCalled).toBeFalse();
+        expect(onErrorCalled).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
@@ -49,7 +49,7 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
 import { AssessmentHeaderComponent } from 'app/assessment/assessment-header/assessment-header.component';
-import { ComplaintsForTutorComponent } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
+import { AssessmentAfterComplaint, ComplaintsForTutorComponent } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
 import { AssessmentComplaintAlertComponent } from 'app/assessment/assessment-complaint-alert/assessment-complaint-alert.component';
 import { CodeEditorGridComponent } from 'app/exercises/programming/shared/code-editor/layout/code-editor-grid.component';
 import { CodeEditorActionsComponent } from 'app/exercises/programming/shared/code-editor/actions/code-editor-actions.component';
@@ -498,9 +498,21 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
     it('should update assessment after complaint', fakeAsync(() => {
         comp.ngOnInit();
         tick(100);
-        comp.onUpdateAssessmentAfterComplaint(new ComplaintResponse());
+
+        let onSuccessCalled = false;
+        let onErrorCalled = false;
+        const assessmentAfterComplaint: AssessmentAfterComplaint = {
+            complaintResponse: new ComplaintResponse(),
+            onSuccess: () => (onSuccessCalled = true),
+            onError: () => (onErrorCalled = true),
+        };
+
+        comp.onUpdateAssessmentAfterComplaint(assessmentAfterComplaint);
+
         expect(updateAfterComplaintStub).toHaveBeenCalledOnce();
         expect(comp.manualResult!.score).toBe(100);
         flush();
+        expect(onSuccessCalled).toBeTrue();
+        expect(onErrorCalled).toBeFalse();
     }));
 });

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
@@ -65,6 +65,7 @@ import { AceEditorComponent } from 'app/shared/markdown-editor/ace-editor/ace-ed
 import { ExtensionPointDirective } from 'app/shared/extension-point/extension-point.directive';
 import { TreeviewComponent } from 'app/exercises/programming/shared/code-editor/treeview/components/treeview/treeview.component';
 import { TreeviewItem } from 'app/exercises/programming/shared/code-editor/treeview/models/treeview-item';
+import { AlertService } from 'app/core/util/alert.service';
 
 function addFeedbackAndValidateScore(comp: CodeEditorTutorAssessmentContainerComponent, pointsAwarded: number, scoreExpected: number) {
     comp.unreferencedFeedback.push({
@@ -522,4 +523,25 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
             expect(onErrorCalled).toBe(serverReturnsError);
         }),
     );
+
+    it('should display error when complaint resolved but assessment invalid', () => {
+        let onSuccessCalled = false;
+        let onErrorCalled = false;
+        const assessmentAfterComplaint: AssessmentAfterComplaint = {
+            complaintResponse: new ComplaintResponse(),
+            onSuccess: () => (onSuccessCalled = true),
+            onError: () => (onErrorCalled = true),
+        };
+        const alertService = TestBed.inject(AlertService);
+        const errorSpy = jest.spyOn(alertService, 'error');
+
+        const validateSpy = jest.spyOn(comp, 'validateFeedback').mockImplementation(() => (comp.assessmentsAreValid = false));
+
+        comp.onUpdateAssessmentAfterComplaint(assessmentAfterComplaint);
+        expect(validateSpy).toHaveBeenCalledOnce();
+        expect(errorSpy).toHaveBeenCalledOnce();
+        expect(errorSpy).toHaveBeenCalledWith('artemisApp.programmingAssessment.invalidAssessments');
+        expect(onSuccessCalled).toBeFalse();
+        expect(onErrorCalled).toBeTrue();
+    });
 });

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
@@ -514,8 +514,11 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
                 updateAfterComplaintStub.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 400 })));
             }
 
+            const validateSpy = jest.spyOn(comp, 'validateFeedback').mockImplementation(() => (comp.assessmentsAreValid = true));
+
             comp.onUpdateAssessmentAfterComplaint(assessmentAfterComplaint);
 
+            expect(validateSpy).toHaveBeenCalledOnce();
             expect(updateAfterComplaintStub).toHaveBeenCalledOnce();
             expect(comp.manualResult!.score).toBe(serverReturnsError ? 0 : 100);
             flush();

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -266,7 +266,7 @@ describe('TextSubmissionAssessmentComponent', () => {
         expect(onErrorCalled).toBeTrue();
     });
 
-    it('should send update when complaint resolved and assessments are valid', () => {
+    it.each([false, true])('should send update when complaint resolved and assessments are valid, serverReturnsError=%s', (serverReturnsError: boolean) => {
         const unreferencedFeedback = new Feedback();
         unreferencedFeedback.credits = 5;
         unreferencedFeedback.detailText = 'gj';
@@ -275,7 +275,8 @@ describe('TextSubmissionAssessmentComponent', () => {
         component.unreferencedFeedback = [unreferencedFeedback];
 
         const updateAssessmentAfterComplaintStub = jest.spyOn(textAssessmentService, 'updateAssessmentAfterComplaint');
-        updateAssessmentAfterComplaintStub.mockReturnValue(of(new HttpResponse({ body: new Result() })));
+        const serverResponse = serverReturnsError ? throwError(() => new HttpErrorResponse({ status: 400 })) : of(new HttpResponse({ body: new Result() }));
+        updateAssessmentAfterComplaintStub.mockReturnValue(serverResponse);
 
         // would be called on receive of event
         let onSuccessCalled = false;
@@ -288,8 +289,8 @@ describe('TextSubmissionAssessmentComponent', () => {
 
         component.updateAssessmentAfterComplaint(assessmentAfterComplaint);
         expect(updateAssessmentAfterComplaintStub).toHaveBeenCalledOnce();
-        expect(onSuccessCalled).toBeTrue();
-        expect(onErrorCalled).toBeFalse();
+        expect(onSuccessCalled).toBe(!serverReturnsError);
+        expect(onErrorCalled).toBe(serverReturnsError);
     });
 
     it('should submit the assessment with correct parameters', () => {

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -41,6 +41,7 @@ import { ExampleSubmission } from 'app/entities/example-submission.model';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { TranslateService } from '@ngx-translate/core';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
+import { AssessmentAfterComplaint } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
 
 describe('TextSubmissionAssessmentComponent', () => {
     let component: TextSubmissionAssessmentComponent;
@@ -248,12 +249,21 @@ describe('TextSubmissionAssessmentComponent', () => {
 
     it('should display error when complaint resolved but assessment invalid', () => {
         // would be called on receive of event
-        const complaintResponse = new ComplaintResponse();
+        let onSuccessCalled = false;
+        let onErrorCalled = false;
+        const assessmentAfterComplaint: AssessmentAfterComplaint = {
+            complaintResponse: new ComplaintResponse(),
+            onSuccess: () => (onSuccessCalled = true),
+            onError: () => (onErrorCalled = true),
+        };
+
         const alertService = TestBed.inject(AlertService);
         const errorStub = jest.spyOn(alertService, 'error');
 
-        component.updateAssessmentAfterComplaint(complaintResponse);
+        component.updateAssessmentAfterComplaint(assessmentAfterComplaint);
         expect(errorStub).toHaveBeenCalledWith('artemisApp.textAssessment.error.invalidAssessments');
+        expect(onSuccessCalled).toBeFalse();
+        expect(onErrorCalled).toBeTrue();
     });
 
     it('should send update when complaint resolved and assessments are valid', () => {
@@ -268,9 +278,18 @@ describe('TextSubmissionAssessmentComponent', () => {
         updateAssessmentAfterComplaintStub.mockReturnValue(of(new HttpResponse({ body: new Result() })));
 
         // would be called on receive of event
-        const complaintResponse = new ComplaintResponse();
-        component.updateAssessmentAfterComplaint(complaintResponse);
+        let onSuccessCalled = false;
+        let onErrorCalled = false;
+        const assessmentAfterComplaint: AssessmentAfterComplaint = {
+            complaintResponse: new ComplaintResponse(),
+            onSuccess: () => (onSuccessCalled = true),
+            onError: () => (onErrorCalled = true),
+        };
+
+        component.updateAssessmentAfterComplaint(assessmentAfterComplaint);
         expect(updateAssessmentAfterComplaintStub).toHaveBeenCalledOnce();
+        expect(onSuccessCalled).toBeTrue();
+        expect(onErrorCalled).toBeFalse();
     });
 
     it('should submit the assessment with correct parameters', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Addresses the issue nr. 6 at [WS22/23 - Issues Assessment Subteam](https://confluence.ase.in.tum.de/pages/viewpage.action?pageId=148579053). Bug descirption copied from there:

> When you assess a complaint and add a new feedback box but do not enter feedback text but only points and click submit, you get an alert that information is missing but the complaint is submitted and you cannot change it anymore.
> 
> Context I was an instructor.

### Description
<!-- Describe your changes in detail -->
`ComplaintsForTutorComponent`, delegates the server call to the parent endpoint when an assessment is saved after a complaint, However, this component assumes the parent component always completes the saving operation successfully and marks the complaint as handled, lock as released and disables the accept/reject buttons (only on UI, no additional server call is made). This PR includes `onSuccess`/onError` functions in the output for the parent components to allow `ComplaintsForTutorComponent` receive feedback for the assessment validation and save operations and adapt accordingly.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Submitted Exam with  at least 1 text, 1 modeling, 1 file upload and 1 programming exercise. (Exercises can be in different exams)

1. Log in to Artemis
2. Navigate to Course Administration
3. As an Instructor, evaluate 1 text, 1 modeling, 1 file upload and 1 programming exercise.
4. As a Student, make a complaint to each one of the above exercises.
5. As an Instructor, add an invalid feedback (e.g. for text exercise, you can add a new feedback box but do not enter feedback text but only points) and accept the complaint.
6. Make sure that there is an error alert shown but the accept/reject buttons are still enabled and the UI still shows the lock is held.
7. Fix the invalid feedback and accept the complaint, ensure that the operation works successfully as expected.

#### Exam Mode Testing
Changes only involve assessment mode and covered by the testing steps above.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
#### Manual Tests
- [x] Test 1
- [x] Test 2
- [x] Test 3

### Test Coverage
#### From Codacy
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->
| [Impacted Files](https://codecov.io/gh/ls1intum/Artemis/pull/6202?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum) | Coverage Δ | |
|---|---|---|
| [complaints-for-tutor.component.ts](https://codecov.io/gh/ls1intum/Artemis/pull/6202?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum#diff-c3JjL21haW4vd2ViYXBwL2FwcC9jb21wbGFpbnRzL2NvbXBsYWludHMtZm9yLXR1dG9yL2NvbXBsYWludHMtZm9yLXR1dG9yLmNvbXBvbmVudC50cw==) | `77.57% <100.00%> (+0.64%)` | :arrow_up: |
| [file-upload-assessment.component.ts](https://codecov.io/gh/ls1intum/Artemis/pull/6202?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum#diff-c3JjL21haW4vd2ViYXBwL2FwcC9leGVyY2lzZXMvZmlsZS11cGxvYWQvYXNzZXNzL2ZpbGUtdXBsb2FkLWFzc2Vzc21lbnQuY29tcG9uZW50LnRz) | `83.96% <100.00%> (+1.06%)` | :arrow_up: |
| [modeling-assessment-editor.component.ts](https://codecov.io/gh/ls1intum/Artemis/pull/6202?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum#diff-c3JjL21haW4vd2ViYXBwL2FwcC9leGVyY2lzZXMvbW9kZWxpbmcvYXNzZXNzL21vZGVsaW5nLWFzc2Vzc21lbnQtZWRpdG9yL21vZGVsaW5nLWFzc2Vzc21lbnQtZWRpdG9yLmNvbXBvbmVudC50cw==) | `67.44% <100.00%> (+1.81%)` | :arrow_up: |
| [code-editor-tutor-assessment-container.component.ts](https://codecov.io/gh/ls1intum/Artemis/pull/6202?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum#diff-c3JjL21haW4vd2ViYXBwL2FwcC9leGVyY2lzZXMvcHJvZ3JhbW1pbmcvYXNzZXNzL2NvZGUtZWRpdG9yLXR1dG9yLWFzc2Vzc21lbnQtY29udGFpbmVyLmNvbXBvbmVudC50cw==) | `75.37% <100.00%> (+2.47%)` | :arrow_up: |
| [text-submission-assessment.component.ts](https://codecov.io/gh/ls1intum/Artemis/pull/6202?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum#diff-c3JjL21haW4vd2ViYXBwL2FwcC9leGVyY2lzZXMvdGV4dC9hc3Nlc3MvdGV4dC1zdWJtaXNzaW9uLWFzc2Vzc21lbnQuY29tcG9uZW50LnRz) | `82.32% <100.00%> (+2.32%)` | :arrow_up: |

------

[Continue to review full report at Codecov](https://codecov.io/gh/ls1intum/Artemis/pull/6202?src=pr&el=continue&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta?utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

#### Screenshot of the error
![image](https://user-images.githubusercontent.com/18427209/216782461-578799ae-7da1-4bf0-955f-1c9fe9ffb1a6.png)
