### PR TITLE
`Exam mode`: Fix multiple edge case issues

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -32,7 +32,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     List<Exam> findByCourseId(long courseId);
 
     @Query("""
-            SELECT ex
+            SELECT DISTINCT ex
             FROM Exam ex
                 LEFT JOIN FETCH ex.exerciseGroups eg
                 LEFT JOIN FETCH eg.exercises

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
@@ -338,7 +338,7 @@ public class StudentExamService {
                     wasEmptyProgrammingParticipation = true;
                     latestSubmission = prepareProgrammingSubmission(latestSubmission, studentParticipation);
                 }
-                if ((latestSubmission.isPresent() && latestSubmission.get().isEmpty()) || wasEmptyProgrammingParticipation) {
+                if (latestSubmission.isPresent() && (latestSubmission.get().isEmpty() || wasEmptyProgrammingParticipation)) {
                     for (int correctionRound = 0; correctionRound < exam.getNumberOfCorrectionRoundsInExam(); correctionRound++) {
                         // required so that the submission is counted in the assessment dashboard
                         latestSubmission.get().submitted(true);
@@ -371,8 +371,7 @@ public class StudentExamService {
      * @return the latestSubmission
      */
     public Optional<Submission> prepareProgrammingSubmission(Optional<Submission> latestSubmission, StudentParticipation studentParticipation) {
-        if (latestSubmission.isEmpty() && studentParticipation.getExercise() instanceof ProgrammingExercise
-                && ((ProgrammingExercise) studentParticipation.getExercise()).areManualResultsAllowed()) {
+        if (latestSubmission.isEmpty() && studentParticipation.getExercise() instanceof ProgrammingExercise programmingExercise && programmingExercise.areManualResultsAllowed()) {
             submissionService.addEmptyProgrammingSubmissionToParticipation(studentParticipation);
             return studentParticipation.findLatestSubmission();
         }

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
+import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { LayoutService } from 'app/shared/breakpoints/layout.service';
 import { CustomBreakpointNames } from 'app/shared/breakpoints/breakpoints.service';
 import dayjs from 'dayjs/esm';
@@ -186,12 +187,13 @@ export class ExamNavigationBarComponent implements OnInit {
         const submission = ExamParticipationService.getSubmissionForExercise(exercise);
         if (!submission) {
             // in case no participation/submission yet exists -> display synced
+            // this should only occur for programming exercises
             return 'synced';
         }
         if (submission.submitted) {
             this.icon = faCheck;
         }
-        if (submission.isSynced) {
+        if (submission.isSynced || this.isOnlyOfflineIDE(exercise)) {
             // make button blue (except for the current page)
             if (exerciseIndex === this.exerciseIndex && !this.overviewPageOpen) {
                 return 'synced active';
@@ -199,10 +201,18 @@ export class ExamNavigationBarComponent implements OnInit {
                 return 'synced';
             }
         } else {
-            // make button yellow
+            // make button yellow except for programming exercises with only offline IDE
             this.icon = faEdit;
             return 'notSynced';
         }
+    }
+
+    isOnlyOfflineIDE(exercise: Exercise): boolean {
+        if (exercise instanceof ProgrammingExercise) {
+            const programmingExercise = exercise as ProgrammingExercise;
+            return programmingExercise.allowOfflineIde === true && programmingExercise.allowOnlineEditor === false;
+        }
+        return false;
     }
 
     /**

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -483,7 +483,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
             // update local studentExam for later sync with server if the student wants to hand in early
             this.updateLocalStudentExam();
             try {
-                this.triggerSave(true, false);
+                this.triggerSave(false, false);
             } catch (error) {
                 captureException(error);
             }
@@ -716,9 +716,13 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
         // in the case saving is forced, we mark the current exercise as not synced, so it will definitely be saved
         if ((activeComponent && forceSave) || (activeComponent as ExamSubmissionComponent)?.hasUnsavedChanges()) {
             const activeSubmission = (activeComponent as ExamSubmissionComponent)?.getSubmission();
+            const activeExercise = (activeComponent as ExamSubmissionComponent)?.getExercise();
             if (activeSubmission) {
                 // this will lead to a save below, because isSynced will be set to false
-                activeSubmission.isSynced = false;
+                // it only makes sense to set "isSynced" to false for quiz, text and modeling
+                if (activeExercise?.type !== ExerciseType.PROGRAMMING && activeExercise?.type !== ExerciseType.FILE_UPLOAD) {
+                    activeSubmission.isSynced = false;
+                }
             }
             (activeComponent as ExamSubmissionComponent).updateSubmissionFromView();
         }

--- a/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
@@ -79,7 +79,6 @@
             class="me-2"
         ></jhi-updating-result>
     </div>
-    <jhi-submission-result-status [exercise]="exercise" [studentParticipation]="studentParticipation" [showBadge]="true"></jhi-submission-result-status>
     <jhi-programming-exercise-instructions
         *ngIf="exercise"
         [exercise]="exercise"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
This PR addresses a couple of edge cases issues found during testing

### Description
1. Fix an edge case issue where two results would be displayed after reloading an exam page
2. Fix an edge case issue where circular dependencies between result and feedback would prevent saving or submitting an exam
3. Fix an issue when navigating back to the exam after pressing `hand in early`
4. Do not force save (i.e. save even if there are no changes) when pressing `hand in early`, because this is not necessary
5. "Assess unsubmitted exams" could throw a NoSuchElementException

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students

1. Create an actual exam with programming exercises (one with and one without the online code editor) and quiz exercises
2. Participate in the exam normally and submit code several times
3. Reload the exam and make sure only one result is shown per programming exercise
4. Press `hand in early`, but do not submit the exam, instead navigate back using `continue`. Do this several times from all exam pages (overview, exercise 1, exercise 2, etc.)

To reproduce issue 5:
1. Have a student who submitted their exam, but has one Programming Exercise where the student did not push any solution.
2. Click "assess unsubmitted student exams" after the exam ends
3. Ensure that no error is shown.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
- [x] Review 3
#### Manual Tests
- [x] Test 1
- [x] Test 2
- [x] Test 3
