### PR TITLE
``Development``: Add Tomcat configuration to increase initial messages request performance

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/TomcatConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/TomcatConfiguration.java
@@ -23,11 +23,13 @@ public class TomcatConfiguration {
                  * The reason for this delay is that Spring needs to introspect the class used as a parameter
                  * for the request handler method. It does so by scanning the classpath with multiple classloaders
                  * to find BeanInfo files.
+                 *
                  * However, the Tomcat Embedded Classloader has two problems:
                  * 1. It is slow because it searches for JAR files inside other JAR files, which is a
                  * time-consuming operation.
                  * 2. By default, it discards its cache every 15 minutes, causing the performance issue
                  * to reappear later when the search is performed again.
+                 *
                  * To address these issues, we've customized the TomcatServletWebServerFactory with two
                  * changes:
                  * - Set the context's reloadable attribute to false, preventing Tomcat from discarding


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We need to ensure consistent performance across requests related to conversation messages to maintain a high usability level. In the current implementation, the initial request to fetch conversation messages takes significantly longer than subsequent requests (up to 8s vs 100ms). This not only negatively impacts the user experience but also penalizes maintainers for pushing new releases, as it contradicts the idea of CI, where changes should be smoothly integrated without causing noticeable performance issues. Moreover, in production environments, this problem would be experienced for each node, further amplifying its effects.

### Description
<!-- Describe your changes in detail -->

To address the performance issue, we have made the following changes:

- In the ``TomcatConfiguration`` class, we've customized the `TomcatServletWebServerFactory` to prevent Tomcat from discarding the loaded classes and refreshing. We achieve this by setting the context's `reloadable` attribute to `false`.
- We've modified the context's resources to use `ExtractingRoot` instead of scanning through un-extracted packages. This instructs Tomcat to extract packages on startup, which requires a bit more disk space but significantly improves the performance of the initial request.

By implementing these changes, we expect to see a considerable improvement in the initial request's response time, leading to a better user experience, smoother integration of new releases, and better support for the CI process.

A special thanks to @maximiliansoelch and @krusche for their collaborative efforts in discovering this solution! 🚀

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 User with Conversations

1. Deploy the PR to a testserver
2. Visit the webapp. Go to a conversation channel with messages.
3. Open dev tools, copy the request to fetch the messages as curl command
4. Close the webapp
5. Restart the server (e.g. deploy sth else, then redeploy the PR). Wait for it to fully boot up.
6. Run the curl command in your terminal
7. Observe that the request does not take sth like multiple seconds but runs in < 1s

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
