### PR TITLE
`Assessment`: Check if score was not increased on accepted complaint

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.html
@@ -119,12 +119,12 @@
             class="form-check-input"
             name="allowComplaintsForAutomaticAssessment"
             [checked]="exercise.allowComplaintsForAutomaticAssessments"
-            [disabled]="exercise.assessmentType !== assessmentType.AUTOMATIC || readOnly"
+            [disabled]="exercise.assessmentType !== assessmentType.AUTOMATIC || !exercise.dueDate || readOnly"
             id="allowComplaintsForAutomaticAssessment"
             (change)="toggleComplaintsType()"
         />
         <label
-            [ngStyle]="exercise.assessmentType !== assessmentType.AUTOMATIC ? { color: 'grey' } : {}"
+            [ngStyle]="exercise.assessmentType !== assessmentType.AUTOMATIC || !exercise.dueDate ? { color: 'grey' } : {}"
             class="form-control-label"
             for="allowComplaintsForAutomaticAssessment"
             jhiTranslate="artemisApp.programmingExercise.timeline.complaintOnAutomaticAssessment"

--- a/src/main/webapp/i18n/de/assessment.json
+++ b/src/main/webapp/i18n/de/assessment.json
@@ -52,6 +52,7 @@
             "useAsExampleSubmissionVerificationQuestion": "Bist du dir sicher, dass du diese Abgabe als Beispielabgabe importieren möchtest?",
             "messages": {
                 "confirmCancel": "Bist du sicher, dass du die Bewertung abbrechen möchtest? Dein aktueller Bewertungsfortschritt wird gelöscht und die Abgabe steht anderen Tutor:innen wieder zur Verfügung.",
+                "acceptComplaintWithoutMoreScore": "Bist du sicher, dass du diesen Complaint annehmen willst, ohne dem Studenten mehr Punkte zu geben?",
                 "loadSubmissionFailed": "Laden der angefragten Abgabe ist fehlgeschlagen.",
                 "submitSuccessful": "Deine Bewertung wurde erfolgreich abgesendet!",
                 "saveSuccessful": "Deine Bewertung wurde erfolgreich gespeichert!",

--- a/src/main/webapp/i18n/en/assessment.json
+++ b/src/main/webapp/i18n/en/assessment.json
@@ -52,6 +52,7 @@
             "useAsExampleSubmissionVerificationQuestion": "Are you sure to import this submission as an example submission?",
             "messages": {
                 "confirmCancel": "Are you sure you want to cancel the assessment? Your current assessment progress will be deleted and the submission will be available for assessment to other tutors again.",
+                "acceptComplaintWithoutMoreScore": "Are you sure you want to accept the complaint without giving the student more points?",
                 "loadSubmissionFailed": "Retrieving requested submission failed.",
                 "submitSuccessful": "Your assessment was submitted successfully!",
                 "saveSuccessful": "Your assessment was saved successfully!",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We discovered a bug where the tutor received an unhelpful message when they did not provide additional feedback after accepting a complaint. This was only the case when there wasn't a manual feedback before the complaint as well.
Additionally tutors should under ideal circumstances only accept complaints, when the score was increased through it. 

### Description
<!-- Describe your changes in detail -->
Fixed the bug, so tutors can now accept complaints without having to provide manual feedback in case there was non before.
Added a prompt that asks the tutor if they actually want to accept the complaint when the score was not increased.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled for automatic assessment

1. Log in to Artemis
2. Navigate to Course Administration
3. Participate in the exercise and complain after the due date with both students
4. Try to answer the first complaint without adding any feedback and accept the prompt
5. Try to answer the second complaint by first adding a feedback that gives more points and check that there is no prompt.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->