### PR TITLE
`Programming exercise`: Fix date picker not resettable

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-test-schedule-date-picker.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-test-schedule-date-picker.component.ts
@@ -43,16 +43,16 @@ export class ProgrammingExerciseTestScheduleDatePickerComponent implements Contr
     setDisabledState(): void {}
 
     writeValue(obj: any): void {
-        if (obj !== undefined && this.selectedDate !== obj) {
-            this.selectedDate = !obj ? undefined : isDate(obj) ? obj : obj.toDate();
+        if (this.selectedDate !== obj) {
+            this.selectedDate = !obj || isDate(obj) ? obj : obj.toDate();
             this.selectedDate?.setSeconds(0, 0);
             this._onChange(obj);
         }
     }
 
     /**
-     * Resets the date to null and informs parent components that the date has been reset.
-     * This makes it easier to also reset date, that can only be selected if the current date is not null
+     * Resets the date and informs parent components that the date has been reset.
+     * This makes it easier to also reset date, that can only be selected if the current date is not set
      */
     resetDate() {
         this.writeValue(undefined);

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-test-schedule-date-picker.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-test-schedule-date-picker.component.spec.ts
@@ -48,15 +48,6 @@ describe('ProgrammingExerciseTestScheduleDatePickerComponent', () => {
             });
     });
 
-    it('should not change date when set date is undefined', () => {
-        comp.selectedDate = selectedDate;
-        const spy = jest.spyOn(comp, '_onChange');
-        comp.writeValue(undefined);
-
-        expect(comp.selectedDate).toEqual(selectedDate);
-        expect(spy).not.toHaveBeenCalled();
-    });
-
     it('should not change date when value is reference-equal to selected date', () => {
         const spy = jest.spyOn(comp, '_onChange');
         comp.writeValue(selectedDate);
@@ -88,7 +79,7 @@ describe('ProgrammingExerciseTestScheduleDatePickerComponent', () => {
         const spy = jest.spyOn(comp.onDateReset, 'emit');
         comp.resetDate();
 
-        expect(comp.selectedDate).toBe(selectedDate);
+        expect(comp.selectedDate).toBeUndefined();
         expect(spy).toHaveBeenCalledOnce();
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently it is not possible to unset a date once it was picked in a programming exercise.

### Description
<!-- Describe your changes in detail -->
The latest change to using undefined instead of null broke the reset operation. This PR fixes it by now correctly handling undefined as parameter.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Log in to Artemis
2. Set a date in the programming exercise
3. Check that you can correctly set and unset it
4. Save the programming exercise
5. Check that the values are correctly saved and displayed

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
