### PR TITLE
`Programming exercises`: Fix updating scores when a manual result exists

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -330,6 +330,12 @@ public class ProgrammingExerciseGradingService {
         List<Feedback> copiedFeedbacks = newAutomaticResult.getFeedbacks().stream().map(Feedback::copyFeedback).toList();
         latestSemiAutomaticResult = resultService.addFeedbackToResult(latestSemiAutomaticResult, copiedFeedbacks, false);
 
+        latestSemiAutomaticResult.setTestCaseCount(newAutomaticResult.getTestCaseCount());
+        latestSemiAutomaticResult.setPassedTestCaseCount(newAutomaticResult.getPassedTestCaseCount());
+        latestSemiAutomaticResult.setCodeIssueCount(newAutomaticResult.getCodeIssueCount());
+
+        latestSemiAutomaticResult.calculateTotalPointsForProgrammingExercises();
+
         return resultRepository.save(latestSemiAutomaticResult);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -334,7 +334,9 @@ public class ProgrammingExerciseGradingService {
         latestSemiAutomaticResult.setPassedTestCaseCount(newAutomaticResult.getPassedTestCaseCount());
         latestSemiAutomaticResult.setCodeIssueCount(newAutomaticResult.getCodeIssueCount());
 
-        latestSemiAutomaticResult.calculateTotalPointsForProgrammingExercises();
+        Exercise exercise = latestSemiAutomaticResult.getParticipation().getExercise();
+        latestSemiAutomaticResult.setScore(latestSemiAutomaticResult.calculateTotalPointsForProgrammingExercises(), exercise.getMaxPoints(),
+                exercise.getCourseViaExerciseGroupOrCourseMember());
 
         return resultRepository.save(latestSemiAutomaticResult);
     }


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
In ITP we encountered an issue when changing test cases after the due date. When the student complained before the updated test cases were run, the new test run was not correctly reflected in the score. Whilst the feedback showed the new test results, the result itself was still using the old score:
![grafik](https://user-images.githubusercontent.com/26540346/216839608-1c657bcb-1a11-47c9-a107-e83bd5618222.png)
![grafik](https://user-images.githubusercontent.com/26540346/216839631-a0464939-20a2-4eae-85b4-4e6e6bcb41e4.png)


### Description
Submitting a complaint or additional feedback request already counts as a manual result.

In these cases, the new programming feedback gets merged with the potential existing manual feedback. This method was not updating the result, only the related feedback objects. This PR changes this behavior.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise with Complaints enabled

1. Student: Submit something to the PE
2. Student: Submit a complaint after the due date
3. Instructor: Change the test cases and trigger all builds (Participations -> Trigger All)
4. Verify that the Student's result got updated (correct score, correct test case count)

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->
