### PR TITLE
`General`: Fix team and start exercise button visible if student is not assigned to a team

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
@@ -75,7 +75,7 @@
                 jhi-exercise-action-button
                 [buttonIcon]="faUsers"
                 [buttonLabel]="'artemisApp.exerciseActions.viewTeam' | artemisTranslate"
-                *ngIf="exercise.teamMode && exercise.studentAssignedTeamIdComputed && !exercise.studentAssignedTeamId"
+                *ngIf="exercise.teamMode && exercise.studentAssignedTeamIdComputed && exercise.studentAssignedTeamId"
                 [smallButton]="smallButtons"
                 [hideLabelMobile]="true"
                 [routerLink]="['/courses', courseId, 'exercises', exercise.id, 'teams', assignedTeamId]"
@@ -274,7 +274,7 @@
                 jhi-exercise-action-button
                 [buttonIcon]="faUsers"
                 [buttonLabel]="'artemisApp.exerciseActions.viewTeam' | artemisTranslate"
-                *ngIf="exercise.teamMode && exercise.studentAssignedTeamIdComputed && !exercise.studentAssignedTeamId"
+                *ngIf="exercise.teamMode && exercise.studentAssignedTeamIdComputed && exercise.studentAssignedTeamId"
                 [smallButton]="smallButtons"
                 [hideLabelMobile]="true"
                 [routerLink]="['/courses', courseId, 'exercises', exercise.id, 'teams', assignedTeamId]"
@@ -346,7 +346,7 @@
                 jhi-exercise-action-button
                 [buttonIcon]="faUsers"
                 [buttonLabel]="'artemisApp.exerciseActions.viewTeam' | artemisTranslate"
-                *ngIf="exercise.teamMode && exercise.studentAssignedTeamIdComputed && !exercise.studentAssignedTeamId"
+                *ngIf="exercise.teamMode && exercise.studentAssignedTeamIdComputed && exercise.studentAssignedTeamId"
                 [smallButton]="smallButtons"
                 [hideLabelMobile]="true"
             ></button>

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
@@ -72,6 +72,7 @@
         <!-- ACTIONS START -->
         <div class="btn-group">
             <button
+                class="view-team"
                 jhi-exercise-action-button
                 [buttonIcon]="faUsers"
                 [buttonLabel]="'artemisApp.exerciseActions.viewTeam' | artemisTranslate"
@@ -271,6 +272,7 @@
         <!-- ACTIONS START -->
         <div class="btn-group">
             <button
+                class="view-team"
                 jhi-exercise-action-button
                 [buttonIcon]="faUsers"
                 [buttonLabel]="'artemisApp.exerciseActions.viewTeam' | artemisTranslate"
@@ -343,6 +345,7 @@
         <!-- ACTIONS START -->
         <div class="btn-group">
             <button
+                class="view-team"
                 jhi-exercise-action-button
                 [buttonIcon]="faUsers"
                 [buttonLabel]="'artemisApp.exerciseActions.viewTeam' | artemisTranslate"

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
@@ -92,7 +92,7 @@
                     [smallButton]="smallButtons"
                     [hideLabelMobile]="false"
                     [overwriteDisabled]="isBeforeStartDateAndStudent"
-                    *ngIf="!gradedParticipation && isStartExerciseAvailable()"
+                    *ngIf="!gradedParticipation && (!exercise.teamMode || exercise.studentAssignedTeamId) && isStartExerciseAvailable()"
                     (click)="startExercise()"
                 ></button>
             </span>
@@ -290,7 +290,7 @@
                     [smallButton]="smallButtons"
                     [hideLabelMobile]="false"
                     [overwriteDisabled]="isBeforeStartDateAndStudent"
-                    *ngIf="!gradedParticipation && isStartExerciseAvailable()"
+                    *ngIf="!gradedParticipation && (!exercise.teamMode || exercise.studentAssignedTeamId) && isStartExerciseAvailable()"
                     (click)="startExercise()"
                 ></button>
             </span>
@@ -358,7 +358,7 @@
                     [buttonIcon]="faPlayCircle"
                     [buttonLabel]="'artemisApp.exerciseActions.startExercise' | artemisTranslate"
                     [buttonLoading]="!!exercise.loading"
-                    *ngIf="!gradedParticipation && isStartExerciseAvailable()"
+                    *ngIf="!gradedParticipation && (!exercise.teamMode || exercise.studentAssignedTeamId) && isStartExerciseAvailable()"
                     [smallButton]="smallButtons"
                     [hideLabelMobile]="false"
                     [overwriteDisabled]="isBeforeStartDateAndStudent"

--- a/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
@@ -119,7 +119,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
     );
 
     it.each([ExerciseType.TEXT, ExerciseType.MODELING, ExerciseType.FILE_UPLOAD, ExerciseType.PROGRAMMING])(
-        'should show the button "Team" for a team exercise for a student to view his team when assigned to a team',
+        'should show the buttons "Team" and "Start exercise" for a team exercise for a student to view his team when assigned to a team',
         fakeAsync((exerciseType: ExerciseType) => {
             comp.exercise = { ...teamExerciseWithTeamAssigned, type: exerciseType };
             fixture.detectChanges();
@@ -127,17 +127,6 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
 
             const viewTeamButton = fixture.debugElement.query(By.css('.view-team'));
             expect(viewTeamButton).not.toBeNull();
-        }),
-    );
-
-    it.each([ExerciseType.PROGRAMMING, ExerciseType.TEXT, ExerciseType.FILE_UPLOAD, ExerciseType.MODELING])(
-        'should show the button "Start exercise" for a team exercise when assigned to a team',
-        fakeAsync((exerciseType: ExerciseType) => {
-            comp.exercise = { ...teamExerciseWithTeamAssigned, type: exerciseType };
-
-            fixture.detectChanges();
-            tick();
-
             const startExerciseButton = fixture.debugElement.query(By.css('.start-exercise'));
             expect(startExerciseButton).not.toBeNull();
         }),

--- a/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
@@ -33,7 +33,6 @@ import { MockRouter } from '../../../helpers/mocks/mock-router';
 import { MockCourseExerciseService } from '../../../helpers/mocks/service/mock-course-exercise.service';
 import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
 import { ArtemisTestModule } from '../../../test.module';
-import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 
 describe('ExerciseDetailsStudentActionsComponent', () => {
     let comp: ExerciseDetailsStudentActionsComponent;
@@ -46,7 +45,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
     let getProfileInfoSub: jest.SpyInstance;
 
     const team = { id: 1, students: [{ id: 99 } as User] } as Team;
-    const programmingExercise: Exercise = {
+    const exercise: Exercise = {
         id: 42,
         type: ExerciseType.PROGRAMMING,
         studentParticipations: [],
@@ -55,7 +54,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
         studentAssignedTeamIdComputed: false,
     };
     const teamExerciseWithoutTeamAssigned: Exercise = {
-        ...programmingExercise,
+        ...exercise,
         mode: ExerciseMode.TEAM,
         teamMode: true,
         studentAssignedTeamIdComputed: true,
@@ -264,7 +263,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
             individualDueDate: undefined,
         };
 
-        comp.exercise = { ...programmingExercise, allowManualFeedbackRequests: true };
+        comp.exercise = { ...exercise, allowManualFeedbackRequests: true };
         comp.gradedParticipation = participation;
 
         expect(comp.isFeedbackRequestButtonDisabled()).toBeTrue();
@@ -277,7 +276,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
             individualDueDate: undefined,
         };
 
-        comp.exercise = { ...programmingExercise, allowManualFeedbackRequests: true };
+        comp.exercise = { ...exercise, allowManualFeedbackRequests: true };
         comp.gradedParticipation = participation;
 
         expect(comp.isFeedbackRequestButtonDisabled()).toBeFalse();

--- a/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
@@ -33,6 +33,7 @@ import { MockRouter } from '../../../helpers/mocks/mock-router';
 import { MockCourseExerciseService } from '../../../helpers/mocks/service/mock-course-exercise.service';
 import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
 import { ArtemisTestModule } from '../../../test.module';
+import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 
 describe('ExerciseDetailsStudentActionsComponent', () => {
     let comp: ExerciseDetailsStudentActionsComponent;
@@ -45,7 +46,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
     let getProfileInfoSub: jest.SpyInstance;
 
     const team = { id: 1, students: [{ id: 99 } as User] } as Team;
-    const programmingExercise: ProgrammingExercise = {
+    const programmingExercise: Exercise = {
         id: 42,
         type: ExerciseType.PROGRAMMING,
         studentParticipations: [],
@@ -53,7 +54,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
         secondCorrectionEnabled: false,
         studentAssignedTeamIdComputed: false,
     };
-    const teamExerciseWithoutTeamAssigned: ProgrammingExercise = {
+    const teamExerciseWithoutTeamAssigned: Exercise = {
         ...programmingExercise,
         mode: ExerciseMode.TEAM,
         teamMode: true,
@@ -102,38 +103,46 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
         jest.restoreAllMocks();
     });
 
-    it('should not show the buttons "Team" and "Start exercise" for a team exercise when not assigned to a team yet', fakeAsync(() => {
-        comp.exercise = teamExerciseWithoutTeamAssigned;
+    it.each([ExerciseType.MODELING, ExerciseType.FILE_UPLOAD, ExerciseType.PROGRAMMING, ExerciseType.TEXT])(
+        'should not show the buttons "Team" and "Start exercise" for a team exercise when not assigned to a team yet',
+        fakeAsync((exerciseType: ExerciseType) => {
+            comp.exercise = { ...teamExerciseWithoutTeamAssigned, type: exerciseType };
 
-        fixture.detectChanges();
-        tick();
+            fixture.detectChanges();
+            tick();
 
-        const viewTeamButton = fixture.debugElement.query(By.css('.view-team'));
-        expect(viewTeamButton).toBeNull();
+            const viewTeamButton = fixture.debugElement.query(By.css('.view-team'));
+            expect(viewTeamButton).toBeNull();
 
-        const startExerciseButton = fixture.debugElement.query(By.css('.start-exercise'));
-        expect(startExerciseButton).toBeNull();
-    }));
+            const startExerciseButton = fixture.debugElement.query(By.css('.start-exercise'));
+            expect(startExerciseButton).toBeNull();
+        }),
+    );
 
-    it('should show the button "Team" for a team exercise for a student to view his team when assigned to a team', fakeAsync(() => {
-        comp.exercise = teamExerciseWithTeamAssigned;
+    it.each([ExerciseType.TEXT, ExerciseType.MODELING, ExerciseType.FILE_UPLOAD, ExerciseType.PROGRAMMING])(
+        'should show the button "Team" for a team exercise for a student to view his team when assigned to a team',
+        fakeAsync((exerciseType: ExerciseType) => {
+            comp.exercise = { ...teamExerciseWithTeamAssigned, type: exerciseType };
+            fixture.detectChanges();
+            tick();
 
-        fixture.detectChanges();
-        tick();
+            const viewTeamButton = fixture.debugElement.query(By.css('.view-team'));
+            expect(viewTeamButton).not.toBeNull();
+        }),
+    );
 
-        const viewTeamButton = fixture.debugElement.query(By.css('.view-team'));
-        expect(viewTeamButton).not.toBeNull();
-    }));
+    it.each([ExerciseType.PROGRAMMING, ExerciseType.TEXT, ExerciseType.FILE_UPLOAD, ExerciseType.MODELING])(
+        'should show the button "Start exercise" for a team exercise when assigned to a team',
+        fakeAsync((exerciseType: ExerciseType) => {
+            comp.exercise = { ...teamExerciseWithTeamAssigned, type: exerciseType };
 
-    it('should show the button "Start exercise" for a team exercise when assigned to a team', fakeAsync(() => {
-        comp.exercise = teamExerciseWithTeamAssigned;
+            fixture.detectChanges();
+            tick();
 
-        fixture.detectChanges();
-        tick();
-
-        const startExerciseButton = fixture.debugElement.query(By.css('.start-exercise'));
-        expect(startExerciseButton).not.toBeNull();
-    }));
+            const startExerciseButton = fixture.debugElement.query(By.css('.start-exercise'));
+            expect(startExerciseButton).not.toBeNull();
+        }),
+    );
 
     it('should reflect the correct participation state when team exercise was started', fakeAsync(() => {
         const inactivePart = { id: 2, initializationState: InitializationState.UNINITIALIZED } as StudentParticipation;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In the current version, the team button and the the start exercise are visible and clickable even if the student is not assigned to a team yet. This leads to a bad request/internal server error if the buttons are clicked
This PR fixes the condition when these buttons are shown. 

### Description
Fixed the condition for the team button (it was incorrectly negated)
added conditions to hide the start exercise button for team exercises if the student is not yet part of a team.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students 

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a team exercise that is released (affected exercise types are file-upload, modeling and text)
4. navigate as a student to the exercise and verify no buttons are visible
5. add the student to a team
6. Navigate again as a student to the exercise and verify that both buttons are visible, clickable and no errors are produced when clicking them.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
my changes are covered
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before
![image](https://user-images.githubusercontent.com/84102468/234998244-a6b7e05b-a236-4a2b-90d6-74edb5f19014.png)

After
![image](https://user-images.githubusercontent.com/84102468/234997327-a9906238-1257-47a0-9593-b5c4473e5146.png)

