### PR TITLE
`Development`: Simplify exam assessment e2e test and make it more robust

### DIFF
--- a/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
@@ -24,7 +24,6 @@ import { Exercise } from '../../support/pageobjects/exam/ExamParticipation';
 
 let exam: Exam;
 let course: Course;
-let exerciseArray: Array<Exercise> = [];
 
 // This is a workaround for uncaught athene errors. When opening a text submission athene throws an uncaught exception, which fails the test
 Cypress.on('uncaught:exception', () => {
@@ -48,8 +47,6 @@ describe('Exam assessment', () => {
 
     // For some reason the typing of cypress gets slower the longer the test runs, so we test the programming exercise first
     describe('Programming exercise assessment', () => {
-        exerciseArray = [];
-
         before('Prepare exam', () => {
             examEnd = dayjs().add(2.5, 'minutes');
             prepareExam(examEnd, EXERCISE_TYPE.Programming);
@@ -74,8 +71,6 @@ describe('Exam assessment', () => {
     });
 
     describe('Modeling exercise assessment', () => {
-        exerciseArray = [];
-
         before('Prepare exam', () => {
             examEnd = dayjs().add(30, 'seconds');
             prepareExam(examEnd, EXERCISE_TYPE.Modeling);
@@ -107,8 +102,6 @@ describe('Exam assessment', () => {
     });
 
     describe('Text exercise assessment', () => {
-        exerciseArray = [];
-
         before('Prepare exam', () => {
             examEnd = dayjs().add(30, 'seconds');
             prepareExam(examEnd, EXERCISE_TYPE.Text);
@@ -135,7 +128,6 @@ describe('Exam assessment', () => {
     });
 
     describe('Quiz exercise assessment', () => {
-        exerciseArray = [];
         let resultDate: Dayjs;
 
         before('Prepare exam', () => {

--- a/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
@@ -1,33 +1,30 @@
 import { Interception } from 'cypress/types/net-stubbing';
 import { Course } from 'app/entities/course.model';
-import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import { Exam } from 'app/entities/exam.model';
-import { CypressAssessmentType, CypressExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
+import { ExamBuilder, ProgrammingExerciseAssessmentType, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import partiallySuccessful from '../../fixtures/exercise/programming/partially_successful/submission.json';
 import dayjs, { Dayjs } from 'dayjs/esm';
-import textSubmission from '../../fixtures/exercise/text/submission.json';
-import multipleChoiceQuizTemplate from '../../fixtures/exercise/quiz/multiple_choice/template.json';
 import {
     courseAssessment,
     courseManagementRequest,
     examAssessment,
+    examExerciseGroupCreation,
     examManagement,
     examNavigation,
+    examParticipation,
     examStartEnd,
     exerciseAssessment,
     modelingExerciseAssessment,
-    modelingExerciseEditor,
     programmingExerciseEditor,
-    quizExerciseMultipleChoice,
     studentAssessment,
-    textExerciseEditor,
 } from '../../support/artemis';
 import { admin, instructor, studentOne, tutor } from '../../support/users';
 import { EXERCISE_TYPE } from '../../support/constants';
+import { Exercise } from '../../support/pageobjects/exam/ExamParticipation';
 
 let exam: Exam;
-let exerciseGroup: ExerciseGroup;
 let course: Course;
+let exerciseArray: Array<Exercise> = [];
 
 // This is a workaround for uncaught athene errors. When opening a text submission athene throws an uncaught exception, which fails the test
 Cypress.on('uncaught:exception', () => {
@@ -51,38 +48,11 @@ describe('Exam assessment', () => {
 
     // For some reason the typing of cypress gets slower the longer the test runs, so we test the programming exercise first
     describe('Programming exercise assessment', () => {
+        exerciseArray = [];
+
         before('Prepare exam', () => {
             examEnd = dayjs().add(2.5, 'minutes');
-            prepareExam(examEnd);
-        });
-
-        before('Create exam, exercise and submission', () => {
-            cy.login(instructor);
-            courseManagementRequest
-                .createProgrammingExercise(
-                    { exerciseGroup },
-                    undefined,
-                    false,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    CypressAssessmentType.SEMI_AUTOMATIC,
-                )
-                .then((progResponse) => {
-                    const programmingExercise = progResponse.body;
-                    courseManagementRequest.generateMissingIndividualExams(exam);
-                    courseManagementRequest.prepareExerciseStartForExam(exam);
-                    cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-                    examStartEnd.startExam();
-                    examNavigation.openExerciseAtIndex(0);
-                    programmingExerciseEditor.makeSubmissionAndVerifyResults(programmingExercise.id!, programmingExercise.packageName!, partiallySuccessful, () => {
-                        examNavigation.handInEarly();
-                        examStartEnd.finishExam();
-                    });
-                });
+            prepareExam(examEnd, EXERCISE_TYPE.Programming);
         });
 
         it('Assess a programming exercise submission (MANUAL)', () => {
@@ -98,32 +68,17 @@ describe('Exam assessment', () => {
 
         it('Complaints about programming exercises assessment', () => {
             if (programmingAssessmentSuccessful) {
-                handleComplaint(false, EXERCISE_TYPE.Programming);
+                handleComplaint(course, exam, false, EXERCISE_TYPE.Programming);
             }
         });
     });
 
     describe('Modeling exercise assessment', () => {
-        before('Prepare exam', () => {
-            examEnd = dayjs().add(20, 'seconds');
-            prepareExam(examEnd);
-        });
+        exerciseArray = [];
 
-        before('Create modeling exercise and submission', () => {
-            cy.login(instructor);
-            courseManagementRequest.createModelingExercise({ exerciseGroup }).then((response) => {
-                const exercise = response.body;
-                courseManagementRequest.generateMissingIndividualExams(exam);
-                courseManagementRequest.prepareExerciseStartForExam(exam);
-                cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-                examStartEnd.startExam();
-                examNavigation.openExerciseAtIndex(0);
-                modelingExerciseEditor.addComponentToModel(exercise.id!, 1);
-                modelingExerciseEditor.addComponentToModel(exercise.id!, 2);
-                modelingExerciseEditor.addComponentToModel(exercise.id!, 3);
-                examNavigation.handInEarly();
-                examStartEnd.finishExam();
-            });
+        before('Prepare exam', () => {
+            examEnd = dayjs().add(30, 'seconds');
+            prepareExam(examEnd, EXERCISE_TYPE.Modeling);
         });
 
         it('Assess a modeling exercise submission', () => {
@@ -146,34 +101,17 @@ describe('Exam assessment', () => {
 
         it('Complaints about modeling exercises assessment', () => {
             if (modelingAssessmentSuccessful) {
-                handleComplaint(true, EXERCISE_TYPE.Modeling);
+                handleComplaint(course, exam, true, EXERCISE_TYPE.Modeling);
             }
         });
     });
 
     describe('Text exercise assessment', () => {
-        before('Prepare exam', () => {
-            examEnd = dayjs().add(25, 'seconds');
-            prepareExam(examEnd);
-        });
+        exerciseArray = [];
 
-        before('Create text exercise and submission', () => {
-            cy.login(instructor);
-            const exerciseTitle = 'Cypress Text Exercise';
-            courseManagementRequest.createTextExercise({ exerciseGroup }, exerciseTitle).then((response) => {
-                const exercise = response.body;
-                courseManagementRequest.generateMissingIndividualExams(exam);
-                courseManagementRequest.prepareExerciseStartForExam(exam);
-                cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-                examStartEnd.startExam();
-                examNavigation.openExerciseAtIndex(0);
-                textExerciseEditor.typeSubmission(exercise.id, textSubmission.text);
-                textExerciseEditor.saveAndContinue().then((submissionResponse) => {
-                    expect(submissionResponse.response?.statusCode).to.equal(200);
-                });
-                examNavigation.handInEarly();
-                examStartEnd.finishExam();
-            });
+        before('Prepare exam', () => {
+            examEnd = dayjs().add(30, 'seconds');
+            prepareExam(examEnd, EXERCISE_TYPE.Text);
         });
 
         it('Assess a text exercise submission', () => {
@@ -191,39 +129,24 @@ describe('Exam assessment', () => {
 
         it('Complaints about text exercises assessment', () => {
             if (textAssessmentSuccessful) {
-                handleComplaint(false, EXERCISE_TYPE.Text);
+                handleComplaint(course, exam, false, EXERCISE_TYPE.Text);
             }
         });
     });
 
     describe('Quiz exercise assessment', () => {
+        exerciseArray = [];
         let resultDate: Dayjs;
 
         before('Prepare exam', () => {
             examEnd = dayjs().add(25, 'seconds');
             resultDate = examEnd.add(5, 'seconds');
-            prepareExam(examEnd, resultDate);
-        });
-
-        before('Create exercise and submission', () => {
-            cy.login(instructor);
-            courseManagementRequest.createQuizExercise({ exerciseGroup }, [multipleChoiceQuizTemplate], 'Cypress Quiz').then((quizResponse) => {
-                const exercise = quizResponse.body;
-                courseManagementRequest.generateMissingIndividualExams(exam);
-                courseManagementRequest.prepareExerciseStartForExam(exam);
-                cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-                examStartEnd.startExam();
-                examNavigation.openExerciseAtIndex(0);
-                quizExerciseMultipleChoice.tickAnswerOption(exercise.id, 0, quizResponse.body.quizQuestions[0].id);
-                quizExerciseMultipleChoice.tickAnswerOption(exercise.id, 2, quizResponse.body.quizQuestions[0].id);
-                examNavigation.handInEarly();
-                examStartEnd.finishExam();
-            });
+            prepareExam(examEnd, EXERCISE_TYPE.Quiz);
         });
 
         it('Assesses quiz automatically', () => {
             if (dayjs().isBefore(examEnd)) {
-                cy.wait(examEnd.diff(dayjs(), 'ms') + 5000);
+                cy.wait(examEnd.diff(dayjs(), 'ms') + 10000);
             }
             cy.login(admin, `/course-management/${course.id}/exams/${exam.id}/assessment-dashboard`);
             courseAssessment.clickEvaluateQuizzes().its('response.statusCode').should('eq', 200);
@@ -239,10 +162,57 @@ describe('Exam assessment', () => {
     });
 
     after('Delete course', () => {
-        cy.login(admin);
-        courseManagementRequest.deleteCourse(course.id!);
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
+        }
     });
 });
+
+function prepareExam(end: dayjs.Dayjs, exerciseType: EXERCISE_TYPE) {
+    cy.login(admin);
+    const resultDate = end.add(1, 'second');
+    const examContent = new ExamBuilder(course)
+        .visibleDate(dayjs().subtract(1, 'hour'))
+        .startDate(dayjs())
+        .endDate(end)
+        .correctionRounds(1)
+        .examStudentReviewStart(resultDate.add(10, 'seconds'))
+        .examStudentReviewEnd(resultDate.add(1, 'minute'))
+        .publishResultsDate(resultDate)
+        .gracePeriod(10)
+        .build();
+    courseManagementRequest.createExam(examContent).then((examResponse) => {
+        exam = examResponse.body;
+        courseManagementRequest.registerStudentForExam(exam, studentOne);
+        let additionalData = {};
+        switch (exerciseType) {
+            case EXERCISE_TYPE.Programming:
+                additionalData = { submission: partiallySuccessful, progExerciseAssessmentType: ProgrammingExerciseAssessmentType.SEMI_AUTOMATIC };
+                break;
+            case EXERCISE_TYPE.Text:
+                additionalData = { textFixture: 'loremIpsum.txt' };
+                break;
+            case EXERCISE_TYPE.Quiz:
+                additionalData = { quizExerciseID: 0 };
+                break;
+        }
+
+        examExerciseGroupCreation.addGroupWithExercise(exam, exerciseType, additionalData).then((response) => {
+            courseManagementRequest.generateMissingIndividualExams(exam);
+            courseManagementRequest.prepareExerciseStartForExam(exam);
+            makeExamSubmission(course, exam, response);
+        });
+    });
+}
+
+function makeExamSubmission(course: Course, exam: Exam, exercise: Exercise) {
+    examParticipation.startParticipation(studentOne, course, exam);
+    examNavigation.openExerciseAtIndex(0);
+    examParticipation.makeSubmission(exercise.id, exercise.type, exercise.additionalData);
+    examNavigation.handInEarly();
+    examStartEnd.finishExam();
+}
 
 function startAssessing() {
     courseAssessment.clickExerciseDashboardButton();
@@ -251,28 +221,7 @@ function startAssessing() {
     cy.get('#assessmentLockedCurrentUser').should('be.visible');
 }
 
-function prepareExam(end: dayjs.Dayjs, resultDate = end.add(1, 'seconds')) {
-    cy.login(admin);
-    const examContent = new CypressExamBuilder(course)
-        .visibleDate(dayjs().subtract(1, 'hour'))
-        .startDate(dayjs())
-        .endDate(end)
-        .correctionRounds(1)
-        .examStudentReviewStart(resultDate.add(10, 'seconds'))
-        .examStudentReviewEnd(resultDate.add(1, 'minute'))
-        .publishResultsDate(resultDate)
-        .gracePeriod(0)
-        .build();
-    courseManagementRequest.createExam(examContent).then((examResponse) => {
-        exam = examResponse.body;
-        courseManagementRequest.registerStudentForExam(exam, studentOne);
-        courseManagementRequest.addExerciseGroupForExam(exam).then((groupResponse) => {
-            exerciseGroup = groupResponse.body;
-        });
-    });
-}
-
-function handleComplaint(reject: boolean, exerciseType: EXERCISE_TYPE) {
+function handleComplaint(course: Course, exam: Exam, reject: boolean, exerciseType: EXERCISE_TYPE) {
     const complaintText = 'Lorem ipsum dolor sit amet';
     const complaintResponseText = ' consetetur sadipscing elitr';
 

--- a/src/test/cypress/e2e/exam/ExamCreationDeletion.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamCreationDeletion.cy.ts
@@ -1,6 +1,6 @@
 import { Interception } from 'cypress/types/net-stubbing';
 import { Course } from 'app/entities/course.model';
-import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
+import { ExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import dayjs from 'dayjs/esm';
 import { dayjsToString, generateUUID, trimDate } from '../../support/utils';
 import { courseManagement, courseManagementRequest, examCreation, examDetails, examManagement, navigationBar } from '../../support/artemis';
@@ -98,7 +98,7 @@ describe('Exam creation/deletion', () => {
     describe('Exam deletion', () => {
         beforeEach(() => {
             examData.title = 'exam' + generateUUID();
-            const exam = new CypressExamBuilder(course).title(examData.title).build();
+            const exam = new ExamBuilder(course).title(examData.title).build();
             courseManagementRequest.createExam(exam).then((examResponse) => {
                 examId = examResponse.body.id;
             });
@@ -116,7 +116,7 @@ describe('Exam creation/deletion', () => {
     describe('Edits an exam', () => {
         beforeEach(() => {
             examData.title = 'exam' + generateUUID();
-            const exam = new CypressExamBuilder(course).title(examData.title).build();
+            const exam = new ExamBuilder(course).title(examData.title).build();
             courseManagementRequest.createExam(exam).then((examResponse) => {
                 examId = examResponse.body.id;
             });

--- a/src/test/cypress/e2e/exam/ExamDateVerification.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamDateVerification.cy.ts
@@ -1,7 +1,7 @@
 import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import { Course } from 'app/entities/course.model';
 import { Exam } from 'app/entities/exam.model';
-import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
+import { ExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import dayjs from 'dayjs/esm';
 import { generateUUID } from '../../support/utils';
 import { courseManagementRequest, courseOverview, examNavigation, examStartEnd, textExerciseEditor } from '../../support/artemis';
@@ -27,7 +27,7 @@ describe('Exam date verification', () => {
     describe('Exam timing', () => {
         let exam: Exam;
         it('Does not show exam before visible date', () => {
-            const examContent = new CypressExamBuilder(course)
+            const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .visibleDate(dayjs().add(1, 'day'))
                 .startDate(dayjs().add(2, 'days'))
@@ -44,7 +44,7 @@ describe('Exam date verification', () => {
         });
 
         it('Shows after visible date', () => {
-            const examContent = new CypressExamBuilder(course)
+            const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .visibleDate(dayjs().subtract(5, 'days'))
                 .startDate(dayjs().add(2, 'days'))
@@ -63,7 +63,7 @@ describe('Exam date verification', () => {
 
         it('Student can start after start Date', () => {
             let exerciseGroup: ExerciseGroup;
-            const examContent = new CypressExamBuilder(course)
+            const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .visibleDate(dayjs().subtract(3, 'days'))
                 .startDate(dayjs().subtract(2, 'days'))
@@ -96,12 +96,7 @@ describe('Exam date verification', () => {
         it('Exam ends after end time', () => {
             let exerciseGroup: ExerciseGroup;
             const examEnd = dayjs().add(30, 'seconds');
-            const examContent = new CypressExamBuilder(course)
-                .title(examTitle)
-                .visibleDate(dayjs().subtract(3, 'days'))
-                .startDate(dayjs().subtract(2, 'days'))
-                .endDate(examEnd)
-                .build();
+            const examContent = new ExamBuilder(course).title(examTitle).visibleDate(dayjs().subtract(3, 'days')).startDate(dayjs().subtract(2, 'days')).endDate(examEnd).build();
             courseManagementRequest.createExam(examContent).then((examResponse) => {
                 exam = examResponse.body;
                 courseManagementRequest.registerStudentForExam(exam, studentOne);

--- a/src/test/cypress/e2e/exam/ExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamManagement.cy.ts
@@ -1,7 +1,7 @@
 import { Interception } from 'cypress/types/net-stubbing';
 import { Exam } from 'app/entities/exam.model';
 import { Course } from 'app/entities/course.model';
-import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
+import { ExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import { generateUUID } from '../../support/utils';
 import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import {
@@ -34,7 +34,7 @@ describe('Exam management', () => {
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertCourseAfterMultiPart(response);
             courseManagementRequest.addStudentToCourse(course, studentOne);
-            const examConfig = new CypressExamBuilder(course).title(examTitle).build();
+            const examConfig = new ExamBuilder(course).title(examTitle).build();
             courseManagementRequest.createExam(examConfig).then((examResponse) => {
                 exam = examResponse.body;
             });

--- a/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
@@ -41,13 +41,14 @@ describe('Exam participation', () => {
                 .build();
             courseManagementRequest.createExam(examContent).then((examResponse) => {
                 exam = examResponse.body;
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Text, { textFixture });
-
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Programming, { submission });
-
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 });
-
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Modeling);
+                Promise.all([
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Text, { textFixture }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Programming, { submission }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Modeling),
+                ]).then((responses) => {
+                    exerciseArray = exerciseArray.concat(responses);
+                });
 
                 courseManagementRequest.registerStudentForExam(exam, studentOne);
                 courseManagementRequest.registerStudentForExam(exam, studentTwo);
@@ -118,7 +119,7 @@ describe('Exam participation', () => {
             exerciseArray = [];
 
             cy.login(admin);
-            const examContent = new CypressExamBuilder(course)
+            const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .visibleDate(dayjs().subtract(3, 'minutes'))
                 .startDate(dayjs().subtract(2, 'minutes'))
@@ -128,7 +129,9 @@ describe('Exam participation', () => {
                 .build();
             courseManagementRequest.createExam(examContent).then((examResponse) => {
                 exam = examResponse.body;
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Text, { textFixture });
+                examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Text, { textFixture }).then((response) => {
+                    exerciseArray.push(response);
+                });
 
                 courseManagementRequest.registerStudentForExam(exam, studentOne);
                 courseManagementRequest.registerStudentForExam(exam, studentTwo);
@@ -214,7 +217,9 @@ describe('Exam participation', () => {
                 .build();
             courseManagementRequest.createExam(examContent).then((examResponse) => {
                 exam = examResponse.body;
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Text, { textFixture });
+                examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Text, { textFixture }).then((response) => {
+                    exerciseArray.push(response);
+                });
 
                 courseManagementRequest.registerStudentForExam(exam, studentOne);
                 courseManagementRequest.generateMissingIndividualExams(exam);

--- a/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
@@ -1,5 +1,5 @@
 import { Exam } from 'app/entities/exam.model';
-import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
+import { ExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import dayjs from 'dayjs/esm';
 import submission from '../../fixtures/exercise/programming/all_successful/submission.json';
 import { Course } from 'app/entities/course.model';
@@ -31,7 +31,7 @@ describe('Exam participation', () => {
 
         before('Create exam', () => {
             cy.login(admin);
-            const examContent = new CypressExamBuilder(course)
+            const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .visibleDate(dayjs().subtract(3, 'minutes'))
                 .startDate(dayjs().subtract(2, 'minutes'))
@@ -207,7 +207,7 @@ describe('Exam participation', () => {
             exerciseArray = [];
 
             cy.login(admin);
-            const examContent = new CypressExamBuilder(course)
+            const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .visibleDate(dayjs().subtract(3, 'minutes'))
                 .startDate(dayjs().subtract(2, 'minutes'))

--- a/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
@@ -1,5 +1,5 @@
 import { Exam } from 'app/entities/exam.model';
-import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
+import { ExamBuilder, convertCourseAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import dayjs from 'dayjs/esm';
 import submission from '../../fixtures/exercise/programming/build_error/submission.json';
 import { Course } from 'app/entities/course.model';
@@ -25,7 +25,7 @@ describe('Exam test run', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertCourseAfterMultiPart(response);
-            const examContent = new CypressExamBuilder(course)
+            const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .visibleDate(dayjs().subtract(3, 'days'))
                 .startDate(dayjs().add(1, 'days'))

--- a/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
@@ -14,7 +14,7 @@ import { admin, instructor } from '../../support/users';
 const textFixture = 'loremIpsum.txt';
 const examTitle = 'exam' + generateUUID();
 
-const exerciseArray: Array<Exercise> = [];
+let exerciseArray: Array<Exercise> = [];
 
 describe('Exam test run', () => {
     let course: Course;
@@ -35,13 +35,14 @@ describe('Exam test run', () => {
                 .build();
             courseManagementRequest.createExam(examContent).then((examResponse) => {
                 exam = examResponse.body;
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Text, { textFixture });
-
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Programming, { submission, practiceMode: true });
-
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 });
-
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Modeling);
+                Promise.all([
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Text, { textFixture }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Programming, { submission, practiceMode: true }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Modeling),
+                ]).then((responses) => {
+                    exerciseArray = exerciseArray.concat(responses);
+                });
             });
         });
     });

--- a/src/test/cypress/e2e/exam/test-exam/TestExamCreationDeletion.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamCreationDeletion.cy.ts
@@ -1,6 +1,6 @@
 import { Interception } from 'cypress/types/net-stubbing';
 import { Course } from 'app/entities/course.model';
-import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
+import { ExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import dayjs from 'dayjs/esm';
 import { dayjsToString, generateUUID, trimDate } from '../../../support/utils';
 import { courseManagement, courseManagementRequest, examCreation, examDetails, examManagement, navigationBar } from '../../../support/artemis';
@@ -79,7 +79,7 @@ describe('Test Exam creation/deletion', () => {
     describe('Test exam deletion', () => {
         beforeEach(() => {
             examData.title = 'exam' + generateUUID();
-            const exam = new CypressExamBuilder(course).title(examData.title).testExam().build();
+            const exam = new ExamBuilder(course).title(examData.title).testExam().build();
             courseManagementRequest.createExam(exam).then((examResponse) => {
                 examId = examResponse.body.id;
             });

--- a/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
@@ -1,6 +1,6 @@
 import { Exam } from 'app/entities/exam.model';
 import { Course } from 'app/entities/course.model';
-import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
+import { ExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import { generateUUID } from '../../../support/utils';
 import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import {
@@ -32,7 +32,7 @@ describe('Test Exam management', () => {
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertCourseAfterMultiPart(response);
             courseManagementRequest.addStudentToCourse(course, studentOne);
-            const examConfig = new CypressExamBuilder(course).title(examTitle).testExam().build();
+            const examConfig = new ExamBuilder(course).title(examTitle).testExam().build();
             courseManagementRequest.createExam(examConfig).then((examResponse) => {
                 exam = examResponse.body;
             });

--- a/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
@@ -1,5 +1,5 @@
 import { Exam } from 'app/entities/exam.model';
-import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
+import { ExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import dayjs from 'dayjs/esm';
 import allSuccessful from '../../../fixtures/exercise/programming/all_successful/submission.json';
 import buildError from '../../../fixtures/exercise/programming/build_error/submission.json';
@@ -32,7 +32,7 @@ describe('Test exam participation', () => {
 
         before('Create test exam', () => {
             cy.login(admin);
-            const examContent = new CypressExamBuilder(course)
+            const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .testExam()
                 .visibleDate(dayjs().subtract(3, 'days'))
@@ -126,7 +126,7 @@ describe('Test exam participation', () => {
             exerciseArray = [];
 
             cy.login(admin);
-            const examContent = new CypressExamBuilder(course)
+            const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .testExam()
                 .visibleDate(dayjs().subtract(3, 'days'))

--- a/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
@@ -44,18 +44,22 @@ describe('Test exam participation', () => {
                 .build();
             courseManagementRequest.createExam(examContent).then((examResponse) => {
                 exam = examResponse.body;
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Text, { textFixture });
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Text, { textFixture });
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Text, { textFixture });
+                Promise.all([
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Text, { textFixture }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Text, { textFixture }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Text, { textFixture }),
 
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Programming, { submission: allSuccessful, expectedScore: 100 });
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Programming, { submission: buildError, expectedScore: 0 });
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Programming, { submission: allSuccessful, expectedScore: 100 }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Programming, { submission: buildError, expectedScore: 0 }),
 
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 });
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 });
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 }),
 
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Modeling);
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Modeling);
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Modeling),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Modeling),
+                ]).then((responses) => {
+                    exerciseArray = exerciseArray.concat(responses);
+                });
             });
         });
 
@@ -134,7 +138,9 @@ describe('Test exam participation', () => {
                 .build();
             courseManagementRequest.createExam(examContent).then((examResponse) => {
                 exam = examResponse.body;
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Text, { textFixture });
+                examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Text, { textFixture }).then((response) => {
+                    exerciseArray.push(response);
+                });
             });
         });
 

--- a/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
@@ -14,7 +14,7 @@ import { admin, instructor } from '../../../support/users';
 const textFixture = 'loremIpsum.txt';
 const examTitle = 'exam' + generateUUID();
 
-const exerciseArray: Array<Exercise> = [];
+let exerciseArray: Array<Exercise> = [];
 
 describe('Test exam test run', () => {
     let course: Course;
@@ -36,13 +36,14 @@ describe('Test exam test run', () => {
                 .build();
             courseManagementRequest.createExam(examContent).then((examResponse) => {
                 exam = examResponse.body;
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Text, { textFixture });
-
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Programming, { submission, practiceMode: true });
-
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 });
-
-                examExerciseGroupCreation.addGroupWithExercise(exerciseArray, exam, EXERCISE_TYPE.Modeling);
+                Promise.all([
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Text, { textFixture }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Programming, { submission, practiceMode: true }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Quiz, { quizExerciseID: 0 }),
+                    examExerciseGroupCreation.addGroupWithExercise(exam, EXERCISE_TYPE.Modeling),
+                ]).then((responses) => {
+                    exerciseArray = exerciseArray.concat(responses);
+                });
             });
         });
     });

--- a/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
@@ -1,5 +1,5 @@
 import { Exam } from 'app/entities/exam.model';
-import { CypressExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
+import { ExamBuilder, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import dayjs from 'dayjs/esm';
 import submission from '../../../fixtures/exercise/programming/build_error/submission.json';
 import { Course } from 'app/entities/course.model';
@@ -25,7 +25,7 @@ describe('Test exam test run', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertCourseAfterMultiPart(response);
-            const examContent = new CypressExamBuilder(course)
+            const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .testExam()
                 .visibleDate(dayjs().subtract(3, 'days'))

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
@@ -1,7 +1,7 @@
 import { Interception } from 'cypress/types/net-stubbing';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { Course } from 'app/entities/course.model';
-import { CypressAssessmentType, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
+import { ProgrammingExerciseAssessmentType, convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import dayjs from 'dayjs/esm';
 import {
     courseAssessment,
@@ -94,7 +94,18 @@ describe('Programming exercise assessment', () => {
             dueDate = dayjs().add(25, 'seconds');
             assessmentDueDate = dueDate.add(30, 'seconds');
             courseManagementRequest
-                .createProgrammingExercise({ course }, undefined, false, dayjs(), dueDate, undefined, undefined, undefined, assessmentDueDate, CypressAssessmentType.SEMI_AUTOMATIC)
+                .createProgrammingExercise(
+                    { course },
+                    undefined,
+                    false,
+                    dayjs(),
+                    dueDate,
+                    undefined,
+                    undefined,
+                    undefined,
+                    assessmentDueDate,
+                    ProgrammingExerciseAssessmentType.SEMI_AUTOMATIC,
+                )
                 .then((programmingResponse) => {
                     exercise = programmingResponse.body;
                 });

--- a/src/test/cypress/support/pageobjects/exam/ExamParticipation.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamParticipation.ts
@@ -15,6 +15,7 @@ import {
 import { Interception } from 'cypress/types/net-stubbing';
 import { CypressCredentials } from '../../users';
 import { ProgrammingExerciseSubmission } from '../exercises/programming/OnlineEditorPage';
+import { ProgrammingExerciseAssessmentType } from '../../requests/CourseManagementRequests';
 
 /**
  * A class which encapsulates UI selectors and actions for the exam details page.
@@ -124,6 +125,7 @@ export class AdditionalData {
     expectedScore?: number;
     textFixture?: string;
     practiceMode?: boolean;
+    progExerciseAssessmentType?: ProgrammingExerciseAssessmentType;
 }
 
 export type Exercise = {

--- a/src/test/cypress/support/requests/CourseManagementRequests.ts
+++ b/src/test/cypress/support/requests/CourseManagementRequests.ts
@@ -581,7 +581,7 @@ export class CourseManagementRequests {
 /**
  * Helper class to construct exam objects for the {@link CourseManagementRequests.createExam} method.
  */
-export class CypressExamBuilder {
+export class ExamBuilder {
     readonly template: any = examTemplate;
 
     /**

--- a/src/test/cypress/support/requests/CourseManagementRequests.ts
+++ b/src/test/cypress/support/requests/CourseManagementRequests.ts
@@ -128,14 +128,14 @@ export class CourseManagementRequests {
         programmingShortName = 'cypress' + generateUUID(),
         packageName = 'de.test',
         assessmentDate = day().add(2, 'days'),
-        assessmentType = CypressAssessmentType.AUTOMATIC,
+        assessmentType = ProgrammingExerciseAssessmentType.AUTOMATIC,
     ): Cypress.Chainable<Cypress.Response<ProgrammingExercise>> {
         const template = {
             ...programmingExerciseTemplate,
             title,
             shortName: programmingShortName,
             packageName,
-            assessmentType: CypressAssessmentType[assessmentType],
+            assessmentType: ProgrammingExerciseAssessmentType[assessmentType],
         };
         const exercise: ProgrammingExercise = Object.assign({}, template, body) as ProgrammingExercise;
         // eslint-disable-next-line no-prototype-builtins
@@ -264,7 +264,7 @@ export class CourseManagementRequests {
 
     /**
      * Creates an exam with the provided settings.
-     * @param exam the exam object created by a {@link CypressExamBuilder}
+     * @param exam the exam object created by a {@link ExamBuilder}
      * @returns <Chainable> request response
      */
     createExam(exam: Exam) {
@@ -289,7 +289,7 @@ export class CourseManagementRequests {
 
     /**
      * Creates an exam with the provided settings.
-     * @param exam the exam object created by a {@link CypressExamBuilder}
+     * @param exam the exam object created by a {@link ExamBuilder}
      * @param exerciseArray an array of exercises
      * @param workingTime the working time in seconds
      * @returns <Chainable> request response
@@ -705,7 +705,7 @@ export class CypressExamBuilder {
     }
 }
 
-export enum CypressAssessmentType {
+export enum ProgrammingExerciseAssessmentType {
     AUTOMATIC,
     SEMI_AUTOMATIC,
     MANUAL,


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
From time to time the exam assessment e2e tests tend to fail. By refactoring the tests we hope to simplify this test suite and make it more robust.  

### Description
<!-- Describe your changes in detail -->
This PR refactors the exam assessment e2e test suite. It also removes "Cypress" from a classname and a enum. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
