### PR TITLE
`Development`: Fix 'ready to review' github action

### DIFF
--- a/.github/workflows/pullrequest-readyforreview.yml
+++ b/.github/workflows/pullrequest-readyforreview.yml
@@ -1,5 +1,6 @@
 name: Pull Request Ready for Review
 on:
+  pull_request:
   pull_request_target:
     types: [ready_for_review]
 
@@ -16,8 +17,16 @@ jobs:
           column: Ready for review
           repo-token: ${{ secrets.GH_TOKEN_ADD_TO_PROJECT }}
 
+      - name: Request Reviews from @ls1intum/artemis-developers Team
+        uses: rowi1de/auto-assign-review-teams@v1.1.3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          teams: "@ls1intum/artemis-developers"
+          skip-with-manual-reviewers: 5
+
       - name: Label "ready for review"
         uses: actions/github-script@v6
+        if: always() # run this step even if previous step failed
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pullrequest-readyforreview.yml
+++ b/.github/workflows/pullrequest-readyforreview.yml
@@ -1,6 +1,5 @@
 name: Pull Request Ready for Review
 on:
-  pull_request:
   pull_request_target:
     types: [ready_for_review]
 
@@ -17,16 +16,8 @@ jobs:
           column: Ready for review
           repo-token: ${{ secrets.GH_TOKEN_ADD_TO_PROJECT }}
 
-      - name: Request Reviews from @ls1intum/artemis-maintainers Team
-        uses: rowi1de/auto-assign-review-teams@v1.1.3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          teams: "@ls1intum/artemis-maintainers"
-          skip-with-manual-reviewers: 5
-
       - name: Label "ready for review"
         uses: actions/github-script@v6
-        if: always() # run this step even if previous step failed
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pullrequest-readyforreview.yml
+++ b/.github/workflows/pullrequest-readyforreview.yml
@@ -17,11 +17,11 @@ jobs:
           column: Ready for review
           repo-token: ${{ secrets.GH_TOKEN_ADD_TO_PROJECT }}
 
-      - name: Request Reviews from @ls1intum/artemis-developers Team
+      - name: Request Reviews from @ls1intum/artemis-maintainers Team
         uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          teams: "@ls1intum/artemis-developers"
+          teams: "@ls1intum/artemis-maintainers"
           skip-with-manual-reviewers: 5
 
       - name: Label "ready for review"

--- a/.github/workflows/pullrequest-readyforreview.yml
+++ b/.github/workflows/pullrequest-readyforreview.yml
@@ -16,16 +16,8 @@ jobs:
           column: Ready for review
           repo-token: ${{ secrets.GH_TOKEN_ADD_TO_PROJECT }}
 
-      - name: Request Reviews from @ls1intum/artemis-developers Team
-        uses: rowi1de/auto-assign-review-teams@v1.1.3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          teams: "@ls1intum/artemis-developers"
-          skip-with-manual-reviewers: 5
-
       - name: Label "ready for review"
         uses: actions/github-script@v6
-        if: always() # run this step even if previous step failed
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pullrequest-readyforreview.yml
+++ b/.github/workflows/pullrequest-readyforreview.yml
@@ -20,11 +20,12 @@ jobs:
         uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          teams: "@ls1intum/artemis"
+          teams: "@ls1intum/artemis-maintainers"
           skip-with-manual-reviewers: 5
 
       - name: Label "ready for review"
         uses: actions/github-script@v6
+        if: success() || failure()    # run this step even if previous step failed
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pullrequest-readyforreview.yml
+++ b/.github/workflows/pullrequest-readyforreview.yml
@@ -16,16 +16,16 @@ jobs:
           column: Ready for review
           repo-token: ${{ secrets.GH_TOKEN_ADD_TO_PROJECT }}
 
-      - name: Request Reviews from @ls1intum/artemis Team
+      - name: Request Reviews from @ls1intum/artemis-developers Team
         uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          teams: "@ls1intum/artemis-maintainers"
+          teams: "@ls1intum/artemis-developers"
           skip-with-manual-reviewers: 5
 
       - name: Label "ready for review"
         uses: actions/github-script@v6
-        if: success() || failure()    # run this step even if previous step failed
+        if: always() # run this step even if previous step failed
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
The 'ready to review' github action (which automatically adds the corresponding label) is currently not working, see: https://github.com/ls1intum/Artemis/actions/runs/4222596831/jobs/7331290191

### Description
The automatic team request action failed ("Reviews may only be requested from collaborators."). Since there already is the automatic review request from Artemis maintainers (via GitHub Code Owners) I decided to remove the review request action.

### Steps for Testing
code review

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2