### PR TITLE
`Development`: Change `docker-compose` to `docker compose` to fix e2e issues

### DIFF
--- a/.bamboo/E2E-tests-with-flake-detection/cleanup.sh
+++ b/.bamboo/E2E-tests-with-flake-detection/cleanup.sh
@@ -4,4 +4,4 @@ cd src/main/docker/cypress
 
 # HOST_HOSTNAME not really necessary for shutdown but otherwise docker-compose complains
 export HOST_HOSTNAME=$(hostname)
-docker-compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml down -v
+docker compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml down -v

--- a/.bamboo/E2E-tests-with-flake-detection/execute.sh
+++ b/.bamboo/E2E-tests-with-flake-detection/execute.sh
@@ -17,8 +17,6 @@ cd src/main/docker/cypress
 # pass current host's hostname to the docker container for server.url (see docker compose config file)
 export HOST_HOSTNAME=$(hostname)
 
-export GH_REGISTRY_TOKEN='${bamboo.GH_REGISTRY_TOKEN}'
-
 docker compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml pull
 docker compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml build --no-cache --pull artemis-cypress
 #do not pull the base image artemis:coverage-latest for artemis-app as it's stored locally and built above

--- a/.bamboo/E2E-tests-with-flake-detection/execute.sh
+++ b/.bamboo/E2E-tests-with-flake-detection/execute.sh
@@ -19,11 +19,11 @@ export HOST_HOSTNAME=$(hostname)
 
 export GH_REGISTRY_TOKEN='${bamboo.GH_REGISTRY_TOKEN}'
 
-docker-compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml pull
-docker-compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml build --no-cache --pull artemis-cypress
+docker compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml pull
+docker compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml build --no-cache --pull artemis-cypress
 #do not pull the base image artemis:coverage-latest for artemis-app as it's stored locally and built above
-docker-compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml build --no-cache artemis-app
-docker-compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml up --exit-code-from artemis-cypress
+docker compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml build --no-cache artemis-app
+docker compose -f cypress-E2E-tests.yml -f cypress-E2E-tests-coverage-override.yml up --exit-code-from artemis-cypress
 exitCode=$?
 echo "Cypress container exit code: $exitCode"
 if [ $exitCode -eq 0 ]

--- a/.bamboo/E2E-tests/cleanup.sh
+++ b/.bamboo/E2E-tests/cleanup.sh
@@ -4,4 +4,4 @@ cd src/main/docker/cypress
 
 # HOST_HOSTNAME not really necessary for shutdown but otherwise docker-compose complains
 export HOST_HOSTNAME=$(hostname)
-docker-compose -f cypress-E2E-tests.yml down -v
+docker compose -f cypress-E2E-tests.yml down -v

--- a/.bamboo/E2E-tests/execute.sh
+++ b/.bamboo/E2E-tests/execute.sh
@@ -10,9 +10,9 @@ cd src/main/docker/cypress
 # pass current host's hostname to the docker container for server.url (see docker compose config file)
 export HOST_HOSTNAME=$(hostname)
 
-docker-compose -f cypress-E2E-tests.yml pull
-docker-compose -f cypress-E2E-tests.yml build --no-cache --pull
-docker-compose -f cypress-E2E-tests.yml up --exit-code-from artemis-cypress
+docker compose -f cypress-E2E-tests.yml pull
+docker compose -f cypress-E2E-tests.yml build --no-cache --pull
+docker compose -f cypress-E2E-tests.yml up --exit-code-from artemis-cypress
 exitCode=$?
 echo "Cypress container exit code: $exitCode"
 if [ $exitCode -eq 0 ]


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Since the upgrade of bamboo, the cleanup of the agents and the update of docker, the e2e tests did not fail, but hung up after the docker container stop:
![image](https://user-images.githubusercontent.com/1368405/224794730-5c415336-988b-4409-a966-15f41d1d224d.png)

After a certain amount of time, bamboo forces the task to stop, since nothing happened anymore. 

### Description
<!-- Describe your changes in detail -->
@4ludwig4 and I tried to debug this, which was not easy, since of all the maintenance that was done in the last weeks, it was not clear, where the issue came from. We noticed that the docker versions changed:
Before the update:
```
Docker Compose version v1.26.0
```

After the update:
```
13-Mar-2023 15:32:06 	Docker-Compose version v2.11.1
13-Mar-2023 15:32:06 	Docker Compose version v2.16.0
```

Since compose is not included within docker itself (by using `docker compose` instead of `docker-compose`) and a newer version of the included compose was available, we tried to use it instead of the external compose package. For some reason this seems to fix our problem. 
The problematic line of code is probably this one:
https://github.com/ls1intum/Artemis/blob/develop/.bamboo/E2E-tests/execute.sh#L15

The containers get started, then the e2e tests run. When cypress is finished testing everything the container will stop (with a certain exit code, that tells if the tests were successful or not) and then all the other containers are being stopped as well. For some reason, the containers were stopped, but nothing happened afterwards. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2
