### PR TITLE
`Development`: Add system health e2e checks

### DIFF
--- a/src/main/webapp/app/admin/health/health.component.html
+++ b/src/main/webapp/app/admin/health/health.component.html
@@ -15,14 +15,14 @@
                 </tr>
             </thead>
             <tbody *ngIf="health">
-                <tr *ngFor="let componentHealth of health.components | keyvalue">
+                <tr *ngFor="let componentHealth of health.components | keyvalue" [id]="componentHealth.key">
                     <td>
                         {{ 'health.indicator.' + componentHealth.key | artemisTranslate }}
                         <a *ngIf="componentHealth.value?.details?.url" class="badge bg-info" [href]="componentHealth.value!.details!.url">
                             {{ componentHealth.value!.details!.url }}
                         </a>
                     </td>
-                    <td class="text-center">
+                    <td class="status text-center">
                         <span class="badge" [ngClass]="getBadgeClass(componentHealth.value!.status)" jhiTranslate="{{ 'health.status.' + componentHealth.value!.status }}">
                             {{ componentHealth.value!.status }}
                         </span>
@@ -33,9 +33,9 @@
                         </a>
                     </td>
                 </tr>
-                <tr>
+                <tr id="websocketConnection">
                     <td>Websocket Connection (Client -> Server)</td>
-                    <td class="text-center">
+                    <td class="status text-center">
                         <jhi-connection-status></jhi-connection-status>
                     </td>
                     <td class="text-center">-</td>

--- a/src/test/cypress/e2e/SystemHealth.cy.ts
+++ b/src/test/cypress/e2e/SystemHealth.cy.ts
@@ -1,0 +1,43 @@
+import { admin } from '../support/users';
+
+describe('Check artemis system health', () => {
+    beforeEach('Login as admin and visit system health page', () => {
+        cy.login(admin, '/admin/health');
+    });
+
+    it('Checks continuous integration health', () => {
+        cy.get('#healthCheck #continuousIntegrationServer .status').contains('UP');
+    });
+
+    it('Checks version control health', () => {
+        cy.get('#healthCheck #versionControlServer .status').contains('UP');
+    });
+
+    it('Checks user management health', () => {
+        cy.get('#healthCheck #userManagement .status').contains('UP');
+    });
+
+    it('Checks database health', () => {
+        cy.get('#healthCheck #db .status').contains('UP');
+    });
+
+    it('Checks hazelcast health', () => {
+        cy.get('#healthCheck #hazelcast .status').contains('UP');
+    });
+
+    it('Checks ping health', () => {
+        cy.get('#healthCheck #ping .status').contains('UP');
+    });
+
+    it('Checks readiness health', () => {
+        cy.get('#healthCheck #readinessState .status').contains('UP');
+    });
+
+    it('Checks websocket broker health', () => {
+        cy.get('#healthCheck #websocketBroker .status').contains('UP');
+    });
+
+    it('Checks websocket connection health', () => {
+        cy.get('#healthCheck #websocketConnection .status').contains('Connected');
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In several occurrences we had an issue with the artemis connection to the bamboo service. The only way to tell that it is the bamboo connection that is failing is to look into the logs of the test run and spot, that for the programming exercises bamboo was not available. 

### Description
<!-- Describe your changes in detail -->
This PR adds tests, that check if all the system health items are up and running before running the other tests. So if for example bamboo is not connected to artemis, the ci test will fail and developers should be able to see the issue easier within the test run. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2
