### PR TITLE
`Programming exercises`: Fix static code analysis for Swift and Xcode exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
@@ -253,9 +253,11 @@ public class JenkinsBuildPlanCreator implements JenkinsXmlConfigBuilder {
             StaticCodeAnalysisTool tool = StaticCodeAnalysisTool.getToolsForProgrammingLanguage(programmingLanguage).get(0);
             // Copy swiftlint configuration into student's repository
             script.append("cp .swiftlint.yml assignment || true").append(lineEnding);
-            // Execute swiftlint within the student's repository and save the report into the sca directory
-            // sh command: swiftlint lint assignment > <scaDir>/<result>.xml
-            script.append("swiftlint lint assignment > ").append(STATIC_CODE_ANALYSIS_REPORT_DIR).append("/").append(tool.getFilePattern()).append(lineEnding);
+            // Change into the student's repository
+            script.append("cd assignment").append(lineEnding);
+            // Execute swiftlint and save the report into the sca directory
+            // sh command: swiftlint > ../<scaDir>/<result>.xml
+            script.append("swiftlint > ../").append(STATIC_CODE_ANALYSIS_REPORT_DIR).append("/").append(tool.getFilePattern()).append(lineEnding);
         }
         return script.toString();
     }

--- a/src/main/resources/templates/bamboo/swift/staticCodeAnalysisRuns/1_run_static_code_analysis.sh
+++ b/src/main/resources/templates/bamboo/swift/staticCodeAnalysisRuns/1_run_static_code_analysis.sh
@@ -1,5 +1,7 @@
-export LC_ALL=en_US.UTF-8
-export LANG=en_US.UTF-8
-
+# Copy SwiftLint rules
+cp .swiftlint.yml assignment || true
+# create target directory for SCA Parser
+mkdir target
+cd assignment
 # Execute static code analysis
-fastlane sca
+swiftlint > ../target/swiftlint-result.xml

--- a/src/main/resources/templates/bamboo/swift/xcode/staticCodeAnalysisRuns/1_run_static_code_analysis.sh
+++ b/src/main/resources/templates/bamboo/swift/xcode/staticCodeAnalysisRuns/1_run_static_code_analysis.sh
@@ -1,5 +1,7 @@
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 
+# Create directory for the swiftlint output specified in the fastfile
+mkdir target
 # Execute static code analysis
 fastlane sca

--- a/src/main/resources/templates/bamboo/swift/xcode/staticCodeAnalysisRuns/1_run_static_code_analysis.sh
+++ b/src/main/resources/templates/bamboo/swift/xcode/staticCodeAnalysisRuns/1_run_static_code_analysis.sh
@@ -1,4 +1,5 @@
-mkdir target
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
 
-# Execute static code analysis with swiftlint
-swiftlint > target/swiftlint-result.xml
+# Execute static code analysis
+fastlane sca

--- a/src/main/resources/templates/jenkins/swift/regularRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/swift/regularRuns/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
                     mkdir results
                     if [ -e assignment/tests.xml ]
                     then
-                        sed -i 's/<testsuites>//g ; s/<\/testsuites>//g' assignment/tests.xml
+                        sed -i 's/<testsuites>/<testsuite>/g ; s/<\/testsuites>/<\/testsuite>/g' assignment/tests.xml
                         cp assignment/tests.xml $WORKSPACE/results/ || true
                         sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                     fi

--- a/src/main/resources/templates/jenkins/swift/regularRuns/Jenkinsfile-staticCodeAnalysis
+++ b/src/main/resources/templates/jenkins/swift/regularRuns/Jenkinsfile-staticCodeAnalysis
@@ -55,7 +55,7 @@ pipeline {
                     mkdir results
                     if [ -e assignment/tests.xml ]
                     then
-                        sed -i 's/<testsuites>//g ; s/<\/testsuites>//g' assignment/tests.xml
+                        sed -i 's/<testsuites>/<testsuite>/g ; s/<\/testsuites>/<\/testsuite>/g' assignment/tests.xml
                         cp assignment/tests.xml $WORKSPACE/results/ || true
                         sed -i 's/[^[:print:]\t]/�/g' $WORKSPACE/results/*.xml || true
                     fi

--- a/src/main/resources/templates/swift/test/.swiftlint.yml
+++ b/src/main/resources/templates/swift/test/.swiftlint.yml
@@ -4,8 +4,6 @@
 
 # The only_rules configuration also includes rules that are enabled by default to provide a good overview of all rules.
 only_rules:
-  - anyobject_protocol
-    # Prefer using AnyObject over class for class-only protocols.
   - array_init
     # Prefer using Array(seq) over seq.map { $0 } to convert a sequence into an Array.
   - block_based_kvo
@@ -48,7 +46,7 @@ only_rules:
     # Discouraged direct initialization of types that can be harmful. e.g. UIDevice(), Bundle()
   - discouraged_optional_boolean
     # Prefer non-optional booleans over optional booleans.
-  # - discouraged_optional_collection # Enable as soon as https://github.com/realm/SwiftLint/issues/2298 is fixed
+  - discouraged_optional_collection
     # Prefer empty collection over optional collection.
   - duplicate_imports
     # Duplicate Imports
@@ -101,8 +99,6 @@ only_rules:
     # Comparing two identical operands is likely a mistake.
   - implicit_getter
     # Computed read-only properties and subscripts should avoid using the get keyword.
-  - inert_defer
-    # If defer is at the end of its parent scope, it will be executed right where it is anyway.
   - is_disjoint
     # Prefer using Set.isDisjoint(with:) over Set.intersection(_:).isEmpty.
   - joined_default_parameter
@@ -259,8 +255,6 @@ only_rules:
     # Parentheses are not needed when declaring closure arguments.
   - untyped_error_in_catch
     # Catch statements should not declare error variables without type casting.
-  - unused_capture_list
-    # Unused reference in a capture list should be removed.
   - unused_closure_parameter
     # Unused parameter in a closure should be replaced with _.
   - unused_control_flow_label
@@ -294,14 +288,6 @@ only_rules:
     # Delegates should be weak to avoid reference cycles.
   - xctfail_message
     # An XCTFail call should include a description of the assertion.
-
-excluded: # paths to ignore during linting. Takes precedence over `included`.
-  - Carthage
-  - Pods
-  - .build
-  - .swiftpm
-  - R.generated.swift
-  - Tests
 
 closure_body_length: # Closure bodies should not span too many lines.
   - 35 # warning - default: 20
@@ -361,6 +347,14 @@ unused_optional_binding:
 
 vertical_whitespace: # Limit vertical whitespace to a single empty line.
   max_empty_lines: 2 # warning - default: 1
+  
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+    - Carthage
+    - Pods
+    - .build
+    - .swiftpm
+    - R.generated.swift
+    - Tests
 
 # reporter type (xcode, json, csv, checkstyle, codeclimate, junit, html, emoji, sonarqube, markdown, github-actions-logging)
 reporter: checkstyle


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server

#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When creating Swift exercises on Artemis with static code analysis (SCA) enabled, building always fails at the SCA step as the necessary build scripts are mixed up (Swift SCA script <-> Xcode SCA script).
Further, the used SwiftLint config file uses some deprecated rules.

### Description
<!-- Describe your changes in detail -->
- Fixed the wrong build script templates for Swift and Xcode exercises.
- Removed deprecated rules from the SwiftLint config file and slightly restructured it.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Prerequisites:
- 1 Instructor

**Testserver 1 (Bamboo):**

1. Create a new Swift programming exercise with SCA enabled
2. Go to the solution build plan 
3. The build should succeed 

**Testserver 2 (Jenkins):** (Jenkins only supports Swift exercises)

1. Create a new Swift programming exercise with SCA enabled
2. Go to the solution build plan 
3. The build should succeed 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before the changes, the SCA step for Swift exercises fails in Bamboo:
![Screenshot 2023-04-25 at 20 58 22](https://user-images.githubusercontent.com/9954674/234376583-7b7bf85a-b673-4f01-a478-bd1c7e9ee8fd.png)

After the change, the build succeeds:

<img width="1497" alt="Screenshot 2023-04-27 at 12 54 18" src="https://user-images.githubusercontent.com/9954674/234842084-684fa788-da74-46fc-8fe3-6c28574dacc4.png">

---

Deprecated SwiftLint rules:
![Screenshot 2023-04-25 at 17 37 27](https://user-images.githubusercontent.com/9954674/234364438-a032be42-5b37-4ab1-8188-ea9ecc8d2be8.png)

