### PR TITLE
`Development`: Update initial GitLab password in documentation

### DIFF
--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -153,7 +153,7 @@ tokens instead of the predefined ones.
         GITLAB_ROOT_PASSWORD=QLzq3QvpD1Zbq7A1VWvw docker compose -f docker/<Jenkins setup to be launched>.yml up --build -d gitlab
 
    If you want to generate a random password for the ``root`` user, remove the part before ``docker compose`` from
-   the command. By default GitLab passwords must not contain commonly used combinations of words and letters.
+   the command. GitLab passwords must not contain commonly used combinations of words and letters.
 
    The file uses the ``GITLAB_OMNIBUS_CONFIG`` environment variable to configure the Gitlab instance after the container
    is started.

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -152,7 +152,7 @@ tokens instead of the predefined ones.
 
         GITLAB_ROOT_PASSWORD=QLzq3QvpD1Zbq7A1VWvw docker compose -f docker/<Jenkins setup to be launched>.yml up --build -d gitlab
 
-   If you want to generate a random password for the ``root`` user, remove the part before ``docker-compose`` from
+   If you want to generate a random password for the ``root`` user, remove the part before ``docker compose`` from
    the command. By default GitLab passwords must not contain commonly used combinations of words and letters.
 
    The file uses the ``GITLAB_OMNIBUS_CONFIG`` environment variable to configure the Gitlab instance after the container

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -150,10 +150,10 @@ tokens instead of the predefined ones.
 
    ::
 
-        GITLAB_ROOT_PASSWORD=artemis_admin docker compose -f docker/<Jenkins setup to be launched>.yml up --build -d gitlab
+        GITLAB_ROOT_PASSWORD=QLzq3QvpD1Zbq7A1VWvw docker compose -f docker/<Jenkins setup to be launched>.yml up --build -d gitlab
 
-   If you want to generate a random password for the ``root`` user, remove the part before ``docker compose`` from
-   the command.
+   If you want to generate a random password for the ``root`` user, remove the part before ``docker-compose`` from
+   the command. By default GitLab passwords must not contain commonly used combinations of words and letters.
 
    The file uses the ``GITLAB_OMNIBUS_CONFIG`` environment variable to configure the Gitlab instance after the container
    is started.


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
GitLab password requirements changed and the password given in the old command was crashing GitLab startup.

### Description
<!-- Describe your changes in detail -->
Updated the command to match GitLab requirements and added comment about those.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Stop and delete your GitLab instance
2. Create it again using the new command
3. GitLab starts normally 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1

