### PR TITLE
`Development`: Fix missing aboutUs translation key

### DIFF
--- a/prebuild.mjs
+++ b/prebuild.mjs
@@ -103,7 +103,7 @@ for (const group of groups) {
         const mergedContent = files.reduce((acc, file) => {
             const content = JSON.parse(fs.readFileSync(path.resolve(group.folder, file)).toString());
             return deepMerge(acc, content);
-        });
+        }, {});
 
         await fs.promises.writeFile(group.output, JSON.stringify(mergedContent));
     } catch (error) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
@JohannesStoehr noticed a bug caused by #6546: The translation keys for the `about us` page had gone missing. This PR fixes that.

### Description
<!-- Describe your changes in detail -->
I noticed that the reported issue was caused by a small mistake in the `prebuild.mjs` script where I forgot the initial value for a call to `.reduce`. This [caused the first filename to be the initial value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce), therefore the first file alphabetically (`aboutUs.json`) not to be considered.

This PR adds an initial value.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
- Visit the About Us page
- Verify that the translations are not broken

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->
tested by 4 people, 1 line of code change

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:

<img width="1050" alt="screenshot-2023-05-24_001381" src="https://github.com/ls1intum/Artemis/assets/9006596/7b6b2ed5-8b0b-4117-a9ed-41c905cb1a47">

After:
<img width="1207" alt="screenshot-2023-05-25_001387" src="https://github.com/ls1intum/Artemis/assets/9006596/afe5da16-a986-4c18-9e14-b018e81c8f67">


