### PR TITLE
`Programming exercises`: Fix cleanup build plan after due date

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.service;
 
-import static de.tum.in.www1.artemis.domain.enumeration.InitializationState.*;
-
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -119,7 +117,7 @@ public class ParticipationService {
         Optional<StudentParticipation> optionalStudentParticipation = findOneByExerciseAndParticipantAnyState(exercise, participant);
         if (optionalStudentParticipation.isPresent() && optionalStudentParticipation.get().isTestRun() && exercise.isCourseExercise()) {
             // In case there is already a practice participation, set it to inactive
-            optionalStudentParticipation.get().setInitializationState(INACTIVE);
+            optionalStudentParticipation.get().setInitializationState(InitializationState.INACTIVE);
             studentParticipationRepository.saveAndFlush(optionalStudentParticipation.get());
 
             optionalStudentParticipation = findOneByExerciseAndParticipantAnyStateAndTestRun(exercise, participant, false);
@@ -141,11 +139,11 @@ public class ParticipationService {
             participation = startProgrammingExercise(programmingExercise, (ProgrammingExerciseStudentParticipation) participation, initializationDate == null);
         }
         else {// for all other exercises: QuizExercise, ModelingExercise, TextExercise, FileUploadExercise
-            if (participation.getInitializationState() == null || participation.getInitializationState() == UNINITIALIZED
-                    || participation.getInitializationState() == FINISHED && !(exercise instanceof QuizExercise)) {
+            if (participation.getInitializationState() == null || participation.getInitializationState() == InitializationState.UNINITIALIZED
+                    || participation.getInitializationState() == InitializationState.FINISHED && !(exercise instanceof QuizExercise)) {
                 // in case the participation was finished before, we set it to initialized again so that the user sees the correct button "Open modeling editor" on the client side.
                 // Only for quiz exercises, the participation status FINISHED should not be overwritten since the user must not change his submission once submitted
-                participation.setInitializationState(INITIALIZED);
+                participation.setInitializationState(InitializationState.INITIALIZED);
             }
 
             if (Optional.ofNullable(participation.getInitializationDate()).isEmpty()) {
@@ -181,7 +179,7 @@ public class ParticipationService {
         else {
             participation = new StudentParticipation();
         }
-        participation.setInitializationState(UNINITIALIZED);
+        participation.setInitializationState(InitializationState.UNINITIALIZED);
         participation.setExercise(exercise);
         participation.setParticipant(participant);
         // StartedDate is used to link a Participation to a test exam exercise
@@ -246,7 +244,7 @@ public class ParticipationService {
         // Step 3) configure the web hook of the student repository
         participation = configureRepositoryWebHook(participation);
         // Step 4a) Set the InitializationState to initialized to indicate, the programming exercise is ready
-        participation.setInitializationState(INITIALIZED);
+        participation.setInitializationState(InitializationState.INITIALIZED);
         // Step 4b) Set the InitializationDate to the current time
         if (setInitializationDate) {
             // Note: For test exams, the InitializationDate is set to the StudentExam: startedDate in {#link #startExerciseWithInitializationDate}
@@ -273,7 +271,7 @@ public class ParticipationService {
         }
 
         optionalGradedStudentParticipation.ifPresent(participation -> {
-            participation.setInitializationState(FINISHED);
+            participation.setInitializationState(InitializationState.FINISHED);
             participationRepository.save(participation);
         });
         Optional<StudentParticipation> optionalStudentParticipation = findOneByExerciseAndParticipantAnyStateAndTestRun(exercise, participant, true);
@@ -281,7 +279,7 @@ public class ParticipationService {
         if (optionalStudentParticipation.isEmpty()) {
             // create a new participation only if no participation can be found
             participation = new ProgrammingExerciseStudentParticipation(versionControlService.get().getDefaultBranchOfArtemis());
-            participation.setInitializationState(UNINITIALIZED);
+            participation.setInitializationState(InitializationState.UNINITIALIZED);
             participation.setExercise(exercise);
             participation.setParticipant(participant);
             participation.setTestRun(true);
@@ -321,7 +319,7 @@ public class ParticipationService {
             else {
                 participation = new StudentParticipation();
             }
-            participation.setInitializationState(UNINITIALIZED);
+            participation.setInitializationState(InitializationState.UNINITIALIZED);
             participation.setInitializationDate(ZonedDateTime.now());
             participation.setExercise(exercise);
             participation.setParticipant(participant);
@@ -358,7 +356,7 @@ public class ParticipationService {
             }
         }
 
-        participation.setInitializationState(FINISHED);
+        participation.setInitializationState(InitializationState.FINISHED);
         participation = studentParticipationRepository.saveAndFlush(participation);
 
         // Take the latest submission or initialize a new empty submission
@@ -394,10 +392,10 @@ public class ParticipationService {
         // If a graded participation gets reset after the deadline set the state back to finished. Otherwise, the participation is initialized
         var dueDate = ExerciseDateService.getDueDate(participation);
         if (!participation.isTestRun() && dueDate.isPresent() && ZonedDateTime.now().isAfter(dueDate.get())) {
-            participation.setInitializationState(FINISHED);
+            participation.setInitializationState(InitializationState.FINISHED);
         }
         else {
-            participation.setInitializationState(INITIALIZED);
+            participation.setInitializationState(InitializationState.INITIALIZED);
         }
         participation = programmingExerciseStudentParticipationRepository.saveAndFlush(participation);
         if (participation.getInitializationDate() == null) {
@@ -423,7 +421,7 @@ public class ParticipationService {
                 newRepoUrl = newRepoUrl.withUser(participation.getParticipantIdentifier());
             }
             participation.setRepositoryUrl(newRepoUrl.toString());
-            participation.setInitializationState(REPO_COPIED);
+            participation.setInitializationState(InitializationState.REPO_COPIED);
 
             return programmingExerciseStudentParticipationRepository.saveAndFlush(participation);
         }
@@ -641,7 +639,15 @@ public class ParticipationService {
         if (participation.getBuildPlanId() != null) {
             final var projectKey = ((ProgrammingExercise) participation.getExercise()).getProjectKey();
             continuousIntegrationService.get().deleteBuildPlan(projectKey, participation.getBuildPlanId());
-            participation.setInitializationState(INACTIVE);
+
+            // If a graded participation gets cleaned up after the deadline set the state back to finished. Otherwise, the participation is initialized
+            var dueDate = ExerciseDateService.getDueDate(participation);
+            if (!participation.isTestRun() && dueDate.isPresent() && ZonedDateTime.now().isAfter(dueDate.get())) {
+                participation.setInitializationState(InitializationState.FINISHED);
+            }
+            else {
+                participation.setInitializationState(InitializationState.INACTIVE);
+            }
             participation.setBuildPlanId(null);
             programmingExerciseStudentParticipationRepository.saveAndFlush(participation);
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.domain.enumeration.InitializationState.*;
 import static java.time.ZonedDateTime.now;
 
 import java.net.URI;
@@ -29,6 +28,7 @@ import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.config.GuidedTourConfiguration;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
+import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
 import de.tum.in.www1.artemis.domain.enumeration.QuizMode;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.participation.*;
@@ -281,11 +281,11 @@ public class ParticipationResource {
                 !participation.isTestRun());
         if (optionalOtherStudentParticipation.isPresent()) {
             StudentParticipation otherParticipation = optionalOtherStudentParticipation.get();
-            if (participation.getInitializationState() == INACTIVE) {
-                otherParticipation.setInitializationState(FINISHED);
+            if (participation.getInitializationState() == InitializationState.INACTIVE) {
+                otherParticipation.setInitializationState(InitializationState.FINISHED);
             }
             else {
-                otherParticipation.setInitializationState(INACTIVE);
+                otherParticipation.setInitializationState(InitializationState.INACTIVE);
             }
             studentParticipationRepository.saveAndFlush(otherParticipation);
         }
@@ -902,7 +902,7 @@ public class ParticipationResource {
 
         // construct participation
         participation = new StudentParticipation();
-        participation.setInitializationState(INITIALIZED);
+        participation.setInitializationState(InitializationState.INITIALIZED);
         participation.setExercise(quizExercise);
         participation.addResult(result);
         return participation;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix bug that prohibits the correct cleanup of participations after the due date when a practice participation was started.

### Description
<!-- Describe your changes in detail -->
We have a constraint in the database, that exerciseId+studentId+participationStatus must be unique. Therefore the graded participation has to be set to final, when a practice participation is started.
This was not respected when cleaning up a participation, which is now added and tested.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise

1. Log in to Artemis
2. Participate in the exercise
3. Wait until after the due date and start a practice participation
4. Go to the participation overview of the exercise as instructor and clean up the graded and practice participation
5. See no error

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->