### PR TITLE
`Development`: Add complaint e2e tests to exam

### DIFF
--- a/src/main/webapp/app/complaints/response/complaint-response.component.html
+++ b/src/main/webapp/app/complaints/response/complaint-response.component.html
@@ -10,6 +10,7 @@
     </p>
 
     <textarea
+        id="complainResponseTextArea"
         class="col-12 px-1"
         rows="4"
         [(ngModel)]="complaint.complaintResponse.responseText"

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
@@ -419,6 +419,7 @@
                                                     [routerLink]="getAssessmentLink(submission)"
                                                     [queryParams]="getAssessmentQueryParams(correctionRound)"
                                                     class="btn btn-warning btn-sm"
+                                                    id="continue-assessment"
                                                 >
                                                     <fa-icon [icon]="faFolderOpen" [fixedWidth]="true"></fa-icon>&nbsp;{{
                                                         'artemisApp.exerciseAssessmentDashboard.continueAssessment' | artemisTranslate
@@ -430,6 +431,7 @@
                                                         [routerLink]="getAssessmentLink(submission)"
                                                         [queryParams]="getAssessmentQueryParams(correctionRound)"
                                                         class="btn btn-primary btn-sm"
+                                                        id="open-assessment"
                                                     >
                                                         <fa-icon [icon]="faFolderOpen" [fixedWidth]="true"></fa-icon>
                                                         &nbsp;{{ 'artemisApp.exerciseAssessmentDashboard.openAssessment' | artemisTranslate }}
@@ -563,6 +565,7 @@
                                             [routerLink]="getAssessmentLink(submissionWithComplaint.submission)"
                                             [queryParams]="getComplaintQueryParams(submissionWithComplaint.complaint)"
                                             class="btn btn-success btn-sm"
+                                            id="evaluate-complaint"
                                         >
                                             <fa-icon [icon]="faFolderOpen" [fixedWidth]="true"></fa-icon>
                                             {{ 'artemisApp.exerciseAssessmentDashboard.evaluateComplaint' | artemisTranslate }}

--- a/src/main/webapp/i18n/en/modelingAssessmentEditor.json
+++ b/src/main/webapp/i18n/en/modelingAssessmentEditor.json
@@ -19,13 +19,13 @@
                 "submitFailed": "Submitting your assessment failed!",
                 "submitFailedWithConflict": "Submission failed! Conflict with existing Assessments detected",
                 "resultDismissed": "Your assessment was dismissed because another tutor already rated this model.",
-                "updateAfterComplaintSuccessful": "The Assessment was updated successfully.",
-                "updateAfterComplaintFailed": "Updating the Assessment failed.",
+                "updateAfterComplaintSuccessful": "The assessment was updated successfully.",
+                "updateAfterComplaintFailed": "Updating the assessment failed.",
                 "confirmSubmission": "You have not assessed all model elements. Are you sure you want to submit this assessment? You will not be able to change it afterwards.",
                 "confirmCancel": "Are you sure you want to cancel the assessment? Your current assessment progress will be deleted and the submission will be available for assessment to other tutors again.",
                 "noConflicts": "Conflicts could not be loaded",
                 "conflictsResolved": "All conflicts have been processed.",
-                "feedbackTextTooLong": "Failed to save Assessment. Feedback text must be no longer than 500 characters."
+                "feedbackTextTooLong": "Failed to save assessment. Feedback text must be no longer than 500 characters."
             },
             "automaticAssessmentAvailable": "Congratulations! To save you some time, parts of this model were already assessed automatically. Please review the automatic assessment and assess the rest of the model afterwards. By submitting the assessment you also confirm the automatic assessment. Please be aware that you are responsible for the whole assessment.",
             "highlightingColors": {

--- a/src/main/webapp/i18n/en/textAssessment.json
+++ b/src/main/webapp/i18n/en/textAssessment.json
@@ -36,8 +36,8 @@
                 "heading": "Submissions and assessments of text exercise \"{{exerciseTitle}}\""
             },
             "notFound": "We couldn't find any unassessed text submissions. Please return to the dashboard.",
-            "updateAfterComplaintSuccessful": "The Assessment was updated successfully.",
-            "updateAfterComplaintFailed": "Updating the Assessment failed.",
+            "updateAfterComplaintSuccessful": "The assessment was updated successfully.",
+            "updateAfterComplaintFailed": "Updating the assessment failed.",
             "cancel": "Cancel assessment",
             "confirmCancel": "Are you sure you want to cancel the assessment? Your current assessment progress will be deleted and the submission will be available for assessment to other tutors again.",
             "feedbackEditor": {

--- a/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
@@ -19,11 +19,12 @@ import {
     modelingExerciseEditor,
     programmingExerciseEditor,
     quizExerciseMultipleChoice,
+    studentAssessment,
     textExerciseEditor,
 } from '../../support/artemis';
 import { admin, instructor, studentOne, tutor } from '../../support/users';
+import { CypressExerciseType } from '../../support/requests/CourseManagementRequests';
 
-// Common primitives
 let exam: Exam;
 let exerciseGroup: ExerciseGroup;
 let course: Course;
@@ -35,6 +36,9 @@ Cypress.on('uncaught:exception', () => {
 
 describe('Exam assessment', () => {
     let examEnd: Dayjs;
+    let programmingAssessmentSuccessful = false;
+    let modelingAssessmentSuccessful = false;
+    let textAssessmentSuccessful = false;
 
     before('Create a course', () => {
         cy.login(admin);
@@ -45,26 +49,14 @@ describe('Exam assessment', () => {
         });
     });
 
-    afterEach('Delete exam', () => {
-        cy.login(admin);
-        courseManagementRequest.deleteExam(exam);
-    });
-
-    after('Delete course', () => {
-        cy.login(admin);
-        courseManagementRequest.deleteCourse(course.id!);
-    });
-
     // For some reason the typing of cypress gets slower the longer the test runs, so we test the programming exercise first
-    describe('Exam programming exercise assessment', () => {
-        const examDuration = 155000;
-
+    describe('Programming exercise assessment', () => {
         before('Prepare exam', () => {
-            examEnd = dayjs().add(examDuration, 'milliseconds');
+            examEnd = dayjs().add(2.5, 'minutes');
             prepareExam(examEnd);
         });
 
-        beforeEach('Create exam, exercise and submission', () => {
+        before('Create exam, exercise and submission', () => {
             cy.login(instructor);
             courseManagementRequest
                 .createProgrammingExercise(
@@ -79,8 +71,8 @@ describe('Exam assessment', () => {
                     undefined,
                     CypressAssessmentType.SEMI_AUTOMATIC,
                 )
-                .then((progRespone) => {
-                    const programmingExercise = progRespone.body;
+                .then((progResponse) => {
+                    const programmingExercise = progResponse.body;
                     courseManagementRequest.generateMissingIndividualExams(exam);
                     courseManagementRequest.prepareExerciseStartForExam(exam);
                     cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
@@ -95,101 +87,125 @@ describe('Exam assessment', () => {
 
         it('Assess a programming exercise submission (MANUAL)', () => {
             cy.login(tutor, '/course-management/' + course.id + '/exams');
-            examManagement.openAssessmentDashboard(exam.id!, examDuration);
+            examManagement.openAssessmentDashboard(exam.id!, 155000);
             startAssessing();
             examAssessment.addNewFeedback(2, 'Good job');
             examAssessment.submit();
             cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
             programmingExerciseEditor.getResultScore().should('contain.text', '66.2%, 6 of 13 passed, 6.6 points').and('be.visible');
+            programmingAssessmentSuccessful = true;
+        });
+
+        it('Complaints about programming exercises assessment', () => {
+            if (programmingAssessmentSuccessful) {
+                handleComplaint(false, CypressExerciseType.PROGRAMMING);
+            }
         });
     });
 
-    describe('Exam exercise assessment', () => {
-        beforeEach('Generate new exam name', () => {
-            examEnd = dayjs().add(45, 'seconds');
+    describe('Modeling exercise assessment', () => {
+        before('Prepare exam', () => {
+            examEnd = dayjs().add(20, 'seconds');
             prepareExam(examEnd);
         });
 
-        describe('Modeling exercise assessment', () => {
-            beforeEach('Create exercise and submission', () => {
-                cy.login(instructor);
-                courseManagementRequest.createModelingExercise({ exerciseGroup }).then((response) => {
-                    const exercise = response.body;
-                    courseManagementRequest.generateMissingIndividualExams(exam);
-                    courseManagementRequest.prepareExerciseStartForExam(exam);
-                    cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-                    examStartEnd.startExam();
-                    examNavigation.openExerciseAtIndex(0);
-                    modelingExerciseEditor.addComponentToModel(exercise.id!, 1);
-                    modelingExerciseEditor.addComponentToModel(exercise.id!, 2);
-                    modelingExerciseEditor.addComponentToModel(exercise.id!, 3);
-                    examNavigation.handInEarly();
-                    examStartEnd.finishExam();
-                });
-            });
-
-            it('Assess a modeling exercise submission', () => {
-                cy.login(tutor, '/course-management/' + course.id + '/exams');
-                examManagement.openAssessmentDashboard(exam.id!, 60000);
-                startAssessing();
-                modelingExerciseAssessment.addNewFeedback(5, 'Good');
-                modelingExerciseAssessment.openAssessmentForComponent(1);
-                modelingExerciseAssessment.assessComponent(-1, 'Wrong');
-                modelingExerciseAssessment.clickNextAssessment();
-                modelingExerciseAssessment.assessComponent(0, 'Neutral');
-                modelingExerciseAssessment.clickNextAssessment();
-                examAssessment.submitModelingAssessment().then((assessmentResponse: Interception) => {
-                    expect(assessmentResponse.response?.statusCode).to.equal(200);
-                });
+        before('Create modeling exercise and submission', () => {
+            cy.login(instructor);
+            courseManagementRequest.createModelingExercise({ exerciseGroup }).then((response) => {
+                const exercise = response.body;
+                courseManagementRequest.generateMissingIndividualExams(exam);
+                courseManagementRequest.prepareExerciseStartForExam(exam);
                 cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-                programmingExerciseEditor.getResultScore().should('contain.text', '40%, 4 points').and('be.visible');
+                examStartEnd.startExam();
+                examNavigation.openExerciseAtIndex(0);
+                modelingExerciseEditor.addComponentToModel(exercise.id!, 1);
+                modelingExerciseEditor.addComponentToModel(exercise.id!, 2);
+                modelingExerciseEditor.addComponentToModel(exercise.id!, 3);
+                examNavigation.handInEarly();
+                examStartEnd.finishExam();
             });
         });
 
-        describe('Text exercise assessment', () => {
-            beforeEach('Create exercise and submission', () => {
-                cy.login(instructor);
-                const exerciseTitle = 'Cypress Text Exercise';
-                courseManagementRequest.createTextExercise({ exerciseGroup }, exerciseTitle).then((response) => {
-                    const exercise = response.body;
-                    courseManagementRequest.generateMissingIndividualExams(exam);
-                    courseManagementRequest.prepareExerciseStartForExam(exam);
-                    cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-                    examStartEnd.startExam();
-                    examNavigation.openExerciseAtIndex(0);
-                    textExerciseEditor.typeSubmission(exercise.id, textSubmission.text);
-                    textExerciseEditor.saveAndContinue().then((submissionResponse) => {
-                        expect(submissionResponse.response?.statusCode).to.equal(200);
-                    });
-                    examNavigation.handInEarly();
-                    examStartEnd.finishExam();
-                });
+        it('Assess a modeling exercise submission', () => {
+            cy.login(tutor, '/course-management/' + course.id + '/exams');
+            examManagement.openAssessmentDashboard(exam.id!, 60000);
+            startAssessing();
+            modelingExerciseAssessment.addNewFeedback(5, 'Good');
+            modelingExerciseAssessment.openAssessmentForComponent(1);
+            modelingExerciseAssessment.assessComponent(-1, 'Wrong');
+            modelingExerciseAssessment.clickNextAssessment();
+            modelingExerciseAssessment.assessComponent(0, 'Neutral');
+            modelingExerciseAssessment.clickNextAssessment();
+            examAssessment.submitModelingAssessment().then((assessmentResponse: Interception) => {
+                expect(assessmentResponse.response?.statusCode).to.equal(200);
             });
+            cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
+            programmingExerciseEditor.getResultScore().should('contain.text', '40%, 4 points').and('be.visible');
+            modelingAssessmentSuccessful = true;
+        });
 
-            it('Assess a text exercise submission', () => {
-                cy.login(tutor, '/course-management/' + course.id + '/exams');
-                examManagement.openAssessmentDashboard(exam.id!, 60000);
-                startAssessing();
-                examAssessment.addNewFeedback(7, 'Good job');
-                examAssessment.submitTextAssessment().then((assessmentResponse: Interception) => {
-                    expect(assessmentResponse.response!.statusCode).to.equal(200);
-                });
-                cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-                programmingExerciseEditor.getResultScore().should('contain.text', '70%, 7 points').and('be.visible');
-            });
+        it('Complaints about modeling exercises assessment', () => {
+            if (modelingAssessmentSuccessful) {
+                handleComplaint(true, CypressExerciseType.MODELING);
+            }
         });
     });
 
-    describe('Assess a quiz exercise submission', () => {
+    describe('Text exercise assessment', () => {
+        before('Prepare exam', () => {
+            examEnd = dayjs().add(25, 'seconds');
+            prepareExam(examEnd);
+        });
+
+        before('Create text exercise and submission', () => {
+            cy.login(instructor);
+            const exerciseTitle = 'Cypress Text Exercise';
+            courseManagementRequest.createTextExercise({ exerciseGroup }, exerciseTitle).then((response) => {
+                const exercise = response.body;
+                courseManagementRequest.generateMissingIndividualExams(exam);
+                courseManagementRequest.prepareExerciseStartForExam(exam);
+                cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
+                examStartEnd.startExam();
+                examNavigation.openExerciseAtIndex(0);
+                textExerciseEditor.typeSubmission(exercise.id, textSubmission.text);
+                textExerciseEditor.saveAndContinue().then((submissionResponse) => {
+                    expect(submissionResponse.response?.statusCode).to.equal(200);
+                });
+                examNavigation.handInEarly();
+                examStartEnd.finishExam();
+            });
+        });
+
+        it('Assess a text exercise submission', () => {
+            cy.login(tutor, '/course-management/' + course.id + '/exams');
+            examManagement.openAssessmentDashboard(exam.id!, 60000);
+            startAssessing();
+            examAssessment.addNewFeedback(7, 'Good job');
+            examAssessment.submitTextAssessment().then((assessmentResponse: Interception) => {
+                expect(assessmentResponse.response!.statusCode).to.equal(200);
+            });
+            cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
+            programmingExerciseEditor.getResultScore().should('contain.text', '70%, 7 points').and('be.visible');
+            textAssessmentSuccessful = true;
+        });
+
+        it('Complaints about text exercises assessment', () => {
+            if (textAssessmentSuccessful) {
+                handleComplaint(false, CypressExerciseType.TEXT);
+            }
+        });
+    });
+
+    describe('Quiz exercise assessment', () => {
         let resultDate: Dayjs;
 
-        beforeEach('Generate new exam name', () => {
+        before('Prepare exam', () => {
             examEnd = dayjs().add(25, 'seconds');
             resultDate = examEnd.add(5, 'seconds');
             prepareExam(examEnd, resultDate);
         });
 
-        beforeEach('Create exercise and submission', () => {
+        before('Create exercise and submission', () => {
             cy.login(instructor);
             courseManagementRequest.createQuizExercise({ exerciseGroup }, [multipleChoiceQuizTemplate], 'Cypress Quiz').then((quizResponse) => {
                 const exercise = quizResponse.body;
@@ -207,7 +223,7 @@ describe('Exam assessment', () => {
 
         it('Assesses quiz automatically', () => {
             if (dayjs().isBefore(examEnd)) {
-                cy.wait(examEnd.diff(dayjs(), 'ms'));
+                cy.wait(examEnd.diff(dayjs(), 'ms') + 5000);
             }
             cy.login(admin, `/course-management/${course.id}/exams/${exam.id}/assessment-dashboard`);
             courseAssessment.clickEvaluateQuizzes().its('response.statusCode').should('eq', 200);
@@ -222,28 +238,73 @@ describe('Exam assessment', () => {
         });
     });
 
-    function startAssessing() {
-        courseAssessment.clickExerciseDashboardButton();
-        exerciseAssessment.clickHaveReadInstructionsButton();
-        exerciseAssessment.clickStartNewAssessment();
-        cy.get('#assessmentLockedCurrentUser').should('be.visible');
+    after('Delete course', () => {
+        cy.login(admin);
+        courseManagementRequest.deleteCourse(course.id!);
+    });
+});
+
+function startAssessing() {
+    courseAssessment.clickExerciseDashboardButton();
+    exerciseAssessment.clickHaveReadInstructionsButton();
+    exerciseAssessment.clickStartNewAssessment();
+    cy.get('#assessmentLockedCurrentUser').should('be.visible');
+}
+
+function prepareExam(end: dayjs.Dayjs, resultDate = end.add(1, 'seconds')) {
+    cy.login(admin);
+    const examContent = new CypressExamBuilder(course)
+        .visibleDate(dayjs().subtract(1, 'hour'))
+        .startDate(dayjs())
+        .endDate(end)
+        .correctionRounds(1)
+        .examStudentReviewStart(resultDate.add(10, 'seconds'))
+        .examStudentReviewEnd(resultDate.add(1, 'minute'))
+        .publishResultsDate(resultDate)
+        .gracePeriod(0)
+        .build();
+    courseManagementRequest.createExam(examContent).then((examResponse) => {
+        exam = examResponse.body;
+        courseManagementRequest.registerStudentForExam(exam, studentOne);
+        courseManagementRequest.addExerciseGroupForExam(exam).then((groupResponse) => {
+            exerciseGroup = groupResponse.body;
+        });
+    });
+}
+
+function handleComplaint(reject: boolean, exerciseType: CypressExerciseType) {
+    const complaintText = 'Lorem ipsum dolor sit amet';
+    const complaintResponseText = ' consetetur sadipscing elitr';
+
+    cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
+    studentAssessment.startComplaint();
+    studentAssessment.enterComplaint(complaintText);
+    studentAssessment.submitComplaint();
+    cy.get('.message').should('contain.text', 'Your complaint has been submitted');
+
+    cy.login(instructor, '/course-management/' + course.id + '/exams');
+    examManagement.openAssessmentDashboard(exam.id!, 60000);
+    courseAssessment.clickExerciseDashboardButton();
+    exerciseAssessment.clickHaveReadInstructionsButton();
+
+    exerciseAssessment.clickEvaluateComplaint();
+    exerciseAssessment.getComplaintText().should('have.value', complaintText);
+    if (reject) {
+        examAssessment.rejectComplaint(complaintResponseText, true, exerciseType);
+    } else {
+        examAssessment.acceptComplaint(complaintResponseText, true, exerciseType);
+    }
+    if (exerciseType == CypressExerciseType.MODELING) {
+        cy.get('.message').should('contain.text', 'Response to complaint has been submitted');
+    } else {
+        cy.get('.message').should('contain.text', 'The assessment was updated successfully.');
     }
 
-    function prepareExam(end: dayjs.Dayjs, resultDate = end.add(1, 'seconds')) {
-        cy.login(admin);
-        const examContent = new CypressExamBuilder(course)
-            .visibleDate(dayjs().subtract(1, 'hour'))
-            .startDate(dayjs())
-            .endDate(end)
-            .publishResultsDate(resultDate)
-            .gracePeriod(0)
-            .build();
-        courseManagementRequest.createExam(examContent).then((examResponse) => {
-            exam = examResponse.body;
-            courseManagementRequest.registerStudentForExam(exam, studentOne);
-            courseManagementRequest.addExerciseGroupForExam(exam).then((groupResponse) => {
-                exerciseGroup = groupResponse.body;
-            });
-        });
+    cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
+    if (reject) {
+        studentAssessment.getComplaintBadge().should('contain.text', 'Complaint was rejected');
+    } else {
+        studentAssessment.getComplaintBadge().should('contain.text', 'Complaint was accepted');
     }
-});
+    studentAssessment.getComplaintResponse().should('have.value', complaintResponseText);
+}

--- a/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
@@ -23,7 +23,7 @@ import {
     textExerciseEditor,
 } from '../../support/artemis';
 import { admin, instructor, studentOne, tutor } from '../../support/users';
-import { CypressExerciseType } from '../../support/requests/CourseManagementRequests';
+import { EXERCISE_TYPE } from '../../support/constants';
 
 let exam: Exam;
 let exerciseGroup: ExerciseGroup;
@@ -98,7 +98,7 @@ describe('Exam assessment', () => {
 
         it('Complaints about programming exercises assessment', () => {
             if (programmingAssessmentSuccessful) {
-                handleComplaint(false, CypressExerciseType.PROGRAMMING);
+                handleComplaint(false, EXERCISE_TYPE.Programming);
             }
         });
     });
@@ -146,7 +146,7 @@ describe('Exam assessment', () => {
 
         it('Complaints about modeling exercises assessment', () => {
             if (modelingAssessmentSuccessful) {
-                handleComplaint(true, CypressExerciseType.MODELING);
+                handleComplaint(true, EXERCISE_TYPE.Modeling);
             }
         });
     });
@@ -191,7 +191,7 @@ describe('Exam assessment', () => {
 
         it('Complaints about text exercises assessment', () => {
             if (textAssessmentSuccessful) {
-                handleComplaint(false, CypressExerciseType.TEXT);
+                handleComplaint(false, EXERCISE_TYPE.Text);
             }
         });
     });
@@ -272,7 +272,7 @@ function prepareExam(end: dayjs.Dayjs, resultDate = end.add(1, 'seconds')) {
     });
 }
 
-function handleComplaint(reject: boolean, exerciseType: CypressExerciseType) {
+function handleComplaint(reject: boolean, exerciseType: EXERCISE_TYPE) {
     const complaintText = 'Lorem ipsum dolor sit amet';
     const complaintResponseText = ' consetetur sadipscing elitr';
 
@@ -294,7 +294,7 @@ function handleComplaint(reject: boolean, exerciseType: CypressExerciseType) {
     } else {
         examAssessment.acceptComplaint(complaintResponseText, true, exerciseType);
     }
-    if (exerciseType == CypressExerciseType.MODELING) {
+    if (exerciseType == EXERCISE_TYPE.Modeling) {
         cy.get('.message').should('contain.text', 'Response to complaint has been submitted');
     } else {
         cy.get('.message').should('contain.text', 'The assessment was updated successfully.');

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseAssessment.cy.ts
@@ -65,7 +65,7 @@ describe('Modeling Exercise Assessment Spec', () => {
         it('Instructor can see complaint and reject it', () => {
             cy.login(instructor, `/course-management/${course.id}/complaints`);
             courseAssessment.showTheComplaint();
-            modelingExerciseAssessment.rejectComplaint('You are wrong.');
+            modelingExerciseAssessment.rejectComplaint('You are wrong.', false);
         });
     });
 

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
@@ -79,7 +79,7 @@ describe('Programming exercise assessment', () => {
 
     function acceptComplaintAsInstructor() {
         cy.login(instructor, `/course-management/${course.id}/complaints`);
-        programmingExerciseAssessment.acceptComplaint('Makes sense').then((request: Interception) => {
+        programmingExerciseAssessment.acceptComplaint('Makes sense', false).then((request: Interception) => {
             expect(request.response!.statusCode).to.equal(200);
         });
     }

--- a/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
@@ -1,7 +1,7 @@
 import { Interception } from 'cypress/types/net-stubbing';
 import { TextExercise } from 'app/entities/text-exercise.model';
 import { Course } from 'app/entities/course.model';
-import { convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
+import { convertCourseAfterMultiPart, CypressExerciseType } from '../../../support/requests/CourseManagementRequests';
 import {
     courseAssessment,
     courseManagement,
@@ -72,7 +72,7 @@ describe('Text exercise assessment', () => {
 
         it('Instructor can see complaint and reject it', () => {
             cy.login(instructor, `/course-management/${course.id}/complaints`);
-            textExerciseAssessment.acceptComplaint('Makes sense').its('response.statusCode').should('eq', 200);
+            textAssessment.acceptComplaint('Makes sense', false).its('response.statusCode').should('eq', 200);
         });
     });
 

--- a/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
@@ -1,7 +1,7 @@
 import { Interception } from 'cypress/types/net-stubbing';
 import { TextExercise } from 'app/entities/text-exercise.model';
 import { Course } from 'app/entities/course.model';
-import { convertCourseAfterMultiPart, CypressExerciseType } from '../../../support/requests/CourseManagementRequests';
+import { convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import {
     courseAssessment,
     courseManagement,
@@ -72,7 +72,7 @@ describe('Text exercise assessment', () => {
 
         it('Instructor can see complaint and reject it', () => {
             cy.login(instructor, `/course-management/${course.id}/complaints`);
-            textAssessment.acceptComplaint('Makes sense', false).its('response.statusCode').should('eq', 200);
+            textExerciseAssessment.acceptComplaint('Makes sense', false).its('response.statusCode').should('eq', 200);
         });
     });
 

--- a/src/test/cypress/support/artemis.ts
+++ b/src/test/cypress/support/artemis.ts
@@ -38,6 +38,8 @@ export const examExerciseGroups = pageObjects.exam.exerciseGroups;
 export const examParticipation = pageObjects.exam.participation;
 export const studentExamManagement = pageObjects.exam.studentExamManagement;
 
+export const studentAssessment = pageObjects.assessment.student;
+
 export const exerciseAssessment = pageObjects.assessment.exercise;
 export const exerciseResult = pageObjects.exercise.result;
 

--- a/src/test/cypress/support/pageobjects/ArtemisPageobjects.ts
+++ b/src/test/cypress/support/pageobjects/ArtemisPageobjects.ts
@@ -41,6 +41,7 @@ import { StudentExamManagementPage } from './exam/StudentExamManagementPage';
 import { CourseExercisePage } from './course/CourseExercisePage';
 import { CourseCreationPage } from './course/CourseCreationPage';
 import { ExamParticipation } from './exam/ExamParticipation';
+import { StudentAssessmentPage } from './assessment/StudentAssessmentPage';
 
 /**
  * A class which encapsulates all pageobjects, which can be used to automate the Artemis UI.
@@ -102,6 +103,7 @@ export class ArtemisPageobjects {
         text: new TextExerciseAssessmentPage(),
         programming: new ProgrammingExerciseAssessmentPage(),
         modeling: new ModelingExerciseAssessmentEditor(),
+        student: new StudentAssessmentPage(),
     };
     lecture = {
         management: new LectureManagementPage(),

--- a/src/test/cypress/support/pageobjects/assessment/AbstractExerciseAssessmentPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/AbstractExerciseAssessmentPage.ts
@@ -25,16 +25,16 @@ export abstract class AbstractExerciseAssessmentPage {
         return cy.wait('@submitAssessment');
     }
 
-    rejectComplaint(response: string, exerciseType: CypressExerciseType) {
-        return this.handleComplaint(response, false, exerciseType);
+    rejectComplaint(response: string, examMode: boolean, exerciseType: CypressExerciseType) {
+        return this.handleComplaint(response, false, exerciseType, examMode);
     }
 
-    acceptComplaint(response: string, exerciseType: CypressExerciseType) {
-        return this.handleComplaint(response, true, exerciseType);
+    acceptComplaint(response: string, examMode: boolean, exerciseType: CypressExerciseType) {
+        return this.handleComplaint(response, true, exerciseType, examMode);
     }
 
-    private handleComplaint(response: string, accept: boolean, exerciseType: CypressExerciseType) {
-        if (exerciseType !== CypressExerciseType.MODELING) {
+    private handleComplaint(response: string, accept: boolean, exerciseType: CypressExerciseType, examMode: boolean) {
+        if (exerciseType !== CypressExerciseType.MODELING && !examMode) {
             cy.get('#show-complaint').click();
         }
         cy.get('#responseTextArea').type(response, { parseSpecialCharSequences: false });

--- a/src/test/cypress/support/pageobjects/assessment/AbstractExerciseAssessmentPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/AbstractExerciseAssessmentPage.ts
@@ -1,5 +1,4 @@
-import { BASE_API, PUT } from '../../constants';
-import { CypressExerciseType } from '../../requests/CourseManagementRequests';
+import { BASE_API, EXERCISE_TYPE, PUT } from '../../constants';
 
 /**
  * Parent class for all exercise assessment pages.
@@ -25,27 +24,27 @@ export abstract class AbstractExerciseAssessmentPage {
         return cy.wait('@submitAssessment');
     }
 
-    rejectComplaint(response: string, examMode: boolean, exerciseType: CypressExerciseType) {
+    rejectComplaint(response: string, examMode: boolean, exerciseType: EXERCISE_TYPE) {
         return this.handleComplaint(response, false, exerciseType, examMode);
     }
 
-    acceptComplaint(response: string, examMode: boolean, exerciseType: CypressExerciseType) {
+    acceptComplaint(response: string, examMode: boolean, exerciseType: EXERCISE_TYPE) {
         return this.handleComplaint(response, true, exerciseType, examMode);
     }
 
-    private handleComplaint(response: string, accept: boolean, exerciseType: CypressExerciseType, examMode: boolean) {
-        if (exerciseType !== CypressExerciseType.MODELING && !examMode) {
+    private handleComplaint(response: string, accept: boolean, exerciseType: EXERCISE_TYPE, examMode: boolean) {
+        if (exerciseType !== EXERCISE_TYPE.Modeling && !examMode) {
             cy.get('#show-complaint').click();
         }
         cy.get('#responseTextArea').type(response, { parseSpecialCharSequences: false });
         switch (exerciseType) {
-            case CypressExerciseType.PROGRAMMING:
+            case EXERCISE_TYPE.Programming:
                 cy.intercept(PUT, BASE_API + 'programming-submissions/*/assessment-after-complaint').as('complaintAnswer');
                 break;
-            case CypressExerciseType.TEXT:
+            case EXERCISE_TYPE.Text:
                 cy.intercept(PUT, BASE_API + 'participations/*/submissions/*/text-assessment-after-complaint').as('complaintAnswer');
                 break;
-            case CypressExerciseType.MODELING:
+            case EXERCISE_TYPE.Modeling:
                 cy.intercept(PUT, BASE_API + 'complaint-responses/complaint/*/resolve').as('complaintAnswer');
                 break;
             default:

--- a/src/test/cypress/support/pageobjects/assessment/ExerciseAssessmentDashboardPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/ExerciseAssessmentDashboardPage.ts
@@ -12,4 +12,16 @@ export class ExerciseAssessmentDashboardPage {
         cy.reloadUntilFound(this.startAssessingSelector);
         cy.get(this.startAssessingSelector).click();
     }
+
+    clickOpenAssessment() {
+        cy.get('#open-assessment').click();
+    }
+
+    clickEvaluateComplaint() {
+        cy.get('#evaluate-complaint').click();
+    }
+
+    getComplaintText() {
+        return cy.get('#complaintTextArea');
+    }
 }

--- a/src/test/cypress/support/pageobjects/assessment/ModelingExerciseAssessmentEditor.ts
+++ b/src/test/cypress/support/pageobjects/assessment/ModelingExerciseAssessmentEditor.ts
@@ -22,11 +22,11 @@ export class ModelingExerciseAssessmentEditor extends AbstractExerciseAssessment
         this.getNextAssessmentField().click();
     }
 
-    rejectComplaint(response: string) {
-        return super.rejectComplaint(response, CypressExerciseType.MODELING);
+    rejectComplaint(response: string, examMode: false) {
+        return super.rejectComplaint(response, examMode, CypressExerciseType.MODELING);
     }
-    acceptComplaint(response: string) {
-        return super.acceptComplaint(response, CypressExerciseType.MODELING);
+    acceptComplaint(response: string, examMode: false) {
+        return super.acceptComplaint(response, examMode, CypressExerciseType.MODELING);
     }
 
     submitExample() {

--- a/src/test/cypress/support/pageobjects/assessment/ModelingExerciseAssessmentEditor.ts
+++ b/src/test/cypress/support/pageobjects/assessment/ModelingExerciseAssessmentEditor.ts
@@ -1,7 +1,6 @@
 import { AbstractExerciseAssessmentPage } from './AbstractExerciseAssessmentPage';
 import { MODELING_EDITOR_CANVAS } from '../exercises/modeling/ModelingEditor';
-import { CypressExerciseType } from '../../requests/CourseManagementRequests';
-import { BASE_API, PUT } from '../../constants';
+import { BASE_API, EXERCISE_TYPE, PUT } from '../../constants';
 
 const ASSESSMENT_CONTAINER = '#modeling-assessment-container';
 
@@ -23,10 +22,10 @@ export class ModelingExerciseAssessmentEditor extends AbstractExerciseAssessment
     }
 
     rejectComplaint(response: string, examMode: false) {
-        return super.rejectComplaint(response, examMode, CypressExerciseType.MODELING);
+        return super.rejectComplaint(response, examMode, EXERCISE_TYPE.Modeling);
     }
     acceptComplaint(response: string, examMode: false) {
-        return super.acceptComplaint(response, examMode, CypressExerciseType.MODELING);
+        return super.acceptComplaint(response, examMode, EXERCISE_TYPE.Modeling);
     }
 
     submitExample() {

--- a/src/test/cypress/support/pageobjects/assessment/ProgrammingExerciseAssessmentPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/ProgrammingExerciseAssessmentPage.ts
@@ -36,11 +36,11 @@ export class ProgrammingExerciseAssessmentPage extends AbstractExerciseAssessmen
         return cy.get('#test-' + index);
     }
 
-    rejectComplaint(response: string) {
-        return super.rejectComplaint(response, CypressExerciseType.PROGRAMMING);
+    rejectComplaint(response: string, examMode: boolean) {
+        return super.rejectComplaint(response, examMode, CypressExerciseType.PROGRAMMING);
     }
 
-    acceptComplaint(response: string) {
-        return super.acceptComplaint(response, CypressExerciseType.PROGRAMMING);
+    acceptComplaint(response: string, examMode: boolean) {
+        return super.acceptComplaint(response, examMode, CypressExerciseType.PROGRAMMING);
     }
 }

--- a/src/test/cypress/support/pageobjects/assessment/ProgrammingExerciseAssessmentPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/ProgrammingExerciseAssessmentPage.ts
@@ -1,4 +1,4 @@
-import { CypressExerciseType } from '../../requests/CourseManagementRequests';
+import { EXERCISE_TYPE } from '../../constants';
 import { AbstractExerciseAssessmentPage } from './AbstractExerciseAssessmentPage';
 
 /**
@@ -37,10 +37,10 @@ export class ProgrammingExerciseAssessmentPage extends AbstractExerciseAssessmen
     }
 
     rejectComplaint(response: string, examMode: boolean) {
-        return super.rejectComplaint(response, examMode, CypressExerciseType.PROGRAMMING);
+        return super.rejectComplaint(response, examMode, EXERCISE_TYPE.Programming);
     }
 
     acceptComplaint(response: string, examMode: boolean) {
-        return super.acceptComplaint(response, examMode, CypressExerciseType.PROGRAMMING);
+        return super.acceptComplaint(response, examMode, EXERCISE_TYPE.Programming);
     }
 }

--- a/src/test/cypress/support/pageobjects/assessment/StudentAssessmentPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/StudentAssessmentPage.ts
@@ -1,0 +1,24 @@
+/**
+ * A class which encapsulates UI selectors and actions for the student assessment page.
+ */
+export class StudentAssessmentPage {
+    startComplaint() {
+        cy.get('#complain').click();
+    }
+
+    enterComplaint(text: string) {
+        cy.get('#complainTextArea').type(text);
+    }
+
+    submitComplaint() {
+        cy.get('#submit-complaint').click();
+    }
+
+    getComplaintBadge() {
+        return cy.get('jhi-complaint-request .badge');
+    }
+
+    getComplaintResponse() {
+        return cy.get('#complainResponseTextArea');
+    }
+}

--- a/src/test/cypress/support/pageobjects/assessment/TextExerciseAssessmentPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/TextExerciseAssessmentPage.ts
@@ -35,12 +35,12 @@ export class TextExerciseAssessmentPage extends AbstractExerciseAssessmentPage {
         return cy.wait('@submitFeedback');
     }
 
-    rejectComplaint(response: string) {
-        return super.rejectComplaint(response, CypressExerciseType.TEXT);
+    rejectComplaint(response: string, examMode: boolean) {
+        return super.rejectComplaint(response, examMode, CypressExerciseType.TEXT);
     }
 
-    acceptComplaint(response: string) {
-        return super.acceptComplaint(response, CypressExerciseType.TEXT);
+    acceptComplaint(response: string, examMode: boolean) {
+        return super.acceptComplaint(response, examMode, CypressExerciseType.TEXT);
     }
 
     getWordCountElement() {

--- a/src/test/cypress/support/pageobjects/assessment/TextExerciseAssessmentPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/TextExerciseAssessmentPage.ts
@@ -1,5 +1,4 @@
-import { BASE_API, POST } from '../../constants';
-import { CypressExerciseType } from '../../requests/CourseManagementRequests';
+import { BASE_API, EXERCISE_TYPE, POST } from '../../constants';
 import { AbstractExerciseAssessmentPage } from './AbstractExerciseAssessmentPage';
 
 /**
@@ -36,11 +35,11 @@ export class TextExerciseAssessmentPage extends AbstractExerciseAssessmentPage {
     }
 
     rejectComplaint(response: string, examMode: boolean) {
-        return super.rejectComplaint(response, examMode, CypressExerciseType.TEXT);
+        return super.rejectComplaint(response, examMode, EXERCISE_TYPE.Text);
     }
 
     acceptComplaint(response: string, examMode: boolean) {
-        return super.acceptComplaint(response, examMode, CypressExerciseType.TEXT);
+        return super.acceptComplaint(response, examMode, EXERCISE_TYPE.Text);
     }
 
     getWordCountElement() {

--- a/src/test/cypress/support/requests/CourseManagementRequests.ts
+++ b/src/test/cypress/support/requests/CourseManagementRequests.ts
@@ -5,7 +5,7 @@ import { Exercise } from 'app/entities/exercise.model';
 import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { Course } from 'app/entities/course.model';
-import { BASE_API, DELETE, GET, POST, PUT } from '../constants';
+import { BASE_API, DELETE, EXERCISE_TYPE, GET, POST, PUT } from '../constants';
 import programmingExerciseTemplate from '../../fixtures/exercise/programming/template.json';
 import { dayjsToString, generateUUID, parseArrayBufferAsJsonObject } from '../utils';
 import examTemplate from '../../fixtures/exam/template.json';
@@ -162,22 +162,22 @@ export class CourseManagementRequests {
 
     updateModelingExerciseDueDate(exercise: ModelingExercise, due = day()) {
         exercise.dueDate = due;
-        return this.updateExercise(exercise, CypressExerciseType.MODELING);
+        return this.updateExercise(exercise, EXERCISE_TYPE.Modeling);
     }
 
-    private updateExercise(exercise: Exercise, type: CypressExerciseType) {
+    private updateExercise(exercise: Exercise, type: EXERCISE_TYPE) {
         let url: string;
         switch (type) {
-            case CypressExerciseType.PROGRAMMING:
+            case EXERCISE_TYPE.Programming:
                 url = PROGRAMMING_EXERCISE_BASE;
                 break;
-            case CypressExerciseType.TEXT:
+            case EXERCISE_TYPE.Text:
                 url = TEXT_EXERCISE_BASE;
                 break;
-            case CypressExerciseType.MODELING:
+            case EXERCISE_TYPE.Modeling:
                 url = MODELING_EXERCISE_BASE;
                 break;
-            case CypressExerciseType.QUIZ:
+            case EXERCISE_TYPE.Quiz:
             default:
                 throw new Error(`Exercise type '${type}' is not supported yet!`);
         }
@@ -311,7 +311,7 @@ export class CourseManagementRequests {
 
     updateModelingExerciseAssessmentDueDate(exercise: ModelingExercise, due = day()) {
         exercise.assessmentDueDate = due;
-        return this.updateExercise(exercise, CypressExerciseType.MODELING);
+        return this.updateExercise(exercise, EXERCISE_TYPE.Modeling);
     }
 
     deleteModelingExercise(exerciseID: number) {
@@ -483,12 +483,12 @@ export class CourseManagementRequests {
 
     updateTextExerciseDueDate(exercise: TextExercise, due = day()) {
         exercise.dueDate = due;
-        return this.updateExercise(exercise, CypressExerciseType.TEXT);
+        return this.updateExercise(exercise, EXERCISE_TYPE.Text);
     }
 
     updateTextExerciseAssessmentDueDate(exercise: TextExercise, due = day()) {
         exercise.assessmentDueDate = due;
-        return this.updateExercise(exercise, CypressExerciseType.TEXT);
+        return this.updateExercise(exercise, EXERCISE_TYPE.Text);
     }
 
     deleteLecture(lectureId: number) {
@@ -645,13 +645,6 @@ export enum CypressAssessmentType {
     AUTOMATIC,
     SEMI_AUTOMATIC,
     MANUAL,
-}
-
-export enum CypressExerciseType {
-    PROGRAMMING,
-    MODELING,
-    TEXT,
-    QUIZ,
 }
 
 export function convertCourseAfterMultiPart(response: Cypress.Response<Course>): Course {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We already test exam assessments by tutors, but not the complain functionality. Since this is a important aspect of the exam assessment, we should test this using e2e tests.

### Description
<!-- Describe your changes in detail -->
This PR adds three new e2e tests for the ExamAssessment test suite. Since we need successful assessments in order for the user to complain, I added conditional logic, that will only run the complaint tests, if the prior assessments test were successful. We only test complains for the programming exercise (manual assessment), the text exercise and the modeling exercises, since complaints are not available for quiz exercises. This PR also slightly refactors the nesting of the tests and puts each of the on the same level.
In order for the e2e tests to work trough the complain process, I needed to add some ids to buttons for them to be clickable by cypress. 
I also adjusted three little translations, since they were not consistent of the letter case for the word `Assessment`. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test
