### PR TITLE
`General`: Hide assessment button for empty participations

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
@@ -227,7 +227,7 @@
                         </span>
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
-                        <jhi-result [exercise]="exercise" [result]="value.results?.[0]" [participation]="value"></jhi-result>
+                        <jhi-result *ngIf="value.results?.[0]" [exercise]="exercise" [result]="value.results?.[0]" [participation]="value"></jhi-result>
                     </ng-template>
                 </ngx-datatable-column>
 
@@ -307,50 +307,52 @@
                                     Online editor
                                 </a>
                             </div>
-                            <ng-container *ngFor="let correctionRound of correctionRoundIndices">
-                                <div
-                                    *ngIf="(correctionRound == 0 || value.results?.[correctionRound - 1]?.completionDate) &&
-                                    (newManualResultAllowed || (value.results?.[correctionRound]?.assessmentType && value.results[correctionRound].assessmentType !== AssessmentType.AUTOMATIC))"
-                                >
-                                    <a
-                                        [routerLink]="getAssessmentLink(value, correctionRound)"
-                                        [queryParams]="correctionRoundIndices?.length && correctionRoundIndices.length > 1 ? { 'correction-round': correctionRound } : {}"
-                                        class="btn btn-sm me-1 mb-2"
-                                        [class.btn-success]="(!value.results?.[correctionRound]?.assessmentType || value.results?.[correctionRound].assessmentType === AssessmentType.AUTOMATIC) && !value.results?.[correctionRound]?.hasComplaint"
-                                        [class.btn-primary]="value.results?.[correctionRound]?.completionDate || value.results?.[correctionRound]?.hasComplaint"
-                                        [class.btn-warning]="value.results?.[correctionRound] && !value.results[correctionRound].completionDate && !value.results[correctionRound].hasComplaint"
+                            <ng-container *ngIf="value.submissionCount">
+                                <ng-container *ngFor="let correctionRound of correctionRoundIndices">
+                                    <div
+                                        *ngIf="(correctionRound == 0 || value.results?.[correctionRound - 1]?.completionDate) &&
+                                        (newManualResultAllowed || (value.results?.[correctionRound]?.assessmentType && value.results[correctionRound].assessmentType !== AssessmentType.AUTOMATIC))"
                                     >
-                                        <fa-icon [icon]="faFolderOpen" [fixedWidth]="true"></fa-icon>
-                                        <ng-container *ngIf="!value.results?.[correctionRound]?.hasComplaint; else complaint">
-                                            {{ ('artemisApp.assessment.dashboard.actions.' + (this.exercise.exerciseGroup ? 'examCorrectionRound.' : '') +
-                                            (!value.results?.[correctionRound]?.assessmentType || value.results?.[correctionRound].assessmentType === AssessmentType.AUTOMATIC ? 'assess' : (value.results?.[correctionRound]?.completionDate ? 'open' : 'continue')))
-                                            | artemisTranslate: { correctionRound: correctionRound + 1 }
-                                            }}
-                                        </ng-container>
-                                        <ng-template #complaint>
-                                            {{ 'artemisApp.exerciseAssessmentDashboard.showComplaint' | artemisTranslate }}
-                                        </ng-template>
-                                    </a>
-                                    <button
-                                        *ngIf="
-                                            newManualResultAllowed &&
-                                            value.results?.[correctionRound]?.assessmentType &&
-                                            !value.results[correctionRound].completionDate &&
-                                            value.results[correctionRound].assessmentType !== AssessmentType.AUTOMATIC
-                                        "
-                                        (click)="cancelAssessment(value.results[correctionRound])"
-                                        [disabled]="isLoading"
-                                        class="btn btn-danger btn-sm mb-1"
-                                    >
-                                        <fa-icon [fixedWidth]="true" [icon]="faBan"></fa-icon>
-                                        <span>
-                                            {{
-                                                'artemisApp.assessment.dashboard.actions.' + (this.exercise.exerciseGroup ? 'examCorrectionRound.' : '') + 'cancel'
-                                                    | artemisTranslate : { correctionRound: correctionRound + 1 }
-                                            }}
-                                        </span>
-                                    </button>
-                                </div>
+                                        <a
+                                            [routerLink]="getAssessmentLink(value, correctionRound)"
+                                            [queryParams]="correctionRoundIndices?.length && correctionRoundIndices.length > 1 ? { 'correction-round': correctionRound } : {}"
+                                            class="btn btn-sm me-1 mb-2"
+                                            [class.btn-success]="(!value.results?.[correctionRound]?.assessmentType || value.results?.[correctionRound].assessmentType === AssessmentType.AUTOMATIC) && !value.results?.[correctionRound]?.hasComplaint"
+                                            [class.btn-primary]="value.results?.[correctionRound]?.completionDate || value.results?.[correctionRound]?.hasComplaint"
+                                            [class.btn-warning]="value.results?.[correctionRound] && !value.results[correctionRound].completionDate && !value.results[correctionRound].hasComplaint"
+                                        >
+                                            <fa-icon [icon]="faFolderOpen" [fixedWidth]="true"></fa-icon>
+                                            <ng-container *ngIf="!value.results?.[correctionRound]?.hasComplaint; else complaint">
+                                                {{ ('artemisApp.assessment.dashboard.actions.' + (this.exercise.exerciseGroup ? 'examCorrectionRound.' : '') +
+                                                (!value.results?.[correctionRound]?.assessmentType || value.results?.[correctionRound].assessmentType === AssessmentType.AUTOMATIC ? 'assess' : (value.results?.[correctionRound]?.completionDate ? 'open' : 'continue')))
+                                                | artemisTranslate: { correctionRound: correctionRound + 1 }
+                                                }}
+                                            </ng-container>
+                                            <ng-template #complaint>
+                                                {{ 'artemisApp.exerciseAssessmentDashboard.showComplaint' | artemisTranslate }}
+                                            </ng-template>
+                                        </a>
+                                        <button
+                                            *ngIf="
+                                                newManualResultAllowed &&
+                                                value.results?.[correctionRound]?.assessmentType &&
+                                                !value.results[correctionRound].completionDate &&
+                                                value.results[correctionRound].assessmentType !== AssessmentType.AUTOMATIC
+                                            "
+                                            (click)="cancelAssessment(value.results[correctionRound])"
+                                            [disabled]="isLoading"
+                                            class="btn btn-danger btn-sm mb-1"
+                                        >
+                                            <fa-icon [fixedWidth]="true" [icon]="faBan"></fa-icon>
+                                            <span>
+                                                {{
+                                                    'artemisApp.assessment.dashboard.actions.' + (this.exercise.exerciseGroup ? 'examCorrectionRound.' : '') + 'cancel'
+                                                        | artemisTranslate : { correctionRound: correctionRound + 1 }
+                                                }}
+                                            </span>
+                                        </button>
+                                    </div>
+                                </ng-container>
                             </ng-container>
                         </div>
                     </ng-template>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix a small issue that is part of #6620

### Description
<!-- Describe your changes in detail -->
The scores table showed a button for assessment and an empty result for participations with no submissions, suggesting that there is something to assess. This is no removed for such participations.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise with manual assessment

1. Log in to Artemis
2. Start the participation as student but don't submit anything
3. Go to the scores table to the programming exercise after the due date and check that there is no button suggesting a possible assessment of the participation

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Taken from issue:
![image](https://github.com/ls1intum/Artemis/assets/22198798/7803294c-438f-44c1-a57e-a394488331b5)