### PR TITLE
`Development`: Filter complaint reviewer from server response

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
@@ -173,17 +173,17 @@ public class ComplaintResource {
             return ResponseEntity.ok().build();
         }
         Complaint complaint = optionalComplaint.get();
-        var user = userRepository.getUserWithGroupsAndAuthorities();
+        User user = userRepository.getUserWithGroupsAndAuthorities();
         StudentParticipation participation = (StudentParticipation) complaint.getResult().getParticipation();
-        var exercise = participation.getExercise();
-        var isOwner = authCheckService.isOwnerOfParticipation(participation, user);
-        var isAtLeastTutor = authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user);
+        Exercise exercise = participation.getExercise();
+        boolean isOwner = authCheckService.isOwnerOfParticipation(participation, user);
+        boolean isAtLeastTutor = authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user);
         if (!isOwner && !isAtLeastTutor) {
             throw new AccessForbiddenException();
         }
-        var isAtLeastInstructor = authCheckService.isAtLeastInstructorForExercise(exercise, user);
-        var isTeamParticipation = participation.getParticipant() instanceof Team;
-        var isTutorOfTeam = user.getLogin().equals(participation.getTeam().map(team -> team.getOwner().getLogin()).orElse(null));
+        boolean isAtLeastInstructor = authCheckService.isAtLeastInstructorForExercise(exercise, user);
+        boolean isTeamParticipation = participation.getParticipant() instanceof Team;
+        boolean isTutorOfTeam = user.getLogin().equals(participation.getTeam().map(team -> team.getOwner().getLogin()).orElse(null));
 
         if (!isAtLeastTutor) {
             complaint.getResult().setAssessor(null);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
@@ -177,17 +177,19 @@ public class ComplaintResource {
         StudentParticipation participation = (StudentParticipation) complaint.getResult().getParticipation();
         var exercise = participation.getExercise();
         var isOwner = authCheckService.isOwnerOfParticipation(participation, user);
-        var isAtLeastTA = authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user);
-        if (!isOwner && !isAtLeastTA) {
+        var isAtLeastTutor = authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user);
+        if (!isOwner && !isAtLeastTutor) {
             throw new AccessForbiddenException();
         }
-        var isAtLeastTutor = authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user);
         var isAtLeastInstructor = authCheckService.isAtLeastInstructorForExercise(exercise, user);
         var isTeamParticipation = participation.getParticipant() instanceof Team;
         var isTutorOfTeam = user.getLogin().equals(participation.getTeam().map(team -> team.getOwner().getLogin()).orElse(null));
 
         if (!isAtLeastTutor) {
             complaint.getResult().setAssessor(null);
+            if (complaint.getComplaintResponse() != null) {
+                complaint.getComplaintResponse().setReviewer(null);
+            }
         }
         if (!isAtLeastInstructor && (!isTeamParticipation || !isTutorOfTeam)) {
             complaint.filterSensitiveInformation();


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
Closes #6320

### Description
We must not only filter out the original assessor, but also the complaint reviewer.

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Exercise with an answered complaint

1. Open the view of the complaint answer while having the network tabs open
2. Verify that the name of the complaint reviewer was not sent by the server.

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2