### PR TITLE
`Development`: Unify test environments / comments for e2e tests

### DIFF
--- a/src/main/webapp/app/course/manage/course-management-tab-bar/course-management-tab-bar.component.html
+++ b/src/main/webapp/app/course/manage/course-management-tab-bar/course-management-tab-bar.component.html
@@ -49,7 +49,12 @@
             <span jhiTranslate="artemisApp.entities.tutorialGroup.plural"></span>
         </a>
         <div class="btn-group tab-item">
-            <a [routerLink]="['/course-management', course.id, 'assessment-dashboard']" class="tab-item btn btn-info btn-md ms-1 my-0" routerLinkActive="active">
+            <a
+                [routerLink]="['/course-management', course.id, 'assessment-dashboard']"
+                id="assessment-dashboard"
+                class="tab-item btn btn-info btn-md ms-1 my-0"
+                routerLinkActive="active"
+            >
                 <fa-icon [icon]="faUserCheck"></fa-icon>
                 <span jhiTranslate="entity.action.assessmentDashboard">Assessment Dashboard</span>
             </a>

--- a/src/main/webapp/app/course/manage/overview/course-management-card.component.html
+++ b/src/main/webapp/app/course/manage/overview/course-management-card.component.html
@@ -1,4 +1,4 @@
-<div class="card mb-4 hover-effect" id="course-card-{{ course.shortName }}">
+<div class="card mb-4 hover-effect" id="course-{{ course.id }}">
     <div id="course-card-header" class="text-white card-heading" [ngStyle]="{ '--background-color-for-hover': courseColor }">
         <a class="stretched-link" [routerLink]="['/course-management', course.id]"></a>
         <div class="card-header-left">

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -73,7 +73,7 @@
                     </div>
                 </div>
                 <div class="row justify-content-center">
-                    <div class="col-md-6" style="font-weight: lighter">
+                    <div id="your-name" class="col-md-6" style="font-weight: lighter">
                         <span> ({{ 'artemisApp.examParticipation.nameDisplay' | artemisTranslate : { fullName: accountName } }}) </span>
                     </div>
                 </div>

--- a/src/test/cypress/cypress.config.ts
+++ b/src/test/cypress/cypress.config.ts
@@ -68,7 +68,7 @@ export default defineConfig({
                 return launchOptions;
             });
         },
-        specPattern: ['init/ImportUsers.cy.ts', 'e2e/**/*.cy.{js,jsx,ts,tsx}'],
+        specPattern: ['init/ImportUsers.cy.ts', 'e2e/**/*.cy.ts'],
         supportFile: 'support/index.ts',
         baseUrl: 'http://localhost:8080',
     },

--- a/src/test/cypress/e2e/Login.cy.ts
+++ b/src/test/cypress/e2e/Login.cy.ts
@@ -1,4 +1,4 @@
-import { loginPage } from '../support/artemis';
+import { loginPage, navigationBar } from '../support/artemis';
 import { studentOne } from '../support/users';
 
 describe('Login page tests', () => {
@@ -16,7 +16,7 @@ describe('Login page tests', () => {
     it('Logs in programmatically and logs out via the UI', () => {
         cy.login(studentOne, '/courses');
         cy.url().should('include', '/courses');
-        cy.get('#account-menu').click().get('#logout').click();
+        navigationBar.logout();
         cy.url().should('equal', Cypress.config().baseUrl + '/');
         cy.getCookie('jwt').should('not.exist');
     });

--- a/src/test/cypress/e2e/Logout.cy.ts
+++ b/src/test/cypress/e2e/Logout.cy.ts
@@ -21,7 +21,15 @@ describe('Logout tests', () => {
 
     it('Logs out by pressing OK when unsaved changes on exercise mode', () => {
         cy.login(studentOne);
-        startExerciseAndMakeChanges(course, modelingExercise);
+
+        const exerciseID = modelingExercise.id!;
+        cy.visit(`/courses/${course.id}/exercises`);
+        courseOverview.startExercise(exerciseID);
+        courseOverview.openRunningExercise(exerciseID);
+        modelingExerciseEditor.addComponentToModel(exerciseID, 1);
+        modelingExerciseEditor.addComponentToModel(exerciseID, 2);
+        navigationBar.logout();
+
         cy.on('window:confirm', (text) => {
             expect(text).to.contains('You have unsaved changes');
             return true;
@@ -31,7 +39,15 @@ describe('Logout tests', () => {
 
     it('Stays logged in by pressing cancel when trying to logout during unsaved changes on exercise mode', () => {
         cy.login(studentTwo);
-        startExerciseAndMakeChanges(course, modelingExercise);
+
+        const exerciseID = modelingExercise.id!;
+        cy.visit(`/courses/${course.id}/exercises`);
+        courseOverview.startExercise(exerciseID);
+        courseOverview.openRunningExercise(exerciseID);
+        modelingExerciseEditor.addComponentToModel(exerciseID, 1);
+        modelingExerciseEditor.addComponentToModel(exerciseID, 2);
+        navigationBar.logout();
+
         cy.on('window:confirm', (text) => {
             expect(text).to.contains('You have unsaved changes');
             return false;
@@ -40,19 +56,6 @@ describe('Logout tests', () => {
     });
 
     after(() => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });
-
-const startExerciseAndMakeChanges = (course: Course, modelingExercise: ModelingExercise) => {
-    const exerciseID = modelingExercise.id!;
-    cy.visit(`/courses/${course.id}/exercises`);
-    courseOverview.startExercise(exerciseID);
-    courseOverview.openRunningExercise(exerciseID);
-    modelingExerciseEditor.addComponentToModel(exerciseID, 1);
-    modelingExerciseEditor.addComponentToModel(exerciseID, 2);
-    navigationBar.logout();
-};

--- a/src/test/cypress/e2e/Logout.cy.ts
+++ b/src/test/cypress/e2e/Logout.cy.ts
@@ -1,6 +1,6 @@
 import { Course } from '../../../main/webapp/app/entities/course.model';
 import { ModelingExercise } from '../../../main/webapp/app/entities/modeling-exercise.model';
-import { courseManagementRequest, courseOverview, modelingExerciseEditor } from '../support/artemis';
+import { courseManagementRequest, courseOverview, modelingExerciseEditor, navigationBar } from '../support/artemis';
 import { convertModelAfterMultiPart } from '../support/requests/CourseManagementRequests';
 import { admin, studentOne, studentTwo } from '../support/users';
 
@@ -54,5 +54,5 @@ const startExerciseAndMakeChanges = (course: Course, modelingExercise: ModelingE
     courseOverview.openRunningExercise(exerciseID);
     modelingExerciseEditor.addComponentToModel(exerciseID, 1);
     modelingExerciseEditor.addComponentToModel(exerciseID, 2);
-    cy.get('#account-menu').click().get('#logout').click();
+    navigationBar.logout();
 };

--- a/src/test/cypress/e2e/course/CourseCommunication.cy.ts
+++ b/src/test/cypress/e2e/course/CourseCommunication.cy.ts
@@ -11,7 +11,7 @@ import { Channel } from '../../../../main/webapp/app/entities/metis/conversation
 
 describe('Course communication', () => {
     let course: Course;
-    let courseId: number;
+    let courseWithMessaging: Course;
 
     before('Create course', () => {
         cy.login(admin);
@@ -619,10 +619,10 @@ describe('Course communication', () => {
     after('Delete Course', () => {
         cy.login(admin);
         if (course.id) {
-            courseManagementRequest.deleteCourse(course.id!);
+            courseManagementRequest.deleteCourse(course, admin);
         }
         if (courseWithMessaging.id) {
-            courseManagementRequest.deleteCourse(courseWithMessaging.id).its('status').should('eq', 200);
+            courseManagementRequest.deleteCourse(courseWithMessaging, admin);
         }
     });
 });

--- a/src/test/cypress/e2e/course/CourseCommunication.cy.ts
+++ b/src/test/cypress/e2e/course/CourseCommunication.cy.ts
@@ -11,7 +11,7 @@ import { Channel } from '../../../../main/webapp/app/entities/metis/conversation
 
 describe('Course communication', () => {
     let course: Course;
-    let courseWithMessaging: Course;
+    let courseId: number;
 
     before('Create course', () => {
         cy.login(admin);
@@ -32,15 +32,13 @@ describe('Course communication', () => {
         uid = generateUUID();
         courseName = 'Cypress course' + uid;
         courseShortName = 'cypress' + uid;
-        courseManagementRequest
-            .createCourse(false, courseName, courseShortName, day().subtract(2, 'hours'), day().add(2, 'hours'), undefined, undefined, true, true)
-            .then((response) => {
-                courseWithMessaging = convertModelAfterMultiPart(response);
-                courseManagementRequest.addInstructorToCourse(courseWithMessaging, instructor);
-                courseManagementRequest.addStudentToCourse(courseWithMessaging, studentOne);
-                courseManagementRequest.addStudentToCourse(courseWithMessaging, studentTwo);
-                courseManagementRequest.addStudentToCourse(courseWithMessaging, studentThree);
-            });
+        courseManagementRequest.createCourse(false, courseName, courseShortName).then((response) => {
+            course = convertModelAfterMultiPart(response);
+            courseManagementRequest.addInstructorToCourse(course, instructor);
+            courseManagementRequest.addStudentToCourse(course, studentOne);
+            courseManagementRequest.addStudentToCourse(course, studentTwo);
+            courseManagementRequest.addStudentToCourse(course, studentThree);
+        });
     });
 
     describe('Course overview communication', () => {
@@ -621,7 +619,7 @@ describe('Course communication', () => {
     after('Delete Course', () => {
         cy.login(admin);
         if (course.id) {
-            courseManagementRequest.deleteCourse(course.id).its('status').should('eq', 200);
+            courseManagementRequest.deleteCourse(course.id!);
         }
         if (courseWithMessaging.id) {
             courseManagementRequest.deleteCourse(courseWithMessaging.id).its('status').should('eq', 200);

--- a/src/test/cypress/e2e/course/CourseCommunication.cy.ts
+++ b/src/test/cypress/e2e/course/CourseCommunication.cy.ts
@@ -17,8 +17,8 @@ describe('Course communication', () => {
         cy.login(admin);
 
         let uid = generateUUID();
-        let courseName = 'Cypress course' + uid;
-        let courseShortName = 'cypress' + uid;
+        const courseName = 'Course ' + uid;
+        const courseShortName = 'course' + uid;
         courseManagementRequest
             .createCourse(false, courseName, courseShortName, day().subtract(2, 'hours'), day().add(2, 'hours'), undefined, undefined, true, false)
             .then((response) => {
@@ -30,15 +30,17 @@ describe('Course communication', () => {
             });
 
         uid = generateUUID();
-        courseName = 'Cypress course' + uid;
-        courseShortName = 'cypress' + uid;
-        courseManagementRequest.createCourse(false, courseName, courseShortName).then((response) => {
-            course = convertModelAfterMultiPart(response);
-            courseManagementRequest.addInstructorToCourse(course, instructor);
-            courseManagementRequest.addStudentToCourse(course, studentOne);
-            courseManagementRequest.addStudentToCourse(course, studentTwo);
-            courseManagementRequest.addStudentToCourse(course, studentThree);
-        });
+        const courseWithMessagingName = 'Course ' + uid;
+        const courseWithMessagingShortName = 'course' + uid;
+        courseManagementRequest
+            .createCourse(false, courseWithMessagingName, courseWithMessagingShortName, day().subtract(2, 'hours'), day().add(2, 'hours'), undefined, undefined, true, true)
+            .then((response) => {
+                courseWithMessaging = convertModelAfterMultiPart(response);
+                courseManagementRequest.addInstructorToCourse(courseWithMessaging, instructor);
+                courseManagementRequest.addStudentToCourse(courseWithMessaging, studentOne);
+                courseManagementRequest.addStudentToCourse(courseWithMessaging, studentTwo);
+                courseManagementRequest.addStudentToCourse(courseWithMessaging, studentThree);
+            });
     });
 
     describe('Course overview communication', () => {
@@ -616,13 +618,8 @@ describe('Course communication', () => {
         });
     });
 
-    after('Delete Course', () => {
-        cy.login(admin);
-        if (course.id) {
-            courseManagementRequest.deleteCourse(course, admin);
-        }
-        if (courseWithMessaging.id) {
-            courseManagementRequest.deleteCourse(courseWithMessaging, admin);
-        }
+    after('Delete Courses', () => {
+        courseManagementRequest.deleteCourse(course, admin);
+        courseManagementRequest.deleteCourse(courseWithMessaging, admin);
     });
 });

--- a/src/test/cypress/e2e/course/CourseExercise.cy.ts
+++ b/src/test/cypress/e2e/course/CourseExercise.cy.ts
@@ -40,13 +40,13 @@ describe('Course Exercise', () => {
 
         it('should filter exercises based on title', () => {
             cy.visit(`/courses/${course.id}/exercises`);
-            cy.get(`#exercise-card-${exercise1.id}`).should('be.visible');
-            cy.get(`#exercise-card-${exercise2.id}`).should('be.visible');
-            cy.get(`#exercise-card-${exercise3.id}`).should('be.visible');
-            courseExercise.search('Course Exercise Quiz');
-            cy.get(`#exercise-card-${exercise1.id}`).should('be.visible');
-            cy.get(`#exercise-card-${exercise2.id}`).should('be.visible');
-            cy.get(`#exercise-card-${exercise3.id}`).should('not.exist');
+            courseOverview.getExercise(exercise1.id).should('be.visible');
+            courseOverview.getExercise(exercise2.id).should('be.visible');
+            courseOverview.getExercise(exercise3.id).should('be.visible');
+            courseOverview.search('Course Exercise Quiz');
+            courseOverview.getExercise(exercise1.id).should('be.visible');
+            courseOverview.getExercise(exercise2.id).should('be.visible');
+            courseOverview.getExercise(exercise3.id).should('not.exist');
         });
 
         after('Delete Exercises', () => {

--- a/src/test/cypress/e2e/course/CourseExercise.cy.ts
+++ b/src/test/cypress/e2e/course/CourseExercise.cy.ts
@@ -1,6 +1,6 @@
 import { Course } from '../../../../main/webapp/app/entities/course.model';
 import multipleChoiceQuizTemplate from '../../fixtures/exercise/quiz/multiple_choice/template.json';
-import { courseExercise, courseManagementRequest } from '../../support/artemis';
+import { courseManagementRequest, courseOverview } from '../../support/artemis';
 import { convertModelAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import { admin } from '../../support/users';
 import { generateUUID } from '../../support/utils';
@@ -40,13 +40,13 @@ describe('Course Exercise', () => {
 
         it('should filter exercises based on title', () => {
             cy.visit(`/courses/${course.id}/exercises`);
-            courseOverview.getExercise(exercise1.id).should('be.visible');
-            courseOverview.getExercise(exercise2.id).should('be.visible');
-            courseOverview.getExercise(exercise3.id).should('be.visible');
+            courseOverview.getExercise(exercise1.id!).should('be.visible');
+            courseOverview.getExercise(exercise2.id!).should('be.visible');
+            courseOverview.getExercise(exercise3.id!).should('be.visible');
             courseOverview.search('Course Exercise Quiz');
-            courseOverview.getExercise(exercise1.id).should('be.visible');
-            courseOverview.getExercise(exercise2.id).should('be.visible');
-            courseOverview.getExercise(exercise3.id).should('not.exist');
+            courseOverview.getExercise(exercise1.id!).should('be.visible');
+            courseOverview.getExercise(exercise2.id!).should('be.visible');
+            courseOverview.getExercise(exercise3.id!).should('not.exist');
         });
 
         after('Delete Exercises', () => {

--- a/src/test/cypress/e2e/course/CourseExercise.cy.ts
+++ b/src/test/cypress/e2e/course/CourseExercise.cy.ts
@@ -3,20 +3,14 @@ import multipleChoiceQuizTemplate from '../../fixtures/exercise/quiz/multiple_ch
 import { courseManagementRequest, courseOverview } from '../../support/artemis';
 import { convertModelAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import { admin } from '../../support/users';
-import { generateUUID } from '../../support/utils';
 import { QuizExercise } from '../../../../main/webapp/app/entities/quiz/quiz-exercise.model';
 
 describe('Course Exercise', () => {
     let course: Course;
-    let courseName: string;
-    let courseShortName: string;
 
     before('Create course', () => {
         cy.login(admin);
-        const uid = generateUUID();
-        courseName = 'Cypress course' + uid;
-        courseShortName = 'cypress' + uid;
-        courseManagementRequest.createCourse(false, courseName, courseShortName).then((response) => {
+        courseManagementRequest.createCourse().then((response) => {
             course = convertModelAfterMultiPart(response);
         });
     });

--- a/src/test/cypress/e2e/course/CourseExercise.cy.ts
+++ b/src/test/cypress/e2e/course/CourseExercise.cy.ts
@@ -57,9 +57,6 @@ describe('Course Exercise', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/course/CourseExercise.cy.ts
+++ b/src/test/cypress/e2e/course/CourseExercise.cy.ts
@@ -6,13 +6,10 @@ import { admin } from '../../support/users';
 import { generateUUID } from '../../support/utils';
 import { QuizExercise } from '../../../../main/webapp/app/entities/quiz/quiz-exercise.model';
 
-// Common primitives
-let courseName: string;
-let courseShortName: string;
-
 describe('Course Exercise', () => {
     let course: Course;
-    let courseId: number;
+    let courseName: string;
+    let courseShortName: string;
 
     before('Create course', () => {
         cy.login(admin);
@@ -21,7 +18,6 @@ describe('Course Exercise', () => {
         courseShortName = 'cypress' + uid;
         courseManagementRequest.createCourse(false, courseName, courseShortName).then((response) => {
             course = convertModelAfterMultiPart(response);
-            courseId = course.id!;
         });
     });
 
@@ -60,9 +56,10 @@ describe('Course Exercise', () => {
         });
     });
 
-    after('Delete Course', () => {
-        if (courseId) {
-            courseManagementRequest.deleteCourse(courseId).its('status').should('eq', 200);
+    after('Delete course', () => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
         }
     });
 });

--- a/src/test/cypress/e2e/course/CourseManagement.cy.ts
+++ b/src/test/cypress/e2e/course/CourseManagement.cy.ts
@@ -7,9 +7,6 @@ import { Course } from 'app/entities/course.model';
 import day from 'dayjs/esm';
 import { admin, studentOne } from '../../support/users';
 
-// Selectors
-const modalDeleteButton = '#delete';
-
 // Common primitives
 const courseData = {
     title: '',
@@ -90,7 +87,8 @@ describe('Course management', () => {
 
         after(() => {
             if (course) {
-                courseManagementRequest.deleteCourse(course.id!).its('status').should('eq', 200);
+                cy.login(admin);
+                courseManagementRequest.deleteCourse(course.id!);
             }
         });
     });
@@ -213,7 +211,7 @@ describe('Course management', () => {
     });
 
     describe('Course edit', () => {
-        let courseId: number;
+        let course: Course;
         const uid = generateUUID();
         editedCourseData.title = 'Cypress course' + uid;
         editedCourseData.shortName = 'cypress' + uid;
@@ -231,11 +229,10 @@ describe('Course management', () => {
             courseCreation.setTestCourse(editedCourseData.testCourse);
 
             courseCreation.update().then((request: Interception) => {
-                const courseBody = request.response!.body;
-                courseId = courseBody.id!;
-                expect(courseBody.title).to.eq(editedCourseData.title);
-                expect(courseBody.shortName).to.eq(courseData.shortName);
-                expect(courseBody.testCourse).to.eq(editedCourseData.testCourse);
+                course = request.response!.body;
+                expect(course.title).to.eq(editedCourseData.title);
+                expect(course.shortName).to.eq(courseData.shortName);
+                expect(course.testCourse).to.eq(editedCourseData.testCourse);
             });
             courseManagement.getCourseHeaderTitle().contains(editedCourseData.title).should('be.visible');
             courseManagement.getCourseTitle().contains(editedCourseData.title);
@@ -243,9 +240,10 @@ describe('Course management', () => {
             courseManagement.getCourseTestCourse().contains(convertBooleanToYesNo(editedCourseData.testCourse));
         });
 
-        after(() => {
-            if (courseId) {
-                courseManagementRequest.deleteCourse(courseId).its('status').should('eq', 200);
+        after('Delete course', () => {
+            if (course) {
+                cy.login(admin);
+                courseManagementRequest.deleteCourse(course.id!);
             }
         });
     });
@@ -259,9 +257,9 @@ describe('Course management', () => {
             navigationBar.openCourseManagement();
             courseManagement.openCourse(courseData.shortName);
             cy.get('#delete-course').click();
-            cy.get(modalDeleteButton).should('be.disabled');
+            cy.get('#delete').should('be.disabled');
             cy.get('#confirm-exercise-name').type(courseData.title);
-            cy.get(modalDeleteButton).should('not.be.disabled').click();
+            cy.get('#delete').should('not.be.disabled').click();
             courseManagement.getCourseCard(courseData.shortName).should('not.exist');
         });
     });

--- a/src/test/cypress/e2e/course/CourseManagement.cy.ts
+++ b/src/test/cypress/e2e/course/CourseManagement.cy.ts
@@ -2,7 +2,7 @@ import { Interception } from 'cypress/types/net-stubbing';
 import { convertModelAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import { BASE_API, PUT } from '../../support/constants';
 import { courseCreation, courseManagement, courseManagementRequest, navigationBar } from '../../support/artemis';
-import { dayjsToString, generateUUID, trimDate } from '../../support/utils';
+import { convertBooleanToYesNo, dayjsToString, generateUUID, trimDate } from '../../support/utils';
 import { Course } from 'app/entities/course.model';
 import day from 'dayjs/esm';
 import { admin, studentOne } from '../../support/users';
@@ -86,16 +86,13 @@ describe('Course management', () => {
         });
 
         after(() => {
-            if (course) {
-                cy.login(admin);
-                courseManagementRequest.deleteCourse(course.id!);
-            }
+            courseManagementRequest.deleteCourse(course, admin);
         });
     });
 
     describe('Course creation', () => {
-        let courseId: number;
-        let courseId2: number;
+        let course: Course;
+        let course2: Course;
 
         beforeEach(() => {
             cy.login(admin, '/');
@@ -126,7 +123,7 @@ describe('Course management', () => {
             courseCreation.setCustomizeGroupNames(courseData.customizeGroupNames);
             courseCreation.submit().then((request: Interception) => {
                 const courseBody = request.response!.body;
-                courseId = courseBody.id!;
+                course = courseBody;
                 expect(courseBody.title).to.eq(courseData.title);
                 expect(courseBody.shortName).to.eq(courseData.shortName);
                 expect(courseBody.description).to.eq(courseData.description);
@@ -181,7 +178,7 @@ describe('Course management', () => {
                 courseCreation.setInstructorGroup(courseData.instructorGroupName);
                 courseCreation.submit().then((request: Interception) => {
                     const courseBody = request.response!.body;
-                    courseId2 = courseBody.id!;
+                    course2 = courseBody;
                     expect(courseBody.title).to.eq(courseData.title);
                     expect(courseBody.shortName).to.eq(courseData.shortName);
                     expect(courseBody.testCourse).to.eq(courseData.testCourse);
@@ -202,14 +199,8 @@ describe('Course management', () => {
         }
 
         after('Delete courses', () => {
-            if (courseId) {
-                cy.login(admin, '/');
-                courseManagementRequest.deleteCourse(courseId).its('status').should('eq', 200);
-            }
-            if (courseId2) {
-                cy.login(admin, '/');
-                courseManagementRequest.deleteCourse(courseId2).its('status').should('eq', 200);
-            }
+            courseManagementRequest.deleteCourse(course, admin);
+            courseManagementRequest.deleteCourse(course2, admin);
         });
     });
 
@@ -247,10 +238,7 @@ describe('Course management', () => {
         });
 
         after('Delete course', () => {
-            if (course) {
-                cy.login(admin);
-                courseManagementRequest.deleteCourse(course.id!);
-            }
+            courseManagementRequest.deleteCourse(course, admin);
         });
     });
 
@@ -310,14 +298,7 @@ describe('Course management', () => {
         });
 
         after('Delete course', () => {
-            if (course) {
-                cy.login(admin);
-                courseManagementRequest.deleteCourse(course.id!);
-            }
+            courseManagementRequest.deleteCourse(course, admin);
         });
     });
 });
-
-function convertBooleanToYesNo(boolean: boolean) {
-    return boolean ? 'Yes' : 'No';
-}

--- a/src/test/cypress/e2e/course/CourseManagement.cy.ts
+++ b/src/test/cypress/e2e/course/CourseManagement.cy.ts
@@ -213,7 +213,7 @@ describe('Course management', () => {
         beforeEach(() => {
             cy.login(admin, '/');
             courseManagementRequest.createCourse(false, courseData.title, courseData.shortName).then((response) => {
-                course = convertCourseAfterMultiPart(response);
+                course = convertModelAfterMultiPart(response);
             });
         });
 
@@ -248,7 +248,7 @@ describe('Course management', () => {
         before(() => {
             cy.login(admin);
             courseManagementRequest.createCourse().then((response) => {
-                course = convertCourseAfterMultiPart(response);
+                course = convertModelAfterMultiPart(response);
             });
         });
 

--- a/src/test/cypress/e2e/course/CourseManagement.cy.ts
+++ b/src/test/cypress/e2e/course/CourseManagement.cy.ts
@@ -1,6 +1,5 @@
 import { Interception } from 'cypress/types/net-stubbing';
 import { convertModelAfterMultiPart } from '../../support/requests/CourseManagementRequests';
-import { BASE_API, PUT } from '../../support/constants';
 import { courseCreation, courseManagement, courseManagementRequest, navigationBar } from '../../support/artemis';
 import { convertBooleanToYesNo, dayjsToString, generateUUID, trimDate } from '../../support/utils';
 import { Course } from 'app/entities/course.model';

--- a/src/test/cypress/e2e/course/CourseMessages.cy.ts
+++ b/src/test/cypress/e2e/course/CourseMessages.cy.ts
@@ -9,15 +9,10 @@ import { generateUUID, titleLowercase } from '../../support/utils';
 
 describe('Course messages', () => {
     let course: Course;
-    let courseName: string;
-    let courseShortName: string;
 
     before('Create course', () => {
         cy.login(admin);
-        const uid = generateUUID();
-        courseName = 'Cypress course' + uid;
-        courseShortName = 'cypress' + uid;
-        courseManagementRequest.createCourse(false, courseName, courseShortName).then((response) => {
+        courseManagementRequest.createCourse().then((response) => {
             course = convertModelAfterMultiPart(response);
             courseManagementRequest.addInstructorToCourse(course, instructor);
             courseManagementRequest.addTutorToCourse(course, tutor);

--- a/src/test/cypress/e2e/course/CourseMessages.cy.ts
+++ b/src/test/cypress/e2e/course/CourseMessages.cy.ts
@@ -7,13 +7,10 @@ import { ExamBuilder } from '../../support/requests/CourseManagementRequests';
 import { admin, instructor, studentOne, studentTwo, tutor, users } from '../../support/users';
 import { generateUUID, titleLowercase } from '../../support/utils';
 
-// Common primitives
-let courseName: string;
-let courseShortName: string;
-
 describe('Course messages', () => {
     let course: Course;
-    let courseId: number;
+    let courseName: string;
+    let courseShortName: string;
 
     before('Create course', () => {
         cy.login(admin);
@@ -22,7 +19,6 @@ describe('Course messages', () => {
         courseShortName = 'cypress' + uid;
         courseManagementRequest.createCourse(false, courseName, courseShortName).then((response) => {
             course = convertModelAfterMultiPart(response);
-            courseId = course.id!;
             courseManagementRequest.addInstructorToCourse(course, instructor);
             courseManagementRequest.addTutorToCourse(course, tutor);
             courseManagementRequest.addStudentToCourse(course, studentOne);
@@ -420,10 +416,10 @@ describe('Course messages', () => {
         });
     });
 
-    after('Delete Course', () => {
-        cy.login(admin);
-        if (courseId) {
-            courseManagementRequest.deleteCourse(courseId).its('status').should('eq', 200);
+    after('Delete course', () => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
         }
     });
 });

--- a/src/test/cypress/e2e/course/CourseMessages.cy.ts
+++ b/src/test/cypress/e2e/course/CourseMessages.cy.ts
@@ -417,9 +417,6 @@ describe('Course messages', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
@@ -15,7 +15,6 @@ import {
     examStartEnd,
     exerciseAssessment,
     modelingExerciseAssessment,
-    programmingExerciseEditor,
     studentAssessment,
 } from '../../support/artemis';
 import { admin, instructor, studentOne, tutor, users } from '../../support/users';
@@ -65,7 +64,7 @@ describe('Exam assessment', () => {
             examAssessment.addNewFeedback(2, 'Good job');
             examAssessment.submit();
             cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-            programmingExerciseEditor.getResultScore().should('contain.text', '66.2%').and('be.visible');
+            examParticipation.getResultScore().should('contain.text', '66.2%').and('be.visible');
             programmingAssessmentSuccessful = true;
         });
 
@@ -97,7 +96,7 @@ describe('Exam assessment', () => {
                 expect(assessmentResponse.response?.statusCode).to.equal(200);
             });
             cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-            programmingExerciseEditor.getResultScore().should('contain.text', '40%').and('be.visible');
+            examParticipation.getResultScore().should('contain.text', '40%').and('be.visible');
             modelingAssessmentSuccessful = true;
         });
 
@@ -124,7 +123,7 @@ describe('Exam assessment', () => {
                 expect(assessmentResponse.response!.statusCode).to.equal(200);
             });
             cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-            programmingExerciseEditor.getResultScore().should('contain.text', '70%').and('be.visible');
+            examParticipation.getResultScore().should('contain.text', '70%').and('be.visible');
             textAssessmentSuccessful = true;
         });
 
@@ -158,10 +157,7 @@ describe('Exam assessment', () => {
             }
             examManagement.checkQuizSubmission(course.id!, exam.id!, studentOneName, '50%');
             cy.login(studentOne, '/courses/' + course.id + '/exams/' + exam.id);
-            // Sometimes the feedback fails to load properly on the first load...
-            const resultSelector = '#result-score';
-            cy.reloadUntilFound(resultSelector);
-            programmingExerciseEditor.getResultScore().should('contain.text', '50%').and('be.visible');
+            examParticipation.getResultScore().should('contain.text', '50%').and('be.visible');
         });
     });
 
@@ -224,7 +220,7 @@ function startAssessing(courseID: number, examID: number, timeout: number) {
     courseAssessment.clickExerciseDashboardButton();
     exerciseAssessment.clickHaveReadInstructionsButton();
     exerciseAssessment.clickStartNewAssessment();
-    cy.get('#assessmentLockedCurrentUser').should('be.visible');
+    exerciseAssessment.getLockedMessage();
 }
 
 function handleComplaint(course: Course, exam: Exam, reject: boolean, exerciseType: EXERCISE_TYPE) {

--- a/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
@@ -162,10 +162,7 @@ describe('Exam assessment', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            // courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });
 

--- a/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
@@ -22,22 +22,22 @@ import { admin, instructor, studentOne, tutor, users } from '../../support/users
 import { EXERCISE_TYPE } from '../../support/constants';
 import { Exercise } from '../../support/pageobjects/exam/ExamParticipation';
 
-let exam: Exam;
-let course: Course;
-
 // This is a workaround for uncaught athene errors. When opening a text submission athene throws an uncaught exception, which fails the test
 Cypress.on('uncaught:exception', () => {
     return false;
 });
 
+let exam: Exam;
+
 describe('Exam assessment', () => {
+    let course: Course;
     let examEnd: Dayjs;
     let programmingAssessmentSuccessful = false;
     let modelingAssessmentSuccessful = false;
     let textAssessmentSuccessful = false;
     let studentOneName: string;
 
-    before('Create a course', () => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -54,7 +54,7 @@ describe('Exam assessment', () => {
     describe('Programming exercise assessment', () => {
         before('Prepare exam', () => {
             examEnd = dayjs().add(3, 'minutes');
-            prepareExam(examEnd, EXERCISE_TYPE.Programming);
+            prepareExam(course, examEnd, EXERCISE_TYPE.Programming);
         });
 
         it('Assess a programming exercise submission (MANUAL)', () => {
@@ -79,7 +79,7 @@ describe('Exam assessment', () => {
     describe('Modeling exercise assessment', () => {
         before('Prepare exam', () => {
             examEnd = dayjs().add(30, 'seconds');
-            prepareExam(examEnd, EXERCISE_TYPE.Modeling);
+            prepareExam(course, examEnd, EXERCISE_TYPE.Modeling);
         });
 
         it('Assess a modeling exercise submission', () => {
@@ -111,7 +111,7 @@ describe('Exam assessment', () => {
     describe('Text exercise assessment', () => {
         before('Prepare exam', () => {
             examEnd = dayjs().add(40, 'seconds');
-            prepareExam(examEnd, EXERCISE_TYPE.Text);
+            prepareExam(course, examEnd, EXERCISE_TYPE.Text);
         });
 
         it('Assess a text exercise submission', () => {
@@ -141,7 +141,7 @@ describe('Exam assessment', () => {
         before('Prepare exam', () => {
             examEnd = dayjs().add(30, 'seconds');
             resultDate = examEnd.add(5, 'seconds');
-            prepareExam(examEnd, EXERCISE_TYPE.Quiz);
+            prepareExam(course, examEnd, EXERCISE_TYPE.Quiz);
         });
 
         it('Assesses quiz automatically', () => {
@@ -173,7 +173,7 @@ describe('Exam assessment', () => {
     });
 });
 
-function prepareExam(end: dayjs.Dayjs, exerciseType: EXERCISE_TYPE) {
+function prepareExam(course: Course, end: dayjs.Dayjs, exerciseType: EXERCISE_TYPE) {
     cy.login(admin);
     const resultDate = end.add(1, 'second');
     const examContent = new ExamBuilder(course)

--- a/src/test/cypress/e2e/exam/ExamCreationDeletion.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamCreationDeletion.cy.ts
@@ -52,7 +52,7 @@ describe('Exam creation/deletion', () => {
 
     it('Creates an exam', () => {
         navigationBar.openCourseManagement();
-        courseManagement.openExamsOfCourse(course.shortName!);
+        courseManagement.openExamsOfCourse(course.id!);
 
         examManagement.createNewExam();
         examCreation.setTitle(examData.title);
@@ -106,7 +106,7 @@ describe('Exam creation/deletion', () => {
 
         it('Deletes an existing exam', () => {
             navigationBar.openCourseManagement();
-            courseManagement.openExamsOfCourse(course.shortName!);
+            courseManagement.openExamsOfCourse(course.id!);
             examManagement.openExam(examId);
             examDetails.deleteExam(examData.title);
             examManagement.getExamSelector(examData.title).should('not.exist');
@@ -124,10 +124,10 @@ describe('Exam creation/deletion', () => {
 
         it('Edits an existing exam', () => {
             navigationBar.openCourseManagement();
-            courseManagement.openExamsOfCourse(course.shortName!);
+            courseManagement.openExamsOfCourse(course.id!);
             examManagement.openExam(examId);
-            cy.get('#exam-detail-title').contains(examData.title);
-            cy.get('#editButton').click();
+            examManagement.getExamTitle().contains(examData.title);
+            examManagement.clickEdit();
 
             examCreation.setTitle(editedExamData.title);
             examCreation.setVisibleDate(editedExamData.visibleDate);

--- a/src/test/cypress/e2e/exam/ExamCreationDeletion.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamCreationDeletion.cy.ts
@@ -171,9 +171,6 @@ describe('Exam creation/deletion', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exam/ExamCreationDeletion.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamCreationDeletion.cy.ts
@@ -39,7 +39,7 @@ describe('Exam creation/deletion', () => {
     let course: Course;
     let examId: number;
 
-    before(() => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -170,8 +170,9 @@ describe('Exam creation/deletion', () => {
         });
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
+            cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);
         }
     });

--- a/src/test/cypress/e2e/exam/ExamDateVerification.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamDateVerification.cy.ts
@@ -127,9 +127,6 @@ describe('Exam date verification', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exam/ExamDateVerification.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamDateVerification.cy.ts
@@ -11,7 +11,7 @@ describe('Exam date verification', () => {
     let course: Course;
     let examTitle: string;
 
-    before(() => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -124,14 +124,9 @@ describe('Exam date verification', () => {
                 });
             });
         });
-
-        afterEach(() => {
-            cy.login(admin);
-            courseManagementRequest.deleteExam(exam);
-        });
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
             cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);

--- a/src/test/cypress/e2e/exam/ExamDateVerification.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamDateVerification.cy.ts
@@ -4,7 +4,7 @@ import { Exam } from 'app/entities/exam.model';
 import { ExamBuilder, convertModelAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import dayjs from 'dayjs/esm';
 import { generateUUID } from '../../support/utils';
-import { courseManagementRequest, courseOverview, examNavigation, examStartEnd, textExerciseEditor } from '../../support/artemis';
+import { courseManagementRequest, courseOverview, examNavigation, examParticipation, examStartEnd, textExerciseEditor } from '../../support/artemis';
 import { admin, studentOne } from '../../support/users';
 
 describe('Exam date verification', () => {
@@ -118,7 +118,7 @@ describe('Exam date verification', () => {
                         if (examEnd.isAfter(dayjs())) {
                             cy.wait(examEnd.diff(dayjs()));
                         }
-                        cy.get('#exam-finished-title').should('contain.text', exam.title, { timeout: 40000 });
+                        examParticipation.checkExamFinishedTitle(exam.title!);
                         examStartEnd.finishExam();
                     });
                 });

--- a/src/test/cypress/e2e/exam/ExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamManagement.cy.ts
@@ -59,7 +59,7 @@ describe('Exam management', () => {
         it('Create exercise group', () => {
             cy.visit('/');
             navigationBar.openCourseManagement();
-            courseManagement.openExamsOfCourse(course.shortName!);
+            courseManagement.openExamsOfCourse(course.id!);
             examManagement.openExerciseGroups(exam.id!);
             examExerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
             examExerciseGroups.clickAddExerciseGroup();
@@ -140,7 +140,7 @@ describe('Exam management', () => {
         it('Delete an exercise group', () => {
             cy.visit('/');
             navigationBar.openCourseManagement();
-            courseManagement.openExamsOfCourse(course.shortName!);
+            courseManagement.openExamsOfCourse(course.id!);
             examManagement.openExerciseGroups(exam.id!);
             // If the group in the "Create group test" was created successfully, we delete it so there is no group with no exercise
             let group = exerciseGroup;
@@ -164,14 +164,14 @@ describe('Exam management', () => {
             studentExamManagement.clickRegisterCourseStudents().then((request: Interception) => {
                 expect(request.response!.statusCode).to.eq(200);
             });
-            cy.get('#registered-students').contains(studentOne.username).should('be.visible');
+            studentExamManagement.getRegisteredStudents().contains(studentOne.username).should('be.visible');
         });
 
         it('Generates student exams', () => {
             cy.visit(`/course-management/${course.id}/exams`);
             examManagement.openStudentExams(exam.id!);
             studentExamManagement.clickGenerateStudentExams();
-            cy.get('#generateMissingStudentExamsButton').should('be.disabled');
+            studentExamManagement.getGenerateStudentExamsButton().should('be.disabled');
         });
     });
 

--- a/src/test/cypress/e2e/exam/ExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamManagement.cy.ts
@@ -176,9 +176,6 @@ describe('Exam management', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exam/ExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamManagement.cy.ts
@@ -22,14 +22,14 @@ import { admin, instructor, studentOne } from '../../support/users';
 // Common primitives
 const uid = generateUUID();
 const examTitle = 'exam' + uid;
-let groupCount = 0;
-let createdGroup: ExerciseGroup;
 
 describe('Exam management', () => {
     let course: Course;
     let exam: Exam;
+    let createdGroup: ExerciseGroup;
+    let groupCount = 0;
 
-    before(() => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -175,7 +175,7 @@ describe('Exam management', () => {
         });
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
             cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);

--- a/src/test/cypress/e2e/exam/ExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamManagement.cy.ts
@@ -19,10 +19,6 @@ import {
 } from '../../support/artemis';
 import { admin, instructor, studentOne } from '../../support/users';
 
-// Common primitives
-const uid = generateUUID();
-const examTitle = 'exam' + uid;
-
 describe('Exam management', () => {
     let course: Course;
     let exam: Exam;
@@ -34,7 +30,7 @@ describe('Exam management', () => {
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertModelAfterMultiPart(response);
             courseManagementRequest.addStudentToCourse(course, studentOne);
-            const examConfig = new ExamBuilder(course).title(examTitle).build();
+            const examConfig = new ExamBuilder(course).title('Exam ' + generateUUID()).build();
             courseManagementRequest.createExam(examConfig).then((examResponse) => {
                 exam = examResponse.body;
             });
@@ -79,7 +75,7 @@ describe('Exam management', () => {
             cy.visit(`/course-management/${course.id}/exams`);
             examManagement.openExerciseGroups(exam.id!);
             examExerciseGroups.clickAddTextExercise(exerciseGroup.id!);
-            const textExerciseTitle = 'text' + uid;
+            const textExerciseTitle = 'Text ' + generateUUID();
             textExerciseCreation.typeTitle(textExerciseTitle);
             textExerciseCreation.typeMaxPoints(10);
             textExerciseCreation.create().its('response.statusCode').should('eq', 201);
@@ -91,7 +87,7 @@ describe('Exam management', () => {
             cy.visit(`/course-management/${course.id}/exams`);
             examManagement.openExerciseGroups(exam.id!);
             examExerciseGroups.clickAddQuizExercise(exerciseGroup.id!);
-            const quizExerciseTitle = 'quiz' + uid;
+            const quizExerciseTitle = 'Quiz ' + generateUUID();
             quizExerciseCreation.setTitle(quizExerciseTitle);
             quizExerciseCreation.addMultipleChoiceQuestion(quizExerciseTitle, 10);
             quizExerciseCreation.saveQuiz().its('response.statusCode').should('eq', 201);
@@ -103,7 +99,7 @@ describe('Exam management', () => {
             cy.visit(`/course-management/${course.id}/exams`);
             examManagement.openExerciseGroups(exam.id!);
             examExerciseGroups.clickAddModelingExercise(exerciseGroup.id!);
-            const modelingExerciseTitle = 'modeling' + uid;
+            const modelingExerciseTitle = 'Modeling ' + generateUUID();
             modelingExerciseCreation.setTitle(modelingExerciseTitle);
             modelingExerciseCreation.setPoints(10);
             modelingExerciseCreation.save().its('response.statusCode').should('eq', 201);
@@ -115,9 +111,11 @@ describe('Exam management', () => {
             cy.visit(`/course-management/${course.id}/exams`);
             examManagement.openExerciseGroups(exam.id!);
             examExerciseGroups.clickAddProgrammingExercise(exerciseGroup.id!);
-            const programmingExerciseTitle = 'programming' + uid;
+            const uid = generateUUID();
+            const programmingExerciseTitle = 'Programming ' + uid;
+            const programmingExerciseShortName = 'programming' + uid;
             programmingExerciseCreation.setTitle(programmingExerciseTitle);
-            programmingExerciseCreation.setShortName(programmingExerciseTitle);
+            programmingExerciseCreation.setShortName(programmingExerciseShortName);
             programmingExerciseCreation.setPackageName('de.test');
             programmingExerciseCreation.setPoints(10);
             programmingExerciseCreation.generate().its('response.statusCode').should('eq', 201);

--- a/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
@@ -288,9 +288,6 @@ describe('Exam participation', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
@@ -13,10 +13,10 @@ import { admin, instructor, studentOne, studentThree, studentTwo, tutor, users }
 // Common primitives
 const textFixture = 'loremIpsum.txt';
 const textFixtureAlternative = 'loremIpsum-alternative.txt';
-let exerciseArray: Array<Exercise> = [];
 
 describe('Exam participation', () => {
     let course: Course;
+    let exerciseArray: Array<Exercise> = [];
     let studentOneName: string;
     let studentTwoName: string;
     let studentThreeName: string;

--- a/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
@@ -236,12 +236,17 @@ describe('Exam participation', () => {
 
     describe('Normal Hand-in', () => {
         let exam: Exam;
+        let studentOneName: string;
         const examTitle = 'exam' + generateUUID();
 
         before('Create exam', () => {
             exerciseArray = [];
 
             cy.login(admin);
+            users.getUserInfo(studentOne.username, (userInfo) => {
+                studentOneName = userInfo.name;
+            });
+
             const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .visibleDate(dayjs().subtract(3, 'minutes'))
@@ -269,7 +274,8 @@ describe('Exam participation', () => {
             examNavigation.openExerciseAtIndex(textExerciseIndex);
             examParticipation.makeSubmission(textExercise.id, textExercise.type, textExercise.additionalData);
             examParticipation.clickSaveAndContinue();
-            cy.get('#fullname', { timeout: 20000 }).should('be.visible');
+            examParticipation.checkExamFullnameInputExists();
+            examParticipation.checkYourFullname(studentOneName);
             examStartEnd.finishExam().then((request: Interception) => {
                 expect(request.response!.statusCode).to.eq(200);
             });

--- a/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
@@ -114,7 +114,7 @@ describe('Exam test run', () => {
 
     it('Conducts a test run', () => {
         examTestRun.startParticipation(instructor, course, exam, testRun.id);
-        cy.get('#testRunRibbon').contains('Test Run');
+        examTestRun.getTestRunRibbon().contains('Test Run');
 
         for (let j = 0; j < exerciseArray.length; j++) {
             const exercise = exerciseArray[j];

--- a/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
@@ -14,14 +14,13 @@ import { admin, instructor } from '../../support/users';
 const textFixture = 'loremIpsum.txt';
 const examTitle = 'exam' + generateUUID();
 
-let exerciseArray: Array<Exercise> = [];
-
 describe('Exam test run', () => {
     let course: Course;
     let exam: Exam;
     let testRun: any;
+    let exerciseArray: Array<Exercise> = [];
 
-    before(() => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -144,7 +143,7 @@ describe('Exam test run', () => {
         examTestRun.getTestRun(testRun.id).should('not.exist');
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
             cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);

--- a/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
@@ -144,9 +144,6 @@ describe('Exam test run', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exam/test-exam/TestExamCreationDeletion.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamCreationDeletion.cy.ts
@@ -38,7 +38,7 @@ describe('Test Exam creation/deletion', () => {
 
     it('Creates a test exam', function () {
         navigationBar.openCourseManagement();
-        courseManagement.openExamsOfCourse(course.shortName!);
+        courseManagement.openExamsOfCourse(course.id!);
 
         examManagement.createNewExam();
         examCreation.setTitle(examData.title);
@@ -73,7 +73,7 @@ describe('Test Exam creation/deletion', () => {
             expect(examBody.confirmationEndText).to.eq(examData.confirmationEndText);
             cy.url().should('contain', `/exams/${examId}`);
         });
-        cy.get('#exam-detail-title').should('contain.text', examData.title);
+        examManagement.getExamTitle().contains(examData.title);
     });
 
     describe('Test exam deletion', () => {
@@ -87,7 +87,7 @@ describe('Test Exam creation/deletion', () => {
 
         it('Deletes an existing test exam', () => {
             navigationBar.openCourseManagement();
-            courseManagement.openExamsOfCourse(course.shortName!);
+            courseManagement.openExamsOfCourse(course.id!);
             examManagement.getExamSelector(examData.title).should('exist');
             examManagement.openExam(examId);
             examDetails.deleteExam(examData.title);

--- a/src/test/cypress/e2e/exam/test-exam/TestExamCreationDeletion.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamCreationDeletion.cy.ts
@@ -96,9 +96,6 @@ describe('Test Exam creation/deletion', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exam/test-exam/TestExamCreationDeletion.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamCreationDeletion.cy.ts
@@ -25,7 +25,7 @@ describe('Test Exam creation/deletion', () => {
     let course: Course;
     let examId: number;
 
-    before(() => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -95,8 +95,9 @@ describe('Test Exam creation/deletion', () => {
         });
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
+            cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);
         }
     });

--- a/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
@@ -57,7 +57,7 @@ describe('Test Exam management', () => {
         it('Create exercise group', () => {
             cy.visit('/');
             navigationBar.openCourseManagement();
-            courseManagement.openExamsOfCourse(course.shortName!);
+            courseManagement.openExamsOfCourse(course.id!);
             examManagement.openExerciseGroups(exam.id!);
             examExerciseGroups.shouldShowNumberOfExerciseGroups(groupCount);
             examExerciseGroups.clickAddExerciseGroup();
@@ -138,7 +138,7 @@ describe('Test Exam management', () => {
         it('Delete an exercise group', () => {
             cy.visit('/');
             navigationBar.openCourseManagement();
-            courseManagement.openExamsOfCourse(course.shortName!);
+            courseManagement.openExamsOfCourse(course.id!);
             examManagement.openExerciseGroups(exam.id!);
             // If the group in the "Create group test" was created successfully, we delete it so there is no group with no exercise
             let group = exerciseGroup;

--- a/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
@@ -151,9 +151,6 @@ describe('Test Exam management', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
@@ -20,14 +20,14 @@ import { admin, instructor, studentOne } from '../../../support/users';
 // Common primitives
 const uid = generateUUID();
 const examTitle = 'test-exam' + uid;
-let groupCount = 0;
-let createdGroup: ExerciseGroup;
 
 describe('Test Exam management', () => {
     let course: Course;
     let exam: Exam;
+    let createdGroup: ExerciseGroup;
+    let groupCount = 0;
 
-    before(() => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -150,7 +150,7 @@ describe('Test Exam management', () => {
         });
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
             cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);

--- a/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
@@ -14,10 +14,10 @@ import { Interception } from 'cypress/types/net-stubbing';
 
 // Common primitives
 const textFixture = 'loremIpsum.txt';
-let exerciseArray: Array<Exercise> = [];
 
 describe('Test exam participation', () => {
     let course: Course;
+    let exerciseArray: Array<Exercise> = [];
 
     before('Create course', () => {
         cy.login(admin);

--- a/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
@@ -8,7 +8,7 @@ import { generateUUID } from '../../../support/utils';
 import { EXERCISE_TYPE } from '../../../support/constants';
 import { Exercise } from 'src/test/cypress/support/pageobjects/exam/ExamParticipation';
 import { examExerciseGroupCreation, examNavigation, examParticipation, examStartEnd } from 'src/test/cypress/support/artemis';
-import { admin, studentOne, studentThree, studentTwo } from 'src/test/cypress/support/users';
+import { admin, studentOne, studentThree, studentTwo, users } from 'src/test/cypress/support/users';
 import { courseManagementRequest } from 'src/test/cypress/support/requests/ArtemisRequests';
 import { Interception } from 'cypress/types/net-stubbing';
 
@@ -120,12 +120,18 @@ describe('Test exam participation', () => {
 
     describe('Normal Hand-in', () => {
         let exam: Exam;
+        let studentOneName: string;
         const examTitle = 'exam' + generateUUID();
 
         before('Create exam', () => {
             exerciseArray = [];
 
             cy.login(admin);
+
+            users.getUserInfo(studentOne.username, (userInfo) => {
+                studentOneName = userInfo.name;
+            });
+
             const examContent = new ExamBuilder(course)
                 .title(examTitle)
                 .testExam()
@@ -151,7 +157,8 @@ describe('Test exam participation', () => {
             examNavigation.openExerciseAtIndex(textExerciseIndex);
             examParticipation.makeSubmission(textExercise.id, textExercise.type, textExercise.additionalData);
             examParticipation.clickSaveAndContinue();
-            cy.get('#fullname', { timeout: 20000 }).should('be.visible');
+            examParticipation.checkExamFullnameInputExists();
+            examParticipation.checkYourFullname(studentOneName);
             examStartEnd.finishExam().then((request: Interception) => {
                 expect(request.response!.statusCode).to.eq(200);
             });

--- a/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
@@ -168,9 +168,6 @@ describe('Test exam participation', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
@@ -117,7 +117,7 @@ describe('Test exam test run', () => {
 
     it('Conducts a test run', () => {
         examTestRun.startParticipation(instructor, course, exam, testRun.id);
-        cy.get('#testRunRibbon').contains('Test Run');
+        examTestRun.getTestRunRibbon().contains('Test Run');
 
         for (let j = 0; j < exerciseArray.length; j++) {
             const exercise = exerciseArray[j];

--- a/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
@@ -14,14 +14,13 @@ import { admin, instructor } from '../../../support/users';
 const textFixture = 'loremIpsum.txt';
 const examTitle = 'exam' + generateUUID();
 
-let exerciseArray: Array<Exercise> = [];
-
 describe('Test exam test run', () => {
     let course: Course;
     let exam: Exam;
     let testRun: any;
+    let exerciseArray: Array<Exercise> = [];
 
-    before(() => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -147,7 +146,7 @@ describe('Test exam test run', () => {
         examTestRun.getTestRun(testRun.id).should('not.exist');
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
             cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);

--- a/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
@@ -147,9 +147,6 @@ describe('Test exam test run', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/ExerciseImport.cy.ts
+++ b/src/test/cypress/e2e/exercises/ExerciseImport.cy.ts
@@ -165,12 +165,7 @@ describe('Import exercises', () => {
     });
 
     after('Delete Courses', () => {
-        cy.login(admin);
-        if (course.id) {
-            courseManagementRequest.deleteCourse(course.id).its('status').should('eq', 200);
-        }
-        if (secondCourse.id) {
-            courseManagementRequest.deleteCourse(secondCourse.id).its('status').should('eq', 200);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
+        courseManagementRequest.deleteCourse(secondCourse, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseAssessment.cy.ts
@@ -20,7 +20,7 @@ describe('Modeling Exercise Assessment', () => {
     before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
-            course = convertCourseAfterMultiPart(response);
+            course = convertModelAfterMultiPart(response);
             courseManagementRequest.addStudentToCourse(course, studentOne);
             courseManagementRequest.addTutorToCourse(course, tutor);
             courseManagementRequest.addInstructorToCourse(course, instructor);

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseAssessment.cy.ts
@@ -86,9 +86,6 @@ describe('Modeling Exercise Assessment', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseManagement.cy.ts
@@ -2,7 +2,15 @@ import dayjs from 'dayjs/esm';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { Course } from 'app/entities/course.model';
 import { MODELING_EDITOR_CANVAS } from '../../../support/pageobjects/exercises/modeling/ModelingEditor';
-import { courseManagementExercises, courseManagementRequest, modelingExerciseAssessment, modelingExerciseCreation, modelingExerciseEditor } from '../../../support/artemis';
+import {
+    courseManagement,
+    courseManagementExercises,
+    courseManagementRequest,
+    modelingExerciseAssessment,
+    modelingExerciseCreation,
+    modelingExerciseEditor,
+    navigationBar,
+} from '../../../support/artemis';
 import { convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import { admin, instructor, studentOne } from '../../../support/users';
 import { generateUUID } from 'src/test/cypress/support/utils';

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseManagement.cy.ts
@@ -116,7 +116,7 @@ describe('Modeling Exercise Management', () => {
             });
         });
 
-        it('Deletes an existing text exercise', () => {
+        it('Deletes an existing Modeling exercise', () => {
             cy.login(instructor, '/');
             navigationBar.openCourseManagement();
             courseManagement.openExercisesOfCourse(course.id!);

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseManagement.cy.ts
@@ -139,9 +139,6 @@ describe('Modeling Exercise Management', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseManagement.cy.ts
@@ -7,12 +7,11 @@ import { convertModelAfterMultiPart } from '../../../support/requests/CourseMana
 import { admin, instructor, studentOne } from '../../../support/users';
 import { generateUUID } from 'src/test/cypress/support/utils';
 
-// Common primitives
-let course: Course;
-let modelingExercise: ModelingExercise;
+describe('Modeling Exercise Management', () => {
+    let course: Course;
+    let modelingExercise: ModelingExercise;
 
-describe('Modeling Exercise Management Spec', () => {
-    before('Create a course', () => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response: Cypress.Response<Course>) => {
             course = convertModelAfterMultiPart(response);
@@ -104,7 +103,7 @@ describe('Modeling Exercise Management Spec', () => {
     });
 
     describe('Modeling Exercise Release', () => {
-        beforeEach('Login intructor', () => {
+        beforeEach('Login as instructor', () => {
             cy.login(instructor);
         });
 
@@ -126,8 +125,10 @@ describe('Modeling Exercise Management Spec', () => {
         });
     });
 
-    after('Delete the test course', () => {
-        cy.login(admin);
-        courseManagementRequest.deleteCourse(course.id!);
+    after('Delete course', () => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
+        }
     });
 });

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseParticipation.cy.ts
@@ -4,12 +4,11 @@ import { convertModelAfterMultiPart } from '../../../support/requests/CourseMana
 import { courseManagementRequest, courseOverview, modelingExerciseEditor } from '../../../support/artemis';
 import { admin, studentOne } from '../../../support/users';
 
-// Common primitives
-let course: Course;
-let modelingExercise: ModelingExercise;
+describe('Modeling Exercise Participation', () => {
+    let course: Course;
+    let modelingExercise: ModelingExercise;
 
-describe('Modeling Exercise Participation Spec', () => {
-    before('Log in as admin and create a course', () => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response: Cypress.Response<Course>) => {
             course = convertModelAfterMultiPart(response);
@@ -20,11 +19,6 @@ describe('Modeling Exercise Participation Spec', () => {
         });
     });
 
-    after('Delete the test course', () => {
-        cy.login(admin);
-        courseManagementRequest.deleteCourse(course.id!);
-    });
-
     it('Student can start and submit their model', () => {
         cy.login(studentOne, `/courses/${course.id}`);
         courseOverview.startExercise(modelingExercise.id!);
@@ -33,5 +27,12 @@ describe('Modeling Exercise Participation Spec', () => {
         modelingExerciseEditor.addComponentToModel(modelingExercise.id!, 2, false, 730, 500);
         modelingExerciseEditor.addComponentToModel(modelingExercise.id!, 3, false, 1000, 100);
         modelingExerciseEditor.submit();
+    });
+
+    after('Delete course', () => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
+        }
     });
 });

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseParticipation.cy.ts
@@ -30,9 +30,6 @@ describe('Modeling Exercise Participation', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
@@ -71,7 +71,7 @@ describe('Programming exercise assessment', () => {
     it('Assesses the programming exercise submission and verifies it', () => {
         // Asses submission
         cy.login(tutor, '/course-management');
-        courseManagement.openAssessmentDashboardOfCourse(course.shortName!);
+        courseManagement.openAssessmentDashboardOfCourse(course.id!);
         courseAssessment.clickExerciseDashboardButton();
         exerciseAssessment.clickHaveReadInstructionsButton();
         exerciseAssessment.clickStartNewAssessment();
@@ -87,7 +87,7 @@ describe('Programming exercise assessment', () => {
             }
         });
 
-        // Verify assesment as student
+        // Verify assessment as student
         cy.login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
         const totalPoints = tutorFeedbackPoints + tutorCodeFeedbackPoints;
         const percentage = totalPoints * 10;
@@ -99,7 +99,7 @@ describe('Programming exercise assessment', () => {
         programmingExerciseFeedback.shouldShowScore(percentage);
         programmingExerciseFeedback.shouldShowCodeFeedback(exercise.id!, 'BubbleSort.java', tutorCodeFeedback, '-2', programmingExerciseEditor);
 
-        // Accept compaint
+        // Accept complaint
         cy.login(instructor, `/course-management/${course.id}/complaints`);
         programmingExerciseAssessment.acceptComplaint('Makes sense', false).then((request: Interception) => {
             expect(request.response!.statusCode).to.equal(200);

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
@@ -107,9 +107,6 @@ describe('Programming exercise assessment', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
@@ -31,7 +31,7 @@ describe('Programming exercise assessment', () => {
     before('Creates a programming exercise and makes a student submission', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
-            course = convertCourseAfterMultiPart(response);
+            course = convertModelAfterMultiPart(response);
             courseManagementRequest.addStudentToCourse(course, studentOne);
             courseManagementRequest.addTutorToCourse(course, tutor);
             courseManagementRequest.addInstructorToCourse(course, instructor);

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseAssessment.cy.ts
@@ -15,79 +15,23 @@ import {
 } from '../../../support/artemis';
 import { admin, instructor, studentOne, tutor } from '../../../support/users';
 
+// Common primitives
+const tutorFeedback = 'You are missing some classes! The classes, which you implemented look good though.';
+const tutorFeedbackPoints = 5;
+const tutorCodeFeedback = 'The input parameter should be mentioned in javadoc!';
+const tutorCodeFeedbackPoints = -2;
+const complaint = "That feedback wasn't very useful!";
+
 describe('Programming exercise assessment', () => {
     let course: Course;
     let exercise: ProgrammingExercise;
-    const tutorFeedback = 'You are missing some classes! The classes, which you implemented look good though.';
-    const tutorFeedbackPoints = 5;
-    const tutorCodeFeedback = 'The input parameter should be mentioned in javadoc!';
-    const tutorCodeFeedbackPoints = -2;
-    const complaint = "That feedback wasn't very useful!";
     let dueDate: dayjs.Dayjs;
     let assessmentDueDate: dayjs.Dayjs;
 
     before('Creates a programming exercise and makes a student submission', () => {
-        createCourseWithProgrammingExercise().then(() => {
-            makeProgrammingSubmissionAsStudent();
-        });
-    });
-
-    it('Assesses the programming exercise submission and verifies it', () => {
-        assessSubmission();
-        verifyAssessmentAsStudent();
-        acceptComplaintAsInstructor();
-    });
-
-    after(() => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
-    });
-
-    function assessSubmission() {
-        cy.login(tutor, '/course-management');
-        courseManagement.openAssessmentDashboardOfCourse(course.shortName!);
-        courseAssessment.clickExerciseDashboardButton();
-        exerciseAssessment.clickHaveReadInstructionsButton();
-        exerciseAssessment.clickStartNewAssessment();
-        programmingExerciseEditor.openFileWithName(exercise.id!, 'BubbleSort.java');
-        programmingExerciseAssessment.provideFeedbackOnCodeLine(9, tutorCodeFeedbackPoints, tutorCodeFeedback);
-        programmingExerciseAssessment.addNewFeedback(tutorFeedbackPoints, tutorFeedback);
-        programmingExerciseAssessment.submit().then((request: Interception) => {
-            expect(request.response!.statusCode).to.eq(200);
-            // Wait until the assessment due date is over
-            const now = dayjs();
-            if (now.isBefore(assessmentDueDate)) {
-                cy.wait(assessmentDueDate.diff(now, 'ms'));
-            }
-        });
-    }
-
-    function verifyAssessmentAsStudent() {
-        cy.login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
-        const totalPoints = tutorFeedbackPoints + tutorCodeFeedbackPoints;
-        const percentage = totalPoints * 10;
-        exerciseResult.shouldShowExerciseTitle(exercise.title!);
-        programmingExerciseFeedback.complain(complaint);
-        exerciseResult.clickOpenCodeEditor(exercise.id!);
-        programmingExerciseFeedback.shouldShowRepositoryLockedWarning();
-        programmingExerciseFeedback.shouldShowAdditionalFeedback(tutorFeedbackPoints, tutorFeedback);
-        programmingExerciseFeedback.shouldShowScore(percentage);
-        programmingExerciseFeedback.shouldShowCodeFeedback(exercise.id!, 'BubbleSort.java', tutorCodeFeedback, '-2', programmingExerciseEditor);
-    }
-
-    function acceptComplaintAsInstructor() {
-        cy.login(instructor, `/course-management/${course.id}/complaints`);
-        programmingExerciseAssessment.acceptComplaint('Makes sense', false).then((request: Interception) => {
-            expect(request.response!.statusCode).to.equal(200);
-        });
-    }
-
-    function createCourseWithProgrammingExercise() {
         cy.login(admin);
-        return courseManagementRequest.createCourse(true).then((response) => {
-            course = convertModelAfterMultiPart(response);
+        courseManagementRequest.createCourse(true).then((response) => {
+            course = convertCourseAfterMultiPart(response);
             courseManagementRequest.addStudentToCourse(course, studentOne);
             courseManagementRequest.addTutorToCourse(course, tutor);
             courseManagementRequest.addInstructorToCourse(course, instructor);
@@ -108,22 +52,64 @@ describe('Programming exercise assessment', () => {
                 )
                 .then((programmingResponse) => {
                     exercise = programmingResponse.body;
+                    cy.login(studentOne);
+                    courseManagementRequest
+                        .startExerciseParticipation(exercise.id!)
+                        .its('body.id')
+                        .then((participationId) => {
+                            courseManagementRequest.makeProgrammingExerciseSubmission(participationId);
+                            // Wait until the due date is in the past
+                            const now = dayjs();
+                            if (now.isBefore(dueDate)) {
+                                cy.wait(dueDate.diff(now, 'ms'));
+                            }
+                        });
                 });
         });
-    }
+    });
 
-    function makeProgrammingSubmissionAsStudent() {
-        cy.login(studentOne);
-        courseManagementRequest
-            .startExerciseParticipation(exercise.id!)
-            .its('body.id')
-            .then((participationId) => {
-                courseManagementRequest.makeProgrammingExerciseSubmission(participationId);
-                // Wait until the due date is in the past
-                const now = dayjs();
-                if (now.isBefore(dueDate)) {
-                    cy.wait(dueDate.diff(now, 'ms'));
-                }
-            });
-    }
+    it('Assesses the programming exercise submission and verifies it', () => {
+        // Asses submission
+        cy.login(tutor, '/course-management');
+        courseManagement.openAssessmentDashboardOfCourse(course.shortName!);
+        courseAssessment.clickExerciseDashboardButton();
+        exerciseAssessment.clickHaveReadInstructionsButton();
+        exerciseAssessment.clickStartNewAssessment();
+        programmingExerciseEditor.openFileWithName(exercise.id!, 'BubbleSort.java');
+        programmingExerciseAssessment.provideFeedbackOnCodeLine(9, tutorCodeFeedbackPoints, tutorCodeFeedback);
+        programmingExerciseAssessment.addNewFeedback(tutorFeedbackPoints, tutorFeedback);
+        programmingExerciseAssessment.submit().then((request: Interception) => {
+            expect(request.response!.statusCode).to.eq(200);
+            // Wait until the assessment due date is over
+            const now = dayjs();
+            if (now.isBefore(assessmentDueDate)) {
+                cy.wait(assessmentDueDate.diff(now, 'ms'));
+            }
+        });
+
+        // Verify assesment as student
+        cy.login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
+        const totalPoints = tutorFeedbackPoints + tutorCodeFeedbackPoints;
+        const percentage = totalPoints * 10;
+        exerciseResult.shouldShowExerciseTitle(exercise.title!);
+        programmingExerciseFeedback.complain(complaint);
+        exerciseResult.clickOpenCodeEditor(exercise.id!);
+        programmingExerciseFeedback.shouldShowRepositoryLockedWarning();
+        programmingExerciseFeedback.shouldShowAdditionalFeedback(tutorFeedbackPoints, tutorFeedback);
+        programmingExerciseFeedback.shouldShowScore(percentage);
+        programmingExerciseFeedback.shouldShowCodeFeedback(exercise.id!, 'BubbleSort.java', tutorCodeFeedback, '-2', programmingExerciseEditor);
+
+        // Accept compaint
+        cy.login(instructor, `/course-management/${course.id}/complaints`);
+        programmingExerciseAssessment.acceptComplaint('Makes sense', false).then((request: Interception) => {
+            expect(request.response!.statusCode).to.equal(200);
+        });
+    });
+
+    after('Delete course', () => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
+        }
+    });
 });

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseManagement.cy.ts
@@ -58,9 +58,6 @@ describe('Programming Exercise Management', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseManagement.cy.ts
@@ -1,7 +1,6 @@
 import { Interception } from 'cypress/types/net-stubbing';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { Course } from 'app/entities/course.model';
-import { DELETE } from '../../../support/constants';
 import { courseManagement, courseManagementExercises, courseManagementRequest, navigationBar, programmingExerciseCreation } from '../../../support/artemis';
 import { generateUUID } from '../../../support/utils';
 import { PROGRAMMING_EXERCISE_BASE, convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
@@ -17,43 +16,11 @@ describe('Programming Exercise Management', () => {
         });
     });
 
-    describe('Programming exercise deletion', () => {
-        let programmingExercise: ProgrammingExercise;
-
-        beforeEach(() => {
-            courseManagementRequest
-                .createProgrammingExercise({ course })
-                .its('body')
-                .then((exercise) => {
-                    expect(exercise).to.not.be.null;
-                    programmingExercise = exercise;
-                });
-        });
-
-        it('Deletes an existing programming exercise', () => {
-            cy.login(admin, '/').wait(500);
-            navigationBar.openCourseManagement();
-            courseManagement.openExercisesOfCourse(course.shortName!);
-            cy.get('#delete-exercise').click();
-            // Check all checkboxes to get rid of the git repositories and build plans
-            cy.get('#additional-check-0').check();
-            cy.get('#additional-check-1').check();
-            cy.get('#confirm-exercise-name').type(programmingExercise.title!);
-            cy.intercept(DELETE, PROGRAMMING_EXERCISE_BASE + '*').as('deleteProgrammingExerciseQuery');
-            // For some reason the deletion sometimes fails if we do it immediately
-            cy.get('#delete').click();
-            cy.wait('@deleteProgrammingExerciseQuery').then((request: any) => {
-                expect(request.response.statusCode).to.equal(200);
-            });
-            cy.contains(programmingExercise.title!).should('not.exist');
-        });
-    });
-
     describe('Programming exercise creation', () => {
         it('Creates a new programming exercise', () => {
             cy.login(admin, '/');
             navigationBar.openCourseManagement();
-            courseManagement.openExercisesOfCourse(course.shortName!);
+            courseManagement.openExercisesOfCourse(course.id!);
             courseManagementExercises.createProgrammingExercise();
             cy.url().should('include', '/programming-exercises/new');
             cy.log('Filling out programming exercise info...');
@@ -65,9 +32,28 @@ describe('Programming Exercise Management', () => {
             programmingExerciseCreation.checkAllowOnlineEditor();
             programmingExerciseCreation.generate().then((request: Interception) => {
                 const exercise = request.response!.body;
-                cy.get('#exercise-detail-title').should('contain.text', exerciseTitle);
+                courseManagementExercises.getExerciseTitle().should('contain.text', exerciseTitle);
                 cy.url().should('include', `/programming-exercises/${exercise.id}`);
             });
+        });
+    });
+
+    describe('Programming exercise deletion', () => {
+        let programmingExercise: ProgrammingExercise;
+
+        before(() => {
+            cy.login(admin, '/');
+            courseManagementRequest.createProgrammingExercise({ course }).then((response) => {
+                programmingExercise = response.body;
+            });
+        });
+
+        it('Deletes an existing programming exercise', () => {
+            cy.login(admin, '/');
+            navigationBar.openCourseManagement();
+            courseManagement.openExercisesOfCourse(course.id!);
+            courseManagementExercises.deleteProgrammingExercise(programmingExercise);
+            courseManagementExercises.getExercise(programmingExercise.id!).should('not.exist');
         });
     });
 

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseManagement.cy.ts
@@ -10,11 +10,10 @@ import { admin } from '../../../support/users';
 describe('Programming Exercise Management', () => {
     let course: Course;
 
-    before(() => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertModelAfterMultiPart(response);
-            expect(course).property('id').to.be.a('number');
         });
     });
 
@@ -72,8 +71,9 @@ describe('Programming Exercise Management', () => {
         });
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
+            cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);
         }
     });

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseManagement.cy.ts
@@ -3,7 +3,7 @@ import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { Course } from 'app/entities/course.model';
 import { courseManagement, courseManagementExercises, courseManagementRequest, navigationBar, programmingExerciseCreation } from '../../../support/artemis';
 import { generateUUID } from '../../../support/utils';
-import { PROGRAMMING_EXERCISE_BASE, convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
+import { convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import { admin } from '../../../support/users';
 
 describe('Programming Exercise Management', () => {

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseParticipation.cy.ts
@@ -27,24 +27,30 @@ describe('Programming exercise participation', () => {
 
     it('Makes a failing submission', () => {
         programmingExerciseEditor.startParticipation(course.id!, exercise.id!, studentOne);
-        makeSubmission(exercise, buildError);
+        const submission = buildError;
+        programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, exercise.packageName!, submission, () => {
+            programmingExerciseEditor.getResultScore().contains(submission.expectedResult).and('be.visible');
+        });
     });
 
     it('Makes a partially successful submission', () => {
         programmingExerciseEditor.startParticipation(course.id!, exercise.id!, studentTwo);
-        makeSubmission(exercise, partiallySuccessful);
+        const submission = partiallySuccessful;
+        programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, exercise.packageName!, submission, () => {
+            programmingExerciseEditor.getResultScore().contains(submission.expectedResult).and('be.visible');
+        });
     });
 
     it('Makes a successful submission', () => {
         programmingExerciseEditor.startParticipation(course.id!, exercise.id!, studentThree);
-        makeSubmission(exercise, allSuccessful);
+        const submission = allSuccessful;
+        programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, exercise.packageName!, submission, () => {
+            programmingExerciseEditor.getResultScore().contains(submission.expectedResult).and('be.visible');
+        });
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 
     /**
@@ -72,12 +78,3 @@ describe('Programming exercise participation', () => {
         });
     }
 });
-
-/**
- * Makes a submission, which fails the CI build and asserts that this is highlighted in the UI.
- */
-function makeSubmission(exercise: ProgrammingExercise, submission: ProgrammingExerciseSubmission) {
-    programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, exercise.packageName!, submission, () => {
-        programmingExerciseEditor.getResultScore().contains(submission.expectedResult).and('be.visible');
-    });
-}

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseParticipation.cy.ts
@@ -3,7 +3,6 @@ import { Course } from 'app/entities/course.model';
 import allSuccessful from '../../../fixtures/exercise/programming/all_successful/submission.json';
 import partiallySuccessful from '../../../fixtures/exercise/programming/partially_successful/submission.json';
 import buildError from '../../../fixtures/exercise/programming/build_error/submission.json';
-import { ProgrammingExerciseSubmission } from '../../../support/pageobjects/exercises/programming/OnlineEditorPage';
 import { convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import { courseManagementRequest, programmingExerciseEditor } from '../../../support/artemis';
 import { admin, studentOne, studentThree, studentTwo } from '../../../support/users';
@@ -52,29 +51,4 @@ describe('Programming exercise participation', () => {
     after('Delete course', () => {
         courseManagementRequest.deleteCourse(course, admin);
     });
-
-    /**
-     * Creates a course and a programming exercise inside that course.
-     */
-    function setupCourseAndProgrammingExercise() {
-        cy.login(admin, '/');
-        courseManagementRequest.createCourse(true).then((response) => {
-            course = convertModelAfterMultiPart(response);
-            courseManagementRequest.addStudentToCourse(course, studentOne);
-            courseManagementRequest.addStudentToCourse(course, studentTwo);
-            courseManagementRequest.addStudentToCourse(course, studentThree);
-            courseManagementRequest.createProgrammingExercise({ course }).then((exerciseResponse) => {
-                exercise = exerciseResponse.body;
-            });
-        });
-    }
-
-    /**
-     * Makes a submission, which fails the CI build and asserts that this is highlighted in the UI.
-     */
-    function makeSubmission(exercise: ProgrammingExercise, submission: ProgrammingExerciseSubmission) {
-        programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, exercise.packageName!, submission, () => {
-            programmingExerciseEditor.getResultScore().contains(submission.expectedResult).and('be.visible');
-        });
-    }
 });

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseParticipation.cy.ts
@@ -15,7 +15,7 @@ describe('Programming exercise participation', () => {
     before('Create course', () => {
         cy.login(admin, '/');
         courseManagementRequest.createCourse(true).then((response) => {
-            course = convertCourseAfterMultiPart(response);
+            course = convertModelAfterMultiPart(response);
             courseManagementRequest.addStudentToCourse(course, studentOne);
             courseManagementRequest.addStudentToCourse(course, studentTwo);
             courseManagementRequest.addStudentToCourse(course, studentThree);

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseParticipation.cy.ts
@@ -8,12 +8,21 @@ import { convertModelAfterMultiPart } from '../../../support/requests/CourseMana
 import { courseManagementRequest, programmingExerciseEditor } from '../../../support/artemis';
 import { admin, studentOne, studentThree, studentTwo } from '../../../support/users';
 
-describe('Programming exercise participations', () => {
+describe('Programming exercise participation', () => {
     let course: Course;
     let exercise: ProgrammingExercise;
 
-    before(() => {
-        setupCourseAndProgrammingExercise();
+    before('Create course', () => {
+        cy.login(admin, '/');
+        courseManagementRequest.createCourse(true).then((response) => {
+            course = convertCourseAfterMultiPart(response);
+            courseManagementRequest.addStudentToCourse(course, studentOne);
+            courseManagementRequest.addStudentToCourse(course, studentTwo);
+            courseManagementRequest.addStudentToCourse(course, studentThree);
+            courseManagementRequest.createProgrammingExercise({ course }).then((exerciseResponse) => {
+                exercise = exerciseResponse.body;
+            });
+        });
     });
 
     it('Makes a failing submission', () => {
@@ -31,7 +40,7 @@ describe('Programming exercise participations', () => {
         makeSubmission(exercise, allSuccessful);
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
             cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);
@@ -63,3 +72,12 @@ describe('Programming exercise participations', () => {
         });
     }
 });
+
+/**
+ * Makes a submission, which fails the CI build and asserts that this is highlighted in the UI.
+ */
+function makeSubmission(exercise: ProgrammingExercise, submission: ProgrammingExerciseSubmission) {
+    programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, exercise.packageName!, submission, () => {
+        programmingExerciseEditor.getResultScore().contains(submission.expectedResult).and('be.visible');
+    });
+}

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseStaticCodeAnalysis.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseStaticCodeAnalysis.cy.ts
@@ -9,42 +9,27 @@ describe('Static code analysis tests', () => {
     let course: Course;
     let exercise: ProgrammingExercise;
 
-    before(() => {
-        setupCourseAndProgrammingExercise();
-    });
-
-    it('Configures SCA grading and makes a successful submission with SCA errors', () => {
-        configureStaticCodeAnalysisGrading();
-        programmingExerciseEditor.startParticipation(course.id!, exercise.id!, studentOne);
-        makeSuccessfulSubmissionWithScaErrors(exercise.id!);
-    });
-
-    after(() => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
-    });
-
-    /**
-     * Creates a course and a programming exercise inside that course.
-     */
-    function setupCourseAndProgrammingExercise() {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse(true).then((response) => {
             course = convertModelAfterMultiPart(response);
             courseManagementRequest.addStudentToCourse(course, studentOne);
-            courseManagementRequest.createProgrammingExercise({ course }, 50).then((dto) => {
-                exercise = dto.body;
+            courseManagementRequest.createProgrammingExercise({ course }, 50).then((exerciseResponse) => {
+                exercise = exerciseResponse.body;
             });
         });
-    }
+    });
 
-    /**
-     * Makes a submission, which passes all tests, but has some static code analysis issues.
-     */
-    function makeSuccessfulSubmissionWithScaErrors(exerciseID: number) {
-        programmingExerciseEditor.makeSubmissionAndVerifyResults(exerciseID, exercise.packageName!, scaSubmission, () => {
+    it('Configures SCA grading and makes a successful submission with SCA errors', () => {
+        // Configure SCA grading
+        cy.login(admin);
+        programmingExercisesScaConfig.visit(course.id!, exercise.id!);
+        programmingExercisesScaConfig.makeEveryScaCategoryInfluenceGrading();
+        programmingExercisesScaConfig.saveChanges();
+
+        // Make submission with SCA errors
+        programmingExerciseEditor.startParticipation(course.id!, exercise.id!, studentOne);
+        programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, exercise.packageName!, scaSubmission, () => {
             programmingExerciseEditor.getResultScore().contains(scaSubmission.expectedResult).and('be.visible').click();
             programmingExerciseScaFeedback.shouldShowPointChart();
             // We have to verify those static texts here. If we don't verify those messages the only difference between the SCA and normal programming exercise
@@ -55,15 +40,12 @@ describe('Static code analysis tests', () => {
             programmingExerciseScaFeedback.shouldShowCodeIssue('Unread public/protected field: de.test.BubbleSort.literal1', '0.2');
             programmingExerciseScaFeedback.closeModal();
         });
-    }
+    });
 
-    /**
-     * Configures every SCA category to affect the grading.
-     */
-    function configureStaticCodeAnalysisGrading() {
-        cy.login(admin);
-        programmingExercisesScaConfig.visit(course.id!, exercise.id!);
-        programmingExercisesScaConfig.makeEveryScaCategoryInfluenceGrading();
-        programmingExercisesScaConfig.saveChanges();
-    }
+    after('Delete course', () => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
+        }
+    });
 });

--- a/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseStaticCodeAnalysis.cy.ts
+++ b/src/test/cypress/e2e/exercises/programming/ProgrammingExerciseStaticCodeAnalysis.cy.ts
@@ -43,9 +43,6 @@ describe('Static code analysis tests', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseAssessment.cy.ts
@@ -23,7 +23,7 @@ describe('Quiz Exercise Assessment', () => {
         before('Creates a quiz and a submission', () => {
             cy.login(admin);
             courseManagementRequest.createQuizExercise({ course }, [multipleChoiceQuizTemplate], undefined, undefined, 1).then((quizResponse) => {
-                quizExercise = quizResponse.body;
+                quizExercise = convertModelAfterMultiPart(quizResponse);
                 courseManagementRequest.setQuizVisible(quizExercise.id!);
                 courseManagementRequest.startQuizNow(quizExercise.id!);
             });
@@ -42,7 +42,7 @@ describe('Quiz Exercise Assessment', () => {
         before('Creates a quiz and a submission', () => {
             cy.login(admin);
             courseManagementRequest.createQuizExercise({ course }, [shortAnswerQuizTemplate], undefined, undefined, 1).then((quizResponse) => {
-                quizExercise = quizResponse.body;
+                quizExercise = convertModelAfterMultiPart(quizResponse);
                 courseManagementRequest.setQuizVisible(quizExercise.id!);
                 courseManagementRequest.startQuizNow(quizExercise.id!);
             });

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseAssessment.cy.ts
@@ -58,9 +58,6 @@ describe('Quiz Exercise Assessment', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseAssessment.cy.ts
@@ -6,14 +6,11 @@ import { convertModelAfterMultiPart } from '../../../support/requests/CourseMana
 import { courseManagementRequest } from '../../../support/artemis';
 import { admin, studentOne, tutor } from '../../../support/users';
 
-// Common primitives
-let course: Course;
-let quizExercise: QuizExercise;
-
-const resultSelector = '#submission-result-graded';
-
 describe('Quiz Exercise Assessment', () => {
-    before('Set up course', () => {
+    let course: Course;
+    let quizExercise: QuizExercise;
+
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -22,18 +19,14 @@ describe('Quiz Exercise Assessment', () => {
         });
     });
 
-    afterEach('Delete Quiz', () => {
-        deleteQuiz();
-    });
-
-    after('Delete Course', () => {
-        cy.login(admin);
-        courseManagementRequest.deleteCourse(course.id!);
-    });
-
     describe('MC Quiz assessment', () => {
         before('Creates a quiz and a submission', () => {
-            createQuiz();
+            cy.login(admin);
+            courseManagementRequest.createQuizExercise({ course }, [multipleChoiceQuizTemplate], undefined, undefined, 1).then((quizResponse) => {
+                quizExercise = quizResponse.body;
+                courseManagementRequest.setQuizVisible(quizExercise.id!);
+                courseManagementRequest.startQuizNow(quizExercise.id!);
+            });
         });
 
         it('Assesses a mc quiz submission automatically', () => {
@@ -41,14 +34,19 @@ describe('Quiz Exercise Assessment', () => {
             courseManagementRequest.startExerciseParticipation(quizExercise.id!);
             courseManagementRequest.createMultipleChoiceSubmission(quizExercise, [0, 2]);
             cy.visit('/courses/' + course.id + '/exercises/' + quizExercise.id);
-            cy.reloadUntilFound(resultSelector);
+            cy.reloadUntilFound('#submission-result-graded');
             cy.contains('50%').should('be.visible');
         });
     });
 
     describe('SA Quiz assessment', () => {
         before('Creates a quiz and a submission', () => {
-            createQuiz(shortAnswerQuizTemplate);
+            cy.login(admin);
+            courseManagementRequest.createQuizExercise({ course }, [shortAnswerQuizTemplate], undefined, undefined, 1).then((quizResponse) => {
+                quizExercise = quizResponse.body;
+                courseManagementRequest.setQuizVisible(quizExercise.id!);
+                courseManagementRequest.startQuizNow(quizExercise.id!);
+            });
         });
 
         it('Assesses a sa quiz submission automatically', () => {
@@ -56,22 +54,15 @@ describe('Quiz Exercise Assessment', () => {
             courseManagementRequest.startExerciseParticipation(quizExercise.id!);
             courseManagementRequest.createShortAnswerSubmission(quizExercise, ['give', 'let', 'run', 'desert']);
             cy.visit('/courses/' + course.id + '/exercises/' + quizExercise.id);
-            cy.reloadUntilFound(resultSelector);
+            cy.reloadUntilFound('#submission-result-graded');
             cy.contains('66.7%').should('be.visible');
         });
     });
-});
 
-function createQuiz(quizQuestions: any = multipleChoiceQuizTemplate) {
-    cy.login(admin);
-    courseManagementRequest.createQuizExercise({ course }, [quizQuestions], undefined, undefined, 1).then((quizResponse) => {
-        quizExercise = convertModelAfterMultiPart(quizResponse);
-        courseManagementRequest.setQuizVisible(quizExercise.id!);
-        courseManagementRequest.startQuizNow(quizExercise.id!);
+    after('Delete course', () => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
+        }
     });
-}
-
-function deleteQuiz() {
-    cy.login(admin);
-    courseManagementRequest.deleteQuizExercise(quizExercise.id!);
-}
+});

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseAssessment.cy.ts
@@ -3,7 +3,7 @@ import { Course } from 'app/entities/course.model';
 import shortAnswerQuizTemplate from '../../../fixtures/exercise/quiz/short_answer/template.json';
 import multipleChoiceQuizTemplate from '../../../fixtures/exercise/quiz/multiple_choice/template.json';
 import { convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
-import { courseManagementRequest } from '../../../support/artemis';
+import { courseManagementRequest, exerciseResult } from '../../../support/artemis';
 import { admin, studentOne, tutor } from '../../../support/users';
 
 describe('Quiz Exercise Assessment', () => {
@@ -34,8 +34,7 @@ describe('Quiz Exercise Assessment', () => {
             courseManagementRequest.startExerciseParticipation(quizExercise.id!);
             courseManagementRequest.createMultipleChoiceSubmission(quizExercise, [0, 2]);
             cy.visit('/courses/' + course.id + '/exercises/' + quizExercise.id);
-            cy.reloadUntilFound('#submission-result-graded');
-            cy.contains('50%').should('be.visible');
+            exerciseResult.shouldShowScore(50);
         });
     });
 
@@ -54,8 +53,7 @@ describe('Quiz Exercise Assessment', () => {
             courseManagementRequest.startExerciseParticipation(quizExercise.id!);
             courseManagementRequest.createShortAnswerSubmission(quizExercise, ['give', 'let', 'run', 'desert']);
             cy.visit('/courses/' + course.id + '/exercises/' + quizExercise.id);
-            cy.reloadUntilFound('#submission-result-graded');
-            cy.contains('66.7%').should('be.visible');
+            exerciseResult.shouldShowScore(66.7);
         });
     });
 

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseDropLocation.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseDropLocation.cy.ts
@@ -58,9 +58,6 @@ describe.skip('Quiz Exercise Drop Location Spec', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseManagement.cy.ts
@@ -4,7 +4,7 @@ import { Course } from 'app/entities/course.model';
 import { generateUUID } from '../../../support/utils';
 import multipleChoiceTemplate from '../../../fixtures/exercise/quiz/multiple_choice/template.json';
 import { DELETE } from '../../../support/constants';
-import { courseManagement, courseManagementExercises, courseManagementRequest, quizExerciseCreation } from '../../../support/artemis';
+import { courseManagement, courseManagementExercises, courseManagementRequest, navigationBar, quizExerciseCreation } from '../../../support/artemis';
 import { convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import { admin } from '../../../support/users';
 
@@ -21,7 +21,7 @@ describe('Quiz Exercise Management', () => {
     describe('Quiz Exercise Creation', () => {
         beforeEach(() => {
             cy.login(admin, '/course-management/');
-            courseManagement.openExercisesOfCourse(course.shortName!);
+            courseManagement.openExercisesOfCourse(course.id!);
             courseManagementExercises.createQuizExercise();
             quizExerciseCreation.setTitle('Quiz Exercise ' + generateUUID());
         });
@@ -57,23 +57,19 @@ describe('Quiz Exercise Management', () => {
     describe('Quiz Exercise deletion', () => {
         let quizExercise: QuizExercise;
 
-        beforeEach('Create Quiz Exercise', () => {
+        before('Create quiz Exercise', () => {
             cy.login(admin);
             courseManagementRequest.createQuizExercise({ course }, [multipleChoiceTemplate]).then((quizResponse) => {
                 quizExercise = convertModelAfterMultiPart(quizResponse);
             });
         });
 
-        it('Deletes a Quiz Exercise', () => {
-            cy.login(admin, '/course-management/');
-            courseManagement.openExercisesOfCourse(course.shortName!);
-            cy.get('#delete-quiz-' + quizExercise.id).click();
-            cy.get('#confirm-exercise-name').type(quizExercise.title!);
-            cy.intercept(DELETE, '/api/quiz-exercises/*').as('deleteQuizQuery');
-            cy.get('#delete').click();
-            cy.wait('@deleteQuizQuery').then((deleteResponse) => {
-                expect(deleteResponse?.response?.statusCode).to.eq(200);
-            });
+        it('Deletes a quiz exercise', () => {
+            cy.login(admin, '/');
+            navigationBar.openCourseManagement();
+            courseManagement.openExercisesOfCourse(course.id!);
+            courseManagementExercises.deleteQuizExercise(quizExercise);
+            courseManagementExercises.getExercise(quizExercise.id!).should('not.exist');
         });
     });
 

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseManagement.cy.ts
@@ -3,7 +3,6 @@ import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
 import { Course } from 'app/entities/course.model';
 import { generateUUID } from '../../../support/utils';
 import multipleChoiceTemplate from '../../../fixtures/exercise/quiz/multiple_choice/template.json';
-import { DELETE } from '../../../support/constants';
 import { courseManagement, courseManagementExercises, courseManagementRequest, navigationBar, quizExerciseCreation } from '../../../support/artemis';
 import { convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import { admin } from '../../../support/users';

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseManagement.cy.ts
@@ -74,9 +74,6 @@ describe('Quiz Exercise Management', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseManagement.cy.ts
@@ -40,7 +40,7 @@ describe('Quiz Exercise Management', () => {
             quizExerciseCreation.addShortAnswerQuestion(title);
             quizExerciseCreation.saveQuiz().then((quizResponse: Interception) => {
                 cy.visit('/course-management/' + course.id + '/quiz-exercises/' + quizResponse.response!.body.id + '/preview');
-                cy.contains(quizQuestionTitle).should('be.visible');
+                cy.contains(title).should('be.visible');
             });
         });
 

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseManagement.cy.ts
@@ -8,19 +8,14 @@ import { courseManagement, courseManagementExercises, courseManagementRequest, q
 import { convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import { admin } from '../../../support/users';
 
-// Common primitives
-let course: Course;
-
 describe('Quiz Exercise Management', () => {
-    before('Set up course', () => {
+    let course: Course;
+
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response) => {
             course = convertModelAfterMultiPart(response);
         });
-    });
-
-    after('Delete Course', () => {
-        courseManagementRequest.deleteCourse(course.id!);
     });
 
     describe('Quiz Exercise Creation', () => {
@@ -45,7 +40,7 @@ describe('Quiz Exercise Management', () => {
             quizExerciseCreation.addShortAnswerQuestion(title);
             quizExerciseCreation.saveQuiz().then((quizResponse: Interception) => {
                 cy.visit('/course-management/' + course.id + '/quiz-exercises/' + quizResponse.response!.body.id + '/preview');
-                cy.contains(title).should('be.visible');
+                cy.contains(quizQuestionTitle).should('be.visible');
             });
         });
 
@@ -80,5 +75,12 @@ describe('Quiz Exercise Management', () => {
                 expect(deleteResponse?.response?.statusCode).to.eq(200);
             });
         });
+    });
+
+    after('Delete course', () => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
+        }
     });
 });

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseParticipation.cy.ts
@@ -78,7 +78,7 @@ describe('Quiz Exercise Participation', () => {
     // describe.skip('DnD Quiz participation', () => {
     //     before('Create DND quiz', () => {
     //         cy.login(admin, '/course-management/' + course.id + '/exercises');
-    //         cy.get('#create-quiz-button').should('be.visible').click();
+    //         courseManagementExercises.createQuizExercise();
     //         quizExerciseCreation.setTitle('Cypress Quiz');
     //         quizExerciseCreation.addDragAndDropQuestion('DnD Quiz');
     //         quizExerciseCreation.saveQuiz().then((quizResponse) => {

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseParticipation.cy.ts
@@ -6,22 +6,16 @@ import { courseManagementRequest, courseOverview, quizExerciseMultipleChoice, qu
 import { convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 import { admin, studentOne } from '../../../support/users';
 
-// Common primitives
-let course: Course;
-let quizExercise: QuizExercise;
-
 describe('Quiz Exercise Participation', () => {
-    before('Set up course', () => {
+    let course: Course;
+    let quizExercise: QuizExercise;
+
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response) => {
             course = convertModelAfterMultiPart(response);
             courseManagementRequest.addStudentToCourse(course, studentOne);
         });
-    });
-
-    after('Delete Course', () => {
-        cy.login(admin);
-        courseManagementRequest.deleteCourse(course.id!);
     });
 
     describe('Quiz exercise participation', () => {
@@ -101,4 +95,11 @@ describe('Quiz Exercise Participation', () => {
     //         quizExerciseDragAndDropQuiz.submit();
     //     });
     // });
+
+    after('Delete course', () => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
+        }
+    });
 });

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseParticipation.cy.ts
@@ -97,9 +97,6 @@ describe('Quiz Exercise Participation', () => {
     // });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
@@ -44,7 +44,7 @@ describe('Text exercise assessment', () => {
 
     it('Assesses the text exercise submission', () => {
         cy.login(tutor, '/course-management');
-        courseManagement.openAssessmentDashboardOfCourse(course.shortName!);
+        courseManagement.openAssessmentDashboardOfCourse(course.id!);
         courseAssessment.clickExerciseDashboardButton();
         exerciseAssessment.clickHaveReadInstructionsButton();
         exerciseAssessment.clickStartNewAssessment();

--- a/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
@@ -84,9 +84,6 @@ describe('Text exercise assessment', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
@@ -27,7 +27,7 @@ describe('Text exercise assessment', () => {
     before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response) => {
-            course = convertCourseAfterMultiPart(response);
+            course = convertModelAfterMultiPart(response);
             courseManagementRequest.addStudentToCourse(course, studentOne);
             courseManagementRequest.addTutorToCourse(course, tutor);
             courseManagementRequest.addInstructorToCourse(course, instructor);

--- a/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
@@ -13,26 +13,33 @@ import {
 } from '../../../support/artemis';
 import { admin, instructor, studentOne, tutor } from '../../../support/users';
 
+// Common primitives
+const tutorFeedback = 'Try to use some newlines next time!';
+const tutorFeedbackPoints = 4;
+const tutorTextFeedback = 'Nice ending of the sentence!';
+const tutorTextFeedbackPoints = 2;
+const complaint = "That feedback wasn't very useful!";
+
 describe('Text exercise assessment', () => {
     let course: Course;
     let exercise: TextExercise;
-    const tutorFeedback = 'Try to use some newlines next time!';
-    const tutorFeedbackPoints = 4;
-    const tutorTextFeedback = 'Nice ending of the sentence!';
-    const tutorTextFeedbackPoints = 2;
-    const complaint = "That feedback wasn't very useful!";
 
-    before('Creates a text exercise and makes a student submission', () => {
-        createCourseWithTextExercise().then(() => {
-            makeTextSubmissionAsStudent();
+    before('Create course', () => {
+        cy.login(admin);
+        courseManagementRequest.createCourse().then((response) => {
+            course = convertCourseAfterMultiPart(response);
+            courseManagementRequest.addStudentToCourse(course, studentOne);
+            courseManagementRequest.addTutorToCourse(course, tutor);
+            courseManagementRequest.addInstructorToCourse(course, instructor);
+            courseManagementRequest.createTextExercise({ course }).then((textResponse) => {
+                exercise = textResponse.body;
+                cy.login(studentOne);
+                courseManagementRequest.startExerciseParticipation(exercise.id!);
+                cy.fixture('loremIpsum.txt').then((submission) => {
+                    courseManagementRequest.makeTextExerciseSubmission(exercise.id!, submission);
+                });
+            });
         });
-    });
-
-    after(() => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
     });
 
     it('Assesses the text exercise submission', () => {
@@ -76,24 +83,10 @@ describe('Text exercise assessment', () => {
         });
     });
 
-    function createCourseWithTextExercise() {
-        cy.login(admin);
-        return courseManagementRequest.createCourse().then((response) => {
-            course = convertModelAfterMultiPart(response);
-            courseManagementRequest.addStudentToCourse(course, studentOne);
-            courseManagementRequest.addTutorToCourse(course, tutor);
-            courseManagementRequest.addInstructorToCourse(course, instructor);
-            courseManagementRequest.createTextExercise({ course }).then((textResponse) => {
-                exercise = textResponse.body;
-            });
-        });
-    }
-
-    function makeTextSubmissionAsStudent() {
-        cy.login(studentOne);
-        courseManagementRequest.startExerciseParticipation(exercise.id!);
-        cy.fixture('loremIpsum.txt').then((submission) => {
-            courseManagementRequest.makeTextExerciseSubmission(exercise.id!, submission);
-        });
-    }
+    after('Delete course', () => {
+        if (course) {
+            cy.login(admin);
+            courseManagementRequest.deleteCourse(course.id!);
+        }
+    });
 });

--- a/src/test/cypress/e2e/exercises/text/TextExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseManagement.cy.ts
@@ -20,7 +20,7 @@ import { admin } from '../../../support/users';
 describe('Text exercise management', () => {
     let course: Course;
 
-    before(() => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -91,7 +91,7 @@ describe('Text exercise management', () => {
         });
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
             cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);

--- a/src/test/cypress/e2e/exercises/text/TextExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseManagement.cy.ts
@@ -87,9 +87,6 @@ describe('Text exercise management', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/text/TextExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseManagement.cy.ts
@@ -1,7 +1,6 @@
 import { Interception } from 'cypress/types/net-stubbing';
 import { TextExercise } from 'app/entities/text-exercise.model';
 import { Course } from 'app/entities/course.model';
-import { BASE_API } from '../../../support/constants';
 import {
     courseManagement,
     courseManagementExercises,
@@ -11,7 +10,6 @@ import {
     textExerciseExampleSubmissionCreation,
     textExerciseExampleSubmissions,
 } from '../../../support/artemis';
-import { DELETE } from '../../../support/constants';
 import { generateUUID } from '../../../support/utils';
 import dayjs from 'dayjs/esm';
 import { convertModelAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
@@ -30,7 +28,7 @@ describe('Text exercise management', () => {
     it('Creates a text exercise in the UI', () => {
         cy.visit('/');
         navigationBar.openCourseManagement();
-        courseManagement.openExercisesOfCourse(course.shortName!);
+        courseManagement.openExercisesOfCourse(course.id!);
         courseManagementExercises.createTextExercise();
 
         // Fill out text exercise form
@@ -51,7 +49,7 @@ describe('Text exercise management', () => {
         });
 
         // Create an example submission
-        cy.get('#example-submissions-button').click();
+        courseManagementExercises.clickExampleSubmissionsButton();
         textExerciseExampleSubmissions.clickCreateExampleSubmission();
         textExerciseExampleSubmissionCreation.showsExerciseTitle(exerciseTitle);
         textExerciseExampleSubmissionCreation.showsProblemStatement(problemStatement);
@@ -65,14 +63,14 @@ describe('Text exercise management', () => {
 
         // Make sure text exercise is shown in exercises list
         cy.visit(`course-management/${course.id}/exercises`).then(() => {
-            courseManagementExercises.getExerciseRowRootElement(exercise.id!).should('be.visible');
+            courseManagementExercises.getExercise(exercise.id!).should('be.visible');
         });
     });
 
     describe('Text exercise deletion', () => {
         let exercise: TextExercise;
 
-        beforeEach(() => {
+        before('Create text exercise', () => {
             cy.login(admin, '/');
             courseManagementRequest.createTextExercise({ course }).then((response: Cypress.Response<TextExercise>) => {
                 exercise = response.body;
@@ -80,14 +78,11 @@ describe('Text exercise management', () => {
         });
 
         it('Deletes an existing text exercise', () => {
+            cy.login(admin, '/');
             navigationBar.openCourseManagement();
-            courseManagement.openExercisesOfCourse(course.shortName!);
-            courseManagementExercises.clickDeleteExercise(exercise.id!);
-            cy.get('#confirm-exercise-name').type(exercise.title!);
-            cy.intercept(DELETE, BASE_API + 'text-exercises/*').as('deleteTextExercise');
-            cy.get('#delete').click();
-            cy.wait('@deleteTextExercise');
-            courseManagementExercises.getExerciseRowRootElement(exercise.id!).should('not.exist');
+            courseManagement.openExercisesOfCourse(course.id!);
+            courseManagementExercises.deleteTextExercise(exercise);
+            courseManagementExercises.getExercise(exercise.id!).should('not.exist');
         });
     });
 

--- a/src/test/cypress/e2e/exercises/text/TextExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseParticipation.cy.ts
@@ -45,9 +45,6 @@ describe('Text exercise participation', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/exercises/text/TextExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseParticipation.cy.ts
@@ -9,7 +9,7 @@ describe('Text exercise participation', () => {
     let course: Course;
     let exercise: TextExercise;
 
-    before(() => {
+    before('Create course', () => {
         cy.login(admin);
         courseManagementRequest.createCourse().then((response) => {
             course = convertModelAfterMultiPart(response);
@@ -44,7 +44,7 @@ describe('Text exercise participation', () => {
         });
     });
 
-    after(() => {
+    after('Delete course', () => {
         if (course) {
             cy.login(admin);
             courseManagementRequest.deleteCourse(course.id!);

--- a/src/test/cypress/e2e/lecture/LectureManagement.cy.ts
+++ b/src/test/cypress/e2e/lecture/LectureManagement.cy.ts
@@ -82,9 +82,6 @@ describe('Lecture management', () => {
     });
 
     after('Delete course', () => {
-        if (course) {
-            cy.login(admin);
-            courseManagementRequest.deleteCourse(course.id!);
-        }
+        courseManagementRequest.deleteCourse(course, admin);
     });
 });

--- a/src/test/cypress/e2e/lecture/LectureManagement.cy.ts
+++ b/src/test/cypress/e2e/lecture/LectureManagement.cy.ts
@@ -20,7 +20,7 @@ describe('Lecture management', () => {
     it('Creates a lecture', () => {
         const lectureTitle = 'Lecture ' + generateUUID();
         cy.login(instructor, '/course-management/' + course.id);
-        cy.get('#lectures').click();
+        lectureManagement.getLectures().click();
         lectureManagement.clickCreateLecture();
         lectureCreation.setTitle(lectureTitle);
         cy.fixture('loremIpsum.txt').then((text) => {

--- a/src/test/cypress/e2e/lecture/LectureManagement.cy.ts
+++ b/src/test/cypress/e2e/lecture/LectureManagement.cy.ts
@@ -34,12 +34,13 @@ describe('Lecture management', () => {
     });
 
     it('Deletes a lecture', () => {
+        let lecture: Lecture;
         cy.login(instructor, '/course-management/' + course.id + '/lectures');
         courseManagementRequest.createLecture(course).then((lectureResponse) => {
             lecture = lectureResponse.body;
             lectureManagement.deleteLecture(lecture).then((resp) => {
                 expect(resp.response!.statusCode).to.eq(200);
-                lectureManagement.getLecture(lecture).should('not.exist');
+                lectureManagement.getLecture(lecture.id!).should('not.exist');
             });
         });
     });

--- a/src/test/cypress/support/artemis.ts
+++ b/src/test/cypress/support/artemis.ts
@@ -19,7 +19,6 @@ export const courseList = pageObjects.course.list;
 export const courseOverview = pageObjects.course.overview;
 export const courseManagement = pageObjects.course.management;
 export const courseManagementExercises = pageObjects.course.managementExercises;
-export const courseExercise = pageObjects.course.exercise;
 export const courseCommunication = pageObjects.course.communication;
 export const courseMessages = pageObjects.course.messages;
 export const courseAssessment = pageObjects.assessment.course;

--- a/src/test/cypress/support/pageobjects/ArtemisPageobjects.ts
+++ b/src/test/cypress/support/pageobjects/ArtemisPageobjects.ts
@@ -38,7 +38,6 @@ import { ModelingExerciseFeedbackPage } from './exercises/modeling/ModelingExerc
 import { LectureManagementPage } from './lecture/LectureManagementPage';
 import { LectureCreationPage } from './lecture/LectureCreationPage';
 import { StudentExamManagementPage } from './exam/StudentExamManagementPage';
-import { CourseExercisePage } from './course/CourseExercisePage';
 import { CourseCreationPage } from './course/CourseCreationPage';
 import { ExamParticipation } from './exam/ExamParticipation';
 import { StudentAssessmentPage } from './assessment/StudentAssessmentPage';
@@ -58,7 +57,6 @@ export class ArtemisPageobjects {
         managementExercises: new CourseManagementExercisesPage(),
         list: new CoursesPage(),
         overview: new CourseOverviewPage(),
-        exercise: new CourseExercisePage(),
         communication: new CourseCommunicationPage(),
         messages: new CourseMessagesPage(),
     };

--- a/src/test/cypress/support/pageobjects/NavigationBar.ts
+++ b/src/test/cypress/support/pageobjects/NavigationBar.ts
@@ -22,4 +22,12 @@ export class NavigationBar {
     getNotifications() {
         return cy.get('.notification-sidebar .notification-item');
     }
+
+    getAccountItem() {
+        return cy.get('#account-menu');
+    }
+
+    logout() {
+        this.getAccountItem().click().get('#logout').click();
+    }
 }

--- a/src/test/cypress/support/pageobjects/assessment/CourseAssessmentDashboardPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/CourseAssessmentDashboardPage.ts
@@ -5,8 +5,6 @@ import { POST } from '../../constants';
  * A class which encapsulates UI selectors and actions for the course assessment dashboard page.
  */
 export class CourseAssessmentDashboardPage {
-    readonly exerciseDashboardButtonSelector = '#open-exercise-dashboard';
-
     openComplaints() {
         cy.get('#open-complaints').click();
     }
@@ -17,8 +15,8 @@ export class CourseAssessmentDashboardPage {
 
     clickExerciseDashboardButton() {
         // Sometimes the page does not load properly, so we reload it if the button is not found
-        cy.reloadUntilFound(this.exerciseDashboardButtonSelector);
-        cy.get(this.exerciseDashboardButtonSelector).click();
+        cy.reloadUntilFound('#open-exercise-dashboard');
+        cy.get('#open-exercise-dashboard').click();
     }
 
     clickEvaluateQuizzes() {

--- a/src/test/cypress/support/pageobjects/assessment/ExerciseAssessmentDashboardPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/ExerciseAssessmentDashboardPage.ts
@@ -24,4 +24,8 @@ export class ExerciseAssessmentDashboardPage {
     getComplaintText() {
         return cy.get('#complaintTextArea');
     }
+
+    getLockedMessage() {
+        return cy.get('#assessmentLockedCurrentUser');
+    }
 }

--- a/src/test/cypress/support/pageobjects/assessment/ModelingExerciseAssessmentEditor.ts
+++ b/src/test/cypress/support/pageobjects/assessment/ModelingExerciseAssessmentEditor.ts
@@ -24,6 +24,7 @@ export class ModelingExerciseAssessmentEditor extends AbstractExerciseAssessment
     rejectComplaint(response: string, examMode: false) {
         return super.rejectComplaint(response, examMode, EXERCISE_TYPE.Modeling);
     }
+
     acceptComplaint(response: string, examMode: false) {
         return super.acceptComplaint(response, examMode, EXERCISE_TYPE.Modeling);
     }

--- a/src/test/cypress/support/pageobjects/course/CourseExercisePage.ts
+++ b/src/test/cypress/support/pageobjects/course/CourseExercisePage.ts
@@ -1,9 +1,0 @@
-/**
- * A class which encapsulates UI selectors and actions for the course exercise page.
- */
-export class CourseExercisePage {
-    search(term: string): void {
-        cy.get('#exercise-search-input').type(term);
-        cy.get('#exercise-search-button').click();
-    }
-}

--- a/src/test/cypress/support/pageobjects/course/CourseManagementExercisesPage.ts
+++ b/src/test/cypress/support/pageobjects/course/CourseManagementExercisesPage.ts
@@ -1,15 +1,58 @@
+import { Exercise } from 'app/entities/exercise.model';
+import { BASE_API, DELETE } from '../../constants';
+
 /**
  * A class which encapsulates UI selectors and actions for the course management exercises page.
  */
 export class CourseManagementExercisesPage {
-    readonly exerciseCardSelector = '#exercise-card-';
-
-    getExerciseRowRootElement(exerciseId: number) {
-        return cy.get(this.exerciseCardSelector + exerciseId);
+    getExercise(exerciseID: number) {
+        return cy.get(`#exercise-card-${exerciseID}`);
     }
 
-    clickDeleteExercise(exerciseId: number) {
-        this.getExerciseRowRootElement(exerciseId).find('#delete-exercise').click();
+    clickDeleteExercise(exerciseID: number) {
+        this.getExercise(exerciseID).find('#delete-exercise').click();
+    }
+
+    clickExampleSubmissionsButton() {
+        cy.get('#example-submissions-button').click();
+    }
+
+    getExerciseTitle() {
+        return cy.get('#exercise-detail-title');
+    }
+
+    deleteTextExercise(exercise: Exercise) {
+        this.getExercise(exercise.id!).find('#delete-exercise').click();
+        cy.get('#confirm-exercise-name').type(exercise.title!);
+        cy.intercept(DELETE, BASE_API + 'text-exercises/*').as('deleteTextExercise');
+        cy.get('#delete').click();
+        cy.wait('@deleteTextExercise');
+    }
+
+    deleteModelingExercise(exercise: Exercise) {
+        this.getExercise(exercise.id!).find('#delete-exercise').click();
+        cy.get('#confirm-exercise-name').type(exercise.title!);
+        cy.intercept(DELETE, BASE_API + 'modeling-exercises/*').as('deleteModelingExercise');
+        cy.get('#delete').click();
+        cy.wait('@deleteModelingExercise');
+    }
+
+    deleteQuizExercise(exercise: Exercise) {
+        this.getExercise(exercise.id!).find(`#delete-quiz-${exercise.id}`).click();
+        cy.get('#confirm-exercise-name').type(exercise.title!);
+        cy.intercept(DELETE, BASE_API + 'quiz-exercises/*').as('deleteQuizExercise');
+        cy.get('#delete').click();
+        cy.wait('@deleteQuizExercise');
+    }
+
+    deleteProgrammingExercise(exercise: Exercise) {
+        this.getExercise(exercise.id!).find('#delete-exercise').click();
+        cy.get('#additional-check-0').check();
+        cy.get('#additional-check-1').check();
+        cy.get('#confirm-exercise-name').type(exercise.title!);
+        cy.intercept(DELETE, BASE_API + 'programming-exercises/*').as('deleteProgrammingExercise');
+        cy.get('#delete').click();
+        cy.wait('@deleteProgrammingExercise');
     }
 
     createProgrammingExercise() {
@@ -52,9 +95,15 @@ export class CourseManagementExercisesPage {
         cy.get(`#instructor-quiz-start-${quizID}`).click();
     }
 
-    shouldContainExerciseWithName(exerciseId: string) {
-        cy.get(this.exerciseCardSelector + exerciseId)
-            .scrollIntoView()
-            .should('be.visible');
+    shouldContainExerciseWithName(exerciseID: number) {
+        this.getExercise(exerciseID).scrollIntoView().should('be.visible');
+    }
+
+    getModelingExerciseTitle(exerciseID: number) {
+        return cy.get(`#exercise-card-${exerciseID}`).find(`#modeling-exercise-${exerciseID}-title`);
+    }
+
+    getModelingExerciseMaxPoints(exerciseID: number) {
+        return cy.get(`#exercise-card-${exerciseID}`).find(`#modeling-exercise-${exerciseID}-maxPoints`);
     }
 }

--- a/src/test/cypress/support/pageobjects/course/CourseManagementPage.ts
+++ b/src/test/cypress/support/pageobjects/course/CourseManagementPage.ts
@@ -1,4 +1,5 @@
-import { POST } from '../../constants';
+import { Course } from 'app/entities/course.model';
+import { BASE_API, DELETE, POST, PUT } from '../../constants';
 import { COURSE_BASE } from '../../requests/CourseManagementRequests';
 import { CypressCredentials } from '../../users';
 
@@ -18,15 +19,15 @@ export class CourseManagementPage {
      * @returns Returns the cypress chainable containing the root element of the course card of our created course.
      * This can be used to find specific elements within this course card.
      */
-    getCourseCard(courseShortName: string) {
-        return cy.get('#course-card-' + courseShortName);
+    getCourse(courseID: number) {
+        return cy.get(`#course-${courseID}`);
     }
 
     /**
      * Opens the exercises (of the first found course).
      */
-    openExercisesOfCourse(courseShortName: string) {
-        this.getCourseCard(courseShortName).find('#course-card-open-exercises').click();
+    openExercisesOfCourse(courseID: number) {
+        this.getCourse(courseID).find('#course-card-open-exercises').click();
         cy.url().should('include', '/exercises');
     }
 
@@ -40,10 +41,19 @@ export class CourseManagementPage {
 
     /**
      * Opens a course.
-     * @param courseShortName
+     * @param courseID
      */
-    openCourse(courseShortName: string) {
-        return this.getCourseCard(courseShortName).find('#course-card-header').click();
+    openCourse(courseID: number) {
+        return this.getCourse(courseID).find('#course-card-header').click();
+    }
+
+    deleteCourse(course: Course) {
+        cy.get('#delete-course').click();
+        cy.get('#delete').should('be.disabled');
+        cy.get('#confirm-exercise-name').type(course.title!);
+        cy.intercept(DELETE, BASE_API + 'admin/courses/' + course.id).as('deleteCourse');
+        cy.get('#delete').click();
+        cy.wait('@deleteCourse');
     }
 
     /**
@@ -90,6 +100,32 @@ export class CourseManagementPage {
         cy.wait('@addInstructorQuery');
     }
 
+    removeFirstUser() {
+        cy.get('#registered-students button[jhideletebutton]').click();
+        cy.get('.modal #delete').click();
+    }
+
+    clickEditCourse() {
+        cy.get('#edit-course').click();
+    }
+
+    updateCourse(course: Course) {
+        cy.intercept(PUT, BASE_API + 'courses/' + course.id).as('updateCourseQuery');
+        cy.get('#save-entity').click();
+        return cy.wait('@updateCourseQuery');
+    }
+
+    checkCourseHasNoIcon() {
+        cy.get('#delete-course-icon').should('not.exist');
+        cy.get('.no-image').should('exist');
+    }
+
+    removeIconFromCourse() {
+        cy.get('#delete-course-icon').click();
+        cy.get('#delete-course-icon').should('not.exist');
+        cy.get('.no-image').should('exist');
+    }
+
     /**
      * helper method to avoid code duplication
      * */
@@ -104,13 +140,13 @@ export class CourseManagementPage {
     /**
      * Opens the exams of a course.
      */
-    openExamsOfCourse(courseShortName: string) {
-        this.getCourseCard(courseShortName).find('#course-card-open-exams').click();
+    openExamsOfCourse(courseID: number) {
+        this.getCourse(courseID).find('#course-card-open-exams').click();
         cy.url().should('include', '/exams');
     }
 
-    openAssessmentDashboardOfCourse(courseShortName: string) {
-        this.getCourseCard(courseShortName).find('#course-card-open-assessment-dashboard').click();
+    openAssessmentDashboardOfCourse(courseID: number) {
+        this.getCourse(courseID).find('#course-card-open-assessment-dashboard').click();
         cy.url().should('include', '/assessment-dashboard');
     }
 
@@ -121,6 +157,11 @@ export class CourseManagementPage {
     /**
      * helper methods to get information about the course
      * */
+
+    getRegisteredStudents() {
+        return cy.get('#registered-students');
+    }
+
     getCourseHeaderTitle() {
         return cy.get('#course-header-title');
     }

--- a/src/test/cypress/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/cypress/support/pageobjects/course/CourseOverviewPage.ts
@@ -6,6 +6,11 @@ import { BASE_API, GET } from '../../constants';
 export class CourseOverviewPage {
     readonly participationRequestId = 'participateInExerciseQuery';
 
+    search(term: string): void {
+        cy.get('#exercise-search-input').type(term);
+        cy.get('#exercise-search-button').click();
+    }
+
     startExercise(exerciseId: number) {
         cy.reloadUntilFound('#start-exercise-' + exerciseId);
         cy.get('#start-exercise-' + exerciseId).click();
@@ -16,9 +21,13 @@ export class CourseOverviewPage {
         cy.get('#open-exercise-' + exerciseId).click();
     }
 
-    openRunningProgrammingExercise(exerciseId: number) {
+    getExercise(exerciseID: number) {
+        return cy.get(`#exercise-card-${exerciseID}`);
+    }
+
+    openRunningProgrammingExercise(exerciseID: number) {
         cy.intercept(GET, BASE_API + 'programming-exercise-participations/*/student-participation-with-latest-result-and-feedbacks').as('initialQuery');
-        this.openRunningExercise(exerciseId);
+        this.openRunningExercise(exerciseID);
         cy.wait('@initialQuery');
     }
 

--- a/src/test/cypress/support/pageobjects/exam/ExamManagementPage.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamManagementPage.ts
@@ -83,6 +83,10 @@ export class ExamManagementPage {
         cy.get('#result-score').contains(score);
     }
 
+    clickEdit() {
+        cy.get('#editButton').click();
+    }
+
     /**
      * helper methods to get information of course
      * */

--- a/src/test/cypress/support/pageobjects/exam/ExamParticipation.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamParticipation.ts
@@ -101,6 +101,23 @@ export class ExamParticipation {
         cy.get('#exam-title').contains(title);
     }
 
+    getResultScore() {
+        cy.reloadUntilFound('#result-score');
+        return cy.get('#result-score');
+    }
+
+    checkExamFinishedTitle(title: string) {
+        cy.get('#exam-finished-title').contains(title, { timeout: 40000 });
+    }
+
+    checkExamFullnameInputExists() {
+        cy.get('#fullname', { timeout: 20000 }).should('exist');
+    }
+
+    checkYourFullname(name: string) {
+        cy.get('#your-name', { timeout: 20000 }).contains(name);
+    }
+
     handInEarly() {
         examNavigation.handInEarly();
         examStartEnd.finishExam().then((request: Interception) => {

--- a/src/test/cypress/support/pageobjects/exam/ExamTestRunPage.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamTestRunPage.ts
@@ -40,6 +40,10 @@ export class ExamTestRunPage {
         return cy.get(`#testrun-${testRunId}`);
     }
 
+    getTestRunRibbon() {
+        return cy.get('#testRunRibbon');
+    }
+
     openTestRunPage(course: Course, exam: Exam) {
         cy.visit('/course-management/' + course.id + '/exams/' + exam.id + '/test-runs');
     }

--- a/src/test/cypress/support/pageobjects/exam/StudentExamManagementPage.ts
+++ b/src/test/cypress/support/pageobjects/exam/StudentExamManagementPage.ts
@@ -6,7 +6,7 @@ import { COURSE_BASE } from '../../requests/CourseManagementRequests';
 export class StudentExamManagementPage {
     clickGenerateStudentExams() {
         cy.intercept(POST, COURSE_BASE + '*/exams/*/generate-student-exams').as('generateStudentExams');
-        cy.get('#generateStudentExamsButton').click();
+        this.getGenerateStudentExamsButton().click();
         return cy.wait('@generateStudentExams');
     }
 
@@ -14,5 +14,13 @@ export class StudentExamManagementPage {
         cy.intercept(POST, COURSE_BASE + '*/exams/*/register-course-students').as('registerCourseStudents');
         cy.get('#register-course-students').click();
         return cy.wait('@registerCourseStudents');
+    }
+
+    getGenerateStudentExamsButton() {
+        return cy.get('#generateStudentExamsButton');
+    }
+
+    getRegisteredStudents() {
+        return cy.get('#registered-students');
     }
 }

--- a/src/test/cypress/support/pageobjects/exercises/ExerciseResultPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/ExerciseResultPage.ts
@@ -12,6 +12,7 @@ export class ExerciseResultPage {
     }
 
     shouldShowScore(percentage: number) {
+        cy.reloadUntilFound('#submission-result-graded');
         cy.contains(`${percentage}%`).should('be.visible');
     }
 

--- a/src/test/cypress/support/pageobjects/exercises/modeling/ModelingEditor.ts
+++ b/src/test/cypress/support/pageobjects/exercises/modeling/ModelingEditor.ts
@@ -22,6 +22,10 @@ export class ModelingEditor {
         getExercise(exerciseID).find(MODELING_EDITOR_CANVAS).trigger('pointerup');
     }
 
+    getModelingCanvas() {
+        return cy.get('#modeling-editor-canvas');
+    }
+
     addComponentToExampleSolutionModel(componentNumber: number, scrollBehavior: scrollBehaviorOptions = 'center') {
         cy.get('#modeling-editor-sidebar').children().eq(componentNumber).drag(MODELING_EDITOR_CANVAS, { scrollBehavior, timeout: 1000 });
         cy.get(MODELING_EDITOR_CANVAS).trigger('mouseup').trigger('pointerup');

--- a/src/test/cypress/support/pageobjects/exercises/programming/OnlineEditorPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/programming/OnlineEditorPage.ts
@@ -139,6 +139,7 @@ export class OnlineEditorPage {
      * @returns the element containing the result score percentage.
      */
     getResultScore() {
+        cy.reloadUntilFound('#result-score');
         return cy.get('#result-score');
     }
 

--- a/src/test/cypress/support/pageobjects/lecture/LectureManagementPage.ts
+++ b/src/test/cypress/support/pageobjects/lecture/LectureManagementPage.ts
@@ -16,6 +16,10 @@ export class LectureManagementPage {
         return cy.wait('@deleteLecture');
     }
 
+    getLectures() {
+        return cy.get('#lectures');
+    }
+
     getLecture(lectureId: number) {
         return cy.get(`#lecture-${lectureId}`);
     }

--- a/src/test/cypress/support/pageobjects/lecture/LectureManagementPage.ts
+++ b/src/test/cypress/support/pageobjects/lecture/LectureManagementPage.ts
@@ -8,7 +8,7 @@ export class LectureManagementPage {
     }
 
     deleteLecture(lecture: Lecture) {
-        cy.get(`#lecture-${lecture.id}`).find('#delete-lecture').click();
+        this.getLecture(lecture.id!).find('#delete-lecture').click();
         cy.get('#delete').should('be.disabled');
         cy.get('#confirm-exercise-name').type(lecture.title!);
         cy.intercept(DELETE, `${BASE_API}lectures/*`).as('deleteLecture');
@@ -16,12 +16,20 @@ export class LectureManagementPage {
         return cy.wait('@deleteLecture');
     }
 
-    getLecture(lecture: Lecture) {
-        return cy.get(`#lecture-${lecture.id}`);
+    getLecture(lectureId: number) {
+        return cy.get(`#lecture-${lectureId}`);
     }
 
     openUnitsPage(lectureID: number) {
         cy.get(`#lecture-${lectureID}`).find('#units').click();
+    }
+
+    getLectureContainer() {
+        return cy.get('#lecture-preview');
+    }
+
+    openUnitsPage(lectureId: number) {
+        this.getLecture(lectureId).find('#units').click();
     }
 
     openCreateUnit(type: UnitType) {

--- a/src/test/cypress/support/pageobjects/lecture/LectureManagementPage.ts
+++ b/src/test/cypress/support/pageobjects/lecture/LectureManagementPage.ts
@@ -24,10 +24,6 @@ export class LectureManagementPage {
         return cy.get(`#lecture-${lectureId}`);
     }
 
-    openUnitsPage(lectureID: number) {
-        cy.get(`#lecture-${lectureID}`).find('#units').click();
-    }
-
     getLectureContainer() {
         return cy.get('#lecture-preview');
     }

--- a/src/test/cypress/support/requests/CourseManagementRequests.ts
+++ b/src/test/cypress/support/requests/CourseManagementRequests.ts
@@ -68,7 +68,7 @@ export class CourseManagementRequests {
     createCourse(
         customizeGroups = false,
         courseName = 'Course ' + generateUUID(),
-        courseShortName = 'cypress' + generateUUID(),
+        courseShortName = 'course' + generateUUID(),
         start = day().subtract(2, 'hours'),
         end = day().add(2, 'hours'),
         fileName?: string,

--- a/src/test/cypress/support/requests/CourseManagementRequests.ts
+++ b/src/test/cypress/support/requests/CourseManagementRequests.ts
@@ -41,13 +41,17 @@ export const MODELING_EXERCISE_BASE = BASE_API + 'modeling-exercises';
 export class CourseManagementRequests {
     /**
      * Deletes the course with the specified id.
-     * @param courseId the course id
+     * @param course the course
+     * @param admin the admin user
      * @returns <Chainable> request response
      */
-    deleteCourse(courseId: number) {
+    deleteCourse(course: Course, admin: CypressCredentials) {
         // Sometimes the server fails with a ConstraintViolationError if we delete the course immediately after a login
         cy.wait(20000);
-        return cy.request({ method: DELETE, url: `${COURSE_ADMIN_BASE}/${courseId}` });
+        if (course) {
+            cy.login(admin);
+            return cy.request({ method: DELETE, url: `${COURSE_ADMIN_BASE}/${course.id}` });
+        }
     }
 
     /**

--- a/src/test/cypress/support/utils.ts
+++ b/src/test/cypress/support/utils.ts
@@ -72,6 +72,10 @@ export function getExercise(exerciseId: number) {
     return cy.get(`#exercise-${exerciseId}`);
 }
 
+export function convertBooleanToYesNo(boolean: boolean) {
+    return boolean ? 'Yes' : 'No';
+}
+
 export function parseArrayBufferAsJsonObject(buffer: ArrayBuffer) {
     const bodyString = Cypress.Blob.arrayBufferToBinaryString(buffer);
     return JSON.parse(bodyString);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the `before` and `after` hooks are different for almost every test file, although they almost always do the same thing. Also some functionality is outsourced into a own function, although the function is only used once within the test. 

### Description
<!-- Describe your changes in detail -->
This PR tries to unify the way courses are created and deleted before test runs. It also adds descriptions to all the `before` and `after` hooks so it's easier to read from the cypress logs, which block failed and that this block was supposed to do. 
Apart from that there is also a little bit of refactoring for how global variables within test files are declared and how they are used. Additionally some functions are inlined, when they are not used multiple times within the test file.  
It also tries to fix issues with the flakiness of the exam assessment tests. Moreover it adds one test for deleting an existing modeling exercise. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
