### PR TITLE
`Exam mode`: Fix test exam working time starting too early

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -187,11 +187,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
                         this.studentExam = studentExam;
                         this.exam = studentExam.exam!;
                         this.testExam = this.exam.testExam!;
-                        if (this.exam.testExam) {
-                            // For TestExams, we either set the StartTime to the current time or the startedDate of the studentExam, if existent
-                            this.testStartTime = this.studentExam.startedDate ? this.studentExam.startedDate! : dayjs();
-                            this.initIndividualEndDates(this.testStartTime);
-                        } else {
+                        if (!this.exam.testExam) {
                             this.initIndividualEndDates(this.exam.startDate!);
                         }
 

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -177,8 +177,6 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
                         this.studentExam.exam!.course.id = this.courseId;
                         this.exam = studentExam.exam!;
                         this.testExam = this.exam.testExam!;
-                        this.testStartTime = dayjs();
-                        this.initIndividualEndDates(this.testStartTime);
                         this.loadingExam = false;
                     },
                     error: () => (this.loadingExam = false),
@@ -310,7 +308,9 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
             this.examParticipationService.setExamExerciseIds(exerciseIds);
             // set endDate with workingTime
             if (!!this.testRunId || this.testExam) {
-                this.individualStudentEndDate = this.testStartTime!.add(this.studentExam.workingTime!, 'seconds');
+                this.testStartTime = studentExam.startedDate ? dayjs(studentExam.startedDate) : dayjs();
+                this.initIndividualEndDates(this.testStartTime);
+                this.individualStudentEndDate = this.testStartTime.add(this.studentExam.workingTime!, 'seconds');
             } else {
                 this.individualStudentEndDate = dayjs(this.exam.startDate).add(this.studentExam.workingTime!, 'seconds');
             }

--- a/src/main/webapp/app/overview/course-overview.component.ts
+++ b/src/main/webapp/app/overview/course-overview.component.ts
@@ -3,7 +3,7 @@ import { Course } from 'app/entities/course.model';
 import { MetisConversationService } from 'app/shared/metis/metis-conversation.service';
 import { CourseManagementService } from '../course/manage/course-management.service';
 import { ActivatedRoute } from '@angular/router';
-import { Subject, Subscription, forkJoin, take, takeUntil } from 'rxjs';
+import { Subject, Subscription, forkJoin, takeUntil } from 'rxjs';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { CourseScoreCalculationService } from 'app/overview/course-score-calculation.service';
 import { TeamService } from 'app/exercises/shared/team/team.service';


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.

### Motivation and Context
Students reported that their test exams would start with way too less working time (e.g. 45min instead of 2h)

### Description
The working time started previously once the exam was opened in the client (when the overview page containing the start text and checkbox was shown)

Some students opened this page before taking a break for half an hour, which resulted in a smaller working time. After reloading the page, the working time was correctly shown again. This is because the server did not yet set a starting time (this is only done after pressing start), but the client already started counting the time.

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Test exam

1. Open the test exam as a student (confirmation text and checkbox is shown)
2. Keep the page open for a couple of minutes
3. Start the exam (enter your name and press start)
4. The displayed working time should have started just now (full working time available)
5. Wait a few minutes and reload the page
6. The now showed woking time should be correctly reduced (the start date is used)

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage

