### PR TITLE
`Development`: Fix cypress linting issues

### DIFF
--- a/src/test/cypress/cypress.config.ts
+++ b/src/test/cypress/cypress.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
         toConsole: true,
     },
     e2e: {
-        setupNodeEvents(on, config) {
+        setupNodeEvents(on) {
             on('task', {
                 error(message: string) {
                     console.error('\x1b[31m', 'ERROR: ', message, '\x1b[0m');

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseParticipation.cy.ts
@@ -3,14 +3,7 @@ import { Course } from 'app/entities/course.model';
 import multipleChoiceQuizTemplate from '../../../fixtures/exercise/quiz/multiple_choice/template.json';
 import shortAnswerQuizTemplate from '../../../fixtures/exercise/quiz/short_answer/template.json';
 import { convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
-import {
-    courseManagementRequest,
-    courseOverview,
-    quizExerciseCreation,
-    quizExerciseDragAndDropQuiz,
-    quizExerciseMultipleChoice,
-    quizExerciseShortAnswerQuiz,
-} from '../../../support/artemis';
+import { courseManagementRequest, courseOverview, quizExerciseMultipleChoice, quizExerciseShortAnswerQuiz } from '../../../support/artemis';
 import { admin, studentOne } from '../../../support/users';
 
 // Common primitives

--- a/src/test/cypress/support/pageobjects/exercises/modeling/ModelingEditor.ts
+++ b/src/test/cypress/support/pageobjects/exercises/modeling/ModelingEditor.ts
@@ -12,11 +12,12 @@ export class ModelingEditor {
      * Adds a Modeling Component to the Example Solution
      * */
     addComponentToModel(exerciseID: number, componentNumber: number, scrollBehavior: scrollBehaviorOptions = 'center', x?: number, y?: number) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore https://github.com/4teamwork/cypress-drag-drop/issues/103
         getExercise(exerciseID)
             .find('#modeling-editor-sidebar')
             .children()
             .eq(componentNumber)
-            // @ts-ignore https://github.com/4teamwork/cypress-drag-drop/issues/103
             .drag(`#exercise-${exerciseID} ${MODELING_EDITOR_CANVAS}`, { target: { x, y }, scrollBehavior, timeout: 1000 });
         getExercise(exerciseID).find(MODELING_EDITOR_CANVAS).trigger('pointerup');
     }

--- a/src/test/cypress/support/pageobjects/exercises/quiz/DragAndDropQuiz.ts
+++ b/src/test/cypress/support/pageobjects/exercises/quiz/DragAndDropQuiz.ts
@@ -24,6 +24,7 @@ export class DragAndDropQuiz {
      * @param y drop location on Y-axis
      */
     dragUsingCoordinates(x: number, y: number) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore https://github.com/4teamwork/cypress-drag-drop/issues/103
         cy.get('#modeling-editor-sidebar').children().eq(2).drag(MODELING_EDITOR_CANVAS, { target: { x, y } });
         cy.wait(200);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There are some linting warnings in the cypress part of the project.

### Description
<!-- Describe your changes in detail -->
This PR fixes those. Since there is an issue with the types of the [cypress drag drop library](https://github.com/4teamwork/cypress-drag-drop/issues/103), we need to use a `ts-ignore` comment. This leads to another linting issue, which we also disable for this particular line. I tried to find a single ignore rule, that avoids this double ignore, but I was not able to find one. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
