### PR TITLE
`Assessment`: Fix an issue with the export dropdown in the exercise scores table

### DIFF
--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-button.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ProgrammingAssessmentRepoExportDialogComponent } from 'app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
@@ -31,6 +31,8 @@ export class ProgrammingAssessmentRepoExportButtonComponent {
     @Input() singleParticipantMode = false;
     @Input() programmingExercises: ProgrammingExercise[];
 
+    @Output() buttonPressed = new EventEmitter<void>();
+
     // Icons
     faDownload = faDownload;
 
@@ -42,6 +44,7 @@ export class ProgrammingAssessmentRepoExportButtonComponent {
      * @param {MouseEvent} event - Mouse event
      */
     openRepoExportDialog(event: MouseEvent) {
+        this.buttonPressed.emit();
         event.stopPropagation();
         const modalRef = this.modalService.open(ProgrammingAssessmentRepoExportDialogComponent, { keyboard: true, size: 'lg' });
         modalRef.componentInstance.programmingExercises = this.programmingExercises;

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
@@ -103,7 +103,7 @@
                     [autoClose]="'outside'"
                     placement="bottom-right auto"
                     container="body"
-                    #popover="ngbPopover"
+                    #exportPopover="ngbPopover"
                 ></button>
                 <ng-template #popContent>
                     <h5 jhiTranslate="artemisApp.exercise.export.options"></h5>
@@ -116,7 +116,7 @@
                         *ngIf="exercise.type === ExerciseType.PROGRAMMING"
                         [programmingExercises]="[exercise]"
                         class="me-1"
-                        (buttonPressed)="closePopover()"
+                        (buttonPressed)="closeExportPopover()"
                     ></jhi-programming-assessment-repo-export>
                     <jhi-exercise-submission-export
                         *ngIf="

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
@@ -100,9 +100,10 @@
                     [buttonLabel]="'entity.action.export' | artemisTranslate"
                     [hideLabelMobile]="false"
                     [ngbPopover]="popContent"
-                    [autoClose]="true"
+                    [autoClose]="'outside'"
                     placement="bottom-right auto"
                     container="body"
+                    #popover="ngbPopover"
                 ></button>
                 <ng-template #popContent>
                     <h5 jhiTranslate="artemisApp.exercise.export.options"></h5>
@@ -115,6 +116,7 @@
                         *ngIf="exercise.type === ExerciseType.PROGRAMMING"
                         [programmingExercises]="[exercise]"
                         class="me-1"
+                        (buttonPressed)="closePopover()"
                     ></jhi-programming-assessment-repo-export>
                     <jhi-exercise-submission-export
                         *ngIf="

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
 import { Participation } from 'app/entities/participation/participation.model';
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
@@ -33,6 +33,7 @@ import { ModelingAssessmentService } from 'app/exercises/modeling/assess/modelin
 import { TextAssessmentService } from 'app/exercises/text/assess/text-assessment.service';
 import { FileUploadAssessmentService } from 'app/exercises/file-upload/assess/file-upload-assessment.service';
 import { getLinkToSubmissionAssessment } from 'app/utils/navigation.utils';
+import { NgbPopover } from '@ng-bootstrap/ng-bootstrap';
 
 /**
  * Filter properties for a result
@@ -72,6 +73,9 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
         new Range(80, 90),
         new Range(90, 100),
     ];
+
+    @ViewChild('popover')
+    private popover: NgbPopover;
 
     course: Course;
     exercise: Exercise;
@@ -402,5 +406,9 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
             this.exercise.exerciseGroup?.id,
             participation.results?.[correctionRound]?.id,
         );
+    }
+
+    closePopover() {
+        this.popover?.close();
     }
 }

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.ts
@@ -74,8 +74,8 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
         new Range(90, 100),
     ];
 
-    @ViewChild('popover')
-    private popover: NgbPopover;
+    @ViewChild('exportPopover')
+    private exportPopover: NgbPopover;
 
     course: Course;
     exercise: Exercise;
@@ -408,7 +408,10 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
         );
     }
 
-    closePopover() {
-        this.popover?.close();
+    /**
+     * Close popover for export options, since it would obstruct the newly opened modal
+     */
+    closeExportPopover() {
+        this.exportPopover?.close();
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The export options popover in the exercise scores view previously either obstructed the modal that is opened when exporting the repositories or was immediately closed when trying to choose one option of the dropdown for downloading the results.

### Description
<!-- Describe your changes in detail -->
Fixes the bug by properly closing the popover whenever needed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Log in to Artemis
2. Go to the scores page of the exercise and check that all export options work properly and are not covered or close too quickly

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Popover obstructing the modal:
![Bildschirmfoto 2023-04-27 um 20 11 09](https://user-images.githubusercontent.com/38322605/235076500-bdb471d7-5862-45dd-9d5b-d15b674eb4f5.png)