### PR TITLE
`Quiz exercises`: Fix drop location of modeling quiz text elements

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
@@ -139,7 +139,7 @@ async function generateDragAndDropItem(
     svgSize: { width: number; height: number },
     fileUploaderService: FileUploaderService,
 ): Promise<DragAndDropMapping> {
-    const textualElementTypes: UMLElementType[] = [UMLElementType.ClassAttribute, UMLElementType.ClassMethod, UMLElementType.ObjectAttribute];
+    const textualElementTypes: UMLElementType[] = [UMLElementType.ClassAttribute, UMLElementType.ClassMethod, UMLElementType.ObjectAttribute, UMLElementType.ObjectMethod];
     if (element.type in UMLRelationshipType) {
         return generateDragAndDropItemForRelationship(element, model, svgSize, fileUploaderService);
     } else if (textualElementTypes.includes(element.type as UMLElementType)) {
@@ -245,6 +245,9 @@ async function generateDragAndDropItemForRelationship(
  */
 function computeDropLocation(elementLocation: { x: number; y: number; width: number; height: number }, totalSize: { width: number; height: number }): DropLocation {
     const dropLocation = new DropLocation();
+    // on quiz exercise generation, svg exports adds 15px padding
+    elementLocation.x += 15;
+    elementLocation.y += 15;
     // round to second decimal
     dropLocation.posX = round((elementLocation.x / totalSize.width) * MAX_SIZE_UNIT, 2);
     dropLocation.posY = round((elementLocation.y / totalSize.height) * MAX_SIZE_UNIT, 2);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis as an Instructor
2. Navigate to Course Management and then Exercises
3. Click on "Create a Drag and Drop Model Quiz"
4. Click on "Create a new Apollon Diagram"
5. Select a Class Diagram or an Object Diagram
6. Drag and Drop a couple of UML elements
7. Click on the Interactive tab and select a few attributes or/and methods.
8. Click "Generate a Quiz Exercise"
9. Return to the exercises overview and find created quiz
10. Click on "Preview Quiz"
11. Observe drop locations are where they should be

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Previously:**
<img width="1068" alt="227293955-1b5099da-fd15-432f-bc75-786005effe68" src="https://user-images.githubusercontent.com/36473858/228484961-c9ad6023-5ab8-4fc5-9dac-894e6bd21e19.png">

**Now:**
![Screenshot 2023-03-29 at 11 10 38](https://user-images.githubusercontent.com/36473858/228485709-6a6d777e-5c42-400e-99a3-9d7a26346e3c.png)
