### PR TITLE
`Development`: Fix another issue in the logout e2e test

### DIFF
--- a/src/test/cypress/e2e/Logout.cy.ts
+++ b/src/test/cypress/e2e/Logout.cy.ts
@@ -48,10 +48,13 @@ describe('Logout tests', () => {
 });
 
 const startExerciseAndMakeChanges = (course: Course, modelingExercise: ModelingExercise) => {
+    const exerciseID = modelingExercise.id!;
     cy.visit(`/courses/${course.id}/exercises`);
-    courseOverview.startExercise(modelingExercise.id!);
-    courseOverview.openRunningExercise(modelingExercise.id!);
-    modelingExerciseEditor.addComponentToModel(modelingExercise.id!, 1);
-    modelingExerciseEditor.addComponentToModel(modelingExercise.id!, 2);
+    cy.reloadUntilFound('#start-exercise-' + exerciseID);
+    courseOverview.startExercise(exerciseID);
+    cy.reloadUntilFound('#open-exercise-' + exerciseID);
+    courseOverview.openRunningExercise(exerciseID);
+    modelingExerciseEditor.addComponentToModel(exerciseID, 1);
+    modelingExerciseEditor.addComponentToModel(exerciseID, 2);
     cy.get('#account-menu').click().get('#logout').click();
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Even after using two students for the logout test, the tests still fail. 

### Description
<!-- Describe your changes in detail -->
This PR adds a `reloadUntilFound` function to the test, so the page will be reloaded until the element is found. This method is already used within the modeling exercise participation tests to ensure the button is there. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
