### PR TITLE
`Assessment`: Fix bonus calculation related bugs

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
@@ -729,6 +729,17 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
     }
 
     /**
+     * Get all participations belonging to a student in a course with relevant results.
+     *
+     * @param courseId the id of the course
+     * @return an unmodifiable list of participations belonging to course
+     */
+    default List<StudentParticipation> findByCourseIdAndStudentIdWithRelevantResult(Long courseId, Long studentId) {
+        List<StudentParticipation> participations = findByCourseIdAndStudentIdWithEagerRatedResults(courseId, studentId);
+        return filterParticipationsWithRelevantResults(participations, false);
+    }
+
+    /**
      * Get all participations belonging to course with relevant results.
      *
      * @param courseId the id of the course

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
@@ -731,8 +731,9 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
     /**
      * Get all participations belonging to a student in a course with relevant results.
      *
-     * @param courseId the id of the course
-     * @return an unmodifiable list of participations belonging to course
+     * @param courseId  the id of the course
+     * @param studentId the id of the student
+     * @return an unmodifiable list of participations belonging to the given student in the given course
      */
     default List<StudentParticipation> findByCourseIdAndStudentIdWithRelevantResult(Long courseId, Long studentId) {
         List<StudentParticipation> participations = findByCourseIdAndStudentIdWithEagerRatedResults(courseId, studentId);

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseScoreCalculationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseScoreCalculationService.java
@@ -80,7 +80,7 @@ public class CourseScoreCalculationService {
         MultiValueMap<Long, StudentParticipation> studentIdToParticipations = new LinkedMultiValueMap<>();
         if (studentIds.size() == 1) {  // Optimize single student case by filtering in the database.
             Long studentId = studentIds.iterator().next();
-            var participations = studentParticipationRepository.findByCourseIdAndStudentIdWithEagerRatedResults(courseId, studentId);
+            var participations = studentParticipationRepository.findByCourseIdAndStudentIdWithRelevantResult(courseId, studentId);
             if (!participations.isEmpty()) {
                 studentIdToParticipations.addAll(studentId, participations);
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -598,6 +598,9 @@ public class ExamService {
             }
         }
 
+        // Round the points again to prevent floating point issues that might occur when summing up the exercise points (e.g. 0.3 + 0.3 + 0.3 = 0.8999999999999999)
+        overallPointsAchieved = roundScoreSpecifiedByCourseSettings(overallPointsAchieved, exam.getCourse());
+
         var overallGrade = "";
         var overallGradeInFirstCorrection = "";
         var hasPassed = false;

--- a/src/main/webapp/app/grading-system/bonus/bonus.component.html
+++ b/src/main/webapp/app/grading-system/bonus/bonus.component.html
@@ -21,20 +21,7 @@
             ></jhi-mode-picker>
         </div>
     </div>
-    <div *ngIf="currentBonusStrategyOption === BonusStrategyOption.GRADES" class="row mt-4">
-        <div class="bonus-form-step col-1"></div>
-        <div class="form-group col">
-            <label class="no-flex-shrink h5" jhiTranslate="artemisApp.bonus.discreteness.title">Select discreteness</label>
-            <ng-container [ngTemplateOutlet]="helpTextTemplate" [ngTemplateOutletContext]="{ translationKey: 'artemisApp.bonus.discreteness.helpText' }"></ng-container>
-            <jhi-mode-picker
-                class="d-block mt-1"
-                [options]="bonusStrategyDiscreteness"
-                [(value)]="currentBonusStrategyDiscreteness"
-                (valueChange)="onBonusStrategyInputChange()"
-            ></jhi-mode-picker>
-        </div>
-    </div>
-    <div *ngIf="bonus.id || currentBonusStrategyOption === BonusStrategyOption.POINTS || currentBonusStrategyDiscreteness !== undefined" class="row mt-4">
+    <div *ngIf="bonus.id || currentBonusStrategyOption !== undefined" class="row mt-4">
         <div class="bonus-form-step col-1"></div>
         <div class="form-group col">
             <label class="no-flex-shrink h5" jhiTranslate="artemisApp.bonus.calculation.title">Select calculation</label>

--- a/src/main/webapp/app/grading-system/bonus/bonus.component.ts
+++ b/src/main/webapp/app/grading-system/bonus/bonus.component.ts
@@ -247,6 +247,7 @@ export class BonusComponent implements OnInit {
         } else if (bonusStrategyOption === BonusStrategyOption.GRADES) {
             switch (bonusStrategyDiscreteness) {
                 case BonusStrategyDiscreteness.CONTINUOUS:
+                case undefined: // undefined case also returns GRADES_CONTINUOUS because GRADES_DISCRETE is not implemented yet.
                     return BonusStrategy.GRADES_CONTINUOUS;
                 case BonusStrategyDiscreteness.DISCRETE:
                     return BonusStrategy.GRADES_DISCRETE;

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -54,6 +54,7 @@ import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.service.exam.ExamQuizService;
 import de.tum.in.www1.artemis.service.exam.StudentExamService;
+import de.tum.in.www1.artemis.service.util.RoundingUtil;
 import de.tum.in.www1.artemis.util.LocalRepository;
 import de.tum.in.www1.artemis.util.ModelFactory;
 import de.tum.in.www1.artemis.web.rest.dto.StudentExamWithGradeDTO;
@@ -1728,6 +1729,52 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         assertThat(studentExamGradeInfoFromServer.studentResult().overallGrade()).isEqualTo("1.0");
         assertThat(studentExamGradeInfoFromServer.studentResult().hasPassed()).isTrue();
         assertThat(studentExamGradeInfoFromServer.studentResult().gradeWithBonus()).isNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testGradedStudentExamSummaryWithGradingScaleWithCorrectlyRoundedPoints() throws Exception {
+        StudentExam studentExam = createStudentExamWithResultsAndAssessments(true);
+
+        GradingScale gradingScale = createGradeScale(false);
+        gradingScale.setExam(exam2);
+        gradingScaleRepository.save(gradingScale);
+
+        studentParticipationRepository.findByStudentIdAndIndividualExercisesWithEagerSubmissionsResultIgnoreTestRuns(studentExam.getUser().getId(), studentExam.getExercises());
+        List<StudentParticipation> participations = studentParticipationRepository
+                .findByStudentIdAndIndividualExercisesWithEagerSubmissionsResultIgnoreTestRuns(studentExam.getUser().getId(), studentExam.getExercises());
+        var latestResults = participations.stream().flatMap(participation -> participation.getSubmissions().stream().map(Submission::getLatestResult)).toList();
+        for (var result : latestResults) {
+            // First set all results to 0 since we don't want any additions to affect the manually assigned results below.
+            result.setScore(0.0);
+        }
+
+        // The sum of the below scores have more than 1 digits after decimal due to how doubles are stored.
+        // i.e. 0.3 + 0.3 + 0.3 = 0.8999999999999999
+        latestResults.stream().limit(3).forEach(result -> {
+            Exercise exercise = result.getSubmission().getParticipation().getExercise();
+            exercise.setMaxPoints(100.0);  // To make points equal to scores for simplicity.
+            result.setScore(0.3);
+        });
+
+        resultRepository.saveAll(latestResults);
+        exerciseRepository.saveAll(latestResults.stream().map(result -> result.getSubmission().getParticipation().getExercise()).toList());
+
+        // Assert prerequisites of this test case
+        final int desiredAccuracyOfScores = 1;
+        assertThat(studentExam.getExam().getCourse().getAccuracyOfScores()).isEqualTo(desiredAccuracyOfScores);
+
+        double sumOfResultScores = latestResults.stream().mapToDouble(Result::getScore).sum();
+        double expectedOverallPoints = RoundingUtil.roundToNDecimalPlaces(sumOfResultScores, desiredAccuracyOfScores);
+
+        assertThat(sumOfResultScores).isNotEqualTo(expectedOverallPoints);
+
+        // Assert actual computed result.
+        database.changeUser(studentExam.getUser().getLogin());
+        var studentExamGradeInfoFromServer = request.get("/api/courses/" + course2.getId() + "/exams/" + exam2.getId() + "/student-exams/grade-summary", HttpStatus.OK,
+                StudentExamWithGradeDTO.class);
+
+        assertThat(studentExamGradeInfoFromServer.studentResult().overallPointsAchieved()).isEqualTo(expectedOverallPoints);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")

--- a/src/test/javascript/spec/component/bonus/bonus.component.spec.ts
+++ b/src/test/javascript/spec/component/bonus/bonus.component.spec.ts
@@ -241,7 +241,7 @@ describe('BonusComponent', () => {
         [BonusStrategy.GRADES_DISCRETE, BonusStrategyOption.GRADES, BonusStrategyDiscreteness.DISCRETE],
         [BonusStrategy.POINTS, BonusStrategyOption.POINTS, undefined],
         [undefined, undefined, undefined],
-        [undefined, BonusStrategyOption.GRADES, undefined],
+        [BonusStrategy.GRADES_CONTINUOUS, BonusStrategyOption.GRADES, undefined],
     ];
 
     beforeEach(async () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).(https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I ~added~ modified integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Some exam results contain points with improper rounding and this can be confusing.

- Also a bug in single student case course score calculation leads some students to see their bonus different from the actual value in exam summary view.

- There are references to the `GRADES_DISCRETE` bonus strategy which is not yet implemented, this can be redundant and/or confusing for the users.

### Description
<!-- Describe your changes in detail -->

- Round overallPointsAchieved to prevent floating point issues that might occur when summing up the exercise points.
- Filter course exercise student participations with relevant results for the single student case (it is already filtered in the multiple student case).
- Remove `GRADES_DISCRETE` references from the UI.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students
- 1 Graded exam with a course assigned as its bonus
- 1 Graded Student Exam with 3 exercises all having max points: 100 and result: 0.3 points. (So that the sum will be 0.3 + 0.3 + 0.3 = 0.8999999999999999 in Java. (Or a similar setup where there is extra rounding after summation is required due to how floating point calculations are made).

Fix for round overallPointsAchieved:
1. Log in to Artemis
2. Navigate to Course Administration
3. As the student, check the exam summary as a student and see that the achieved points are 0.9.

Remove `GRADES_DISCRETE` references from the UI:
1. As the instructor, click Bonus button in an exam with a grading scale type GRADE.
2. When creating or editing a bonus, ensure that no references to discreteness are visible. `Select discreteness` selection should not appear even when `Select a bonus strategy` is `Grades`.

Filter course exercise student participations with relevant results:
1. In the exam with course bonus, ensure that the bonus points assigned to a student is the same as the bonus points seen in the Exam > Scores view.

<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage

# [Codecov](https://codecov.io/gh/ls1intum/Artemis/pull/6339?src=pr&el=h1&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum) Report
> Merging [#6339](https://codecov.io/gh/ls1intum/Artemis/pull/6339?src=pr&el=desc&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum) (0bfba8b) into [develop](https://codecov.io/gh/ls1intum/Artemis/commit/12b86eb34b338b8ded63688f7639cf8f4b46049f?el=desc&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum) (12b86eb) will **increase** coverage by `3.83%`.
> The diff coverage is `100.00%`.

:mega: This organization is not using Codecov’s [GitHub App Integration](https://github.com/apps/codecov). We recommend you install it so Codecov can continue to function properly for your repositories. [Learn more](https://about.codecov.io/blog/codecov-is-updating-its-github-integration/?utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum)

Additional details and impacted files


```diff
@@              Coverage Diff              @@
##             develop    #6339      +/-   ##
=============================================
+ Coverage      76.46%   80.30%   +3.83%     
- Complexity         0    12986   +12986     
=============================================
  Files           1242     2303    +1061     
  Lines          46998    89150   +42152     
  Branches        8759    13172    +4413     
=============================================
+ Hits           35938    71590   +35652     
- Misses          5678     9750    +4072     
- Partials        5382     7810    +2428     
```

| [Impacted Files](https://codecov.io/gh/ls1intum/Artemis/pull/6339?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum) | Coverage Δ | |
|---|---|---|
| [...webapp/app/grading-system/bonus/bonus.component.ts](https://codecov.io/gh/ls1intum/Artemis/pull/6339?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum#diff-c3JjL21haW4vd2ViYXBwL2FwcC9ncmFkaW5nLXN5c3RlbS9ib251cy9ib251cy5jb21wb25lbnQudHM=) | `82.26% <ø> (ø)` | |
| [...mis/repository/StudentParticipationRepository.java](https://codecov.io/gh/ls1intum/Artemis/pull/6339?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum#diff-c3JjL21haW4vamF2YS9kZS90dW0vaW4vd3d3MS9hcnRlbWlzL3JlcG9zaXRvcnkvU3R1ZGVudFBhcnRpY2lwYXRpb25SZXBvc2l0b3J5LmphdmE=) | `84.61% <100.00%> (ø)` | |
| [...artemis/service/CourseScoreCalculationService.java](https://codecov.io/gh/ls1intum/Artemis/pull/6339?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum#diff-c3JjL21haW4vamF2YS9kZS90dW0vaW4vd3d3MS9hcnRlbWlzL3NlcnZpY2UvQ291cnNlU2NvcmVDYWxjdWxhdGlvblNlcnZpY2UuamF2YQ==) | `84.95% <100.00%> (ø)` | |
| [.../tum/in/www1/artemis/service/exam/ExamService.java](https://codecov.io/gh/ls1intum/Artemis/pull/6339?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum#diff-c3JjL21haW4vamF2YS9kZS90dW0vaW4vd3d3MS9hcnRlbWlzL3NlcnZpY2UvZXhhbS9FeGFtU2VydmljZS5qYXZh) | `87.50% <100.00%> (ø)` | |

... and [1059 files with indirect coverage changes](https://codecov.io/gh/ls1intum/Artemis/pull/6339/indirect-changes?src=pr&el=tree-more&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=ls1intum)

| Flag | Coverage Δ | |
|---|---|---|
| client | `76.46% <ø> (+<0.01%)` | :arrow_up: |
| server | `84.57% <100.00%> (?)` | |
