### PR TITLE
`Development`: Update documentation to Sphinx 6

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,4 @@
-Sphinx==5.3.0
+Sphinx==6.2.1
 sphinx-rtd-theme==1.2.0
 sphinx-autobuild==2021.3.14
-docutils==0.18.1
 sphinxcontrib-bibtex==2.5.0
-urllib3==1.25.2,<1.26


### PR DESCRIPTION
Update to the latest compatible Sphinx version 6.2.1
(Sphinx 7 was recently released, but is not compatible yet with `sphinx-rtd-theme`)

### Review
- [ ] The Github action for the documentation passes