### PR TITLE
`Development`: Fix Gradle build on Windows

### DIFF
--- a/gradle/liquibase.gradle
+++ b/gradle/liquibase.gradle
@@ -11,7 +11,7 @@ dependencies {
 if (OperatingSystem.current().isWindows()) {
     task pathingLiquibaseJar(type: Jar) {
         dependsOn configurations.liquibase
-        appendix = 'pathingLiquibase'
+        archiveAppendix = 'pathingLiquibase'
 
         doFirst {
             manifest {


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
#6163 upgraded Gradle to version 8.0. This broke the build on windows since deprecated and now removed gradle property was used.

### Description
Replaces `appendix` with `archiveAppendix`. See: https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:appendix

### Steps for Testing
verify that building Artemis locally works again.

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2