### PR TITLE
`Adaptive Learning`: Add missing translations to competency management

### DIFF
--- a/src/main/webapp/app/course/learning-goals/learning-goal-management/learning-goal-management.component.html
+++ b/src/main/webapp/app/course/learning-goals/learning-goal-management/learning-goal-management.component.html
@@ -21,12 +21,12 @@
     <div *ngIf="showRelations" class="container mt-3 mb-3">
         <ngb-accordion [closeOthers]="true">
             <ngb-panel id="panel-1">
-                <ng-template ngbPanelTitle>Competency Relations <span class="badge rounded-pill text-bg-warning ms-1">BETA</span> </ng-template>
+                <ng-template ngbPanelTitle>{{ 'artemisApp.learningGoal.relation.competencyRelations' | artemisTranslate }}<span class="badge rounded-pill text-bg-warning ms-1">BETA</span> </ng-template>
                 <ng-template ngbPanelContent>
                     <form class="row p-3 g-3 align-items-center">
                         <div class="col">
                             <div class="form-group">
-                                <label for="tail">Tail Learning Goal</label>
+                                <label for="tail">{{ 'artemisApp.learningGoal.relation.tailLearningGoal' | artemisTranslate }}</label>
                                 <select class="form-select" id="tail" name="tail" [(ngModel)]="tailLearningGoal">
                                     <option *ngFor="let learningGoal of learningGoals" [value]="learningGoal.id">{{ learningGoal.title }}</option>
                                 </select>
@@ -34,18 +34,18 @@
                         </div>
                         <div class="col">
                             <div class="form-group">
-                                <label for="type">Relation Type</label>
+                                <label for="type">{{ 'artemisApp.learningGoal.relation.relationType' | artemisTranslate }}</label>
                                 <select class="form-select" id="type" name="type" [(ngModel)]="relationType">
-                                    <option value="RELATES" selected>Relates</option>
-                                    <option value="ASSUMES">Assumes</option>
-                                    <option value="EXTENDS">Extends</option>
-                                    <option value="MATCHES">Matches</option>
+                                    <option value="RELATES" selected>{{ 'artemisApp.learningGoal.relation.relates' | artemisTranslate }}</option>
+                                    <option value="ASSUMES">{{ 'artemisApp.learningGoal.relation.assumes' | artemisTranslate }}</option>
+                                    <option value="EXTENDS">{{ 'artemisApp.learningGoal.relation.extends' | artemisTranslate }}</option>
+                                    <option value="MATCHES">{{ 'artemisApp.learningGoal.relation.matches' | artemisTranslate }}</option>
                                 </select>
                             </div>
                         </div>
                         <div class="col">
                             <div class="form-group">
-                                <label for="head">Head Learning Goal</label>
+                                <label for="head">{{ 'artemisApp.learningGoal.relation.headLearningGoal' | artemisTranslate }}</label>
                                 <select class="form-select" id="head" name="head" [(ngModel)]="headLearningGoal">
                                     <option *ngFor="let learningGoal of learningGoals" [value]="learningGoal.id">{{ learningGoal.title }}</option>
                                 </select>
@@ -55,7 +55,7 @@
                             <input
                                 type="button"
                                 class="btn btn-primary"
-                                value="Create Relation"
+                                value="{{ 'artemisApp.learningGoal.relation.createRelation' | artemisTranslate }}"
                                 (click)="createRelation()"
                                 [disabled]="!headLearningGoal || !tailLearningGoal || !relationType || headLearningGoal == tailLearningGoal"
                             />
@@ -97,7 +97,7 @@
                                 <svg:path class="line" stroke-width="2" marker-end="url(#arrow)"></svg:path>
                                 <svg:text class="edge-label" text-anchor="middle">
                                     <textPath class="text-path" [attr.href]="'#' + link.id" [style.dominant-baseline]="link.dominantBaseline" startOffset="50%">
-                                        {{ link.label }}
+                                        {{ ('artemisApp.learningGoal.relation.' + link.label.toLowerCase() | artemisTranslate).toUpperCase() }}
                                     </textPath>
                                 </svg:text>
                             </svg:g>

--- a/src/main/webapp/app/course/learning-goals/learning-goal-management/learning-goal-management.component.html
+++ b/src/main/webapp/app/course/learning-goals/learning-goal-management/learning-goal-management.component.html
@@ -21,7 +21,9 @@
     <div *ngIf="showRelations" class="container mt-3 mb-3">
         <ngb-accordion [closeOthers]="true">
             <ngb-panel id="panel-1">
-                <ng-template ngbPanelTitle>{{ 'artemisApp.learningGoal.relation.competencyRelations' | artemisTranslate }}<span class="badge rounded-pill text-bg-warning ms-1">BETA</span> </ng-template>
+                <ng-template ngbPanelTitle
+                    >{{ 'artemisApp.learningGoal.relation.competencyRelations' | artemisTranslate }}<span class="badge rounded-pill text-bg-warning ms-1">BETA</span>
+                </ng-template>
                 <ng-template ngbPanelContent>
                     <form class="row p-3 g-3 align-items-center">
                         <div class="col">

--- a/src/main/webapp/i18n/de/learningGoal.json
+++ b/src/main/webapp/i18n/de/learningGoal.json
@@ -122,10 +122,10 @@
                 "relationType": "Beziehungstyp",
                 "headLearningGoal": "Kopflernziel",
                 "relates": "Bezieht sich auf",
-                "assumes":  "Setzt voraus",
+                "assumes": "Setzt voraus",
                 "extends": "Erweitert",
                 "matches": "Stimmt überein mit",
-                "createRelation":  "Beziehung erstellen"
+                "createRelation": "Beziehung erstellen"
             }
         }
     }

--- a/src/main/webapp/i18n/de/learningGoal.json
+++ b/src/main/webapp/i18n/de/learningGoal.json
@@ -115,6 +115,17 @@
                     "searchLearningGoal": "Nach Kompetenz suchen:",
                     "loading": "Lade..."
                 }
+            },
+            "relation": {
+                "competencyRelations": "Beziehungen zwischen Kompetenzen",
+                "tailLearningGoal": "Schwanzlernziel",
+                "relationType": "Beziehungstyp",
+                "headLearningGoal": "Kopflernziel",
+                "relates": "Bezieht sich auf",
+                "assumes":  "Setzt voraus",
+                "extends": "Erweitert",
+                "matches": "Stimmt überein mit",
+                "createRelation":  "Beziehung erstellen"
             }
         }
     }

--- a/src/main/webapp/i18n/de/learningGoal.json
+++ b/src/main/webapp/i18n/de/learningGoal.json
@@ -125,7 +125,7 @@
                 "assumes": "Setzt voraus",
                 "extends": "Erweitert",
                 "matches": "Stimmt überein mit",
-                "createRelation": "Beziehung erstellen"
+                "createRelation": "Beziehung Erstellen"
             }
         }
     }

--- a/src/main/webapp/i18n/de/learningGoal.json
+++ b/src/main/webapp/i18n/de/learningGoal.json
@@ -125,7 +125,7 @@
                 "assumes": "Setzt voraus",
                 "extends": "Erweitert",
                 "matches": "Stimmt überein mit",
-                "createRelation": "Beziehung Erstellen"
+                "createRelation": "Beziehung erstellen"
             }
         }
     }

--- a/src/main/webapp/i18n/en/learningGoal.json
+++ b/src/main/webapp/i18n/en/learningGoal.json
@@ -124,7 +124,7 @@
                 "assumes": "Assumes",
                 "extends": "Extends",
                 "matches": "Matches",
-                "createRelation": "Beziehung erstellen"
+                "createRelation": "Create Relation"
             }
         }
     }

--- a/src/main/webapp/i18n/en/learningGoal.json
+++ b/src/main/webapp/i18n/en/learningGoal.json
@@ -114,6 +114,17 @@
                     "searchLearningGoal": "Search competency:",
                     "loading": "Loading..."
                 }
+            },
+            "relation": {
+                "competencyRelations": "Competency Relations",
+                "tailLearningGoal": "Tail Learning Goal",
+                "relationType": "Relation Type",
+                "headLearningGoal": "Head Learning Goal",
+                "relates": "Relates",
+                "assumes": "Assumes",
+                "extends": "Extends",
+                "matches": "Matches",
+                "createRelation": "Beziehung erstellen"
             }
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some labels on the competency management page were hardcoded in English and therefore couldn't be displayed in German even if German was the set language.

### Description
<!-- Describe your changes in detail -->
I added the missing translations and applied the correct one using artemisTranslate.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Administrator (Some parts are only visible to administrators)

1. Log in to Artemis
2. Navigate to Course Administration
3. Select a course
4. Click on competencies
5. Verify that all texts are correctly translated into German and English
Note: There is a bug while rendering the competency relation graph. This will be fixed when the next version of ngx-graph gets released. See: https://github.com/ls1intum/Artemis/pull/6396

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
#### Manual Tests
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->
No changes in test coverage.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
German page before this PR:

![Screenshot 2023-04-13 at 18-37-28 Kompetenzmanagement](https://user-images.githubusercontent.com/44734881/231826843-74d84be5-5d32-485e-9b75-577f30526d00.png)

German page after this PR:
![Screenshot 2023-04-13 at 18-33-43 Kompetenzmanagement](https://user-images.githubusercontent.com/44734881/231826237-d2c79833-0984-471a-b0da-dda00541d6da.png)
