### PR TITLE
`Programming exercises`: Fix a visual issue with static code analysis warnings in the online editor

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.scss
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.scss
@@ -73,7 +73,7 @@ Ace Editor
     }
 
     .ace_gutter-cell.gutter-diff-newLine {
-        transition: background 0s;
-        background: var(--code-editor-gutter-newline-background);
+        transition: background-color 0s;
+        background-color: var(--code-editor-gutter-newline-background);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Closes #6366.

### Description
Sets the colour of the diff as background-colour instead of background. Therefore, the image for the warning is not replaced, but instead remains with the colour now in the background behind it.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Java Programming Exercise with manual assessment

1. Submit as student to the exercise a submission that contains static code analysis issues. E.g. introduce an attribute `public static int non_uppercase = 0;`
2. Start the manual assessment as instructor.
3. The issue should be shown in the gutter like in the screenshot below in the online code editor view.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
For screenshots from before, check #6366.

Warning is shown with green background:
![Screenshot 2023-03-28 at 10-54-55 Programming Exercises](https://user-images.githubusercontent.com/64250573/228183935-5fdb2b32-91c5-400c-bd31-8b25bfdb7dc0.png)

