### PR TITLE
`General`: Always show editor buttons for modeling, text and file upload exercises

### DIFF
--- a/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
@@ -5,13 +5,7 @@
             <h4 class="mb-0 me-1">Online Code Editor</h4>
         </div>
         <!-- ngIf offline-ide clone button -->
-        <jhi-exercise-details-student-actions
-            *ngIf="exercise.allowOfflineIde"
-            [examMode]="true"
-            [exercise]="exercise"
-            [courseId]="courseId"
-            [showResult]="true"
-        ></jhi-exercise-details-student-actions>
+        <jhi-exercise-details-student-actions *ngIf="exercise.allowOfflineIde" [examMode]="true" [exercise]="exercise" [courseId]="courseId"></jhi-exercise-details-student-actions>
     </div>
 
     <jhi-code-editor-container
@@ -65,7 +59,7 @@
         <span class="exercise-title">{{ exercise.title }}</span>
         <span>&nbsp;[{{ exercise.maxPoints }} {{ 'artemisApp.examParticipation.points' | artemisTranslate }}]</span>
     </h4>
-    <jhi-exercise-details-student-actions [exercise]="exercise" [courseId]="courseId" [showResult]="true" [examMode]="true"></jhi-exercise-details-student-actions>
+    <jhi-exercise-details-student-actions [exercise]="exercise" [courseId]="courseId" [examMode]="true"></jhi-exercise-details-student-actions>
     <div style="display: flex; justify-content: flex-end">
         <jhi-updating-result
             *ngIf="studentParticipation"

--- a/src/main/webapp/app/orion/participation/orion-course-exercise-details.component.ts
+++ b/src/main/webapp/app/orion/participation/orion-course-exercise-details.component.ts
@@ -4,8 +4,8 @@ import { Component } from '@angular/core';
     selector: 'jhi-orion-course-exercise-details',
     template: `
         <jhi-course-exercise-details>
-            <ng-template #overrideStudentActions let-exercise="exercise" let-showResult="showResult" let-courseId="courseId">
-                <jhi-orion-exercise-details-student-actions [exercise]="exercise" [showResult]="showResult" [courseId]="courseId"></jhi-orion-exercise-details-student-actions>
+            <ng-template #overrideStudentActions let-exercise="exercise" let-courseId="courseId">
+                <jhi-orion-exercise-details-student-actions [exercise]="exercise" [courseId]="courseId"></jhi-orion-exercise-details-student-actions>
             </ng-template>
         </jhi-course-exercise-details>
     `,

--- a/src/main/webapp/app/orion/participation/orion-exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/orion/participation/orion-exercise-details-student-actions.component.html
@@ -1,11 +1,4 @@
-<jhi-exercise-details-student-actions
-    [exercise]="exercise"
-    [courseId]="courseId"
-    [actionsOnly]="actionsOnly"
-    [smallButtons]="smallButtons"
-    [showResult]="showResult"
-    [examMode]="examMode"
->
+<jhi-exercise-details-student-actions [exercise]="exercise" [courseId]="courseId" [smallButtons]="smallButtons" [examMode]="examMode">
     <ng-template #overrideCloneOnlineEditorButton>
         <jhi-ide-button
             [featureToggle]="FeatureToggle.ProgrammingExercises"

--- a/src/main/webapp/app/orion/participation/orion-exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/orion/participation/orion-exercise-details-student-actions.component.ts
@@ -20,9 +20,7 @@ export class OrionExerciseDetailsStudentActionsComponent implements OnInit {
 
     @Input() exercise: Exercise;
     @Input() courseId: number;
-    @Input() actionsOnly: boolean;
     @Input() smallButtons: boolean;
-    @Input() showResult: boolean;
     @Input() examMode: boolean;
 
     constructor(private orionConnectorService: OrionConnectorService, private ideBuildAndTestService: OrionBuildAndTestService, private route: ActivatedRoute) {}

--- a/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
+++ b/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
@@ -28,7 +28,6 @@
             <jhi-exercise-details-student-actions
                 jhiOrionFilter
                 [showInOrionWindow]="false"
-                [actionsOnly]="true"
                 [smallButtons]="true"
                 [courseId]="course.id!"
                 [smallColumns]="true"

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -8,10 +8,9 @@
     <div class="tab-bar tab-bar-exercise-details ps-3 pe-3 justify-content-end">
         <jhi-exercise-details-student-actions
             class="col"
-            *jhiExtensionPoint="overrideStudentActions; context: { courseId: courseId, exercise: exercise, showResult: showResults && latestRatedResult }"
+            *jhiExtensionPoint="overrideStudentActions; context: { courseId: courseId, exercise: exercise }"
             [courseId]="courseId"
             [exercise]="exercise"
-            [showResult]="showResults && latestRatedResult != undefined"
         >
         </jhi-exercise-details-student-actions>
 

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -385,18 +385,6 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
         return this.sortedHistoryResults.length > MAX_RESULT_HISTORY_LENGTH;
     }
 
-    get showResults(): boolean {
-        if (!this.sortedHistoryResults?.length) {
-            return false;
-        }
-
-        if (this.exercise!.type === ExerciseType.MODELING || this.exercise!.type === ExerciseType.TEXT) {
-            return this.isAfterAssessmentDueDate;
-        } else {
-            return true;
-        }
-    }
-
     /**
      * Loads and stores the complaint if any exists. Furthermore, loads the latest rated result and stores it.
      */

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
@@ -1,7 +1,6 @@
 <div [ngSwitch]="exercise.type">
     <!-- QUIZ EXERCISE ACTIONS START -->
     <ng-container *ngSwitchCase="ExerciseType.QUIZ">
-        <!-- ACTIONS START -->
         <div class="btn-group">
             <button
                 jhi-exercise-action-button
@@ -22,7 +21,7 @@
                 [smallButton]="smallButtons"
                 [hideLabelMobile]="false"
                 *ngIf="quizNotStarted || gradedParticipation?.initializationState === InitializationState.INITIALIZED"
-                (click)="startExercise()"
+                [routerLink]="['/courses', courseId, 'quiz-exercises', exercise.id, 'live']"
             ></button>
             <button
                 id="student-quiz-start-{{ exercise.id }}"
@@ -34,13 +33,8 @@
                 [smallButton]="smallButtons"
                 [hideLabelMobile]="false"
                 *ngIf="uninitializedQuiz"
-                (click)="startExercise()"
+                [routerLink]="['/courses', courseId, 'quiz-exercises', exercise.id, 'live']"
             ></button>
-        </div>
-        <!-- ACTIONS END -->
-        <!-- INFORMATION START -->
-        <!-- TODO using startExercise() in these buttons is misleading, we should rather insert the route here -->
-        <div class="btn-group" *ngIf="!actionsOnly">
             <button
                 id="view-submission"
                 jhi-exercise-action-button
@@ -50,7 +44,7 @@
                 [buttonLoading]="!!exercise.loading"
                 *ngIf="gradedParticipation?.initializationState === InitializationState.FINISHED && !gradedParticipation?.results?.length"
                 [smallButton]="smallButtons"
-                (click)="startExercise()"
+                [routerLink]="['/courses', courseId, 'quiz-exercises', exercise.id, 'live']"
             ></button>
             <button
                 jhi-exercise-action-button
@@ -60,16 +54,14 @@
                 [buttonLoading]="!!exercise.loading"
                 *ngIf="gradedParticipation?.results?.length"
                 [smallButton]="smallButtons"
-                (click)="startExercise()"
+                [routerLink]="['/courses', courseId, 'quiz-exercises', exercise.id, 'live']"
             ></button>
         </div>
-        <!-- INFORMATION END -->
     </ng-container>
     <!-- QUIZ EXERCISE ACTIONS END -->
 
     <!-- MODELING EXERCISE ACTIONS START -->
     <ng-container *ngSwitchCase="ExerciseType.MODELING">
-        <!-- ACTIONS START -->
         <div class="btn-group gap-1">
             <button
                 class="view-team"
@@ -102,49 +94,27 @@
                 jhi-exercise-action-button
                 id="open-modeling-editor-action"
                 [buttonIcon]="faFolderOpen"
-                [buttonLabel]="'artemisApp.exerciseActions.openModelingEditor' | artemisTranslate"
+                [buttonLabel]="
+                    'artemisApp.exerciseActions.' +
+                        (gradedParticipation?.initializationState === InitializationState.INITIALIZED || beforeDueDate
+                            ? 'openModelingEditor'
+                            : resultAfterDueDate
+                            ? 'viewResults'
+                            : 'viewSubmissions') | artemisTranslate
+                "
+                [outlined]="!beforeDueDate && gradedParticipation?.initializationState === InitializationState.FINISHED"
                 [buttonLoading]="!!exercise.loading"
                 [smallButton]="smallButtons"
                 [hideLabelMobile]="false"
-                *ngIf="gradedParticipation?.initializationState === InitializationState.INITIALIZED"
+                *ngIf="gradedParticipation?.initializationState === InitializationState.INITIALIZED || gradedParticipation?.initializationState === InitializationState.FINISHED"
                 [routerLink]="['/courses', courseId, 'modeling-exercises', exercise.id, 'participate', gradedParticipation!.id]"
             ></button>
         </div>
-        <!-- ACTIONS END -->
-        <!-- INFORMATION START -->
-        <div class="btn-group" *ngIf="!actionsOnly">
-            <div class="btn-group">
-                <button
-                    id="view-submission"
-                    jhi-exercise-action-button
-                    [buttonIcon]="faFolderOpen"
-                    [buttonLabel]="'artemisApp.exerciseActions.viewSubmissions' | artemisTranslate"
-                    [outlined]="true"
-                    [buttonLoading]="!!exercise.loading"
-                    [smallButton]="smallButtons"
-                    *ngIf="gradedParticipation?.initializationState === InitializationState.FINISHED && (!gradedParticipation?.results?.length || !showResult)"
-                    [routerLink]="['/courses', courseId, 'modeling-exercises', exercise.id, 'participate', gradedParticipation!.id]"
-                ></button>
-                <!-- TODO improve the distinction, in particular if there are multiple submissions and results -->
-                <button
-                    jhi-exercise-action-button
-                    [buttonIcon]="faFolderOpen"
-                    [buttonLabel]="'artemisApp.exerciseActions.viewResults' | artemisTranslate"
-                    [outlined]="true"
-                    [buttonLoading]="!!exercise.loading"
-                    [smallButton]="smallButtons"
-                    *ngIf="gradedParticipation?.initializationState === InitializationState.FINISHED && gradedParticipation?.results?.length && showResult"
-                    [routerLink]="['/courses', courseId, 'modeling-exercises', exercise.id, 'participate', gradedParticipation!.id]"
-                ></button>
-            </div>
-        </div>
-        <!-- INFORMATION END -->
     </ng-container>
     <!-- MODELING EXERCISE ACTIONS END -->
 
     <!-- PROGRAMMING EXERCISE ACTIONS START -->
     <ng-container *ngSwitchCase="ExerciseType.PROGRAMMING">
-        <!-- ACTION START -->
         <div class="btn-group gap-1">
             <button
                 class="view-team"
@@ -263,13 +233,11 @@
                 <span class="d-none d-md-inline" jhiTranslate="artemisApp.exerciseActions.goToBuildPlan">Go to build plan</span>
             </a>
         </div>
-        <!-- ACTION END -->
     </ng-container>
     <!-- PROGRAMMING EXERCISE ACTIONS END -->
 
     <!-- TEXT EXERCISE ACTIONS START -->
     <ng-container *ngSwitchCase="ExerciseType.TEXT">
-        <!-- ACTIONS START -->
         <div class="btn-group gap-1">
             <button
                 class="view-team"
@@ -300,49 +268,27 @@
                 [id]="'open-exercise-' + exercise.id"
                 jhi-exercise-action-button
                 [buttonIcon]="faFolderOpen"
-                [buttonLabel]="'artemisApp.exerciseActions.openTextEditor' | artemisTranslate"
+                [buttonLabel]="
+                    'artemisApp.exerciseActions.' +
+                        (gradedParticipation?.initializationState === InitializationState.INITIALIZED || beforeDueDate
+                            ? 'openTextEditor'
+                            : resultAfterDueDate
+                            ? 'viewResults'
+                            : 'viewSubmissions') | artemisTranslate
+                "
+                [outlined]="!beforeDueDate && gradedParticipation?.initializationState === InitializationState.FINISHED"
                 [buttonLoading]="!!exercise.loading"
                 [smallButton]="smallButtons"
                 [hideLabelMobile]="false"
-                *ngIf="gradedParticipation?.initializationState === InitializationState.INITIALIZED"
+                *ngIf="gradedParticipation?.initializationState === InitializationState.INITIALIZED || gradedParticipation?.initializationState === InitializationState.FINISHED"
                 [routerLink]="['/courses', courseId, 'text-exercises', exercise.id, 'participate', gradedParticipation!.id]"
             ></button>
         </div>
-        <!-- ACTIONS END -->
-        <!-- INFORMATION START -->
-        <div class="btn-group" *ngIf="!actionsOnly">
-            <button
-                id="view-submission"
-                jhi-exercise-action-button
-                [buttonIcon]="faFolderOpen"
-                [buttonLabel]="'artemisApp.exerciseActions.viewSubmissions' | artemisTranslate"
-                [outlined]="true"
-                [buttonLoading]="!!exercise.loading"
-                [smallButton]="smallButtons"
-                [hideLabelMobile]="false"
-                *ngIf="gradedParticipation?.initializationState === InitializationState.FINISHED && (!gradedParticipation?.results?.length || !showResult)"
-                [routerLink]="['/courses', courseId, 'text-exercises', exercise.id, 'participate', gradedParticipation!.id]"
-            ></button>
-            <!-- TODO improve the distinction, in particular if there are multiple submissions and results -->
-            <button
-                jhi-exercise-action-button
-                [buttonIcon]="faFolderOpen"
-                [buttonLabel]="'artemisApp.exerciseActions.viewResults' | artemisTranslate"
-                [outlined]="true"
-                [buttonLoading]="!!exercise.loading"
-                [smallButton]="smallButtons"
-                [hideLabelMobile]="false"
-                *ngIf="gradedParticipation?.initializationState === InitializationState.FINISHED && gradedParticipation?.results?.length && showResult"
-                [routerLink]="['/courses', courseId, 'text-exercises', exercise.id, 'participate', gradedParticipation!.id]"
-            ></button>
-        </div>
-        <!-- INFORMATION END -->
     </ng-container>
     <!-- TEXT EXERCISE ACTIONS END -->
 
     <!-- FILE UPLOAD EXERCISE ACTIONS START -->
     <ng-container *ngSwitchCase="ExerciseType.FILE_UPLOAD">
-        <!-- ACTIONS START -->
         <div class="btn-group gap-1">
             <button
                 class="view-team"
@@ -372,42 +318,22 @@
             <button
                 jhi-exercise-action-button
                 [buttonIcon]="faFolderOpen"
-                [buttonLabel]="'artemisApp.exerciseActions.uploadFile' | artemisTranslate"
+                [buttonLabel]="
+                    'artemisApp.exerciseActions.' +
+                        (gradedParticipation?.initializationState === InitializationState.INITIALIZED || beforeDueDate
+                            ? 'uploadFile'
+                            : resultAfterDueDate
+                            ? 'viewResults'
+                            : 'viewSubmissions') | artemisTranslate
+                "
+                [outlined]="!beforeDueDate && gradedParticipation?.initializationState === InitializationState.FINISHED"
                 [buttonLoading]="!!exercise.loading"
                 [smallButton]="smallButtons"
                 [hideLabelMobile]="false"
-                *ngIf="gradedParticipation?.initializationState === InitializationState.INITIALIZED"
+                *ngIf="gradedParticipation?.initializationState === InitializationState.INITIALIZED || gradedParticipation?.initializationState === InitializationState.FINISHED"
                 [routerLink]="['/courses', courseId, 'file-upload-exercises', exercise.id, 'participate', gradedParticipation!.id]"
             ></button>
         </div>
-        <!-- ACTIONS END-->
-        <!-- INFORMATION START -->
-        <div class="btn-group" *ngIf="!actionsOnly">
-            <button
-                id="view-submission"
-                jhi-exercise-action-button
-                [buttonIcon]="faFolderOpen"
-                [buttonLabel]="'artemisApp.exerciseActions.viewSubmissions' | artemisTranslate"
-                [outlined]="true"
-                [buttonLoading]="!!exercise.loading"
-                [smallButton]="smallButtons"
-                [hideLabelMobile]="false"
-                *ngIf="gradedParticipation?.initializationState === InitializationState.FINISHED && (!gradedParticipation?.results?.length || !showResult)"
-                [routerLink]="['/courses', courseId, 'file-upload-exercises', exercise.id, 'participate', gradedParticipation!.id]"
-            ></button>
-            <button
-                jhi-exercise-action-button
-                [buttonIcon]="faFolderOpen"
-                [buttonLabel]="'artemisApp.exerciseActions.viewResults' | artemisTranslate"
-                [outlined]="true"
-                [buttonLoading]="!!exercise.loading"
-                [smallButton]="smallButtons"
-                [hideLabelMobile]="false"
-                *ngIf="gradedParticipation?.initializationState === InitializationState.FINISHED && gradedParticipation?.results?.length && showResult"
-                [routerLink]="['/courses', courseId, 'file-upload-exercises', exercise.id, 'participate', gradedParticipation!.id]"
-            ></button>
-        </div>
-        <!-- INFORMATION END -->
     </ng-container>
     <!-- FILE UPLOAD EXERCISE ACTIONS END -->
 </div>

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
@@ -60,59 +60,6 @@
     </ng-container>
     <!-- QUIZ EXERCISE ACTIONS END -->
 
-    <!-- MODELING EXERCISE ACTIONS START -->
-    <ng-container *ngSwitchCase="ExerciseType.MODELING">
-        <div class="btn-group gap-1">
-            <button
-                class="view-team"
-                jhi-exercise-action-button
-                [buttonIcon]="faUsers"
-                [buttonLabel]="'artemisApp.exerciseActions.viewTeam' | artemisTranslate"
-                *ngIf="isTeamAvailable"
-                [smallButton]="smallButtons"
-                [hideLabelMobile]="true"
-                [routerLink]="['/courses', courseId, 'exercises', exercise.id, 'teams', assignedTeamId]"
-            ></button>
-            <span tabindex="0" [ngbTooltip]="isBeforeStartDateAndStudent ? ('artemisApp.exerciseActions.startExerciseBeforeDueDate' | artemisTranslate) : ''">
-                <button
-                    [id]="'start-exercise-' + exercise.id"
-                    class="start-exercise"
-                    jhi-exercise-action-button
-                    id="start-modeling-exercise-action"
-                    [buttonIcon]="faPlayCircle"
-                    [buttonLabel]="'artemisApp.exerciseActions.startExercise' | artemisTranslate"
-                    [buttonLoading]="!!exercise.loading"
-                    [smallButton]="smallButtons"
-                    [hideLabelMobile]="false"
-                    [overwriteDisabled]="isBeforeStartDateAndStudent"
-                    *ngIf="!gradedParticipation && isStartExerciseAvailable()"
-                    (click)="startExercise()"
-                ></button>
-            </span>
-            <button
-                [id]="'open-exercise-' + exercise.id"
-                jhi-exercise-action-button
-                id="open-modeling-editor-action"
-                [buttonIcon]="faFolderOpen"
-                [buttonLabel]="
-                    'artemisApp.exerciseActions.' +
-                        (gradedParticipation?.initializationState === InitializationState.INITIALIZED || beforeDueDate
-                            ? 'openModelingEditor'
-                            : resultAfterDueDate
-                            ? 'viewResults'
-                            : 'viewSubmissions') | artemisTranslate
-                "
-                [outlined]="!beforeDueDate && gradedParticipation?.initializationState === InitializationState.FINISHED"
-                [buttonLoading]="!!exercise.loading"
-                [smallButton]="smallButtons"
-                [hideLabelMobile]="false"
-                *ngIf="gradedParticipation?.initializationState === InitializationState.INITIALIZED || gradedParticipation?.initializationState === InitializationState.FINISHED"
-                [routerLink]="['/courses', courseId, 'modeling-exercises', exercise.id, 'participate', gradedParticipation!.id]"
-            ></button>
-        </div>
-    </ng-container>
-    <!-- MODELING EXERCISE ACTIONS END -->
-
     <!-- PROGRAMMING EXERCISE ACTIONS START -->
     <ng-container *ngSwitchCase="ExerciseType.PROGRAMMING">
         <div class="btn-group gap-1">
@@ -236,8 +183,8 @@
     </ng-container>
     <!-- PROGRAMMING EXERCISE ACTIONS END -->
 
-    <!-- TEXT EXERCISE ACTIONS START -->
-    <ng-container *ngSwitchCase="ExerciseType.TEXT">
+    <!-- MODELING/TEXT/FILE UPLOAD EXERCISE ACTIONS START -->
+    <ng-container *ngSwitchDefault>
         <div class="btn-group gap-1">
             <button
                 class="view-team"
@@ -270,70 +217,23 @@
                 [buttonIcon]="faFolderOpen"
                 [buttonLabel]="
                     'artemisApp.exerciseActions.' +
-                        (gradedParticipation?.initializationState === InitializationState.INITIALIZED || beforeDueDate
-                            ? 'openTextEditor'
-                            : resultAfterDueDate
+                        (gradedParticipation?.initializationState === InitializationState.INITIALIZED || (beforeDueDate && !hasRatedGradedResult)
+                            ? editorLabel
+                            : hasRatedGradedResult
                             ? 'viewResults'
                             : 'viewSubmissions') | artemisTranslate
                 "
-                [outlined]="!beforeDueDate && gradedParticipation?.initializationState === InitializationState.FINISHED"
+                [outlined]="(!beforeDueDate || hasRatedGradedResult) && gradedParticipation?.initializationState === InitializationState.FINISHED"
                 [buttonLoading]="!!exercise.loading"
                 [smallButton]="smallButtons"
                 [hideLabelMobile]="false"
-                *ngIf="gradedParticipation?.initializationState === InitializationState.INITIALIZED || gradedParticipation?.initializationState === InitializationState.FINISHED"
-                [routerLink]="['/courses', courseId, 'text-exercises', exercise.id, 'participate', gradedParticipation!.id]"
-            ></button>
-        </div>
-    </ng-container>
-    <!-- TEXT EXERCISE ACTIONS END -->
-
-    <!-- FILE UPLOAD EXERCISE ACTIONS START -->
-    <ng-container *ngSwitchCase="ExerciseType.FILE_UPLOAD">
-        <div class="btn-group gap-1">
-            <button
-                class="view-team"
-                jhi-exercise-action-button
-                [buttonIcon]="faUsers"
-                [buttonLabel]="'artemisApp.exerciseActions.viewTeam' | artemisTranslate"
-                *ngIf="isTeamAvailable"
-                [smallButton]="smallButtons"
-                [hideLabelMobile]="true"
-                [routerLink]="['/courses', courseId, 'exercises', exercise.id, 'teams', assignedTeamId]"
-            ></button>
-            <span tabindex="0" [ngbTooltip]="isBeforeStartDateAndStudent ? ('artemisApp.exerciseActions.startExerciseBeforeDueDate' | artemisTranslate) : ''">
-                <button
-                    [id]="'start-exercise-' + exercise.id"
-                    class="start-exercise"
-                    jhi-exercise-action-button
-                    [buttonIcon]="faPlayCircle"
-                    [buttonLabel]="'artemisApp.exerciseActions.startExercise' | artemisTranslate"
-                    [buttonLoading]="!!exercise.loading"
-                    *ngIf="!gradedParticipation && isStartExerciseAvailable()"
-                    [smallButton]="smallButtons"
-                    [hideLabelMobile]="false"
-                    [overwriteDisabled]="isBeforeStartDateAndStudent"
-                    (click)="startExercise()"
-                ></button>
-            </span>
-            <button
-                jhi-exercise-action-button
-                [buttonIcon]="faFolderOpen"
-                [buttonLabel]="
-                    'artemisApp.exerciseActions.' +
-                        (gradedParticipation?.initializationState === InitializationState.INITIALIZED || beforeDueDate
-                            ? 'uploadFile'
-                            : resultAfterDueDate
-                            ? 'viewResults'
-                            : 'viewSubmissions') | artemisTranslate
+                *ngIf="
+                    (gradedParticipation?.initializationState === InitializationState.INITIALIZED && this.beforeDueDate) ||
+                    gradedParticipation?.initializationState === InitializationState.FINISHED
                 "
-                [outlined]="!beforeDueDate && gradedParticipation?.initializationState === InitializationState.FINISHED"
-                [buttonLoading]="!!exercise.loading"
-                [smallButton]="smallButtons"
-                [hideLabelMobile]="false"
-                *ngIf="gradedParticipation?.initializationState === InitializationState.INITIALIZED || gradedParticipation?.initializationState === InitializationState.FINISHED"
-                [routerLink]="['/courses', courseId, 'file-upload-exercises', exercise.id, 'participate', gradedParticipation!.id]"
+                [routerLink]="['/courses', courseId, exercise.type + '-exercises', exercise.id, 'participate', gradedParticipation!.id]"
             ></button>
         </div>
     </ng-container>
-    <!-- FILE UPLOAD EXERCISE ACTIONS END -->
+    <!-- MODELING/TEXT/FILE UPLOAD EXERCISE ACTIONS END -->
 </div>

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
@@ -213,6 +213,7 @@
             </span>
             <button
                 [id]="'open-exercise-' + exercise.id"
+                class="open-exercise"
                 jhi-exercise-action-button
                 [buttonIcon]="faFolderOpen"
                 [buttonLabel]="

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -29,16 +29,13 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
     readonly FeatureToggle = FeatureToggle;
     readonly ExerciseType = ExerciseType;
     readonly InitializationState = InitializationState;
-    readonly dayjs = dayjs;
 
     @Input() @HostBinding('class.col') equalColumns = true;
     @Input() @HostBinding('class.col-auto') smallColumns = false;
 
     @Input() exercise: Exercise;
     @Input() courseId: number;
-    @Input() actionsOnly: boolean;
     @Input() smallButtons: boolean;
-    @Input() showResult: boolean;
     @Input() examMode: boolean;
 
     // extension points, see shared/extension-point
@@ -50,6 +47,8 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
     practiceParticipation?: StudentParticipation;
     programmingExercise?: ProgrammingExercise;
     isTeamAvailable: boolean;
+    resultAfterDueDate: boolean;
+    beforeDueDate: boolean;
 
     // Icons
     faComment = faComment;
@@ -101,10 +100,19 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
         const studentParticipations = this.exercise.studentParticipations ?? [];
         this.gradedParticipation = this.participationService.getSpecificStudentParticipation(studentParticipations, false);
         this.practiceParticipation = this.participationService.getSpecificStudentParticipation(studentParticipations, true);
+
+        this.beforeDueDate = !!this.exercise.dueDate && dayjs().isBefore(this.exercise.dueDate);
+        const afterAssessmentDueDate = !this.exercise.assessmentDueDate || dayjs().isAfter(this.exercise.assessmentDueDate);
+        this.resultAfterDueDate = afterAssessmentDueDate && !!this.gradedParticipation?.results?.some((result) => result.rated === true);
+
+        if (this.exercise.title === 'fdsbgvdfybvdfb') {
+            console.log(this.exercise);
+        }
     }
 
     /**
-     * Starting an exercise is not possible in the exam or if it's a team exercise and the student is not yet assigned a team, otherwise see exercise.utils -> isStartExerciseAvailable
+     * Starting an exercise is not possible in the exam or if it's a team exercise and the student is not yet assigned a team, otherwise see exercise.utils ->
+     * isStartExerciseAvailable
      */
     isStartExerciseAvailable(): boolean {
         const individualExerciseOrTeamAssigned = !!(!this.exercise.teamMode || this.exercise.studentAssignedTeamId);
@@ -126,10 +134,6 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
     }
 
     startExercise() {
-        if (this.exercise.type === ExerciseType.QUIZ) {
-            // Start the quiz
-            return this.router.navigate(['/courses', this.courseId, 'quiz-exercises', this.exercise.id, 'live']);
-        }
         this.exercise.loading = true;
         this.courseExerciseService
             .startExercise(this.exercise.id!)

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -47,8 +47,9 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
     practiceParticipation?: StudentParticipation;
     programmingExercise?: ProgrammingExercise;
     isTeamAvailable: boolean;
-    resultAfterDueDate: boolean;
+    hasRatedGradedResult: boolean;
     beforeDueDate: boolean;
+    editorLabel?: string;
 
     // Icons
     faComment = faComment;
@@ -75,7 +76,15 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
             this.quizNotStarted = ArtemisQuizService.notStarted(quizExercise);
         } else if (this.exercise.type === ExerciseType.PROGRAMMING) {
             this.programmingExercise = this.exercise as ProgrammingExercise;
+        } else if (this.exercise.type === ExerciseType.MODELING) {
+            this.editorLabel = 'openModelingEditor';
+        } else if (this.exercise.type === ExerciseType.TEXT) {
+            this.editorLabel = 'openTextEditor';
+        } else if (this.exercise.type === ExerciseType.FILE_UPLOAD) {
+            this.editorLabel = 'uploadFile';
         }
+
+        this.beforeDueDate = !this.exercise.dueDate || dayjs().isBefore(this.exercise.dueDate);
     }
 
     /**
@@ -101,13 +110,7 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
         this.gradedParticipation = this.participationService.getSpecificStudentParticipation(studentParticipations, false);
         this.practiceParticipation = this.participationService.getSpecificStudentParticipation(studentParticipations, true);
 
-        this.beforeDueDate = !!this.exercise.dueDate && dayjs().isBefore(this.exercise.dueDate);
-        const afterAssessmentDueDate = !this.exercise.assessmentDueDate || dayjs().isAfter(this.exercise.assessmentDueDate);
-        this.resultAfterDueDate = afterAssessmentDueDate && !!this.gradedParticipation?.results?.some((result) => result.rated === true);
-
-        if (this.exercise.title === 'fdsbgvdfybvdfb') {
-            console.log(this.exercise);
-        }
+        this.hasRatedGradedResult = !!this.gradedParticipation?.results?.some((result) => result.rated === true);
     }
 
     /**

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseAssessment.cy.ts
@@ -55,7 +55,7 @@ describe('Modeling Exercise Assessment Spec', () => {
             cy.login(studentOne, `/courses/${course.id}/exercises/${modelingExercise.id}`);
             exerciseResult.shouldShowExerciseTitle(modelingExercise.title!);
             exerciseResult.shouldShowScore(20);
-            exerciseResult.clickViewSubmission();
+            exerciseResult.clickOpenExercise(modelingExercise.id!);
             modelingExerciseFeedback.shouldShowScore(20);
             modelingExerciseFeedback.shouldShowAdditionalFeedback(1, 'Thanks, good job.');
             modelingExerciseFeedback.shouldShowComponentFeedback(1, 2, 'Good');

--- a/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseAssessment.cy.ts
@@ -63,7 +63,7 @@ describe('Text exercise assessment', () => {
             exerciseResult.shouldShowExerciseTitle(exercise.title!);
             exerciseResult.shouldShowProblemStatement(exercise.problemStatement!);
             exerciseResult.shouldShowScore(percentage);
-            exerciseResult.clickViewSubmission();
+            exerciseResult.clickOpenExercise(exercise.id!);
             textExerciseFeedback.shouldShowTextFeedback(1, tutorTextFeedback);
             textExerciseFeedback.shouldShowAdditionalFeedback(tutorFeedbackPoints, tutorFeedback);
             textExerciseFeedback.shouldShowScore(percentage);

--- a/src/test/cypress/support/pageobjects/exercises/ExerciseResultPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/ExerciseResultPage.ts
@@ -15,9 +15,9 @@ export class ExerciseResultPage {
         cy.contains(`${percentage}%`).should('be.visible');
     }
 
-    clickViewSubmission() {
+    clickOpenExercise(exerciseId: number) {
         cy.intercept(GET, BASE_API + 'results/*/rating').as('getResults');
-        cy.get('#view-submission').click();
+        cy.get('#open-exercise-' + exerciseId).click();
         return cy.wait('@getResults');
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It is confusing for students when some buttons of exercises are shown in the exercise overview, while others are only shown in the exercise details view. These buttons are the ones showing the submission/result after submissions are done.

### Description
<!-- Describe your changes in detail -->
This PR refactors the student actions to always show the submission/result button.
Additionally the modeling, text and file upload buttons are merged, since they share the same behavior.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Tutor
- 2 Text/Modeling/File upload exercises (one with due date, one without)

1. Log in to Artemis
2. Create the exercises and participate as a student
3. You should be able to open the editor as long as you can submit (before due date or no due date and no result yet)
4. You should see "View submission" when you cannot participate any more but did not receive an assessment yet
5. You should see "View result" once you received an assessment

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| exercise-details-student-actions.component.ts | 86% | ✅ |