### PR TITLE
`Development`: #6197: add buttons to quickly navigate to management

### DIFF
--- a/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.html
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.html
@@ -19,6 +19,13 @@
                     </span>
                 </h4>
             </div>
+            <ng-container *ngIf="showGoToLectureManagementButton()">
+                <div class="col-auto wrapper-btn-manage-lecture">
+                    <button id="manageLectureButton" class="btn btn-manage-lecture" (click)="redirectToLectureManagement()">
+                        {{ 'artemisApp.courseOverview.manage' | artemisTranslate }}
+                    </button>
+                </div>
+            </ng-container>
         </div>
     </div>
     <!-- HEADER INFORMATION END -->

--- a/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.scss
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.scss
@@ -1,0 +1,9 @@
+.wrapper-btn-manage-lecture {
+    display: flex;
+    align-items: center;
+}
+
+.btn-manage-lecture {
+    height: fit-content;
+    background-color: rgb(0, 188, 140) !important;
+}

--- a/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.ts
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.ts
@@ -14,6 +14,7 @@ import { finalize } from 'rxjs/operators';
 import { AlertService } from 'app/core/util/alert.service';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
+import { Router } from '@angular/router';
 
 export interface LectureUnitCompletionEvent {
     lectureUnit: LectureUnit;
@@ -23,7 +24,7 @@ export interface LectureUnitCompletionEvent {
 @Component({
     selector: 'jhi-course-lecture-details',
     templateUrl: './course-lecture-details.component.html',
-    styleUrls: ['../course-overview.scss', './course-lectures.scss'],
+    styleUrls: ['../course-overview.scss', './course-lectures.scss', 'course-lecture-details.component.scss'],
 })
 export class CourseLectureDetailsComponent implements OnInit {
     lectureId?: number;
@@ -45,6 +46,7 @@ export class CourseLectureDetailsComponent implements OnInit {
         private lectureUnitService: LectureUnitService,
         private activatedRoute: ActivatedRoute,
         private fileService: FileService,
+        private router: Router,
     ) {}
 
     ngOnInit(): void {
@@ -84,6 +86,14 @@ export class CourseLectureDetailsComponent implements OnInit {
                 },
                 error: (errorResponse: HttpErrorResponse) => onError(this.alertService, errorResponse),
             });
+    }
+
+    showGoToLectureManagementButton(): boolean {
+        return !!this.lecture?.course?.isAtLeastTutor;
+    }
+
+    redirectToLectureManagement(): void {
+        this.router.navigate([`/course-management/${this.lecture?.course?.id}/lectures/${this.lecture?.id}`]);
     }
 
     attachmentNotReleased(attachment: Attachment): boolean {

--- a/src/main/webapp/app/overview/header-course.component.html
+++ b/src/main/webapp/app/overview/header-course.component.html
@@ -9,6 +9,13 @@
                 </h6>
             </ng-container>
         </div>
+        <ng-container *ngIf="showGoToCourseManagementButton()">
+            <div class="col-auto wrapper-btn-manage-course">
+                <button class="btn btn-manage-course" (click)="redirectToCourseManagement()">
+                    {{ 'artemisApp.courseOverview.manage' | artemisTranslate }}
+                </button>
+            </div>
+        </ng-container>
         <div class="col-auto d-none d-lg-flex justify-content-end course-icon" *ngIf="course.courseIcon">
             <jhi-secured-image [src]="course.courseIcon" [cachingStrategy]="CachingStrategy.LOCAL_STORAGE" [alt]="'artemisApp.courseOverview.noCourseIcon' | artemisTranslate">
             </jhi-secured-image>

--- a/src/main/webapp/app/overview/header-course.component.scss
+++ b/src/main/webapp/app/overview/header-course.component.scss
@@ -6,6 +6,16 @@
     margin-bottom: 0;
 }
 
+.wrapper-btn-manage-course {
+    display: flex;
+    align-items: center;
+}
+
+.btn-manage-course {
+    height: fit-content;
+    background-color: rgb(0, 188, 140) !important;
+}
+
 .course-icon {
     ::ng-deep {
         img {

--- a/src/main/webapp/app/overview/header-course.component.ts
+++ b/src/main/webapp/app/overview/header-course.component.ts
@@ -2,6 +2,7 @@ import { Component, HostListener, Input, OnChanges } from '@angular/core';
 import { Course } from 'app/entities/course.model';
 import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 import { CachingStrategy } from 'app/shared/image/secured-image.component';
+import { Router } from '@angular/router';
 
 @Component({
     selector: 'jhi-header-course',
@@ -17,6 +18,8 @@ export class HeaderCourseComponent implements OnChanges {
     public courseDescription?: string;
     public enableShowMore = false;
     public longDescriptionShown = false;
+
+    constructor(private router: Router) {}
 
     ngOnChanges() {
         this.adjustCourseDescription();
@@ -48,5 +51,14 @@ export class HeaderCourseComponent implements OnChanges {
                 this.courseDescription = this.course.description;
             }
         }
+    }
+
+    showGoToCourseManagementButton() {
+        const courseManagementPage = this.router.url.startsWith('/course-management');
+        return !courseManagementPage && this.course.isAtLeastTutor;
+    }
+
+    redirectToCourseManagement() {
+        this.router.navigate([`/course-management/${this.course.id}`]);
     }
 }

--- a/src/main/webapp/i18n/de/student-dashboard.json
+++ b/src/main/webapp/i18n/de/student-dashboard.json
@@ -25,6 +25,7 @@
             "noCourseIcon": "Kein Kurs Icon verfügbar",
             "showMore": "Mehr anzeigen",
             "showLess": "Weniger anzeigen",
+            "manage": "Verwalten",
             "menu": {
                 "exercises": "Aufgaben",
                 "statistics": "Statistiken",

--- a/src/main/webapp/i18n/en/student-dashboard.json
+++ b/src/main/webapp/i18n/en/student-dashboard.json
@@ -25,6 +25,7 @@
             "noCourseIcon": "No course icon available",
             "showMore": "Show more",
             "showLess": "Show less",
+            "manage": "Manage",
             "menu": {
                 "exercises": "Exercises",
                 "statistics": "Statistics",

--- a/src/test/javascript/spec/component/course/header-course.component.spec.ts
+++ b/src/test/javascript/spec/component/course/header-course.component.spec.ts
@@ -2,6 +2,8 @@ import { TestBed } from '@angular/core/testing';
 import { HeaderCourseComponent } from 'app/overview/header-course.component';
 import { ArtemisTestModule } from '../../test.module';
 import { Course } from 'app/entities/course.model';
+import { MockProvider } from 'ng-mocks';
+import { Router } from '@angular/router';
 
 describe('Header Course Component', () => {
     let component: HeaderCourseComponent;
@@ -22,7 +24,7 @@ describe('Header Course Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            providers: [HeaderCourseComponent],
+            providers: [HeaderCourseComponent, MockProvider(Router)],
             imports: [ArtemisTestModule],
         })
             .compileComponents()
@@ -73,5 +75,47 @@ describe('Header Course Component', () => {
         component.onResize();
         expect(component.enableShowMore).toBeFalse();
         expect(component.courseDescription).toBe(courseWithShortDescription.description);
+    });
+
+    it('should display manage button', () => {
+        component.course = courseWithShortDescription;
+        component.course.isAtLeastTutor = true;
+        const router = TestBed.inject(Router);
+        const urlSpy = jest.spyOn(router, 'url', 'get');
+        urlSpy.mockReturnValue('/some-url');
+
+        const showManageLectureButton = component.showGoToCourseManagementButton();
+        expect(showManageLectureButton).toBeTrue();
+    });
+
+    it('should not display manage button in course management', () => {
+        component.course = courseWithShortDescription;
+        component.course!.isAtLeastTutor = true;
+        const router = TestBed.inject(Router);
+        const urlSpy = jest.spyOn(router, 'url', 'get');
+        urlSpy.mockReturnValue('/course-management/some-path');
+
+        const showManageLectureButton = component.showGoToCourseManagementButton();
+        expect(showManageLectureButton).toBeFalse();
+    });
+
+    it('should not display manage button to student', () => {
+        component.course = courseWithShortDescription;
+        component.course!.isAtLeastTutor = false;
+        const router = TestBed.inject(Router);
+        const urlSpy = jest.spyOn(router, 'url', 'get');
+        urlSpy.mockReturnValue('/some-url');
+
+        const showManageLectureButton = component.showGoToCourseManagementButton();
+        expect(showManageLectureButton).toBeFalse();
+    });
+
+    it('should redirect to course management', () => {
+        component.course = courseWithShortDescription;
+        const router = TestBed.inject(Router);
+        const navigateSpy = jest.spyOn(router, 'navigate');
+
+        component.redirectToCourseManagement();
+        expect(navigateSpy).toHaveBeenCalledWith([`/course-management/234`]);
     });
 });

--- a/src/test/javascript/spec/component/overview/course-lectures/course-lecture-details.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-lectures/course-lecture-details.component.spec.ts
@@ -124,6 +124,7 @@ describe('CourseLectureDetails', () => {
                         params: of({ lectureId: '1', courseId: '1' }),
                     },
                 },
+                MockProvider(Router),
             ],
             schemas: [],
         })
@@ -171,6 +172,31 @@ describe('CourseLectureDetails', () => {
         const downloadButton = debugElement.query(By.css('#downloadButton'));
         expect(downloadButton).toBeNull();
         expect(courseLecturesDetailsComponent.hasPdfLectureUnit).toBeFalse();
+    }));
+
+    it('should display manage button', fakeAsync(() => {
+        lecture.course!.isAtLeastTutor = true;
+        fixture.detectChanges();
+
+        const manageLectureButton = debugElement.query(By.css('#manageLectureButton'));
+        expect(manageLectureButton).not.toBeNull();
+    }));
+
+    it('should not display manage button', fakeAsync(() => {
+        lecture.course!.isAtLeastTutor = false;
+        fixture.detectChanges();
+
+        const manageLectureButton = debugElement.query(By.css('#manageLectureButton'));
+        expect(manageLectureButton).toBeNull();
+    }));
+
+    it('should redirect to lecture management', fakeAsync(() => {
+        const router = TestBed.inject(Router);
+        const navigateSpy = jest.spyOn(router, 'navigate');
+        fixture.detectChanges();
+
+        courseLecturesDetailsComponent.redirectToLectureManagement();
+        expect(navigateSpy).toHaveBeenCalledWith([`/course-management/456/lectures/1`]);
     }));
 
     it('should check attachment release date', fakeAsync(() => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [ ] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I implemented the changes with a good performance and prevented too many database calls.
- [ ] I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #6197

### Description
<!-- Describe your changes in detail -->
Added two buttons for quick redirection to course management. One on course page pointing to course management and second on lecture page going to lecture management. Both buttons are visible only to users who are at least tutors.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Course with lecture

1. Log in to Artemis as instructor 
1. Navigate to the course 
1. The button is visible next to course image
1. Navigate to the lecture
1. The button is visible next to the right on the header
1. Log in to Artemis as student 
1. Navigate to the course 
1. The button is not visible
1. Navigate to the lecture
1. The button is not visible

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

-

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
