### PR TITLE
`Programming exercises`: Fix missing translation when creating a programming exercise

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -16,7 +16,7 @@
     <form name="editForm" role="form" novalidate #editForm="ngForm" (keydown.enter)="isEventInsideTextArea($event)" *ngIf="!isShowingWizardMode">
         <div class="d-flex" *ngIf="!isImport && !programmingExercise.id">
             <div class="flex-grow-1 align-items-center">
-                <h4 *ngIf="!isImport && !programmingExercise.id" id="jhi-programming-exercise-heading-create" jhiTranslate="artemisApp.programmingExercise.home.generateLabel">
+                <h4 *ngIf="!isImport && !programmingExercise.id" id="jhi-programming-exercise-heading-create" jhiTranslate="artemisApp.programmingExercise.home.createLabel">
                     Generate new Programming Exercise
                 </h4>
                 <jhi-documentation-button [type]="documentationType"></jhi-documentation-button>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
### Motivation and Context
#6356 unified the labels and deleted a lot of unused labels.
When creating a programming exercise, no translation is currently found because the programming-exercise-update component hasn't been changed and still uses the old (now deleted) label.

### Description
Just change the translation key to use the correct (existing label)
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Generate programming exercise
2. Check that the correct heading is shown and **not** translation not found.

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->
Testing is the same as above.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [x] Test

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->
unchanged

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/84102468/229373271-6612130c-dc52-49bb-b334-50199060ca5d.png)

