### PR TITLE
`General`: Limit number of concurrent test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,13 @@ on:
     types:
     - created
 
+# Limit the number of concurrent runs to one per PR
+# If a run is already in progress, cancel it
+# If the run is not for a PR, then this limit does not apply
+concurrency:
+  group: test-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 # Keep in sync with codeql-analysis.yml and build-deploy.yml
 env:
   CI: true
@@ -79,8 +86,12 @@ jobs:
         reporter: java-junit
 
   server-tests-mysql:
+      needs: [ server-tests ]
       runs-on: ubuntu-latest
       timeout-minutes: 120
+      # Limit the number of concurrent mysql tests to one in total
+      concurrency:
+          group: server-tests-mysql
       steps:
           - uses: actions/checkout@v3
           - name: Setup Java
@@ -116,8 +127,12 @@ jobs:
                 reporter: java-junit
 
   server-tests-postgres:
+      needs: [ server-tests ]
       runs-on: ubuntu-latest
       timeout-minutes: 150
+      # Limit the number of concurrent postgres tests to one in total
+      concurrency:
+          group: server-tests-postgres
       steps:
           - uses: actions/checkout@v3
           - name: Setup Java


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
GitHub has a limit of 20 concurrent jobs that can be executed. If this limit is reached all other jobs will be put into a queue.
Some time ago we introduced MySQL and PostgreSQL server test jobs. These currently take 1-2 hours and can easily cause us to reach this job limit. A lot of these jobs are redundant, as a new push already happened.
This can cause the queue to rise to over 100 jobs, a lot of them being way more important than these test jobs.

### Description
<!-- Describe your changes in detail -->
To temporarily tackle this problem I made two changes:
1. Only one MySQL test and one PostgreSQL job can be executed at any time. This will mean that there is always space for at least 18 other jobs
2. The entire test workflow will only ever be run once at the same time per PR. If a new workflow run starts for a PR and an old one is still running, the old one will be canceled, and the new one will start.

### Steps for Testing
Not really testable, unless you want to do so in a fork of this repository.
Code review is still possible if you have experience with GitHub actions.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2