### PR TITLE
`Development`: Add user role e2e test

### DIFF
--- a/src/test/cypress/e2e/Logout.cy.ts
+++ b/src/test/cypress/e2e/Logout.cy.ts
@@ -1,6 +1,6 @@
-import { Course } from '../../../main/webapp/app/entities/course.model';
-import { ModelingExercise } from '../../../main/webapp/app/entities/modeling-exercise.model';
-import { courseManagementRequest, courseOverview, modelingExerciseEditor } from '../support/artemis';
+import { Course } from 'app/entities/course.model';
+import { ModelingExercise } from 'app/entities/modeling-exercise.model';
+import { courseManagementRequest, courseOverview, modelingExerciseEditor, navigationBar } from '../support/artemis';
 import { convertCourseAfterMultiPart } from '../support/requests/CourseManagementRequests';
 import { admin, studentOne, studentTwo } from '../support/users';
 
@@ -56,5 +56,5 @@ const startExerciseAndMakeChanges = (course: Course, modelingExercise: ModelingE
     courseOverview.openRunningExercise(exerciseID);
     modelingExerciseEditor.addComponentToModel(exerciseID, 1);
     modelingExerciseEditor.addComponentToModel(exerciseID, 2);
-    cy.get('#account-menu').click().get('#logout').click();
+    navigationBar.logout();
 };

--- a/src/test/cypress/support/pageobjects/NavigationBar.ts
+++ b/src/test/cypress/support/pageobjects/NavigationBar.ts
@@ -22,4 +22,8 @@ export class NavigationBar {
     checkServerAdministrationMenuItem() {
         return cy.get('#admin-menu');
     }
+
+    logout() {
+        cy.get('#account-menu').click().get('#logout').click();
+    }
 }

--- a/src/test/cypress/support/pageobjects/NavigationBar.ts
+++ b/src/test/cypress/support/pageobjects/NavigationBar.ts
@@ -14,4 +14,12 @@ export class NavigationBar {
         cy.wait('@courseManagementQuery', { timeout: 30000 });
         cy.url().should('include', '/course-management');
     }
+
+    checkCourseManagementMenuItem() {
+        return cy.get('#course-admin-menu');
+    }
+
+    checkServerAdministrationMenuItem() {
+        return cy.get('#admin-menu');
+    }
 }


### PR DESCRIPTION
# Currently blocked by #6258

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When @JohannesStoehr changed the route for a tutor that clicks on a exam (https://github.com/ls1intum/Artemis/pull/6240), a e2e test failed that used a student user account. We then noticed that the user had tutor permissions, which is not ideal, since every user should only have the minimum permission needed for the tests.

### Description
<!-- Describe your changes in detail -->
This PR adds new tests, that check if the users only have the permissions they should have on the test instance. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
