### PR TITLE
`Development`: Fix flaky case in ParticipationIntegrationTest

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ParticipationIntegrationTest.java
@@ -584,12 +584,12 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         assertThat(receivedOnlyParticipation.getSubmissions()).isEmpty();
         assertThat(receivedOnlyParticipation.getSubmissionCount()).isEqualTo(0);
 
-        assertThat(receivedParticipationWithResult.getResults()).containsExactly(result2, result3);
+        assertThat(receivedParticipationWithResult.getResults()).containsExactlyInAnyOrder(result2, result3);
         assertThat(receivedParticipationWithResult.getSubmissions()).isEmpty();
         assertThat(receivedParticipationWithResult.getSubmissionCount()).isEqualTo(1);
 
         assertThat(receivedParticipationWithOnlySubmission.getResults()).isEmpty();
-        assertThat(receivedParticipationWithOnlySubmission.getSubmissions()).containsExactly(onlySubmissioin);
+        assertThat(receivedParticipationWithOnlySubmission.getSubmissions()).containsExactlyInAnyOrder(onlySubmissioin);
         assertThat(receivedParticipationWithOnlySubmission.getSubmissionCount()).isEqualTo(1);
 
         assertThat(receivedTestParticipation.getResults()).isEmpty();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

#6489 changed the test case `getAllParticipationsForExercise_withLatestResults`. It's using ``.containsExactly`` to assert the contents of a `Set`. `.containsExactly` expects an order, `Set`s don't have any. This causes a flaky error: https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS-JAVATEST-4560/test/case/629453918

### Description
<!-- Describe your changes in detail -->

Replacing `.containsExactly` with `.containsExactlyInAnyOrder`.

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

