### PR TITLE
`Develpment`: Improve exception assertions in server test

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -3324,7 +3324,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         request.getMvc().perform(post("/api/courses/" + course1.getId() + "/exam-import").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(exam)))
                 .andExpect(status().isBadRequest())
-                .andExpect(result -> assertThat(result.getResolvedException().getMessage()).isEqualTo("Exam contains programming exercise(s) with invalid short name."));
+                .andExpect(result -> assertThat(result.getResolvedException()).hasMessage("Exam contains programming exercise(s) with invalid short name."));
     }
 
     private int prepareExerciseStart(Exam exam) throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
@@ -250,10 +250,10 @@ class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
     @Test
     void testActualPathForPublicFileUploadExercisePath_shouldThrowException() {
         Exception exception = assertThrows(FilePathParsingException.class, () -> fileService.actualPathForPublicPath("asdasdfiles/file-upload-exercises"));
-        assertThat(exception.getMessage()).startsWith("Public path does not contain correct exerciseId or submissionId:");
+        assertThat(exception).hasMessageStartingWith("Public path does not contain correct exerciseId or submissionId:");
 
         exception = assertThrows(FilePathParsingException.class, () -> fileService.actualPathForPublicPath("asdasdfiles/file-asd-exercises"));
-        assertThat(exception.getMessage()).startsWith("Unknown Filepath:");
+        assertThat(exception).hasMessageStartingWith("Unknown Filepath:");
     }
 
     @Test
@@ -269,28 +269,28 @@ class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
             Path actualFileUploadPath = Path.of(FilePathService.getFileUploadExercisesFilePath());
             fileService.publicPathForActualPath(actualFileUploadPath.toString(), 1L);
         });
-        assertThat(exception.getMessage()).startsWith("Unexpected String in upload file path. Exercise ID should be present here:");
+        assertThat(exception).hasMessageStartingWith("Unexpected String in upload file path. Exercise ID should be present here:");
 
         exception = assertThrows(FilePathParsingException.class, () -> fileService.publicPathForActualPath(Path.of("asdasdfiles", "file-asd-exercises").toString(), 1L));
-        assertThat(exception.getMessage()).startsWith("Unknown Filepath:");
+        assertThat(exception).hasMessageStartingWith("Unknown Filepath:");
     }
 
     @Test
     void testReplaceVariablesInFileRecursive_shouldThrowException() {
         Exception exception = assertThrows(RuntimeException.class, () -> fileService.replaceVariablesInFileRecursive("some-path", new HashMap<>()));
-        assertThat(exception.getMessage()).endsWith("should be replaced but the directory does not exist.");
+        assertThat(exception).hasMessageEndingWith("should be replaced but the directory does not exist.");
     }
 
     @Test
     void testNormalizeLineEndingsDirectory_shouldThrowException() {
         Exception exception = assertThrows(RuntimeException.class, () -> fileService.normalizeLineEndingsDirectory("some-path"));
-        assertThat(exception.getMessage()).endsWith("should be normalized but the directory does not exist.");
+        assertThat(exception).hasMessageEndingWith("should be normalized but the directory does not exist.");
     }
 
     @Test
     void testConvertToUTF8Directory_shouldThrowException() {
         Exception exception = assertThrows(RuntimeException.class, () -> fileService.convertToUTF8Directory("some-path"));
-        assertThat(exception.getMessage()).endsWith("should be converted to UTF-8 but the directory does not exist.");
+        assertThat(exception).hasMessageEndingWith("should be converted to UTF-8 but the directory does not exist.");
     }
 
     // TODO: either rework those tests or delete them

--- a/src/test/java/de/tum/in/www1/artemis/service/GradingScaleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/GradingScaleServiceTest.java
@@ -72,7 +72,7 @@ class GradingScaleServiceTest extends AbstractSpringIntegrationBambooBitbucketJi
         BadRequestAlertException exception = assertThrows(BadRequestAlertException.class,
                 () -> gradingScaleRepository.matchPercentageToGradeStep(invalidPercentage, savedGradingScale.getId()));
 
-        assertThat(exception.getMessage()).isEqualTo("Grade percentages must be greater than 0");
+        assertThat(exception).hasMessage("Grade percentages must be greater than 0");
         assertThat(exception.getEntityName()).isEqualTo("gradeStep");
         assertThat(exception.getErrorKey()).isEqualTo("invalidGradePercentage");
     }
@@ -85,13 +85,13 @@ class GradingScaleServiceTest extends AbstractSpringIntegrationBambooBitbucketJi
     void testMatchPercentageToGradeStepNoValidMapping() {
         gradeSteps = database.generateGradeStepSet(gradingScale, false);
         gradingScale.setGradeSteps(gradeSteps);
-        Long id = gradingScaleRepository.save(gradingScale).getId();
+        long id = gradingScaleRepository.save(gradingScale).getId();
 
         double percentage = 85;
 
         EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () -> gradingScaleRepository.matchPercentageToGradeStep(percentage, id));
 
-        assertThat(exception.getMessage()).isEqualTo("No grade step in selected grading scale matches given percentage");
+        assertThat(exception).hasMessage("No grade step in selected grading scale matches given percentage");
     }
 
     /**
@@ -134,7 +134,7 @@ class GradingScaleServiceTest extends AbstractSpringIntegrationBambooBitbucketJi
 
         assertThat(exception.getEntityName()).isEqualTo("gradeStep");
         assertThat(exception.getErrorKey()).isEqualTo("invalidGradeStepFormat");
-        assertThat(exception.getMessage()).isEqualTo("Not all grade steps are following the correct format.");
+        assertThat(exception).hasMessage("Not all grade steps are following the correct format.");
     }
 
     /**
@@ -147,7 +147,7 @@ class GradingScaleServiceTest extends AbstractSpringIntegrationBambooBitbucketJi
 
         BadRequestAlertException exception = assertThrows(BadRequestAlertException.class, () -> gradingScaleService.saveGradingScale(gradingScale));
 
-        assertThat(exception.getMessage()).isEqualTo("Not all grade steps are following the correct format.");
+        assertThat(exception).hasMessage("Not all grade steps are following the correct format.");
         assertThat(exception.getEntityName()).isEqualTo("gradeStep");
         assertThat(exception.getErrorKey()).isEqualTo("invalidGradeStepFormat");
     }
@@ -176,7 +176,7 @@ class GradingScaleServiceTest extends AbstractSpringIntegrationBambooBitbucketJi
 
         BadRequestAlertException exception = assertThrows(BadRequestAlertException.class, () -> gradingScaleService.saveGradingScale(gradingScale));
 
-        assertThat(exception.getMessage()).isEqualTo("Grade step set can't match to a valid grading scale.");
+        assertThat(exception).hasMessage("Grade step set can't match to a valid grading scale.");
         assertThat(exception.getEntityName()).isEqualTo("gradeStep");
         assertThat(exception.getErrorKey()).isEqualTo("invalidGradeStepAdjacency");
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/JenkinsJobPermissionServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/JenkinsJobPermissionServiceTest.java
@@ -62,7 +62,7 @@ class JenkinsJobPermissionServiceTest extends AbstractSpringIntegrationJenkinsGi
             jenkinsJobPermissionsService.addInstructorAndEditorAndTAPermissionsToUsersForFolder(Set.of(TEST_PREFIX + "ta1"), Set.of(TEST_PREFIX + "editor1"),
                     Set.of(TEST_PREFIX + "instructor1"), folderName);
         });
-        Assertions.assertThat(exception.getMessage()).startsWith("Cannot add instructor, editor, and/or ta permissions to users for folder");
+        Assertions.assertThat(exception).hasMessageStartingWith("Cannot add instructor, editor, and/or ta permissions to users for folder");
     }
 
     @Test
@@ -80,7 +80,7 @@ class JenkinsJobPermissionServiceTest extends AbstractSpringIntegrationJenkinsGi
         Exception exception = assertThrows(IOException.class, () -> {
             jenkinsJobPermissionsService.addTeachingAssistantPermissionsToUserForFolder(taLogin, folderName);
         });
-        Assertions.assertThat(exception.getMessage()).startsWith("Cannot add ta permissions to user for folder");
+        Assertions.assertThat(exception).hasMessageStartingWith("Cannot add ta permissions to user for folder");
     }
 
     @Test
@@ -97,7 +97,7 @@ class JenkinsJobPermissionServiceTest extends AbstractSpringIntegrationJenkinsGi
         Exception exception = assertThrows(IOException.class, () -> {
             jenkinsJobPermissionsService.addPermissionsForUsersToFolder(taLogins, folderName, taPermissions);
         });
-        Assertions.assertThat(exception.getMessage()).startsWith("Cannot add permissions to users for folder:");
+        Assertions.assertThat(exception).hasMessageStartingWith("Cannot add permissions to users for folder:");
     }
 
     @Test
@@ -115,7 +115,7 @@ class JenkinsJobPermissionServiceTest extends AbstractSpringIntegrationJenkinsGi
         Exception exception = assertThrows(IOException.class, () -> {
             jenkinsJobPermissionsService.removePermissionsFromUserOfFolder(taLogin, folderName, taPermissions);
         });
-        Assertions.assertThat(exception.getMessage()).startsWith("Cannot remove permissions to user for folder:");
+        Assertions.assertThat(exception).hasMessageStartingWith("Cannot remove permissions to user for folder:");
     }
 
     @Test
@@ -133,6 +133,6 @@ class JenkinsJobPermissionServiceTest extends AbstractSpringIntegrationJenkinsGi
         Exception exception = assertThrows(IOException.class, () -> {
             jenkinsJobPermissionsService.removePermissionsFromUsersForFolder(taLogins, folderName, taPermissions);
         });
-        Assertions.assertThat(exception.getMessage()).startsWith("Cannot remove permissions to user for folder:");
+        Assertions.assertThat(exception).hasMessageStartingWith("Cannot remove permissions to user for folder:");
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/JenkinsServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/JenkinsServiceTest.java
@@ -135,7 +135,7 @@ class JenkinsServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
                 () -> continuousIntegrationService.createBuildPlanForExercise(programmingExercise, TEMPLATE.getName(), exerciseRepoUrl, testsRepoUrl, solutionRepoUrl));
 
         mockedStreamUtils.close();
-        assertThat(exception.getMessage()).startsWith("Error loading template Jenkins build XML: ");
+        assertThat(exception).hasMessageStartingWith("Error loading template Jenkins build XML: ");
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
@@ -158,7 +158,7 @@ class JenkinsServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
         Exception exception = assertThrows(UnsupportedOperationException.class,
                 () -> continuousIntegrationService.createBuildPlanForExercise(finalProgrammingExercise, TEMPLATE.getName(), exerciseRepoUrl, testsRepoUrl, solutionRepoUrl));
 
-        assertThat(exception.getMessage()).endsWith("templates are not available for Jenkins.");
+        assertThat(exception).hasMessageEndingWith("templates are not available for Jenkins.");
     }
 
     @Test
@@ -175,7 +175,7 @@ class JenkinsServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
         jenkinsRequestMockProvider.mockGivePlanPermissionsThrowException(programmingExercise.getProjectKey(), programmingExercise.getProjectKey());
 
         Exception exception = assertThrows(JenkinsException.class, () -> programmingExerciseImportService.importBuildPlans(programmingExercise, programmingExercise));
-        assertThat(exception.getMessage()).startsWith("Cannot give assign permissions to plan");
+        assertThat(exception).hasMessageStartingWith("Cannot give assign permissions to plan");
     }
 
     @Test
@@ -192,7 +192,7 @@ class JenkinsServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
         jenkinsRequestMockProvider.mockGivePlanPermissionsThrowException(programmingExercise.getProjectKey(), programmingExercise.getProjectKey());
 
         Exception exception = assertThrows(JenkinsException.class, () -> programmingExerciseImportService.importBuildPlans(programmingExercise, programmingExercise));
-        assertThat(exception.getMessage()).startsWith("Cannot give assign permissions to plan");
+        assertThat(exception).hasMessageStartingWith("Cannot give assign permissions to plan");
     }
 
     @Test
@@ -248,6 +248,6 @@ class JenkinsServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
             continuousIntegrationService.updatePlanRepository(projectKey, planName, ASSIGNMENT_REPO_NAME, null, participation.getRepositoryUrl(), templateRepoUrl, "main",
                     List.of());
         });
-        assertThat(exception.getMessage()).startsWith("Error trying to configure build plan in Jenkins");
+        assertThat(exception).hasMessageStartingWith("Error trying to configure build plan in Jenkins");
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [ ] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [ ] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A follow-up PR of https://github.com/ls1intum/Artemis/pull/6588, deals with assertions related to exceptions. There are a few instances where assertThrows and assertDoesNotThrow instead of the corresponding AssertJ assertion. 


### Description
<!-- Describe your changes in detail -->
Also an architecture test has been added, checking that no JUnit assertions are used in server tests


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
unchanged
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->