### PR TITLE
`General`: Increase feedback length limit

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -123,17 +123,22 @@ public final class Constants {
 
     public static final String PROGRAMMING_EXERCISE_SUCCESSFUL_UNLOCK_OPERATION_NOTIFICATION = "The student repositories for this programming exercise were unlocked successfully.";
 
-    public static final int FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS = 5000;
+    // The db-column of type TEXT in MySQL can hold up to 65_535 _bytes_, PostgreSQL has no limitation.
+    private static final int MYSQL_MAX_TEXT_SIZE = 65_535;
+
+    // Since some characters might use up to four bytes, some overhead is reserved for that
+    // (assuming that most characters are regular ASCII ones).
+    private static final int MYSQL_SAFE_MAX_TEXT_SIZE = 50_000;
+
+    public static final int FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS = MYSQL_SAFE_MAX_TEXT_SIZE;
 
     // This value limits the amount of characters allowed for a complaint response text.
-    // Set to 65535 as the db-column has type TEXT which can hold up to 65535 characters.
     // Also, the value on the client side must match this value.
-    public static final int COMPLAINT_RESPONSE_TEXT_LIMIT = 65535;
+    public static final int COMPLAINT_RESPONSE_TEXT_LIMIT = MYSQL_MAX_TEXT_SIZE;
 
     // This value limits the amount of characters allowed for a complaint text.
-    // Set to 65535 as the db-column has type TEXT which can hold up to 65535 characters.
     // Also, the value on the client side must match this value.
-    public static final int COMPLAINT_TEXT_LIMIT = 65535;
+    public static final int COMPLAINT_TEXT_LIMIT = MYSQL_MAX_TEXT_SIZE;
 
     public static final String ASSIGNMENT_CHECKOUT_PATH = "assignment";
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/FeedbackRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/FeedbackRepository.java
@@ -103,8 +103,7 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
                 issue.setFilePath(removeCIDirectoriesFromPath(issue.getFilePath()));
 
                 if (issue.getMessage() != null) {
-                    // Note: the feedback detail text is limited to 5.000 characters, so we limit the issue message to 4.500 characters to avoid issues
-                    // the remaining 500 characters are used for the json structure of the issue
+                    // Note: the remaining 500 characters are used for the json structure of the issue
                     int maxLength = Math.min(issue.getMessage().length(), FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS - 500);
                     issue.setMessage(issue.getMessage().substring(0, maxLength));
                 }

--- a/src/main/resources/config/liquibase/changelog/20230207120000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230207120000_changelog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.18.xsd">
+    <changeSet author="b-fein" id="20230207120000">
+        <modifyDataType tableName="feedback" columnName="detail_text" newDataType="text"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -18,6 +18,7 @@
     <include file="classpath:config/liquibase/changelog/20230121123250_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230123101046_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230201102700_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20230207120000_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command 'date '+%Y%m%d%H%M%S'' to get the current date and time in the correct format -->

--- a/src/main/webapp/app/course/manage/course-update.component.ts
+++ b/src/main/webapp/app/course/manage/course-update.component.ts
@@ -63,10 +63,11 @@ export class CourseUpdateComponent implements OnInit {
     faExclamationTriangle = faExclamationTriangle;
 
     // NOTE: These constants are used to define the maximum length of complaints and complaint responses.
-    // This is the maximum value allowed in our database. These values must be the same as in Constants.java
-    // Currently set to 65535 as this is the limit of TEXT
-    readonly COMPLAINT_RESPONSE_TEXT_LIMIT = 65535;
-    readonly COMPLAINT_TEXT_LIMIT = 65535;
+    // These values must be the same as in Constants.java.
+    // See Constants.java for details on why this value has been chosen.
+    readonly COMPLAINT_RESPONSE_TEXT_LIMIT = 65_535;
+    readonly COMPLAINT_TEXT_LIMIT = 65_535;
+
     tutorialGroupsFeatureActivated = false;
 
     constructor(

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment.service.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment.service.ts
@@ -12,7 +12,9 @@ export type EntityResponseType = HttpResponse<Result>;
 @Injectable({ providedIn: 'root' })
 export class ModelingAssessmentService {
     private readonly MAX_FEEDBACK_TEXT_LENGTH = 500;
-    private readonly MAX_FEEDBACK_DETAIL_TEXT_LENGTH = 5000;
+    // keep in sync with Constants.java
+    private readonly MAX_FEEDBACK_DETAIL_TEXT_LENGTH = 50_000;
+
     private resourceUrl = SERVER_API_URL + 'api';
 
     constructor(private http: HttpClient) {}


### PR DESCRIPTION
# Do _NOT_ deploy this PR on a test server

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Similar to #4796, we have some exercises that test programs via CLI interactions. Therefore, more text output is generated which sometimes is longer than 5.000 characters.

### Description
In principle, there were several options on how to achieve this goal:

- (a) change the `varchar(5000)` definition to something longer
- (b) replace `varchar` with datatype `text` entirely.

#### Option (a)
MySQL theoretically allows `varchar`s up to a maximum length of 65.535 bytes [1]. However, since each tuple/row in the database table is only allowed to have up to this same length [2] the actual length is lower in practice.
Additionally, Artemis uses a database in `utf8mb4` character set. That means each character can use up to four bytes of storage [3]. Therefore, the actually allowed maximum length in our case would be $\frac{65535}{4} = 16383$. To then also allow for the other columns in the `feedback` table, the maximum length has to be reduced to about 15000 characters (see appendix at the end of the PR description).

Benefits:
- No performance impact since unused bytes in `varchar`s remain unallocated.

Disadvantages:
- This hinders possible extension in the future, since the table does not have enough space to accommodate additional columns.


#### Option (b)
MySQL has a special data type for longer texts which allows the storage of up to 65.535 bytes in a single string regardless which other columns contains [4]. PostgreSQL also supports this data type without any upper byte limit and explicitly no performance difference compared to `varchar` [6].
One disadvantage of the `text` column type is the possible performance impact. Whenever a temporary table has to be created by MySQL that includes a `text` column, this table has to be written to disk. Nevertheless, for Artemis this should not have an impact, since temporary tables only need to be created for operations that are usually avoided in the Artemis codebase anyway (e.g. `UNION`, subqueries) [5].

Disadvantages:
- Possible performance impact.

Benefits:
- Future extensibility of the `feedback` table.
- Better suited for PostgreSQL databases.


#### Conclusions

Based on those facts, we decided to change the datatype of the `feedback.detail_text` to `text`, for two reasons: a performance impact is unlikely, and the `feedback` table remains extensible in the future.

Allowing up to 15.000 characters in a `varchar` would be acceptable to us, too. However, we believe that this severely limits the future extensibility. Additionally, allowing the flexibility a `text` column provides, other instructors can freely decide which amount of feedback they find acceptable based only on the actual task/exercise, not based on database limitations.

A temporary compromise to investigate the possible performance impact would be to change the data type to `text` in the database, but keep the maximum length enforced in the Artemis code by `FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS` to 5000.
With that the impact could be tested on a large database like at TUM, with the option to later revert the data type back to a `varchar(n)` with $n \geq 5000$ without data loss.


#### Additional Considerations
PostgreSQL supports arbitrary length `text`s, MySQL sadly does not. Therefore, a length check in the code has to remain to keep supporting both database types.

Since the limit for `text` objects is not counted as actual _characters_, but _bytes_, the actual length limit is less than 65.535. For `FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS` we decided that 50.000 should be length where most feedbacks should safely fit even if they contain many unicode characters that take up more than one byte each.
`COMPLAINT_RESPONSE_TEXT_LIMIT` and `COMPLAINT_TEXT_LIMIT` face this same issue but have not been adapted, since this might be a breaking change: The `@Size` constraint on the corresponding attributes of the `Complaint` domain object might fail in case some elements already exist which exceed this limit.


[1] https://dev.mysql.com/doc/refman/8.0/en/char.html
[2] https://dev.mysql.com/doc/refman/8.0/en/column-count-limit.html
[3] https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-sets.html
[4] https://dev.mysql.com/doc/refman/8.0/en/blob.html
[5] https://dev.mysql.com/doc/refman/8.0/en/internal-temporary-tables.html
[6] https://www.postgresql.org/docs/current/datatype-character.html




### Steps for Testing

# Do _NOT_ deploy this PR on a test server

Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Submit to the programming exercise.
2. The feedback should be shown as usual.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
unchanged


## Appendix

<details>
<summary>Feedback table size</summary>

| column                 | type          | size (B)  |
| ---------------------- | ------------- | --------: |
| id                     | bigint        |         8 |
| detail_text            | varchar(5000) |     20000 |
| text                   | varchar(500)  |      2000 |
| result_id              | bigint        |         8 |
| type                   | varchar(255)  |      1020 |
| positive               | boolean       |         1 |
| feedbacks_order        | integer       |         4 |
| credits                | double        |         8 |
| reference              | varchar(255)  |      1020 |
| grading_instruction_id | bigint        |         8 |
| visibility             | varchar(255)  |      1020 |
| **Σ**                  |               | **25097** |

⇒ remaining bytes: $65535 - 25097 = 40438$
⇒ divided by 4 bytes per character, 10.000 additional characters possible

</details>