### PR TITLE
`General`: Fix injection of translateService in client

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/grading/charts/test-case-distribution-chart.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/grading/charts/test-case-distribution-chart.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { ProgrammingExerciseTestCase, Visibility } from 'app/entities/programming-exercise-test-case.model';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { TestCaseStatsMap } from 'app/entities/programming-exercise-test-case-statistics.model';
@@ -104,7 +104,7 @@ enum TestCaseBarTitle {
         </div>
     `,
 })
-export class TestCaseDistributionChartComponent extends ProgrammingGradingChartsDirective implements OnChanges {
+export class TestCaseDistributionChartComponent extends ProgrammingGradingChartsDirective implements OnInit, OnChanges {
     @Input() testCases: ProgrammingExerciseTestCase[];
     @Input() testCaseStatsMap?: TestCaseStatsMap;
     @Input() totalParticipations?: number;
@@ -120,19 +120,21 @@ export class TestCaseDistributionChartComponent extends ProgrammingGradingCharts
     // ngx
     // array containing the ngx-dedicated objects in order to display the weight and bonus chart
     ngxWeightData: NgxChartsMultiSeriesDataEntry[] = [
-        { name: this.translateService.instant('artemisApp.programmingExercise.configureGrading.charts.testCaseWeights.weight'), series: [] as any[] },
-        { name: this.translateService.instant('artemisApp.programmingExercise.configureGrading.charts.testCaseWeights.weightAndBonus'), series: [] as any[] },
+        { name: '', series: [] as any[] },
+        { name: '', series: [] as any[] },
     ];
     // array containing the ngx-dedicated objects in order to display the points chart
-    ngxPointsData: NgxChartsMultiSeriesDataEntry[] = [
-        { name: this.translateService.instant('artemisApp.programmingExercise.configureGrading.charts.testCasePoints.points'), series: [] as any[] },
-    ];
+    ngxPointsData: NgxChartsMultiSeriesDataEntry[] = [{ name: '', series: [] as any[] }];
 
     constructor(private translateService: TranslateService, private navigationUtilService: ArtemisNavigationUtilService) {
         super();
         this.translateService.onLangChange.subscribe(() => {
             this.updateTranslation();
         });
+    }
+
+    ngOnInit(): void {
+        this.updateTranslation();
     }
 
     ngOnChanges(): void {

--- a/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.ts
@@ -25,7 +25,7 @@ export class ProgrammingExerciseLifecycleComponent implements OnInit, OnChanges 
     faUserCheck = faUserCheck;
     faUserSlash = faUserSlash;
 
-    constructor(private translator: TranslateService, private exerciseService: ExerciseService) {}
+    constructor(private translateService: TranslateService, private exerciseService: ExerciseService) {}
 
     /**
      * If the programming exercise does not have an id, set the assessment Type to AUTOMATIC
@@ -136,14 +136,14 @@ export class ProgrammingExerciseLifecycleComponent implements OnInit, OnChanges 
      * @param dueDate the new dueDate
      */
     private updateDueDate(dueDate: dayjs.Dayjs) {
-        alert(this.translator.instant('artemisApp.programmingExercise.timeline.alertNewDueDate'));
+        alert(this.translateService.instant('artemisApp.programmingExercise.timeline.alertNewDueDate'));
         this.exercise.dueDate = dueDate;
 
         // If the new due date is after the "After Due Date", then we have to set the "After Due Date" to the new due date
         const afterDue = this.exercise.buildAndTestStudentSubmissionsAfterDueDate;
         if (afterDue && dueDate.isAfter(afterDue)) {
             this.exercise.buildAndTestStudentSubmissionsAfterDueDate = dueDate;
-            alert(this.translator.instant('artemisApp.programmingExercise.timeline.alertNewAfterDueDate'));
+            alert(this.translateService.instant('artemisApp.programmingExercise.timeline.alertNewAfterDueDate'));
         }
     }
 
@@ -160,7 +160,7 @@ export class ProgrammingExerciseLifecycleComponent implements OnInit, OnChanges 
                 newReleaseOrDueDate && dayjs(newReleaseOrDueDate).isSame(this.exercise.dueDate)
                     ? 'artemisApp.programmingExercise.timeline.alertNewExampleSolutionPublicationDateAsDueDate'
                     : 'artemisApp.programmingExercise.timeline.alertNewExampleSolutionPublicationDateAsReleaseDate';
-            alert(this.translator.instant(message));
+            alert(this.translateService.instant(message));
             this.exercise.exampleSolutionPublicationDate = newReleaseOrDueDate;
             if (!newReleaseOrDueDate) {
                 this.exercise.releaseTestsWithExampleSolution = false;

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-export.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-export.component.ts
@@ -21,20 +21,14 @@ export class QuizExerciseExportComponent implements OnInit {
     courseId: number;
     course: Course;
 
-    translateService: TranslateService;
-    router: Router;
-
     constructor(
         private route: ActivatedRoute,
         private quizExerciseService: QuizExerciseService,
         private courseService: CourseManagementService,
         private alertService: AlertService,
-        router: Router,
-        translateService: TranslateService,
-    ) {
-        this.router = router;
-        this.translateService = translateService;
-    }
+        private router: Router,
+        private translateService: TranslateService,
+    ) {}
 
     /**
      * Load the quizzes of the course for export on init.

--- a/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.ts
+++ b/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.ts
@@ -70,7 +70,6 @@ export class ParticipationSubmissionComponent implements OnInit {
         private textAssessmentService: TextAssessmentService,
         private programmingAssessmentService: ProgrammingAssessmentManualResultService,
         private eventManager: EventManager,
-        private translate: TranslateService,
         private profileService: ProfileService,
     ) {}
 
@@ -115,7 +114,7 @@ export class ParticipationSubmissionComponent implements OnInit {
                         solutionParticipation.programmingExercise = this.exercise;
                     } else {
                         // Should not happen
-                        alert(this.translate.instant('artemisApp.participation.noParticipation'));
+                        alert(this.translateService.instant('artemisApp.participation.noParticipation'));
                     }
                     this.isLoading = false;
                 });
@@ -177,9 +176,9 @@ export class ParticipationSubmissionComponent implements OnInit {
         if (this.participation?.type === ParticipationType.STUDENT || this.participation?.type === ParticipationType.PROGRAMMING) {
             return (this.participation as StudentParticipation).student?.name || (this.participation as StudentParticipation).team?.name;
         } else if (this.participation?.type === ParticipationType.SOLUTION) {
-            return this.translate.instant('artemisApp.participation.solutionParticipation');
+            return this.translateService.instant('artemisApp.participation.solutionParticipation');
         } else if (this.participation?.type === ParticipationType.TEMPLATE) {
-            return this.translate.instant('artemisApp.participation.templateParticipation');
+            return this.translateService.instant('artemisApp.participation.templateParticipation');
         }
         return 'N/A';
     }

--- a/src/main/webapp/app/exercises/shared/result/result.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/result.component.ts
@@ -74,7 +74,7 @@ export class ResultComponent implements OnInit, OnChanges {
     constructor(
         private jhiWebsocketService: JhiWebsocketService,
         private participationService: ParticipationService,
-        private translate: TranslateService,
+        private translateService: TranslateService,
         private http: HttpClient,
         private modalService: NgbModal,
         private exerciseService: ExerciseService,
@@ -128,7 +128,7 @@ export class ResultComponent implements OnInit, OnChanges {
 
         this.evaluate();
 
-        this.translate.onLangChange.subscribe(() => {
+        this.translateService.onLangChange.subscribe(() => {
             if (this.resultString) {
                 this.resultString = this.resultService.getResultString(this.result, this.exercise, this.short);
             }

--- a/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-from-file-form.component.ts
+++ b/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-from-file-form.component.ts
@@ -45,7 +45,7 @@ export class TeamsImportFromFileFormComponent {
     // Icons
     faSpinner = faSpinner;
 
-    constructor(private changeDetector: ChangeDetectorRef, private translate: TranslateService) {}
+    constructor(private changeDetector: ChangeDetectorRef, private translateService: TranslateService) {}
 
     /**
      * Move file reader creation to separate function to be able to mock
@@ -68,7 +68,7 @@ export class TeamsImportFromFileFormComponent {
                 const csvEntries = await this.parseCSVFile(fileReader.result as string);
                 this.importedTeams = this.convertCsvEntries(csvEntries);
             } else {
-                throw new Error(this.translate.instant('artemisApp.team.invalidFileType', { fileType: this.importFile?.type }));
+                throw new Error(this.translateService.instant('artemisApp.team.invalidFileType', { fileType: this.importFile?.type }));
             }
             this.sourceTeams = this.convertTeams(this.importedTeams);
             this.teamsChanged.emit(this.sourceTeams);
@@ -82,7 +82,7 @@ export class TeamsImportFromFileFormComponent {
             }
         } catch (e) {
             this.loading = false;
-            const message = `${this.translate.instant('artemisApp.team.errors.importFailed')} ${e}`;
+            const message = `${this.translateService.instant('artemisApp.team.errors.importFailed')} ${e}`;
             alert(message);
         }
     }
@@ -167,17 +167,17 @@ export class TeamsImportFromFileFormComponent {
             const entryNr = index + 1;
 
             if ((typeof student.username !== 'string' || !student.username.trim()) && (typeof student.registrationNumber !== 'string' || !student.registrationNumber.trim())) {
-                throw new Error(this.translate.instant('artemisApp.team.missingUserNameOrId', { entryNr }));
+                throw new Error(this.translateService.instant('artemisApp.team.missingUserNameOrId', { entryNr }));
             }
             newStudent.name = `${newStudent.firstName} ${newStudent.lastName}`.trim();
 
             if (typeof student.teamName !== 'string' || !student.teamName.trim()) {
-                throw new Error(this.translate.instant('artemisApp.team.teamName.missingTeamName', { entryNr, studentName: newStudent.name }));
+                throw new Error(this.translateService.instant('artemisApp.team.teamName.missingTeamName', { entryNr, studentName: newStudent.name }));
             }
 
             const shortName = student.teamName.replace(/[^0-9a-z]/gi, '').toLowerCase();
             if (!shortName.match(SHORT_NAME_PATTERN)) {
-                throw new Error(this.translate.instant('artemisApp.team.teamName.pattern', { entryNr, teamName: shortName }));
+                throw new Error(this.translateService.instant('artemisApp.team.teamName.pattern', { entryNr, teamName: shortName }));
             }
 
             const teamIndex = teams.findIndex((team) => team.name === student.teamName);

--- a/src/main/webapp/app/shared/participant-scores/participant-scores-distribution/participant-scores-distribution.component.ts
+++ b/src/main/webapp/app/shared/participant-scores/participant-scores-distribution/participant-scores-distribution.component.ts
@@ -47,8 +47,8 @@ export class ParticipantScoresDistributionComponent implements OnInit, OnChanges
     height = 500;
 
     showYAxisLabel = true;
-    yAxisLabel = this.translateService.instant('artemisApp.examScores.yAxes');
-    xAxisLabel = this.translateService.instant('artemisApp.examScores.xAxes');
+    yAxisLabel: string;
+    xAxisLabel: string;
 
     helpIconTooltip: string;
 
@@ -65,6 +65,8 @@ export class ParticipantScoresDistributionComponent implements OnInit, OnChanges
     constructor(private gradingSystemService: GradingSystemService, private translateService: TranslateService) {}
 
     ngOnInit() {
+        this.setupAxisLabels();
+
         this.translateService.onLangChange.subscribe(() => {
             this.setupAxisLabels();
         });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix #6555

### Description
<!-- Describe your changes in detail -->
Since an update it is no longer possible to directly use the injected services to initialize attributes in the client directly. This PR fixes the occurrences of the translateService and unifies it's name in all components to "translateService".

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Log in to Artemis
2. Go to the grading settings of the exercise
3. Check that it works again

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2