### PR TITLE
`General`: Improve button layout in exercise details page and improve export dialog

### DIFF
--- a/src/main/webapp/app/assessment/assessment-shared.module.ts
+++ b/src/main/webapp/app/assessment/assessment-shared.module.ts
@@ -6,8 +6,6 @@ import { AssessmentComplaintAlertComponent } from './assessment-complaint-alert/
 import { ScoreDisplayComponent } from '../shared/score-display/score-display.component';
 import { AssessmentDetailComponent } from './assessment-detail/assessment-detail.component';
 import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
-import { ExternalSubmissionDialogComponent } from 'app/exercises/shared/external-submission/external-submission-dialog.component';
-import { ExternalSubmissionButtonComponent } from 'app/exercises/shared/external-submission/external-submission-button.component';
 import { ArtemisComplaintsForTutorModule } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.module';
 import { AssessmentLocksComponent } from 'app/assessment/assessment-locks/assessment-locks.component';
 import { RouterModule } from '@angular/router';
@@ -34,8 +32,6 @@ const ENTITY_STATES = [...assessmentLocksRoute];
         AssessmentComplaintAlertComponent,
         ScoreDisplayComponent,
         AssessmentDetailComponent,
-        ExternalSubmissionButtonComponent,
-        ExternalSubmissionDialogComponent,
         AssessmentLocksComponent,
         UnreferencedFeedbackComponent,
         AssessmentCorrectionRoundBadgeComponent,
@@ -44,7 +40,6 @@ const ENTITY_STATES = [...assessmentLocksRoute];
         AssessmentLayoutComponent,
         ScoreDisplayComponent,
         AssessmentDetailComponent,
-        ExternalSubmissionButtonComponent,
         AssessmentLocksComponent,
         UnreferencedFeedbackComponent,
         AssessmentCorrectionRoundBadgeComponent,

--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.html
@@ -49,13 +49,15 @@
             <div class="checkbox">
                 <label class="control-label">
                     <input class="form-check-input" type="checkbox" name="filterLateSubmissions" [(ngModel)]="this.repositoryExportOptions.filterLateSubmissions" />
-                    <strong jhiTranslate="artemisApp.programmingExercise.export.filterLateSubmissions">Filter late submissions</strong>
+                    <strong jhiTranslate="artemisApp.programmingExercise.export.filterLateSubmissions.title">Filter late submissions</strong>
+                    <jhi-help-icon text="artemisApp.programmingExercise.export.filterLateSubmissions.tooltip"></jhi-help-icon>
                 </label>
             </div>
             <div class="form-group">
-                <strong jhiTranslate="artemisApp.programmingExercise.export.filterLateSubmissionsDate"
+                <strong jhiTranslate="artemisApp.programmingExercise.export.filterLateSubmissionsDate.title"
                     >Date for filter late submissions (defaults to exercise due date if not set)</strong
                 >
+                <jhi-help-icon text="artemisApp.programmingExercise.export.filterLateSubmissionsDate.tooltip"></jhi-help-icon>
                 <jhi-date-time-picker
                     [(ngModel)]="this.repositoryExportOptions.filterLateSubmissionsDate"
                     [disabled]="!this.repositoryExportOptions.filterLateSubmissions"
@@ -67,7 +69,8 @@
         <div *ngIf="!singleParticipantMode" class="checkbox">
             <label class="control-label">
                 <input class="form-check-input" type="checkbox" name="excludePracticeSubmissions" [(ngModel)]="this.repositoryExportOptions.excludePracticeSubmissions" />
-                <strong jhiTranslate="artemisApp.programmingExercise.export.excludePracticeSubmissions">Exclude practice submissions</strong>
+                <strong jhiTranslate="artemisApp.programmingExercise.export.excludePracticeSubmissions.title">Exclude practice submissions</strong>
+                <jhi-help-icon text="artemisApp.programmingExercise.export.excludePracticeSubmissions.tooltip"></jhi-help-icon>
             </label>
         </div>
         <div *ngIf="!singleParticipantMode" class="checkbox">
@@ -76,39 +79,45 @@
                 <strong
                     *ngIf="!isRepoExportForMultipleExercises"
                     [jhiTranslate]="
-                        'artemisApp.programmingExercise.export.' + (!isRepoExportForMultipleExercises && programmingExercises[0].teamMode ? 'addTeamName' : 'addStudentName')
+                        'artemisApp.programmingExercise.export.addToProject.title.' + (!isRepoExportForMultipleExercises && programmingExercises[0].teamMode ? 'team' : 'student')
                     "
                 >
                     Add {{ programmingExercises[0].teamMode ? 'team' : 'student' }} name to project
                 </strong>
-                <strong *ngIf="isRepoExportForMultipleExercises" [jhiTranslate]="'artemisApp.programmingExercise.export.addTeamOrStudentName'">
+                <strong *ngIf="isRepoExportForMultipleExercises" [jhiTranslate]="'artemisApp.programmingExercise.export.addToProject.title.teamOrStudent'">
                     Add team/student name to project
                 </strong>
+                <jhi-help-icon text="artemisApp.programmingExercise.export.addToProject.tooltip"></jhi-help-icon>
             </label>
         </div>
         <div class="checkbox">
             <label class="control-label">
                 <input class="form-check-input" type="checkbox" name="combineStudentCommits" [(ngModel)]="this.repositoryExportOptions.combineStudentCommits" />
-                <strong jhiTranslate="artemisApp.programmingExercise.export.combineStudentCommits">Combine all changes after instructor into one commit</strong>
+                <strong jhiTranslate="artemisApp.programmingExercise.export.combineStudentCommits.title">Combine all changes after instructor into one commit</strong>
+                <jhi-help-icon text="artemisApp.programmingExercise.export.combineStudentCommits.tooltip"></jhi-help-icon>
             </label>
         </div>
         <ng-container *ngIf="isAtLeastInstructor">
             <div class="checkbox">
                 <label class="control-label">
                     <input class="form-check-input" type="checkbox" name="anonymizeStudentCommits" [(ngModel)]="this.repositoryExportOptions.anonymizeStudentCommits" checked />
-                    <strong jhiTranslate="artemisApp.programmingExercise.export.anonymizeStudentCommits">Anonymize all of the student's commits</strong>
+                    <strong jhiTranslate="artemisApp.programmingExercise.export.anonymizeStudentCommits.title">Anonymize all of the student's commits</strong>
+                    <jhi-help-icon text="artemisApp.programmingExercise.export.anonymizeStudentCommits.tooltip"></jhi-help-icon>
                 </label>
             </div>
         </ng-container>
         <div class="checkbox">
             <label class="control-label">
                 <input class="form-check-input" type="checkbox" name="normalizeCodeStyle" [(ngModel)]="this.repositoryExportOptions.normalizeCodeStyle" />
-                <strong jhiTranslate="artemisApp.programmingExercise.export.normalizeCodeStyle">Normalize code style (line endings, encoding)</strong>
+                <strong jhiTranslate="artemisApp.programmingExercise.export.normalizeCodeStyle.title">Normalize code style (line endings, encoding)</strong>
+                <jhi-help-icon text="artemisApp.programmingExercise.export.normalizeCodeStyle.tooltip"></jhi-help-icon>
             </label>
         </div>
-        <p *ngIf="!singleParticipantMode" jhiTranslate="artemisApp.instructorDashboard.exportRepos.timeWarning">
-            <b>Note:</b> This action can take several minutes depending on number and size of repositories.
-        </p>
+        <div *ngIf="!singleParticipantMode" class="alert alert-warning mt-3">
+            <span jhiTranslate="artemisApp.instructorDashboard.exportRepos.timeWarning">
+                <b>Note:</b> This action can take several minutes depending on number and size of repositories.
+            </span>
+        </div>
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal" (click)="clear()">

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -47,7 +47,6 @@
                         <fa-icon [icon]="faUserCheck"></fa-icon>
                         <span jhiTranslate="artemisApp.programmingExercise.configureGrading.shortTitle">Grading</span>
                     </a>
-                    <jhi-external-submission *ngIf="programmingExercise.isAtLeastInstructor" [exercise]="programmingExercise" class="me-1"> </jhi-external-submission>
                 </div>
                 <div>
                     <a *ngIf="programmingExercise.isAtLeastTutor" [routerLink]="baseResource + 'participations'" class="btn btn-primary btn-sm me-1" style="margin-bottom: 10px">

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -102,11 +102,6 @@
                         [exerciseId]="programmingExercise.id!"
                         class="me-1"
                     ></jhi-programming-exercise-instructor-exercise-download>
-                    <jhi-programming-assessment-repo-export
-                        *ngIf="programmingExercise.isAtLeastInstructor"
-                        [programmingExercises]="[programmingExercise]"
-                        class="me-1"
-                    ></jhi-programming-assessment-repo-export>
                     <a
                         *ngIf="programmingExercise.isAtLeastTutor && programmingExercise.course && !isExamExercise"
                         [routerLink]="['/course-management', programmingExercise.course!.id!, 'programming-exercises', programmingExercise.id!, 'exercise-statistics']"

--- a/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
@@ -75,17 +75,11 @@
             [entityTitle]="exercise.title || ''"
             deleteQuestion="artemisApp.exercise.delete.question"
             deleteConfirmationText="artemisApp.exercise.delete.typeNameToConfirm"
-            class="me-1"
-            style="margin-bottom: 10px"
+            class="me-1 mb-2"
             (delete)="deleteExercise()"
             [dialogError]="dialogError$"
         >
             <fa-icon [icon]="faTimes"></fa-icon>
         </button>
-    </div>
-
-    <div class="mb-1">
-        <!-- import external submissions -->
-        <jhi-external-submission *ngIf="exercise.isAtLeastInstructor" class="d-inline-block me-1 mb-1" [exercise]="exercise"></jhi-external-submission>
     </div>
 </ng-container>

--- a/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
@@ -87,13 +87,5 @@
     <div class="mb-1">
         <!-- import external submissions -->
         <jhi-external-submission *ngIf="exercise.isAtLeastInstructor" class="d-inline-block me-1 mb-1" [exercise]="exercise"></jhi-external-submission>
-
-        <!-- Export submissions -->
-        <jhi-exercise-submission-export
-            *ngIf="exercise.isAtLeastInstructor"
-            class="d-inline-block mb-1"
-            [exerciseId]="exercise.id!"
-            [exerciseType]="exercise.type!"
-        ></jhi-exercise-submission-export>
     </div>
 </ng-container>

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
@@ -92,7 +92,7 @@
                     <fa-icon [icon]="faListAlt"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="artemisApp.exercise.participations">Participations</span>
                 </a>
-
+                <jhi-external-submission *ngIf="exercise.isAtLeastInstructor" class="d-inline-block me-1 mb-1" [exercise]="exercise"></jhi-external-submission>
                 <button
                     jhi-exercise-action-button
                     [buttonIcon]="faDownload"

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.module.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.module.ts
@@ -14,6 +14,9 @@ import { ArtemisSharedComponentModule } from 'app/shared/components/shared-compo
 import { SubmissionExportDialogComponent } from 'app/exercises/shared/submission-export/submission-export-dialog.component';
 import { ExerciseScoresExportButtonComponent } from 'app/exercises/shared/exercise-scores/exercise-scores-export-button.component';
 import { SubmissionResultStatusModule } from 'app/overview/submission-result-status.module';
+import { ArtemisMarkdownModule } from 'app/shared/markdown.module';
+import { ExternalSubmissionDialogComponent } from 'app/exercises/shared/external-submission/external-submission-dialog.component';
+import { ExternalSubmissionButtonComponent } from 'app/exercises/shared/external-submission/external-submission-button.component';
 
 @NgModule({
     imports: [
@@ -28,8 +31,16 @@ import { SubmissionResultStatusModule } from 'app/overview/submission-result-sta
         FeatureToggleModule,
         ArtemisSharedComponentModule,
         SubmissionResultStatusModule,
+        ArtemisMarkdownModule,
     ],
-    declarations: [ExerciseScoresComponent, SubmissionExportButtonComponent, SubmissionExportDialogComponent, ExerciseScoresExportButtonComponent],
-    exports: [SubmissionExportButtonComponent, ExerciseScoresExportButtonComponent],
+    declarations: [
+        ExerciseScoresComponent,
+        SubmissionExportButtonComponent,
+        SubmissionExportDialogComponent,
+        ExerciseScoresExportButtonComponent,
+        ExternalSubmissionButtonComponent,
+        ExternalSubmissionDialogComponent,
+    ],
+    exports: [SubmissionExportButtonComponent, ExerciseScoresExportButtonComponent, ExternalSubmissionButtonComponent],
 })
 export class ArtemisExerciseScoresModule {}

--- a/src/main/webapp/app/exercises/shared/external-submission/external-submission-button.component.ts
+++ b/src/main/webapp/app/exercises/shared/external-submission/external-submission-button.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { faAsterisk } from '@fortawesome/free-solid-svg-icons';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { Exercise } from 'app/entities/exercise.model';
 import { ExternalSubmissionDialogComponent } from 'app/exercises/shared/external-submission/external-submission-dialog.component';
@@ -12,7 +12,7 @@ import { ButtonSize, ButtonType } from 'app/shared/components/button.component';
             *ngIf="!exercise.teamMode"
             [btnType]="ButtonType.WARNING"
             [btnSize]="ButtonSize.SMALL"
-            [icon]="faAsterisk"
+            [icon]="faPlus"
             [title]="'entity.action.addExternalSubmission'"
             (onClick)="openExternalSubmissionDialog($event)"
         ></jhi-button>
@@ -25,7 +25,7 @@ export class ExternalSubmissionButtonComponent {
     @Input() exercise: Exercise;
 
     // Icons
-    faAsterisk = faAsterisk;
+    faPlus = faPlus;
 
     constructor(private modalService: NgbModal) {}
 

--- a/src/main/webapp/app/exercises/shared/submission-export/submission-export-dialog.component.html
+++ b/src/main/webapp/app/exercises/shared/submission-export/submission-export-dialog.component.html
@@ -34,9 +34,10 @@
                 </label>
             </div>
             <div class="form-group">
-                <strong jhiTranslate="artemisApp.instructorDashboard.exportSubmissions.filterLateSubmissionsDate"
+                <strong jhiTranslate="artemisApp.instructorDashboard.exportSubmissions.filterLateSubmissionsDate.title"
                     >Date for filter late submissions (defaults to exercise due date if not set)</strong
                 >
+                <jhi-help-icon text="artemisApp.instructorDashboard.exportSubmissions.filterLateSubmissionsDate.tooltip"></jhi-help-icon>
                 <jhi-date-time-picker
                     [(ngModel)]="this.submissionExportOptions.filterLateSubmissionsDate"
                     [disabled]="!this.submissionExportOptions.filterLateSubmissions"

--- a/src/main/webapp/i18n/de/instructorDashboard.json
+++ b/src/main/webapp/i18n/de/instructorDashboard.json
@@ -56,7 +56,10 @@
                 "downloadAllStudents": "Oder lade die Abgaben aller Studierenden herunter",
                 "question": "Tragen sie hier alle Kennungen der Studierenden getrennt durch ein Komma ein, deren Abgaben heruntergeladen werden sollen (z.B. ga87fix,ga63dut)",
                 "filterLateSubmissions": "Verspätete Abgaben herausfiltern",
-                "filterLateSubmissionsDate": "Datum zum Filtern verspäteter Abgaben (standardmäßig Einreichungsfrist der Aufgabe)",
+                "filterLateSubmissionsDate": {
+                    "title": "Datum zum Filtern verspäteter Abgaben",
+                    "tooltip": "Standardmäßig das Abgabedatum der Aufgabe, falls kein Datum gesetzt"
+                },
                 "successMessage": "Die Abgaben wurden erfolgreich exportiert. Die generierte Zip-Datei wird jetzt heruntergeladen."
             },
             "loadingStudents": "Lade die Ergebnisse aller Studierenden..."

--- a/src/main/webapp/i18n/de/programmingExercise.json
+++ b/src/main/webapp/i18n/de/programmingExercise.json
@@ -283,15 +283,38 @@
                 "downloadExercise": "Programmierübung herunterladen",
                 "downloadAllStudents": "Oder lade die Repositories aller Studierenden herunter",
                 "downloadAllTeams": "Oder lade die Repositories aller Teams herunter",
-                "filterLateSubmissions": "Verspätete Abgaben herausfiltern",
-                "filterLateSubmissionsDate": "Datum zum Filtern verspäteter Abgaben (standardmäßig Einreichungsfrist der Aufgabe)",
-                "excludePracticeSubmissions": "Abgaben aus dem Übungsmodus ausschließen",
-                "addStudentName": "Namen der Studierenden zum Projekt hinzufügen (erlaubt es mehrere Projekte gleichzeitig in Eclipse zu importieren)",
-                "addTeamName": "Namen der Teams zum Projekt hinzufügen (erlaubt es mehrere Projekte gleichzeitig in Eclipse zu importieren)",
-                "addTeamOrStudentName": "Namen der Teams/Studierenden zum Projekt hinzufügen (erlaubt es mehrere Projekte gleichzeitig in Eclipse zu importieren)",
-                "combineStudentCommits": "Alle Änderungen von Studierenden in einem Commit zusammenfassen (um das Review zu vereinfachen)",
-                "anonymizeStudentCommits": "Alle Änderungen von Studierenden anonymisieren",
-                "normalizeCodeStyle": "Code-Style normalisieren (Zeilenumbrüche, Kodierung)",
+                "filterLateSubmissions": {
+                    "title": "Verspätete Abgaben herausfiltern",
+                    "tooltip": "Alle Abgaben und Commits nach einem bestimmten Datum ausschließen"
+                },
+                "filterLateSubmissionsDate": {
+                    "title": "Datum zum Filtern verspäteter Abgaben",
+                    "tooltip": "Standardmäßig das Abgabedatum der Aufgabe, falls kein Datum gesetzt"
+                },
+                "excludePracticeSubmissions": {
+                    "title": "Abgaben aus dem Übungsmodus ausschließen",
+                    "tooltip": "Ignoriere als Übung markierte Abgaben und behalte nur benotete Abgaben"
+                },
+                "addToProject": {
+                    "title": {
+                        "student": "Namen der Studierenden zum Projekt hinzufügen",
+                        "team": "Namen der Teams zum Projekt hinzufügen",
+                        "teamOrStudent": "Namen der Teams/Studierenden zum Projekt hinzufügen"
+                    },
+                    "tooltip": "Erlaubt das gleichzeitige Importieren mehrerer Projekte in Eclipse"
+                },
+                "combineStudentCommits": {
+                    "title": "Alle Änderungen in einem Commit zusammenfassen",
+                    "tooltip": "Fasst alle Commits eines Studierenden in einem einzigen Commit für leichtere Korrektur zusammen"
+                },
+                "anonymizeStudentCommits": {
+                    "title": "Alle Änderungen von Studierenden anonymisieren",
+                    "tooltip": "Verberge die Namen der Studierenden in Commits für eine unvoreingenommene Bewertung"
+                },
+                "normalizeCodeStyle": {
+                    "title": "Code-Style normalisieren",
+                    "tooltip": "Standardisiere Zeilenumbrüche und Kodierung für Konsistenz"
+                },
                 "successMessageRepos": "Die Repositories wurden erfolgreich exportiert. Die generierte zip-Datei wird jetzt heruntergeladen.",
                 "successMessageExercise": "Die Programmierübung wurde erfolgreich exportiert. Die generierte zip-Datei wird jetzt heruntergeladen."
             },

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -287,7 +287,7 @@
             "title": "Confirm archive operation"
         },
         "exportRepos": {
-            "title": "Confirm download of repos"
+            "title": "Export Repositories"
         },
         "validation": {
             "required": "This field is required.",

--- a/src/main/webapp/i18n/en/instructorDashboard.json
+++ b/src/main/webapp/i18n/en/instructorDashboard.json
@@ -56,7 +56,10 @@
                 "downloadAllStudents": "Or download the submissions of all students",
                 "question": "Enter all logins separated by ',' (e.g ga87fix,ga63dut) of students you want to download the submission from",
                 "filterLateSubmissions": "Filter late submissions",
-                "filterLateSubmissionsDate": "Date for filter late submissions (defaults to exercise due date if not set)",
+                "filterLateSubmissionsDate": {
+                    "title": "Date for filter late submissions",
+                    "tooltip": "Defaults to the due date of the exercise if not set"
+                },
                 "successMessage": "Export of submissions was successful. The exported zip file is currently being downloaded."
             },
             "loadingStudents": "Loading the results of all students..."

--- a/src/main/webapp/i18n/en/programmingExercise.json
+++ b/src/main/webapp/i18n/en/programmingExercise.json
@@ -283,15 +283,38 @@
                 "downloadExercise": "Download Exercise",
                 "downloadAllStudents": "Or download the repositories of all students",
                 "downloadAllTeams": "Or download the repositories of all teams",
-                "filterLateSubmissions": "Filter late submissions",
-                "filterLateSubmissionsDate": "Date to filter late submissions (defaults to exercise due date if not set)",
-                "excludePracticeSubmissions": "Exclude practice submissions",
-                "addStudentName": "Add student name to project (allows importing multiple projects into Eclipse at the same time)",
-                "addTeamName": "Add team name to project (allows importing multiple projects into Eclipse at the same time)",
-                "addTeamOrStudentName": "Add team/student name to project (allows importing multiple projects into Eclipse at the same time)",
-                "combineStudentCommits": "Combine all student changes into one commit (to simplify the review)",
-                "anonymizeStudentCommits": "Anonymize all of the student's commits",
-                "normalizeCodeStyle": "Normalize code style (line endings, encoding)",
+                "filterLateSubmissions": {
+                    "title": "Filter late submissions",
+                    "tooltip": "Cut off all submissions and commits after a certain date"
+                },
+                "filterLateSubmissionsDate": {
+                    "title": "Date to filter late submissions",
+                    "tooltip": "Defaults to the due date of the exercise if not set"
+                },
+                "excludePracticeSubmissions": {
+                    "title": "Exclude practice submissions",
+                    "tooltip": "Ignore submissions marked as practice to only include graded submissions"
+                },
+                "addToProject": {
+                    "title": {
+                        "student": "Add student name to project",
+                        "team": "Add team name to project",
+                        "teamOrStudent": "Add team/student name to project"
+                    },
+                    "tooltip": "Allows importing multiple projects into Eclipse at the same time"
+                },
+                "combineStudentCommits": {
+                    "title": "Combine changes into one commit",
+                    "tooltip": "Squashes all commits of a student into a single commit for easier review"
+                },
+                "anonymizeStudentCommits": {
+                    "title": "Anonymize all of the student's commits",
+                    "tooltip": "Hide student names in commit messages for unbiased evaluation"
+                },
+                "normalizeCodeStyle": {
+                    "title": "Normalize code style",
+                    "tooltip": "Standardize line endings and encoding for consistency"
+                },
                 "successMessageRepos": "Export of repos was successful. The exported zip file with all repositories is currently being downloaded.",
                 "successMessageExercise": "Export of exercise was successful. The exported zip file with all exercise material is currently being downloaded."
             },


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
<!--
#### Server
- [ ] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I implemented the changes with a good performance and prevented too many database calls.
- [ ] I documented the Java code using JavaDoc style.
-->
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] ~~I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).~~ (Only small UI changes)
- [x] ~~I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).~~ (No routes added)
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

<!--
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR addresses several changes requested by @krusche as a followup PR to #6345. 
 * Remove the download submissions/repositories button from from exercise's detail pages (programming exercises, as well as non-programming exercises). It already exists on the scores page and should only be there.
 * Move the "Add External Submission" from the exercise's detail page to the scores page
 * Change the wording of the options in the export submissions/repositories dialog to be easier to understand and generally shorter, and adding a (?) tooltip for extra information


### Description
<!-- Describe your changes in detail -->

Removed "Export Submissions" from the non-programming exercise's detail page as well as the "Download Repos" from the programming exercise's detail page. Additionally, the "Add External Submission" button moved to the scores page and its icon changed. 

In the export repositories dialog, the options got simplified and tooltips are added for most of the options. Also, the caution warning for exporting multiple programming exercises is now more consistent with the other warnings. 
In the export submissions dialog, one tooltip has been added and the text was adjusted for the late submissions' date. 

Also fixed a UI inconsistency with the delete button on the text exercise's detail page.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students
- 1 Programming Exercise
- 1 Non-Programming Exercise

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to the programming exercise's detail page
4. Verify that "Download Repos" and "Add External Submission" is missing
5. Click Scores
6. Verify that "Add External Submission" exists, and works as previously
7. Export -> "Download Repos"
8. Verify titles of the options and tooltips are meaningful
9. Go back to the exercises overview
10. Go to the non-programming exercise's detail page
11. Verify that "Export Submissions" and "Add External Submission" is missing
12. Click Scores
13. Verify that "Add External Submission" exists, and works as previously
14. Export -> "Export Submissions"
15. Verify titles of the options and tooltips are meaningful (only late submission date changed)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2

#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->
unchanged

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

#### Exercise's Detail Page

**Text Exercise (Old)**
<img width="1076" alt="TE Detail Old" src="https://user-images.githubusercontent.com/5898705/227383439-6c665fa3-e0e5-471d-9ce5-fb61b1e01a67.png">

**Text Exercise (New)**
<img width="1076" alt="TE Detail New" src="https://user-images.githubusercontent.com/5898705/227383413-f5f7dbfc-a762-4d5d-8bc0-d808fb43469b.png">

**Programming Exercise (Old)**
<img width="1002" alt="PE Detail Old" src="https://user-images.githubusercontent.com/5898705/227383446-fb154ba9-0d10-4721-97b1-1324f38ddb3e.png">

**Programming Exercise (New)**
<img width="1076" alt="PE Detail New" src="https://user-images.githubusercontent.com/5898705/227383445-b4ca5d77-eaed-46d8-8717-1cc416386842.png">

#### Exercise's Scores Page

**Text Exercise (Old)**
<img width="1076" alt="TE Scores Old" src="https://user-images.githubusercontent.com/5898705/227383441-de958dd4-dd49-4cb6-8072-89f091b7022d.png">

**Text Exercise (New)**
<img width="1002" alt="TE Scores New" src="https://user-images.githubusercontent.com/5898705/227383431-641d4129-7480-4acd-ae21-3f1e0b8ae83f.png">

**Programming Exercise (Old)**
<img width="1076" alt="PE Scores Old" src="https://user-images.githubusercontent.com/5898705/227383443-972bef55-531d-4570-b1cc-6b77af78a0a9.png">

**Programming Exercise (New)**
<img width="1076" alt="PE Scores New" src="https://user-images.githubusercontent.com/5898705/227383433-c7193b36-9179-4c7d-8768-59c8f9a23235.png">

#### Exercise Export 

**Text Exercise (Old)**
<img width="1076" alt="TE Export Old" src="https://user-images.githubusercontent.com/5898705/227383436-b53a3c02-9686-471a-8035-5d9287f920d5.png">

**Text Exercise (New)**
<img width="1076" alt="TE Scores Export New" src="https://user-images.githubusercontent.com/5898705/227383427-ddb9533a-ee7b-4794-98e2-e2bf043c2fae.png">

**Programming Exercise (Old)**
<img width="1076" alt="PE Export Old" src="https://user-images.githubusercontent.com/5898705/227383442-fac1d547-af1b-4d4f-8f41-7f4261a51f59.png">

**Programming Exercise (New)**
<img width="1076" alt="PE Export New" src="https://user-images.githubusercontent.com/5898705/227383434-12ffdf2b-7b07-4f37-a535-d5496a3565de.png">
