### PR TITLE
`Programming exercises`: Add new entities for local CI build plans

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import de.tum.in.www1.artemis.domain.enumeration.*;
 import de.tum.in.www1.artemis.domain.hestia.ExerciseHint;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseTask;
+import de.tum.in.www1.artemis.domain.localci.LocalCIBuildPlan;
 import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.TemplateProgrammingExerciseParticipation;
@@ -135,6 +136,11 @@ public class ProgrammingExercise extends Exercise {
 
     @Column(name = "release_tests_with_example_solution", table = "programming_exercise_details")
     private boolean releaseTestsWithExampleSolution;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "local_ci_build_plan_id", table = "programming_exercise_details")
+    @JsonIgnoreProperties("programmingExercises")
+    private LocalCIBuildPlan localCIBuildPlan;
 
     /**
      * This boolean flag determines whether the solution repository should be checked out during the build (additional to the student's submission).

--- a/src/main/java/de/tum/in/www1/artemis/domain/localci/LocalCIBuildPlan.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/localci/LocalCIBuildPlan.java
@@ -1,0 +1,70 @@
+package de.tum.in.www1.artemis.domain.localci;
+
+import java.util.*;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+
+@Entity
+@Table(name = "local_ci_build_plan")
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class LocalCIBuildPlan extends DomainObject {
+
+    @Column(name = "name", table = "local_ci_build_plan")
+    private String name;
+
+    @OneToMany(mappedBy = "localCIBuildPlan", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @JsonIgnoreProperties(value = "localCIBuildPlan", allowSetters = true)
+    private Set<ProgrammingExercise> programmingExercises = new HashSet<>();
+
+    @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinTable(name = "local_ci_build_plan_stages", joinColumns = @JoinColumn(name = "local_ci_build_plan_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "local_ci_build_stage_id", referencedColumnName = "id"))
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @JsonIgnoreProperties(value = "buildPlans")
+    @OrderColumn(name = "stage_order")
+    private List<LocalCIBuildStage> stages = new ArrayList<>();
+
+    @Column(name = "docker_image", table = "local_ci_build_plan")
+    private String dockerImage;
+
+    public String getName() {
+        return name;
+    }
+
+    public Optional<ProgrammingExercise> getProgrammingExerciseById(Long exerciseId) {
+        return programmingExercises.stream().filter(programmingExercise -> programmingExercise.getId() == exerciseId).findFirst();
+    }
+
+    public Optional<LocalCIBuildStage> getStagebyId(Long stageId) {
+        return stages.stream().filter(stage -> stage.getId() == stageId).findFirst();
+    }
+
+    public String getDockerImage() {
+        return dockerImage;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDockerImage(String dockerImage) {
+        this.dockerImage = dockerImage;
+    }
+
+    public void addProgrammingExercise(ProgrammingExercise exercise) {
+        this.programmingExercises.add(exercise);
+    }
+
+    public void removeProgrammingExercise(ProgrammingExercise exercise) {
+        this.programmingExercises.remove(exercise);
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/domain/localci/LocalCIBuildStage.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/localci/LocalCIBuildStage.java
@@ -1,0 +1,57 @@
+package de.tum.in.www1.artemis.domain.localci;
+
+import java.util.*;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
+
+@Entity
+@Table(name = "local_ci_build_stage")
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class LocalCIBuildStage extends DomainObject {
+
+    @Column(name = "name", table = "local_ci_build_stage")
+    private String name;
+
+    @ManyToMany(mappedBy = "stages")
+    private Set<LocalCIBuildPlan> buildPlans = new HashSet<>();
+
+    @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinTable(name = "local_ci_build_stage_tasks", joinColumns = @JoinColumn(name = "local_ci_build_stage_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "local_ci_build_task_id", referencedColumnName = "id"))
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @JsonIgnoreProperties("stages")
+    @OrderColumn(name = "task_order")
+    private List<LocalCIBuildTask> tasks = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Optional<LocalCIBuildTask> getTaskById(Long taskId) {
+        return tasks.stream().filter(task -> task.getId().equals(taskId)).findFirst();
+    }
+
+    public Optional<LocalCIBuildPlan> getBuildPlanById(Long buildPlanId) {
+        return buildPlans.stream().filter(buildPlan -> buildPlan.getId().equals(buildPlanId)).findFirst();
+    }
+
+    public void addBuildPlan(LocalCIBuildPlan buildPlan) {
+        buildPlans.add(buildPlan);
+    }
+
+    public void removeBuildPlan(LocalCIBuildPlan buildPlan) {
+        buildPlans.remove(buildPlan);
+    }
+
+}

--- a/src/main/java/de/tum/in/www1/artemis/domain/localci/LocalCIBuildTask.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/localci/LocalCIBuildTask.java
@@ -1,0 +1,58 @@
+package de.tum.in.www1.artemis.domain.localci;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
+
+@Entity
+@Table(name = "local_ci_build_task")
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class LocalCIBuildTask extends DomainObject {
+
+    @Column(name = "name", table = "local_ci_build_task")
+    private String name;
+
+    @ManyToMany(mappedBy = "tasks")
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<LocalCIBuildStage> stages = new HashSet<>();
+
+    @Column(name = "script", table = "local_ci_build_task")
+    private String script;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getScript() {
+        return script;
+    }
+
+    public Optional<LocalCIBuildStage> getStageById(Long stageId) {
+        return stages.stream().filter(stage -> stage.getId().equals(stageId)).findFirst();
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setScript(String script) {
+        this.script = script;
+    }
+
+    public void addStage(LocalCIBuildStage stage) {
+        stages.add(stage);
+    }
+
+    public void removeStage(LocalCIBuildStage stage) {
+        stages.remove(stage);
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/repository/LocalCIBuildPlanRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/LocalCIBuildPlanRepository.java
@@ -1,0 +1,34 @@
+package de.tum.in.www1.artemis.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.localci.LocalCIBuildPlan;
+
+public interface LocalCIBuildPlanRepository extends JpaRepository<LocalCIBuildPlan, Long> {
+
+    @Query("""
+            SELECT buildPlan
+            FROM LocalCIBuildPlan buildPlan
+                INNER JOIN FETCH buildPlan.programmingExercises programmingExercises
+            WHERE programmingExercises.id = :exerciseId
+            """)
+    Optional<LocalCIBuildPlan> findByProgrammingExercises_IdWithProgrammingExercises(@Param("exerciseId") long exerciseId);
+
+    @Query("""
+            SELECT buildPlan
+            FROM LocalCIBuildPlan buildPlan
+            WHERE buildPlan.name = :name
+            """)
+    Optional<LocalCIBuildPlan> findByName(@Param("name") String name);
+
+    default void setBuildPlanForExercise(String name, ProgrammingExercise exercise) {
+        LocalCIBuildPlan buildPlanWrapper = findByName(name).orElseThrow();
+        buildPlanWrapper.addProgrammingExercise(exercise);
+        save(buildPlanWrapper);
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/repository/LocalCIBuildStageRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/LocalCIBuildStageRepository.java
@@ -1,0 +1,19 @@
+package de.tum.in.www1.artemis.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import de.tum.in.www1.artemis.domain.localci.LocalCIBuildStage;
+
+public interface LocalCIBuildStageRepository extends JpaRepository<LocalCIBuildStage, Long> {
+
+    @Query("""
+            SELECT buildStage
+            FROM LocalCIBuildStage buildStage
+            WHERE buildStage.name = :name
+            """)
+    Optional<LocalCIBuildStage> findByName(@Param("name") String name);
+}

--- a/src/main/java/de/tum/in/www1/artemis/repository/LocalCIBuildTaskRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/LocalCIBuildTaskRepository.java
@@ -1,0 +1,18 @@
+package de.tum.in.www1.artemis.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import de.tum.in.www1.artemis.domain.localci.LocalCIBuildStage;
+
+public interface LocalCIBuildTaskRepository {
+
+    @Query("""
+            SELECT buildTask
+            FROM LocalCIBuildStage buildTask
+            WHERE buildTask.name = :name
+            """)
+    Optional<LocalCIBuildStage> findByName(@Param("name") String name);
+}

--- a/src/main/resources/config/liquibase/changelog/20230419222222_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230419222222_changelog.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="m-loehde" id="20230419222222">
+        <!-- Create the new local CI build tables -->
+        <createTable tableName="local_ci_build_plan">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="docker_image" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createTable tableName="local_ci_build_stage">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+
+        <createTable tableName="local_ci_build_task">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="script" type="longtext">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+
+        <!-- Adapt the programming_exercise_details table to establish the one-to-many relationship
+         between it and localCIBuildPlan-->
+        <addColumn tableName="programming_exercise_details">
+            <column name="local_ci_build_plan_id" type="bigint">
+                <constraints foreignKeyName="fk_local_ci_build_plan_id" referencedTableName="local_ci_build_plan" referencedColumnNames="id" nullable="true"/>
+            </column>
+        </addColumn>
+
+        <!-- Create the intermediate tables for the many-to-many relationships-->
+        <createTable tableName="local_ci_build_plan_stages">
+            <column name="local_ci_build_plan_id" type="bigint">
+                <constraints nullable="false" />
+            </column>
+            <column name="local_ci_build_stage_id" type="bigint">
+                <constraints nullable="false" />
+            </column>
+            <column name="stage_order" type="int">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="local_ci_build_plan_stages"
+                                 baseColumnNames="local_ci_build_plan_id"
+                                 constraintName="fk_local_ci_build_plan_stages_local_ci_build_plan_id"
+                                 referencedTableName="local_ci_build_plan"
+                                 referencedColumnNames="id"
+                                 onUpdate="RESTRICT"
+                                 onDelete="RESTRICT"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 validate="true"/>
+        <addForeignKeyConstraint baseTableName="local_ci_build_plan_stages"
+                                 baseColumnNames="local_ci_build_stage_id"
+                                 constraintName="fk_local_ci_build_plan_stages_local_ci_build_stage_id"
+                                 referencedTableName="local_ci_build_stage"
+                                 referencedColumnNames="id"
+                                 onUpdate="RESTRICT"
+                                 onDelete="RESTRICT"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 validate="true"/>
+        <addPrimaryKey tableName="local_ci_build_plan_stages"
+                       columnNames="local_ci_build_plan_id, local_ci_build_stage_id"
+                       constraintName="pk_local_ci_build_plan_stages" />
+
+        <createTable tableName="local_ci_build_stage_tasks">
+            <column name="local_ci_build_stage_id" type="bigint">
+                <constraints nullable="false" />
+            </column>
+            <column name="local_ci_build_task_id" type="bigint">
+                <constraints nullable="false" />
+            </column>
+            <column name="task_order" type="int">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="local_ci_build_stage_tasks"
+                                 baseColumnNames="local_ci_build_stage_id"
+                                 constraintName="fk_local_ci_build_stage_tasks_local_ci_build_stage_id"
+                                 referencedTableName="local_ci_build_stage"
+                                 referencedColumnNames="id"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 onUpdate="RESTRICT"
+                                 onDelete="RESTRICT"
+                                 validate="true"/>
+        <addForeignKeyConstraint baseTableName="local_ci_build_stage_tasks"
+                                    baseColumnNames="local_ci_build_task_id"
+                                    constraintName="fk_local_ci_build_stage_tasks_local_ci_build_task_id"
+                                    referencedTableName="local_ci_build_task"
+                                    referencedColumnNames="id"
+                                    onUpdate="RESTRICT"
+                                    onDelete="RESTRICT"
+                                    deferrable="false"
+                                    initiallyDeferred="false"
+                                    validate="true"/>
+        <addPrimaryKey tableName="local_ci_build_stage_tasks"
+                          columnNames="local_ci_build_stage_id, local_ci_build_task_id"
+                          constraintName="pk_local_ci_build_stage_tasks" />
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -25,6 +25,7 @@
     <include file="classpath:config/liquibase/changelog/20230217140000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230222092714_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230227191919_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20230419222222_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command 'date '+%Y%m%d%H%M%S'' to get the current date and time in the correct format -->


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

(DO NOT DEPLOY, involves db changes)

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [ ] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [ ] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.
#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [ ] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The introduction of the three new objects `LocalCIBuildPlan`, `LocalCIBuildStage`, and `LocalCIBuildTask` is part of a refactoring of the way the local VC&CI profile deals with building and testing submissions. The goal is to adapt a structure similar to Bamboo, i.e.
<img width="559" alt="Screenshot 2023-04-19 at 11 34 39" src="https://user-images.githubusercontent.com/62858679/233400920-82ffc340-2cab-4a59-bafb-067e1dc4acb4.png">
The goal of the refactoring is modularising the build plan for local CI and thereby making it easier to maintain and extend, e.g. for adding support for programming languages other than Java.

### Description
<!-- Describe your changes in detail -->
I have created a new domain class for each of the objects and defined their relationships to one another. Furthermore, I have created the necessary liquibase changeset for the correct creation of the tables and have created a (dummy) repository for each new object. 
No functionality has yet been added but my goal is to create small and conceptually sensible PRs to reduce the review time and effort.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->
Since this is a "first" for me in many aspects (first PR for my thesis, first database PR, first liquibase change set etc.) any suggestions are welcome!

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
