### PR TITLE
`General`: Fix broken refresh button in course details

### DIFF
--- a/src/main/webapp/app/overview/course-overview.component.ts
+++ b/src/main/webapp/app/overview/course-overview.component.ts
@@ -219,7 +219,7 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
      */
     loadCourse(refresh = false): Observable<void> {
         this.refreshingCourse = refresh;
-        return this.courseService.findOneForDashboard(this.courseId, refresh).pipe(
+        const observable = this.courseService.findOneForDashboard(this.courseId, refresh).pipe(
             map((res: HttpResponse<Course>) => {
                 if (res.body) {
                     this.course = res.body;
@@ -249,6 +249,10 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
                 return throwError(() => error);
             }),
         );
+        // Start fetching, even if we don't subscribe to the result.
+        // This enables just calling this method to refresh the course, without subscribing to it:
+        observable.subscribe();
+        return observable;
     }
 
     ngOnDestroy() {

--- a/src/main/webapp/app/overview/course-overview.component.ts
+++ b/src/main/webapp/app/overview/course-overview.component.ts
@@ -44,6 +44,8 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
 
     // Rendered embedded view for controls in the bar so we can destroy it if needed
     private controlsEmbeddedView?: EmbeddedViewRef<any>;
+    // Subscription for the course fetching
+    private loadCourseSubscription?: Subscription;
     // Subscription to listen to changes on the control configuration
     private controlsSubscription?: Subscription;
     // Subscription to listen for the ng-container for controls to be mounted
@@ -251,7 +253,7 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
         );
         // Start fetching, even if we don't subscribe to the result.
         // This enables just calling this method to refresh the course, without subscribing to it:
-        observable.subscribe();
+        this.loadCourseSubscription = observable.subscribe();
         return observable;
     }
 
@@ -262,6 +264,7 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
         if (this.quizExercisesChannel) {
             this.jhiWebsocketService.unsubscribe(this.quizExercisesChannel);
         }
+        this.loadCourseSubscription?.unsubscribe();
         this.controlsSubscription?.unsubscribe();
         this.vcSubscription?.unsubscribe();
         this.ngUnsubscribe.next();

--- a/src/main/webapp/app/overview/course-overview.component.ts
+++ b/src/main/webapp/app/overview/course-overview.component.ts
@@ -253,6 +253,7 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
         );
         // Start fetching, even if we don't subscribe to the result.
         // This enables just calling this method to refresh the course, without subscribing to it:
+        this.loadCourseSubscription?.unsubscribe();
         this.loadCourseSubscription = observable.subscribe();
         return observable;
     }

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -118,7 +118,6 @@ describe('CourseOverviewComponent', () => {
     let jhiWebsocketServiceReceiveStub: jest.SpyInstance;
     let jhiWebsocketServiceSubscribeSpy: jest.SpyInstance;
     let findOneForDashboardStub: jest.SpyInstance;
-    let findOneForRegistrationStub: jest.SpyInstance;
 
     let metisConversationService: MetisConversationService;
     const course = { id: 1 } as Course;
@@ -194,10 +193,6 @@ describe('CourseOverviewComponent', () => {
                 jest.spyOn(teamService, 'teamAssignmentUpdates', 'get').mockResolvedValue(of(new TeamAssignmentPayload()));
                 // default for findOneForDashboardStub is to return the course
                 findOneForDashboardStub = jest.spyOn(courseService, 'findOneForDashboard').mockReturnValue(of(new HttpResponse({ body: course1, headers: new HttpHeaders() })));
-                // default for findOneForRegistrationStub is to return the course as well
-                findOneForRegistrationStub = jest
-                    .spyOn(courseService, 'findOneForRegistration')
-                    .mockReturnValue(of(new HttpResponse({ body: course1, headers: new HttpHeaders() })));
             });
     }));
 
@@ -263,23 +258,6 @@ describe('CourseOverviewComponent', () => {
         expect(subscribeToTeamAssignmentUpdatesStub).toHaveBeenCalledOnce();
     });
 
-    it('should show an alert when loading the course fails', async () => {
-        findOneForDashboardStub.mockReturnValue(throwError(new HttpResponse({ status: 404 })));
-        const alertService = TestBed.inject(AlertService);
-        const alertServiceSpy = jest.spyOn(alertService, 'addAlert');
-
-        component.loadCourse().subscribe(
-            () => {
-                throw new Error('should not happen');
-            },
-            (error) => {
-                expect(error).toBeDefined();
-            },
-        );
-
-        expect(alertServiceSpy).toHaveBeenCalled();
-    });
-
     it('should load the course, even when just calling loadCourse by itself (for refreshing)', () => {
         // check that loadCourse already subscribes to the course itself
 
@@ -295,35 +273,6 @@ describe('CourseOverviewComponent', () => {
 
         expect(subscribeStub).toHaveBeenCalledOnce();
     });
-
-    it('should not say that the user can register if the server returns 403', fakeAsync(() => {
-        findOneForRegistrationStub.mockReturnValue(throwError(new HttpResponse({ status: 403 })));
-
-        // test that canRegisterForCourse subscribe gives false
-        component.canRegisterForCourse().subscribe((canRegister) => {
-            expect(canRegister).toBeFalse();
-        });
-
-        // wait for the observable to complete
-        tick();
-    }));
-
-    it('should throw for unexpected registration responses from the server', fakeAsync(() => {
-        findOneForRegistrationStub.mockReturnValue(throwError(new HttpResponse({ status: 404 })));
-
-        // test that canRegisterForCourse throws
-        component.canRegisterForCourse().subscribe(
-            () => {
-                throw new Error('should not be called');
-            },
-            (error) => {
-                expect(error).toEqual(new HttpResponse({ status: 404 }));
-            },
-        );
-
-        // wait for the observable to complete
-        tick();
-    }));
 
     it('should have visible exams', () => {
         const getCourseStub = jest.spyOn(courseStorageService, 'getCourse');

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -118,6 +118,7 @@ describe('CourseOverviewComponent', () => {
     let jhiWebsocketServiceReceiveStub: jest.SpyInstance;
     let jhiWebsocketServiceSubscribeSpy: jest.SpyInstance;
     let findOneForDashboardStub: jest.SpyInstance;
+    let findOneForRegistrationStub: jest.SpyInstance;
 
     let metisConversationService: MetisConversationService;
     const course = { id: 1 } as Course;
@@ -193,6 +194,10 @@ describe('CourseOverviewComponent', () => {
                 jest.spyOn(teamService, 'teamAssignmentUpdates', 'get').mockResolvedValue(of(new TeamAssignmentPayload()));
                 // default for findOneForDashboardStub is to return the course
                 findOneForDashboardStub = jest.spyOn(courseService, 'findOneForDashboard').mockReturnValue(of(new HttpResponse({ body: course1, headers: new HttpHeaders() })));
+                // default for findOneForRegistrationStub is to return the course as well
+                findOneForRegistrationStub = jest
+                    .spyOn(courseService, 'findOneForRegistration')
+                    .mockReturnValue(of(new HttpResponse({ body: course1, headers: new HttpHeaders() })));
             });
     }));
 
@@ -273,6 +278,35 @@ describe('CourseOverviewComponent', () => {
 
         expect(subscribeSpy).toHaveBeenCalledOnce();
     });
+
+    it('should not say that the user can register if the server returns 403', fakeAsync(() => {
+        findOneForRegistrationStub.mockReturnValue(throwError(new HttpResponse({ status: 403 })));
+
+        // test that canRegisterForCourse subscribe gives false
+        component.canRegisterForCourse().subscribe((canRegister) => {
+            expect(canRegister).toBeFalse();
+        });
+
+        // wait for the observable to complete
+        tick();
+    }));
+
+    it('should throw for unexpected registration responses from the server', fakeAsync(() => {
+        findOneForRegistrationStub.mockReturnValue(throwError(new HttpResponse({ status: 404 })));
+
+        // test that canRegisterForCourse throws
+        component.canRegisterForCourse().subscribe(
+            () => {
+                throw new Error('should not be called');
+            },
+            (error) => {
+                expect(error).toEqual(new HttpResponse({ status: 404 }));
+            },
+        );
+
+        // wait for the observable to complete
+        tick();
+    }));
 
     it('should have visible exams', () => {
         const getCourseStub = jest.spyOn(courseStorageService, 'getCourse');

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -263,6 +263,23 @@ describe('CourseOverviewComponent', () => {
         expect(subscribeToTeamAssignmentUpdatesStub).toHaveBeenCalledOnce();
     });
 
+    it('should show an alert when loading the course fails', async () => {
+        findOneForDashboardStub.mockReturnValue(throwError(new HttpResponse({ status: 404 })));
+        const alertService = TestBed.inject(AlertService);
+        const alertServiceSpy = jest.spyOn(alertService, 'addAlert');
+
+        component.loadCourse().subscribe(
+            () => {
+                throw new Error('should not happen');
+            },
+            (error) => {
+                expect(error).toBeDefined();
+            },
+        );
+
+        expect(alertServiceSpy).toHaveBeenCalled();
+    });
+
     it('should load the course, even when just calling loadCourse by itself (for refreshing)', () => {
         // check that loadCourse already subscribes to the course itself
 
@@ -271,12 +288,12 @@ describe('CourseOverviewComponent', () => {
             subscriber.next(course1);
             subscriber.complete();
         });
-        const subscribeSpy = jest.spyOn(findOneForDashboardResponse, 'subscribe');
+        const subscribeStub = jest.spyOn(findOneForDashboardResponse, 'subscribe');
         findOneForDashboardStub.mockReturnValue(findOneForDashboardResponse);
 
         component.loadCourse();
 
-        expect(subscribeSpy).toHaveBeenCalledOnce();
+        expect(subscribeStub).toHaveBeenCalledOnce();
     });
 
     it('should not say that the user can register if the server returns 403', fakeAsync(() => {

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -1,7 +1,7 @@
 import { HeaderCourseComponent } from 'app/overview/header-course.component';
 import { FeatureToggleHideDirective } from 'app/shared/feature-toggle/feature-toggle-hide.directive';
 import { MetisConversationService } from 'app/shared/metis/metis-conversation.service';
-import { EMPTY, Subject, of, throwError } from 'rxjs';
+import { EMPTY, Observable, Subject, of, throwError } from 'rxjs';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ArtemisTestModule } from '../../test.module';
@@ -256,6 +256,22 @@ describe('CourseOverviewComponent', () => {
         expect(getCourseStub).toHaveBeenCalledOnce();
         expect(subscribeForQuizChangesStub).toHaveBeenCalledOnce();
         expect(subscribeToTeamAssignmentUpdatesStub).toHaveBeenCalledOnce();
+    });
+
+    it('should load the course, even when just calling loadCourse by itself (for refreshing)', () => {
+        // check that loadCourse already subscribes to the course itself
+
+        // create observable httpResponse with course1, where we detect whether it was called
+        const findOneForDashboardResponse = new Observable((subscriber) => {
+            subscriber.next(course1);
+            subscriber.complete();
+        });
+        const subscribeSpy = jest.spyOn(findOneForDashboardResponse, 'subscribe');
+        findOneForDashboardStub.mockReturnValue(findOneForDashboardResponse);
+
+        component.loadCourse();
+
+        expect(subscribeSpy).toHaveBeenCalledOnce();
     });
 
     it('should have visible exams', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [X] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [X] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
@krusche pointed out an issue with the refresh button on course pages: Pressing the refresh button didn't trigger a request to the server and just caused the loading spinner to spin forever.

### Description
<!-- Describe your changes in detail -->
My investigation showed that the issue was in #6318, which changed the way courses are loaded on the client: 
Previously, the request to `findOneForDashboard` was directly consumed, because it was `.subscribe`d to. The change was to use a `.pipe` instead for simpler error handling. This however also meant that the actual course result would only be fetched after the `loadCourse` result was consumed = subscribed to. This was not the case for the refresh function.

This PR adds an artificial `subscribe` to the generated observable to change the behavior back again and fix the course refresh. It also adds a test so that this issue won't happen in the future anymore.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Instructor
- 1 Course

1. Log in to Artemis
2. Navigate to the course
3. Click "refresh". Verify that the course is refreshed and not loading forever.
4. Modify the course in some way as the instructor (e.g. change the title).
5. Verify that the refresh triggers the change.
6. Go to #6318 and verify that the testing steps there are unaffected.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [X] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 

#### Code Review
- [X] Code Review 1
- [X] Code Review 2
#### Manual Tests
- [X] Test 1
- [X] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| course-overview.component.ts | 83.57% | ✅              |

**Note: The coverage is too low, but it will be improved in #6491 to be > 90%.**

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
After clicking "refresh":

Before, forever:
![image](https://user-images.githubusercontent.com/9006596/234660756-2a8ddc02-f9e3-4f5a-ba7e-78dc4aad7381.png)

Now, after some short waiting time:
![screenshot-2023-04-26_001261](https://user-images.githubusercontent.com/9006596/234660858-9b6148c5-9e2e-4984-8e19-e66e6df64544.png)
(refresh finished)