### PR TITLE
`Development`: Fix Markdown preview functionality

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.html
@@ -7,10 +7,11 @@
         [markdown]="exercise.problemStatement"
         (markdownChange)="updateProblemStatement($event)"
         (onPreviewSelect)="generateHtml()"
+        [showDefaultPreview]="false"
         [enableResize]="false"
     >
         <jhi-programming-exercise-instructions
-            #preview
+            id="preview"
             *ngIf="exercise"
             class="editable-instruction-container__instructions"
             [participation]="participation"

--- a/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
@@ -105,10 +105,11 @@
                     [domainCommands]="commandMultipleChoiceQuestions"
                     (markdownChange)="changesInMarkdown()"
                     (textWithDomainCommandsFound)="domainCommandsFound($event)"
+                    [showDefaultPreview]="false"
                     class="h-auto"
                 >
                     <!-- Preview -->
-                    <ng-container id="preview" #preview>
+                    <ng-container id="preview">
                         <jhi-multiple-choice-question *ngIf="showMultipleChoiceQuestionPreview" [question]="question" [selectedAnswerOptions]="[]" [questionIndex]="questionIndex">
                         </jhi-multiple-choice-question>
                         <hr />

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
@@ -132,6 +132,10 @@ export class MarkdownEditorComponent implements AfterViewInit {
      * 2. false -> the preview of the parent component is used, parent has to set this value to false with an input */
     @Input() showPreviewButton = true;
 
+    /**
+     * true -> the markdown content will be rendered and shown, used when there are no special additions (e.g. text exercises)
+     * false -> the parent component adds its own preview content with id=preview. Used e.g. for programming exercises
+     */
     @Input() showDefaultPreview = true;
 
     @Input() showEditButton = true;

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
@@ -132,6 +132,8 @@ export class MarkdownEditorComponent implements AfterViewInit {
      * 2. false -> the preview of the parent component is used, parent has to set this value to false with an input */
     @Input() showPreviewButton = true;
 
+    @Input() showDefaultPreview = true;
+
     @Input() showEditButton = true;
 
     @Input() showVisualModeButton = false;
@@ -145,9 +147,6 @@ export class MarkdownEditorComponent implements AfterViewInit {
     /** {visualMode} when editor is created the visual mode is set to false, since the edit mode is set active */
     visualMode = false;
 
-    /** {previewChild} Is not null when the parent component is responsible for the preview content
-     * -> parent component has to implement ng-content and set the showPreviewButton on true through an input */
-    @ContentChild('preview', { static: false }) previewChild: ElementRef;
     @ContentChild(MultipleChoiceVisualQuestionComponent, { static: false }) visualChild: MultipleChoiceVisualQuestionComponent;
 
     /** Resizable constants **/
@@ -175,11 +174,6 @@ export class MarkdownEditorComponent implements AfterViewInit {
 
     constructor(private artemisMarkdown: ArtemisMarkdownService, private fileUploaderService: FileUploaderService, private alertService: AlertService) {
         this.uniqueMarkdownEditorId = 'markdown-editor-' + uuid();
-    }
-
-    /** {boolean} true when the plane html view is needed, false when the preview content is needed from the parent */
-    get showDefaultPreview(): boolean {
-        return this.previewChild == undefined;
     }
 
     /** opens the button for selecting the color */

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.html
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.html
@@ -12,9 +12,10 @@
         [defaultCommands]="defaultCommands"
         [enableFileUpload]="false"
         [colorCommands]="[]"
+        [showDefaultPreview]="false"
     >
         <!-- Preview -->
-        <ng-container #preview>
+        <ng-container id="preview">
             <jhi-posting-content *ngIf="previewMode" [content]="content"></jhi-posting-content>
             <hr />
         </ng-container>


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
Closes #6359

### Description
We currently use a `ContentChild` to determine whether a component uses their own or a custom preview. However, during my testing, this value was always undefined. According to the documentation it "does not retrieve elements or directives that are in other components' templates, since a component's template is always a black box to its ancestors".

Instead, we not use a boolean input to determine if a custom preview should be shown.

Also, since the template uses an id-selector (`#preview`), the id must also be set for all the preview childs.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

Use the markdown editor at the following places and check that the prview works correctly:
- Editing programming exercises
- Editing multiple-choice questions
- Editing a posting

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2