### PR TITLE
`Programming exercises`: Fix test case feedback processing in Jenkins setups

### DIFF
--- a/src/main/resources/templates/jenkins/c/fact/regularRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/c/fact/regularRuns/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
                 sh  '''
                     if [ -e test-reports/tests-results.xml ]
                     then
-                        sed -i 's/[^[:print:]]/�/g' test-reports/tests-results.xml
+                        sed -i 's/[^[:print:]\t]/�/g' test-reports/tests-results.xml
                         sed -i 's/<skipped/<error/g' test-reports/tests-results.xml
                         sed -i 's/<\/skipped>/<\/error>/g' test-reports/tests-results.xml
                     fi

--- a/src/main/resources/templates/jenkins/c/gcc/regularRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/c/gcc/regularRuns/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
                 sh  '''
                     if [ -e test-reports/tests-results.xml ]
                     then
-                        sed -i 's/[^[:print:]]/�/g' test-reports/tests-results.xml
+                        sed -i 's/[^[:print:]\t]/�/g' test-reports/tests-results.xml
                         sed -i 's/<skipped/<error/g' test-reports/tests-results.xml
                         sed -i 's/<\/skipped>/<\/error>/g' test-reports/tests-results.xml
                     fi

--- a/src/main/resources/templates/jenkins/haskell/regularRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/haskell/regularRuns/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                     sed -i 's/<testsuites[^>]*>//g ; s/<\/testsuites>//g' test-reports/results.xml
                 fi
                 cp test-reports/*.xml $WORKSPACE/results/ || true
-                sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                 '''
             sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'
             cleanWs()

--- a/src/main/resources/templates/jenkins/java/gradle/regularRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/java/gradle/regularRuns/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
                 rm -rf results
                 mkdir results
                 cp build/test-results/test/*.xml $WORKSPACE/results/ || true
-                sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                 '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'
                 cleanWs()

--- a/src/main/resources/templates/jenkins/java/gradle/regularRuns/Jenkinsfile-staticCodeAnalysis
+++ b/src/main/resources/templates/jenkins/java/gradle/regularRuns/Jenkinsfile-staticCodeAnalysis
@@ -39,7 +39,7 @@ pipeline {
                 rm -rf results
                 mkdir results
                 cp build/test-results/test/*.xml $WORKSPACE/results/ || true
-                sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                 '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'
                 cleanWs()

--- a/src/main/resources/templates/jenkins/java/gradle/sequentialRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/java/gradle/sequentialRuns/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
                 mkdir results
                 cp build/test-results/structuralTests/*.xml $WORKSPACE/results/ || true
                 cp build/test-results/behaviorTests/*.xml $WORKSPACE/results/ || true
-                sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                 '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'
                 cleanWs()

--- a/src/main/resources/templates/jenkins/java/maven/regularRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/java/maven/regularRuns/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                 rm -rf results
                 mkdir results
                 cp target/surefire-reports/*.xml $WORKSPACE/results/ || true
-                sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                 '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'
                 cleanWs()

--- a/src/main/resources/templates/jenkins/java/maven/regularRuns/Jenkinsfile-staticCodeAnalysis
+++ b/src/main/resources/templates/jenkins/java/maven/regularRuns/Jenkinsfile-staticCodeAnalysis
@@ -41,7 +41,7 @@ pipeline {
                 rm -rf results
                 mkdir results
                 cp target/surefire-reports/*.xml $WORKSPACE/results/ || true
-                sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                 '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'
                 cleanWs()

--- a/src/main/resources/templates/jenkins/java/maven/sequentialRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/java/maven/sequentialRuns/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 mkdir results
                 cp structural/target/surefire-reports/*.xml $WORKSPACE/results/ || true
                 cp behavior/target/surefire-reports/*.xml $WORKSPACE/results/ || true
-                sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                 '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'
                 cleanWs()

--- a/src/main/resources/templates/jenkins/kotlin/regularRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/kotlin/regularRuns/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
                 rm -rf results
                 mkdir results
                 cp target/surefire-reports/*.xml $WORKSPACE/results/ || true
-                sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                 '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'
                 cleanWs()

--- a/src/main/resources/templates/jenkins/kotlin/sequentialRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/kotlin/sequentialRuns/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                 mkdir results
                 cp structural/target/surefire-reports/*.xml $WORKSPACE/results/ || true
                 cp behavior/target/surefire-reports/*.xml $WORKSPACE/results/ || true
-                sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                 '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'
                 cleanWs()

--- a/src/main/resources/templates/jenkins/python/regularRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/python/regularRuns/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
                         sed -i 's/<testsuites>//g ; s/<\/testsuites>//g' test-reports/results.xml
                     fi
                     cp test-reports/*.xml $WORKSPACE/results/ || true
-                    sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                    sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                     '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'
                 cleanWs()

--- a/src/main/resources/templates/jenkins/swift/regularRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/swift/regularRuns/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
                     then
                         sed -i 's/<testsuites>//g ; s/<\/testsuites>//g' assignment/tests.xml
                         cp assignment/tests.xml $WORKSPACE/results/ || true
-                        sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                        sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                     fi
                     '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'

--- a/src/main/resources/templates/jenkins/swift/regularRuns/Jenkinsfile-staticCodeAnalysis
+++ b/src/main/resources/templates/jenkins/swift/regularRuns/Jenkinsfile-staticCodeAnalysis
@@ -57,7 +57,7 @@ pipeline {
                     then
                         sed -i 's/<testsuites>//g ; s/<\/testsuites>//g' assignment/tests.xml
                         cp assignment/tests.xml $WORKSPACE/results/ || true
-                        sed -i 's/[^[:print:]]/�/g' $WORKSPACE/results/*.xml || true
+                        sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                     fi
                     '''
                 sendTestResults credentialsId: '#jenkinsNotificationToken', notificationUrl: '#notificationsUrl'


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Changes affecting Programming Exercises
- [ ] ~~I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).~~ not affected
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Exception stack traces should be removed from feedback messages.
This mechanism is currently broken. It should be fixed before the new semester starts.

Together with bug #6434 the feedback for Gradle exercises is completely lost. → marked as prio:critical

### Description
<!-- Describe your changes in detail -->
They were not removed properly since the `tab` character was not considered to be printable, so it was replaced as well. However, the feedback cleaning service assumes the specific stack trace message format where each line starts with `\t at `. Due to replacing `\t` this mechanism was broken.
Since the tab character is visible in the feedback for all other exercise types and programming languages, the replacement has been updated there as well.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Create a new Java programming exercise.
2. Add a test case that always fails, e.g. by adding `fail("some message");` in it.
3. Look at the build result for the solution repository. The feedback should only contain your message, no stack trace.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

The same fix was already part of PR #6284 and has been reviewed there https://github.com/ls1intum/Artemis/pull/6284#discussion_r1148876472.

### Test Coverage
unchanged

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
![Screenshot 2023-04-11 at 15-09-34 Programming Exercises](https://user-images.githubusercontent.com/64250573/231172730-5a2bcb99-92dc-4efd-a199-5c03e2748b34.png)

After:
![Screenshot 2023-04-11 at 15-08-12 Programming Exercises](https://user-images.githubusercontent.com/64250573/231172724-9ab3131a-381f-43a6-9285-b9f2c0ee6bbe.png)