### PR TITLE
`General`: Fix course overview control items inconsistencies and persist lecture sorting locally

### DIFF
--- a/src/main/webapp/app/overview/course-exercises/course-exercises.component.ts
+++ b/src/main/webapp/app/overview/course-exercises/course-exercises.component.ts
@@ -95,7 +95,6 @@ export class CourseExercisesComponent implements OnInit, OnChanges, OnDestroy, A
     // Provides the control configuration to be read and used by "CourseOverviewComponent"
     public readonly controlConfiguration: BarControlConfiguration = {
         subject: new Subject<TemplateRef<any>>(),
-        useIndentation: true,
     };
 
     constructor(

--- a/src/main/webapp/app/overview/course-lectures/course-lectures.component.html
+++ b/src/main/webapp/app/overview/course-lectures/course-lectures.component.html
@@ -1,19 +1,10 @@
 <ng-template #controls>
     <div class="course-overview-controls d-none d-sm-block" *ngIf="course?.lectures && course!.lectures!.length > 0">
-        <div ngbDropdown placement="bottom-right auto" class="d-inline-block">
-            <button class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>
-                {{ 'artemisApp.courseOverview.lectureList.sortLectures' | artemisTranslate }}
+        <div class="d-inline-block">
+            <button id="flip" (click)="flipOrder()" class="btn btn-primary">
+                <fa-icon [icon]="sortingOrder === ASC ? faSortNumericUp : faSortNumericDown"></fa-icon>
+                <span class="ms-1">{{ 'artemisApp.courseOverview.exerciseList.' + (sortingOrder === ASC ? 'oldFirst' : 'newFirst') | artemisTranslate }}</span>
             </button>
-            <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
-                <button class="dropdown-item" (click)="groupLectures(DUE_DATE_DESC)">
-                    <fa-icon [icon]="faSortAmountUp"></fa-icon>
-                    {{ 'artemisApp.courseOverview.exerciseList.newFirst' | artemisTranslate }}
-                </button>
-                <button class="dropdown-item" (click)="groupLectures(DUE_DATE_ASC)">
-                    <fa-icon [icon]="faSortAmountDown"></fa-icon>
-                    {{ 'artemisApp.courseOverview.exerciseList.oldFirst' | artemisTranslate }}
-                </button>
-            </div>
         </div>
     </div>
 </ng-template>

--- a/src/main/webapp/app/overview/course-lectures/course-lectures.component.ts
+++ b/src/main/webapp/app/overview/course-lectures/course-lectures.component.ts
@@ -100,6 +100,9 @@ export class CourseLecturesComponent implements OnInit, OnDestroy, AfterViewInit
         this.paramSubscription.unsubscribe();
     }
 
+    /**
+     * Loads the sorting order from local storage
+     */
     private loadSortingOrder() {
         const orderInStorage = this.localStorage.retrieve(SortFilterStorageKey.ORDER);
         const parsedOrderInStorage = Object.keys(LectureSortingOrder).find((exerciseOrder) => exerciseOrder === orderInStorage);

--- a/src/main/webapp/app/overview/course-lectures/course-lectures.component.ts
+++ b/src/main/webapp/app/overview/course-lectures/course-lectures.component.ts
@@ -86,7 +86,7 @@ export class CourseLecturesComponent implements OnInit, OnDestroy, AfterViewInit
     }
 
     private onCourseLoad() {
-        this.groupLectures(this.DUE_DATE_DESC);
+        this.groupLectures(this.DUE_DATE_ASC);
     }
 
     public groupLectures(selectedOrder: number): void {

--- a/src/main/webapp/app/overview/course-lectures/course-lectures.component.ts
+++ b/src/main/webapp/app/overview/course-lectures/course-lectures.component.ts
@@ -53,7 +53,6 @@ export class CourseLecturesComponent implements OnInit, OnDestroy, AfterViewInit
     // Provides the control configuration to be read and used by "CourseOverviewComponent"
     public readonly controlConfiguration: BarControlConfiguration = {
         subject: new Subject<TemplateRef<any>>(),
-        useIndentation: true,
     };
 
     constructor(

--- a/src/main/webapp/app/overview/course-lectures/course-lectures.component.ts
+++ b/src/main/webapp/app/overview/course-lectures/course-lectures.component.ts
@@ -6,10 +6,20 @@ import { Subject, Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import dayjs from 'dayjs/esm';
 import { Lecture } from 'app/entities/lecture.model';
+import { LocalStorageService } from 'ngx-webstorage';
 import { CourseScoreCalculationService } from 'app/overview/course-score-calculation.service';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
-import { faAngleDown, faAngleUp, faSortAmountDown, faSortAmountUp } from '@fortawesome/free-solid-svg-icons';
+import { faAngleDown, faAngleUp, faSortNumericDown, faSortNumericUp } from '@fortawesome/free-solid-svg-icons';
 import { BarControlConfiguration, BarControlConfigurationProvider } from 'app/overview/tab-bar/tab-bar';
+
+export enum LectureSortingOrder {
+    ASC = 1,
+    DESC = -1,
+}
+
+enum SortFilterStorageKey {
+    ORDER = 'artemis.course.lectures.order',
+}
 
 @Component({
     selector: 'jhi-course-lectures',
@@ -17,8 +27,6 @@ import { BarControlConfiguration, BarControlConfigurationProvider } from 'app/ov
     styleUrls: ['../course-overview.scss'],
 })
 export class CourseLecturesComponent implements OnInit, OnDestroy, AfterViewInit, BarControlConfigurationProvider {
-    public readonly DUE_DATE_ASC = 1;
-    public readonly DUE_DATE_DESC = -1;
     private courseId: number;
     private paramSubscription: Subscription;
     private courseUpdatesSubscription: Subscription;
@@ -29,11 +37,16 @@ export class CourseLecturesComponent implements OnInit, OnDestroy, AfterViewInit
 
     public exerciseCountMap: Map<string, number>;
 
+    readonly ASC = LectureSortingOrder.ASC;
+    readonly DESC = LectureSortingOrder.DESC;
+
     // Icons
-    faSortAmountUp = faSortAmountUp;
-    faSortAmountDown = faSortAmountDown;
+    faSortNumericDown = faSortNumericDown;
+    faSortNumericUp = faSortNumericUp;
     faAngleUp = faAngleUp;
     faAngleDown = faAngleDown;
+
+    sortingOrder: LectureSortingOrder;
 
     // The extracted controls template from our template to be rendered in the top bar of "CourseOverviewComponent"
     @ViewChild('controls', { static: false }) private controls: TemplateRef<any>;
@@ -50,10 +63,12 @@ export class CourseLecturesComponent implements OnInit, OnDestroy, AfterViewInit
         private translateService: TranslateService,
         private exerciseService: ExerciseService,
         private route: ActivatedRoute,
+        private localStorage: LocalStorageService,
     ) {}
 
     ngOnInit() {
         this.exerciseCountMap = new Map<string, number>();
+        this.loadSortingOrder();
         this.paramSubscription = this.route.parent!.params.subscribe((params) => {
             this.courseId = parseInt(params['courseId'], 10);
         });
@@ -68,7 +83,7 @@ export class CourseLecturesComponent implements OnInit, OnDestroy, AfterViewInit
         });
 
         this.translateSubscription = this.translateService.onLangChange.subscribe(() => {
-            this.groupLectures(this.DUE_DATE_DESC);
+            this.groupLectures();
         });
     }
 
@@ -85,17 +100,32 @@ export class CourseLecturesComponent implements OnInit, OnDestroy, AfterViewInit
         this.paramSubscription.unsubscribe();
     }
 
-    private onCourseLoad() {
-        this.groupLectures(this.DUE_DATE_ASC);
+    private loadSortingOrder() {
+        const orderInStorage = this.localStorage.retrieve(SortFilterStorageKey.ORDER);
+        const parsedOrderInStorage = Object.keys(LectureSortingOrder).find((exerciseOrder) => exerciseOrder === orderInStorage);
+        this.sortingOrder = parsedOrderInStorage ? (+parsedOrderInStorage as LectureSortingOrder) : LectureSortingOrder.ASC;
     }
 
-    public groupLectures(selectedOrder: number): void {
+    private onCourseLoad() {
+        this.groupLectures();
+    }
+
+    /**
+     * Reorders all displayed lectures
+     */
+    flipOrder() {
+        this.sortingOrder = this.sortingOrder === this.ASC ? this.DESC : this.ASC;
+        this.localStorage.store(SortFilterStorageKey.ORDER, this.sortingOrder.toString());
+        this.groupLectures();
+    }
+
+    public groupLectures(): void {
         this.weeklyLecturesGrouped = {};
         this.weeklyIndexKeys = [];
         const groupedLectures = {};
         const indexKeys: string[] = [];
         const courseLectures = this.course?.lectures ? [...this.course!.lectures] : [];
-        const sortedLectures = this.sortLectures(courseLectures, selectedOrder);
+        const sortedLectures = this.sortLectures(courseLectures, this.sortingOrder);
         const notAssociatedLectures: Lecture[] = [];
         sortedLectures.forEach((lecture) => {
             const dateValue = lecture.startDate ? dayjs(lecture.startDate) : undefined;

--- a/src/main/webapp/app/overview/course-overview.component.html
+++ b/src/main/webapp/app/overview/course-overview.component.html
@@ -2,7 +2,7 @@
     <div *ngIf="course">
         <jhi-header-course [course]="course"></jhi-header-course>
         <div class="tab-bar tab-bar-overview" id="tab-bar">
-            <div class="col-12" [ngClass]="{ 'no-indent': !controlConfiguration?.useIndentation, 'col-lg-8': controlConfiguration?.useIndentation }">
+            <div class="col-12" [ngClass]="{ 'no-indent': true }">
                 <div>
                     <div
                         id="exam-tab"

--- a/src/main/webapp/app/overview/course-overview.component.html
+++ b/src/main/webapp/app/overview/course-overview.component.html
@@ -2,7 +2,7 @@
     <div *ngIf="course">
         <jhi-header-course [course]="course"></jhi-header-course>
         <div class="tab-bar tab-bar-overview" id="tab-bar">
-            <div class="col-12" [ngClass]="{ 'no-indent': true }">
+            <div class="col-12 no-indent">
                 <div>
                     <div
                         id="exam-tab"

--- a/src/main/webapp/app/overview/course-statistics/course-statistics.component.ts
+++ b/src/main/webapp/app/overview/course-statistics/course-statistics.component.ts
@@ -183,7 +183,6 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy, AfterViewIn
     // Provides the control configuration to be read and used by "CourseOverviewComponent"
     public readonly controlConfiguration: BarControlConfiguration = {
         subject: new Subject<TemplateRef<any>>(),
-        useIndentation: false,
     };
 
     constructor(

--- a/src/main/webapp/app/overview/course-tutorial-groups/course-tutorial-groups.component.ts
+++ b/src/main/webapp/app/overview/course-tutorial-groups/course-tutorial-groups.component.ts
@@ -27,7 +27,6 @@ export class CourseTutorialGroupsComponent implements AfterViewInit, OnInit, OnD
     @ViewChild('controls', { static: false }) private controls: TemplateRef<any>;
     public readonly controlConfiguration: BarControlConfiguration = {
         subject: new Subject<TemplateRef<any>>(),
-        useIndentation: true,
     };
     tutorialGroups: TutorialGroup[] = [];
     courseId: number;

--- a/src/main/webapp/app/overview/tab-bar/tab-bar.ts
+++ b/src/main/webapp/app/overview/tab-bar/tab-bar.ts
@@ -3,7 +3,6 @@ import { TemplateRef } from '@angular/core';
 
 export interface BarControlConfiguration {
     subject?: Subject<TemplateRef<any>>;
-    useIndentation: boolean;
 }
 
 export interface BarControlConfigurationProvider {

--- a/src/main/webapp/i18n/de/student-dashboard.json
+++ b/src/main/webapp/i18n/de/student-dashboard.json
@@ -142,8 +142,7 @@
                 "totalLectures": "Vorlesungen insgesamt:",
                 "totalAttachments": "Anhänge insgesamt:",
                 "isLecture": "Das ist eine Vorlesung",
-                "noLectures": "Es gibt keine Vorlesungen für diesen Kurs.",
-                "sortLectures": "Vorlesungen sortieren"
+                "noLectures": "Es gibt keine Vorlesungen für diesen Kurs."
             },
             "lectureDetails": {
                 "description": "Beschreibung",

--- a/src/main/webapp/i18n/en/student-dashboard.json
+++ b/src/main/webapp/i18n/en/student-dashboard.json
@@ -144,8 +144,7 @@
                 "totalLectures": "Total lectures:",
                 "totalAttachments": "Total attachments:",
                 "isLecture": "This is a lecture",
-                "noLectures": "No lectures available for the course.",
-                "sortLectures": "Sort lectures"
+                "noLectures": "No lectures available for the course."
             },
             "lectureDetails": {
                 "description": "Description",

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -98,7 +98,6 @@ class ControlsTestingComponent implements BarControlConfigurationProvider, After
     @ViewChild('controls', { static: false }) private controls: TemplateRef<any>;
     public readonly controlConfiguration: BarControlConfiguration = {
         subject: new Subject<TemplateRef<any>>(),
-        useIndentation: true,
     };
 
     ngAfterViewInit(): void {

--- a/src/test/javascript/spec/component/overview/course-lectures/course-lectures.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-lectures/course-lectures.component.spec.ts
@@ -126,35 +126,46 @@ describe('CourseLectures', () => {
     it('should sort and flip sort order correctly', fakeAsync(() => {
         courseLecturesComponentFixture.detectChanges();
 
-        const checkLectureOrder = (lectures: Lecture[] | undefined, order: LectureSortingOrder) => {
-            if (!lectures) {
-                return true;
-            }
-
-            for (let i = 0; i < lectures.length - 1; i++) {
-                const firstLecture = lectures[i];
-                const secondLecture = lectures[i + 1];
-
-                const firstStartDate = firstLecture.startDate ? firstLecture.startDate.valueOf() : dayjs().valueOf();
-                const secondStartDate = secondLecture.startDate ? secondLecture.startDate.valueOf() : dayjs().valueOf();
+        const checkSortingOrder = (order: LectureSortingOrder) => {
+            const groups = Object.keys(courseLecturesComponent.weeklyLecturesGrouped);
+            for (let i = 0; i < groups.length - 1; i++) {
+                const firstGroup = groups[i];
+                const secondGroup = groups[i + 1];
 
                 if (order === courseLecturesComponent.ASC) {
-                    expect(firstStartDate).toBeLessThanOrEqual(secondStartDate);
+                    expect(firstGroup < secondGroup).toBeTruthy();
                 } else {
-                    expect(firstStartDate).toBeGreaterThanOrEqual(secondStartDate);
+                    expect(firstGroup > secondGroup).toBeTruthy();
+                }
+            }
+
+            // check if the lectures are sorted correctly inside the groups
+            for (const group of groups) {
+                const lectures = courseLecturesComponent.weeklyLecturesGrouped[group].lectures;
+                for (let i = 0; i < lectures.length - 1; i++) {
+                    const firstLecture = lectures[i];
+                    const secondLecture = lectures[i + 1];
+                    const firstStartDate = firstLecture.startDate ? firstLecture.startDate.valueOf() : dayjs().valueOf();
+                    const secondStartDate = secondLecture.startDate ? secondLecture.startDate.valueOf() : dayjs().valueOf();
+
+                    if (order === courseLecturesComponent.ASC) {
+                        expect(firstStartDate).toBeLessThanOrEqual(secondStartDate);
+                    } else {
+                        expect(firstStartDate).toBeGreaterThanOrEqual(secondStartDate);
+                    }
                 }
             }
         };
 
         expect(courseLecturesComponent.sortingOrder).toEqual(courseLecturesComponent.ASC);
-        expect(checkLectureOrder(course.lectures, courseLecturesComponent.ASC)).toBeTruthy();
+        checkSortingOrder(courseLecturesComponent.ASC);
 
         courseLecturesComponent.flipOrder();
         expect(courseLecturesComponent.sortingOrder).toEqual(courseLecturesComponent.DESC);
-        expect(checkLectureOrder(course.lectures, courseLecturesComponent.DESC)).toBeTruthy();
+        checkSortingOrder(courseLecturesComponent.DESC);
 
         courseLecturesComponent.flipOrder();
         expect(courseLecturesComponent.sortingOrder).toEqual(courseLecturesComponent.ASC);
-        expect(checkLectureOrder(course.lectures, courseLecturesComponent.ASC)).toBeTruthy();
+        checkSortingOrder(courseLecturesComponent.ASC);
     }));
 });

--- a/src/test/javascript/spec/component/overview/course-lectures/course-lectures.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-lectures/course-lectures.component.spec.ts
@@ -10,7 +10,7 @@ import { LocalStorageService } from 'ngx-webstorage';
 import { Course } from 'app/entities/course.model';
 import { Lecture } from 'app/entities/lecture.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
-import { CourseLecturesComponent } from 'app/overview/course-lectures/course-lectures.component';
+import { CourseLecturesComponent, LectureSortingOrder } from 'app/overview/course-lectures/course-lectures.component';
 import { CourseScoreCalculationService } from 'app/overview/course-score-calculation.service';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
@@ -121,5 +121,40 @@ describe('CourseLectures', () => {
             const lectures = courseLecturesComponentFixture.debugElement.queryAll(By.directive(CourseLectureRowStubComponent));
             expect(lectures).toHaveLength(3);
         });
+    }));
+
+    it('should sort and flip sort order correctly', fakeAsync(() => {
+        courseLecturesComponentFixture.detectChanges();
+
+        const checkLectureOrder = (lectures: Lecture[] | undefined, order: LectureSortingOrder) => {
+            if (!lectures) {
+                return true;
+            }
+
+            for (let i = 0; i < lectures.length - 1; i++) {
+                const firstLecture = lectures[i];
+                const secondLecture = lectures[i + 1];
+
+                const firstStartDate = firstLecture.startDate ? firstLecture.startDate.valueOf() : dayjs().valueOf();
+                const secondStartDate = secondLecture.startDate ? secondLecture.startDate.valueOf() : dayjs().valueOf();
+
+                if (order === courseLecturesComponent.ASC) {
+                    expect(firstStartDate).toBeLessThanOrEqual(secondStartDate);
+                } else {
+                    expect(firstStartDate).toBeGreaterThanOrEqual(secondStartDate);
+                }
+            }
+        };
+
+        expect(courseLecturesComponent.sortingOrder).toEqual(courseLecturesComponent.ASC);
+        expect(checkLectureOrder(course.lectures, courseLecturesComponent.ASC)).toBeTruthy();
+
+        courseLecturesComponent.flipOrder();
+        expect(courseLecturesComponent.sortingOrder).toEqual(courseLecturesComponent.DESC);
+        expect(checkLectureOrder(course.lectures, courseLecturesComponent.DESC)).toBeTruthy();
+
+        courseLecturesComponent.flipOrder();
+        expect(courseLecturesComponent.sortingOrder).toEqual(courseLecturesComponent.ASC);
+        expect(checkLectureOrder(course.lectures, courseLecturesComponent.ASC)).toBeTruthy();
     }));
 });

--- a/src/test/javascript/spec/component/overview/course-lectures/course-lectures.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-lectures/course-lectures.component.spec.ts
@@ -6,6 +6,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateService } from '@ngx-translate/core';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
+import { LocalStorageService } from 'ngx-webstorage';
 import { Course } from 'app/entities/course.model';
 import { Lecture } from 'app/entities/lecture.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
@@ -19,6 +20,7 @@ import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { of } from 'rxjs';
 import { MockTranslateService } from '../../../helpers/mocks/service/mock-translate.service';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
 
 @Component({ selector: 'jhi-course-lecture-row', template: '' })
 class CourseLectureRowStubComponent {
@@ -85,6 +87,7 @@ describe('CourseLectures', () => {
                         },
                     },
                 },
+                { provide: LocalStorageService, useClass: MockSyncStorage },
             ],
         })
             .compileComponents()


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.
<!-- - [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I translated all newly inserted strings into English and German.
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There are some inconsistencies/bugs in the course overview page across the different tabs (Exercises, Lectures, ...):
 - Control items alignment (Refresh, filter, sort, etc.)
 - Sorting inconsistency of groups between exercise groups (ascending by date) and lecture groups (descending by date)
 - Sorting of "Lectures" is not persisted in local storage like "Exercises" for example
 - Sort button of "Lectures" inconsistent with sort button of "Exercises"

Fixes #6288
Fixes #6176
Fixes #6289

### Description
<!-- Describe your changes in detail -->

In the course overview page the control items are now consistently left-aligned in every tab. The lecture groups are now sorted by default in ascending order like the exercise groups. Additionally, the sorting is locally stored so when the user refreshes the sorting is kept. The drop-down menu for sorting lectures is now a simple button for flipping the sorting with one click. It also uses the same button style and iconography as the exercises' sort button. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course
- 2 Exercises in different weeks
- 2 Lectures in different weeks

1. Go to the course's overview
2. Check sorting of "Exercises". Should be ascending (unchanged).
3. Check sorting of "Lectures" . Should be ascending as well.
4. Compare consistency of the changed sorting button of "Lectures" with the "Exercises" sorting button
5. Press sort button of "Lectures" and refresh. Should now always persist the sorting.
6. Observe the consistent alignment of buttons across tabs (Exercises, Lectures, etc.)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2

#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->
unchanged.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Exercises old:
<img width="1011" alt="Exercises_old" src="https://user-images.githubusercontent.com/5898705/221881940-51275579-482b-4a09-949c-ac3a46281654.png">

Lectures old:
<img width="1511" alt="Lectures_old" src="https://user-images.githubusercontent.com/5898705/221881932-20688ba8-1dce-4c2d-a56d-4ec38656f1d2.png">

Exercises new:
<img width="1512" alt="Exercises_new" src="https://user-images.githubusercontent.com/5898705/221881921-cd0e85b7-3153-4930-93f6-d3f073f46f0f.png">

Lectures new:
<img width="1512" alt="Lectures_new" src="https://user-images.githubusercontent.com/5898705/221881914-5ebc3310-df62-433a-9d85-8fa8f266141d.png">

Going through tabs and refreshing changed Lectures sorting:
![changes](https://user-images.githubusercontent.com/5898705/221881806-d542722f-a4e7-4d62-9f06-b289bf4e30c7.gif)
