### PR TITLE
`Development`: Add test exam test run e2e test

### DIFF
--- a/src/test/cypress/e2e/course/CourseManagement.cy.ts
+++ b/src/test/cypress/e2e/course/CourseManagement.cy.ts
@@ -136,7 +136,7 @@ describe('Course management', () => {
                 expect(courseBody.testCourse).to.eq(courseData.testCourse);
                 expect(trimDate(courseBody.startDate)).to.eq(trimDate(dayjsToString(courseData.startDate)));
                 expect(trimDate(courseBody.endDate)).to.eq(trimDate(dayjsToString(courseData.endDate)));
-                expect(courseBody.validStartAndEndDate).to.eq(true);
+                expect(courseBody.validStartAndEndDate).to.be.true;
                 expect(courseBody.semester).to.eq(courseData.semester);
                 expect(courseBody.maxPoints).to.eq(courseData.maxPoints);
                 expect(courseBody.defaultProgrammingLanguage).to.eq(courseData.programmingLanguage);

--- a/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
@@ -48,7 +48,7 @@ describe('Exam test run', () => {
 
     beforeEach('Create test run instance', () => {
         cy.login(instructor);
-        // API call does not work yet, for now we use the UI to create the test run
+        // TODO: API call does not work yet, for now we use the UI to create the test run
         // courseManagementRequests.createExamTestRun(exam, exerciseArray).then((response: any) => {
         //     testRun = response.body;
         // });
@@ -77,8 +77,8 @@ describe('Exam test run', () => {
             testRunID = testRun.id;
 
             expect(testRunResponse.response!.statusCode).to.eq(200);
-            expect(testRun.testRun).to.eq(true);
-            expect(testRun.submitted).to.eq(false);
+            expect(testRun.testRun).to.be.true;
+            expect(testRun.submitted).to.be.false;
             expect(testRun.workingTime).to.eq(minutes * 60 + seconds);
 
             examTestRun.getWorkingTime(testRunID).contains('40min 30s');

--- a/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
@@ -5,7 +5,7 @@ import submission from '../../../fixtures/exercise/programming/build_error/submi
 import { Course } from 'app/entities/course.model';
 import { generateUUID } from '../../../support/utils';
 import { EXERCISE_TYPE } from '../../../support/constants';
-import { Exercise } from 'src/test/cypress/support/pageobjects/exam/ExamParticipation';
+import { Exercise } from '../../../support/pageobjects/exam/ExamParticipation';
 import { Interception } from 'cypress/types/net-stubbing';
 import { courseManagementRequest, examExerciseGroupCreation, examManagement, examNavigation, examParticipation, examTestRun } from '../../../support/artemis';
 import { admin, instructor } from '../../../support/users';
@@ -49,7 +49,7 @@ describe('Test exam test run', () => {
 
     beforeEach('Create test run instance', () => {
         cy.login(instructor);
-        // API call does not work yet, for now we use the UI to create the test run
+        // TODO: API call does not work yet, for now we use the UI to create the test run
         // courseManagementRequest.createExamTestRun(exam, exerciseArray).then((response: any) => {
         //     testRun = response.body;
         // });
@@ -78,8 +78,8 @@ describe('Test exam test run', () => {
             testRunID = testRun.id;
 
             expect(testRunResponse.response!.statusCode).to.eq(200);
-            expect(testRun.testRun).to.eq(true);
-            expect(testRun.submitted).to.eq(false);
+            expect(testRun.testRun).to.be.true;
+            expect(testRun.submitted).to.be.false;
             expect(testRun.workingTime).to.eq(minutes * 60 + seconds);
 
             examTestRun.getWorkingTime(testRunID).contains('40min 30s');

--- a/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
@@ -1,0 +1,154 @@
+import { Exam } from 'app/entities/exam.model';
+import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
+import dayjs from 'dayjs/esm';
+import submission from '../../../fixtures/exercise/programming/build_error/submission.json';
+import { Course } from 'app/entities/course.model';
+import { generateUUID } from '../../../support/utils';
+import { EXERCISE_TYPE } from '../../../support/constants';
+import { Exercise } from 'src/test/cypress/support/pageobjects/exam/ExamParticipation';
+import { Interception } from 'cypress/types/net-stubbing';
+import { courseManagementRequest, examExerciseGroupCreation, examManagement, examNavigation, examParticipation, examTestRun } from '../../../support/artemis';
+import { admin, instructor } from '../../../support/users';
+
+// Common primitives
+const textFixture = 'loremIpsum.txt';
+const examTitle = 'exam' + generateUUID();
+
+const exerciseArray: Array<Exercise> = [];
+
+describe('Test exam test run', () => {
+    let course: Course;
+    let exam: Exam;
+    let testRun: any;
+
+    before(() => {
+        cy.login(admin);
+        courseManagementRequest.createCourse(true).then((response) => {
+            course = convertCourseAfterMultiPart(response);
+            const examContent = new CypressExamBuilder(course)
+                .title(examTitle)
+                .testExam()
+                .visibleDate(dayjs().subtract(3, 'days'))
+                .startDate(dayjs().add(1, 'days'))
+                .endDate(dayjs().add(3, 'days'))
+                .examMaxPoints(40)
+                .numberOfExercises(4)
+                .build();
+            courseManagementRequest.createExam(examContent).then((examResponse) => {
+                exam = examResponse.body;
+                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Text, { textFixture });
+
+                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Programming, { submission, practiceMode: true });
+
+                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 });
+
+                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Modeling);
+            });
+        });
+    });
+
+    beforeEach('Create test run instance', () => {
+        cy.login(instructor);
+        // API call does not work yet, for now we use the UI to create the test run
+        // courseManagementRequest.createExamTestRun(exam, exerciseArray).then((response: any) => {
+        //     testRun = response.body;
+        // });
+        cy.visit(`/course-management/${course.id}/exams/${exam.id}`);
+        examManagement.openTestRun();
+        examTestRun.createTestRun();
+        examTestRun.confirmTestRun().then((testRunResponse: Interception) => {
+            testRun = testRunResponse.response!.body;
+        });
+    });
+
+    it('Create a test run', () => {
+        cy.login(instructor);
+
+        let testRunID: number;
+        const minutes = 40;
+        const seconds = 30;
+
+        cy.visit(`/course-management/${course.id}/exams/${exam.id}`);
+        examManagement.openTestRun();
+        examTestRun.createTestRun();
+        examTestRun.setWorkingTimeMinutes(minutes);
+        examTestRun.setWorkingTimeSeconds(seconds);
+        examTestRun.confirmTestRun().then((testRunResponse: Interception) => {
+            const testRun = testRunResponse.response!.body;
+            testRunID = testRun.id;
+
+            expect(testRunResponse.response!.statusCode).to.eq(200);
+            expect(testRun.testRun).to.eq(true);
+            expect(testRun.submitted).to.eq(false);
+            expect(testRun.workingTime).to.eq(minutes * 60 + seconds);
+
+            examTestRun.getWorkingTime(testRunID).contains('40min 30s');
+            examTestRun.getStarted(testRunID).contains('No');
+            examTestRun.getSubmitted(testRunID).contains('No');
+        });
+    });
+
+    // Skip since this functionality is not yet supported
+    it.skip('Change test run working time', () => {
+        const hour = 1;
+        const minutes = 20;
+        const seconds = 45;
+
+        cy.login(instructor);
+        examTestRun.openTestRunPage(course, exam);
+        examTestRun.changeWorkingTime(testRun.id);
+        examTestRun.setWorkingTimeHours(hour);
+        examTestRun.setWorkingTimeMinutes(minutes);
+        examTestRun.setWorkingTimeSeconds(seconds);
+        examTestRun.saveTestRun().then((testRunResponse: Interception) => {
+            const testRun = testRunResponse.response!.body;
+
+            expect(testRun.id).to.eq(testRun.id);
+            expect(testRunResponse.response!.statusCode).to.eq(200);
+            expect(testRun.workingTime).to.eq(hour * 3600 + minutes * 60 + seconds);
+
+            examTestRun.openTestRunPage(course, exam);
+            examTestRun.getWorkingTime(testRun.id).contains(`${hour}h ${minutes}min ${seconds}s`);
+            examTestRun.getStarted(testRun.id).contains('No');
+            examTestRun.getSubmitted(testRun.id).contains('No');
+        });
+    });
+
+    it('Conducts a test run', () => {
+        examTestRun.startParticipation(instructor, course, exam, testRun.id);
+        cy.get('#testRunRibbon').contains('Test Run');
+
+        for (let j = 0; j < exerciseArray.length; j++) {
+            const exercise = exerciseArray[j];
+            examNavigation.openExerciseAtIndex(j);
+            examParticipation.makeSubmission(exercise.id, exercise.type, exercise.additionalData);
+        }
+        examParticipation.handInEarly();
+        for (let j = 0; j < exerciseArray.length; j++) {
+            const exercise = exerciseArray[j];
+            examParticipation.verifyExerciseTitleOnFinalPage(exercise.id, exercise.title);
+            if (exercise.type === EXERCISE_TYPE.Text) {
+                examParticipation.verifyTextExerciseOnFinalPage(exercise.additionalData!.textFixture!);
+            }
+        }
+        examParticipation.checkExamTitle(examTitle);
+        examTestRun.openTestRunPage(course, exam);
+        examTestRun.getStarted(testRun.id).contains('Yes');
+        examTestRun.getSubmitted(testRun.id).contains('Yes');
+    });
+
+    it('Deletes a test run', () => {
+        cy.login(instructor);
+        examTestRun.openTestRunPage(course, exam);
+        examTestRun.getTestRunIdElement(testRun.id).should('exist');
+        examTestRun.deleteTestRun(testRun.id);
+        examTestRun.getTestRun(testRun.id).should('not.exist');
+    });
+
+    after(() => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
+        }
+    });
+});

--- a/src/test/cypress/e2e/exercises/text/TextExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseParticipation.cy.ts
@@ -38,7 +38,7 @@ describe('Text exercise participation', () => {
             textExerciseEditor.shouldShowNumberOfCharacters(591);
             textExerciseEditor.submit().then((request: Interception) => {
                 expect(request.response!.body.text).to.eq(submission);
-                expect(request.response!.body.submitted).to.eq(true);
+                expect(request.response!.body.submitted).to.be.true;
                 expect(request.response!.statusCode).to.eq(200);
             });
         });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Test exams support test runs, where a instructor can test the exam before conducting it. 

### Description
<!-- Describe your changes in detail -->
This PR adds e2e tests for the test run within test exams. We create a test run, change the working time, conduct it and delete it. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
