### PR TITLE
`Exam mode`: Disable internal auto save interval of the online code editor in exams

### DIFF
--- a/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
@@ -19,6 +19,7 @@
         [participation]="studentParticipation"
         [showEditorInstructions]="showEditorInstructions"
         [course]="getCourseFromExercise(exercise)"
+        [disableAutoSave]="true"
         (onCommitStateChange)="onCommitStateChange($event)"
         (onFileChanged)="onFileChanged()"
     >

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -28,6 +28,7 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy, OnChanges 
     @Input()
     unsavedFiles: { [fileName: string]: string };
     @Input() disableActions = false;
+    @Input() disableAutoSave = false;
     @Input()
     get editorState() {
         return this.editorStateValue;
@@ -105,13 +106,15 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy, OnChanges 
             .pipe(tap((isBuilding: boolean) => (this.isBuilding = isBuilding)))
             .subscribe();
 
-        this.autoSaveInterval = window.setInterval(() => {
-            this.autoSaveTimer++;
-            if (this.autoSaveTimer >= AUTOSAVE_EXERCISE_INTERVAL) {
-                this.autoSaveTimer = 0;
-                this.onSave();
-            }
-        }, AUTOSAVE_CHECK_INTERVAL);
+        if (!this.disableAutoSave) {
+            this.autoSaveInterval = window.setInterval(() => {
+                this.autoSaveTimer++;
+                if (this.autoSaveTimer >= AUTOSAVE_EXERCISE_INTERVAL) {
+                    this.autoSaveTimer = 0;
+                    this.onSave();
+                }
+            }, AUTOSAVE_CHECK_INTERVAL);
+        }
     }
 
     /**

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.html
@@ -11,6 +11,7 @@
                 [unsavedFiles]="unsavedFiles"
                 [(editorState)]="editorState"
                 [(commitState)]="commitState"
+                [disableAutoSave]="disableAutoSave"
                 (onSavedFiles)="onSavedFiles($event)"
                 (onRefreshFiles)="onRefreshFiles()"
                 (commitStateChange)="onCommitStateChange.emit($event)"

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
@@ -62,6 +62,8 @@ export class CodeEditorContainerComponent implements ComponentCanDeactivate {
     readOnlyManualFeedback = false;
     @Input()
     highlightDifferences: boolean;
+    @Input()
+    disableAutoSave = false;
 
     @Output()
     onResizeEditorInstructions = new EventEmitter<void>();

--- a/src/test/javascript/spec/component/code-editor/code-editor-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-actions.component.spec.ts
@@ -272,27 +272,40 @@ describe('CodeEditorActionsComponent', () => {
         flush();
     }));
 
-    it('should autosave unsaved files after 30 seconds', fakeAsync(() => {
-        const unsavedFiles = { fileName: 'lorem ipsum fileContent lorem ipsum' };
-        const savedFilesResult: { [fileName: string]: null } = { fileName: null };
-        const saveObservable = new Subject<typeof savedFilesResult>();
-        comp.editorState = EditorState.UNSAVED_CHANGES;
-        comp.isBuilding = false;
-        comp.unsavedFiles = unsavedFiles;
-        fixture.detectChanges();
+    it.each([false, true])(
+        'should autosave unsaved files after 30 seconds if autosave is not disabled',
+        fakeAsync((disableAutoSave: boolean) => {
+            const unsavedFiles = { fileName: 'lorem ipsum fileContent lorem ipsum' };
+            const savedFilesResult: { [fileName: string]: null } = { fileName: null };
+            const saveObservable = new Subject<typeof savedFilesResult>();
+            comp.editorState = EditorState.UNSAVED_CHANGES;
+            comp.isBuilding = false;
+            comp.unsavedFiles = unsavedFiles;
+            comp.disableAutoSave = disableAutoSave;
 
-        updateFilesStub.mockReturnValue(saveObservable);
+            const saveChangedFilesSpy = jest.spyOn(comp, 'saveChangedFiles');
+            fixture.detectChanges();
 
-        tick(1000 * 31);
+            updateFilesStub.mockReturnValue(saveObservable);
 
-        // receive result for save
-        saveObservable.next(savedFilesResult);
-        expect(comp.editorState).toEqual(EditorState.SAVING);
+            tick(1000 * 31);
 
-        fixture.detectChanges();
-        fixture.destroy();
-        flush();
-    }));
+            // receive result for save
+            if (disableAutoSave) {
+                expect(saveChangedFilesSpy).not.toHaveBeenCalled();
+                expect(comp.editorState).toEqual(EditorState.UNSAVED_CHANGES);
+            } else {
+                expect(saveChangedFilesSpy).toHaveBeenCalledOnce();
+                expect(saveChangedFilesSpy).toHaveBeenCalledWith();
+                saveObservable.next(savedFilesResult);
+                expect(comp.editorState).toEqual(EditorState.SAVING);
+            }
+
+            fixture.detectChanges();
+            fixture.destroy();
+            flush();
+        }),
+    );
 
     it('should save on destroy', () => {
         const unsavedFiles = { fileName: 'lorem ipsum fileContent lorem ipsum' };


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Issue 8 from[WS22/23 - Testing Exam Mode - Issues Student Subteam][](https://confluence.ase.in.tum.de/pages/viewpage.action?pageId=148579035):
![image](https://user-images.githubusercontent.com/23171488/217040379-55711560-46cc-4da7-b007-98b3520e356a.png)

https://user-images.githubusercontent.com/23171488/217050689-c08d9488-42d6-486c-96e7-e9c8e3a50fa7.mov



### Description
<!-- Describe your changes in detail -->

In exams, switching away from a programming exercise doesn't mean that the code editor is unmounted; it continues to live in the background. The code editor has an inbuilt auto-save timer that triggers a save of all changed files if unsaved changes exist. It determines whether unsaved changes exist by checking if the collection of unsaved files is empty. That collection is passed in using an ``@Input()``. However, due to performance reasons, Angular's change detection is disabled for mounted exam components that are not on the selected exam page, but in the background / on other exam pages. Therefore, the hidden code editor didn't notice that the unsaved files collection is empty, wrongly assumed that there are still some, even though it just saved the changes due to the page switch, and triggered the save after 30 seconds due to the inbuilt timer. As change detection is disabled, this is an endless loop, as it never notices that the unsaved files collection is actually empty. The cause triggering the actual visual error is that the service used to push files, the ``CodeEditorRepositoryFileService``, is domain-dependent. That means that the currently active code editor sets the repository URI to push to dynamically. When the code editor in the background tries to push a file, it pushes the file towards the wrong repository, which causes a "File not found" error on the server.

The main solution to this entire problem is to just disable the built in auto save timer in the code editor when it is used in an exam. It is not required as it causes the problem above; additionally, the save function is already triggered regularly (if there are unsaved files) by the global exam-wide auto-save timer, plus it's triggered if you switch the page away from the programming exercise. That combined is already enough.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 exam with two programming exercises with online code editor enabled. If testing with the default BubbleSort template, choose two different package names for each exercise.
- 1 Student registered for the exam
- 1 regular programming exercise with online editor enabled

1. Log in to Artemis, open network tab in dev console
2. Start to participate in the exam as a student
2. Change something in the first exercise; do not submit
3. Immediately switch to the second exercise
4. Verify that the client pushed the changed file on the page switch
5. Wait 60 seconds or so. Do nothing; verify that no more files are pushed to server
6. Verify that no save failure warnings are shown at all times like in the examples above
7. Reload. Verify that the new content was saved and is available after a reload
8. Exit the exam. Go to the regular programming exercise and open the code editor
9. Change something; do not save. Wait for about 30 seconds; Artemis should automatically upload your changes

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

<!-- ### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan.
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. 
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. 
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->
