### PR TITLE
`Programming exercises`: Refactor local VC and local CI services

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/localvcci/ArtemisGitServlet.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/localvcci/ArtemisGitServlet.java
@@ -1,11 +1,8 @@
 package de.tum.in.www1.artemis.config.localvcci;
 
-import java.util.Optional;
-
 import org.eclipse.jgit.http.server.GitServlet;
 import org.eclipse.jgit.transport.ReceivePack;
 
-import de.tum.in.www1.artemis.service.connectors.localci.LocalCIConnectorService;
 import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCFetchFilter;
 import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCPostPushHook;
 import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCPrePushHook;
@@ -20,10 +17,9 @@ public class ArtemisGitServlet extends GitServlet {
     /**
      * Constructor for ArtemisGitServlet.
      *
-     * @param localVCServletService   the service for authenticating and authorizing users and retrieving the repository from disk
-     * @param localCIConnectorService the service for triggering a new build after a successful push
+     * @param localVCServletService the service for authenticating and authorizing users and retrieving the repository from disk
      */
-    public ArtemisGitServlet(LocalVCServletService localVCServletService, Optional<LocalCIConnectorService> localCIConnectorService) {
+    public ArtemisGitServlet(LocalVCServletService localVCServletService) {
         this.setRepositoryResolver((req, name) -> {
             // req – the current request, may be used to inspect session state including cookies or user authentication.
             // name – name of the repository, as parsed out of the URL (everything after /git/).
@@ -41,7 +37,7 @@ public class ArtemisGitServlet extends GitServlet {
             // Add a hook that prevents illegal actions on push (delete branch, rename branch, force push).
             receivePack.setPreReceiveHook(new LocalVCPrePushHook());
             // Add a hook that triggers the creation of a new submission after the push went through successfully.
-            receivePack.setPostReceiveHook(new LocalVCPostPushHook(localCIConnectorService));
+            receivePack.setPostReceiveHook(new LocalVCPostPushHook(localVCServletService));
             return receivePack;
         });
     }

--- a/src/main/java/de/tum/in/www1/artemis/config/localvcci/JGitServletConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/localvcci/JGitServletConfiguration.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.config.localvcci;
 
-import java.util.Optional;
-
 import org.eclipse.jgit.http.server.GitServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,7 +8,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-import de.tum.in.www1.artemis.service.connectors.localci.LocalCIConnectorService;
 import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCServletService;
 
 /**
@@ -24,11 +21,8 @@ public class JGitServletConfiguration {
 
     private final LocalVCServletService localVCServletService;
 
-    private final Optional<LocalCIConnectorService> localCIConnectorService;
-
-    public JGitServletConfiguration(LocalVCServletService localVCServletService, Optional<LocalCIConnectorService> localCIConnectorService) {
+    public JGitServletConfiguration(LocalVCServletService localVCServletService) {
         this.localVCServletService = localVCServletService;
-        this.localCIConnectorService = localCIConnectorService;
     }
 
     /**
@@ -36,7 +30,7 @@ public class JGitServletConfiguration {
      */
     @Bean
     public ServletRegistrationBean<GitServlet> jgitServlet() {
-        ArtemisGitServlet gitServlet = new ArtemisGitServlet(localVCServletService, localCIConnectorService);
+        ArtemisGitServlet gitServlet = new ArtemisGitServlet(localVCServletService);
         log.info("Registering ArtemisGitServlet for handling fetch and push requests to [Artemis URL]/git/[Project Key]/[Repository Slug].git");
         return new ServletRegistrationBean<>(gitServlet, "/git/*");
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
-import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.HostConfig;
@@ -53,8 +52,6 @@ public class LocalCIBuildJobExecutionService {
 
     private final Optional<VersionControlService> versionControlService;
 
-    private final DockerClient dockerClient;
-
     private final LocalCIContainerService localCIContainerService;
 
     /**
@@ -68,11 +65,10 @@ public class LocalCIBuildJobExecutionService {
     @Value("${artemis.version-control.local-vcs-repo-path}")
     private String localVCBasePath;
 
-    public LocalCIBuildJobExecutionService(LocalCIBuildPlanService localCIBuildPlanService, Optional<VersionControlService> versionControlService, DockerClient dockerClient,
+    public LocalCIBuildJobExecutionService(LocalCIBuildPlanService localCIBuildPlanService, Optional<VersionControlService> versionControlService,
             LocalCIContainerService localCIContainerService, XMLInputFactory localCIXMLInputFactory) {
         this.localCIBuildPlanService = localCIBuildPlanService;
         this.versionControlService = versionControlService;
-        this.dockerClient = dockerClient;
         this.localCIContainerService = localCIContainerService;
         this.localCIXMLInputFactory = localCIXMLInputFactory;
     }
@@ -196,7 +192,7 @@ public class LocalCIBuildJobExecutionService {
         // Get an input stream of the test result files.
         TarArchiveInputStream testResultsTarInputStream;
         try {
-            testResultsTarInputStream = new TarArchiveInputStream(dockerClient.copyArchiveFromContainerCmd(containerId, testResultsPath).exec());
+            testResultsTarInputStream = localCIContainerService.getArchiveFromContainer(containerId, testResultsPath);
         }
         catch (NotFoundException e) {
             // If the test results are not found, this means that something went wrong during the build and testing of the submission.

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIConnectorService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIConnectorService.java
@@ -29,12 +29,7 @@ import de.tum.in.www1.artemis.exception.LocalCIException;
 import de.tum.in.www1.artemis.exception.VersionControlException;
 import de.tum.in.www1.artemis.exception.localvc.LocalVCInternalException;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
-import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
-import de.tum.in.www1.artemis.repository.SolutionProgrammingExerciseParticipationRepository;
-import de.tum.in.www1.artemis.repository.TemplateProgrammingExerciseParticipationRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
-import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.connectors.localci.dto.LocalCIBuildResult;
 import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCRepositoryUrl;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseGradingService;
@@ -70,17 +65,7 @@ public class LocalCIConnectorService {
 
     private final ProgrammingExerciseParticipationService programmingExerciseParticipationService;
 
-    private final ProgrammingExerciseStudentParticipationRepository studentParticipationRepository;
-
-    private final TemplateProgrammingExerciseParticipationRepository templateParticipationRepository;
-
-    private final SolutionProgrammingExerciseParticipationRepository solutionParticipationRepository;
-
     private final LocalCITriggerService localCITriggerService;
-
-    private final AuthorizationCheckService authorizationCheckService;
-
-    private final UserRepository userRepository;
 
     @Value("${artemis.version-control.url}")
     private URL localVCBaseUrl;
@@ -88,9 +73,7 @@ public class LocalCIConnectorService {
     public LocalCIConnectorService(ProgrammingExerciseRepository programmingExerciseRepository, ProgrammingSubmissionService programmingSubmissionService,
             ProgrammingMessagingService programmingMessagingService, ProgrammingTriggerService programmingTriggerService,
             LocalCIBuildJobManagementService localCIBuildJobManagementService, ProgrammingExerciseGradingService programmingExerciseGradingService,
-            ProgrammingExerciseParticipationService programmingExerciseParticipationService, ProgrammingExerciseStudentParticipationRepository studentParticipationRepository,
-            TemplateProgrammingExerciseParticipationRepository templateParticipationRepository, SolutionProgrammingExerciseParticipationRepository solutionParticipationRepository,
-            LocalCITriggerService localCITriggerService, AuthorizationCheckService authorizationCheckService, UserRepository userRepository) {
+            ProgrammingExerciseParticipationService programmingExerciseParticipationService, LocalCITriggerService localCITriggerService) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.programmingSubmissionService = programmingSubmissionService;
         this.programmingMessagingService = programmingMessagingService;
@@ -98,16 +81,11 @@ public class LocalCIConnectorService {
         this.localCIBuildJobManagementService = localCIBuildJobManagementService;
         this.programmingExerciseGradingService = programmingExerciseGradingService;
         this.programmingExerciseParticipationService = programmingExerciseParticipationService;
-        this.studentParticipationRepository = studentParticipationRepository;
-        this.templateParticipationRepository = templateParticipationRepository;
-        this.solutionParticipationRepository = solutionParticipationRepository;
         this.localCITriggerService = localCITriggerService;
-        this.authorizationCheckService = authorizationCheckService;
-        this.userRepository = userRepository;
     }
 
     /**
-     * Trigger the respective build and process the results.
+     * Create a submission, trigger the respective build, and process the results.
      *
      * @param commitHash the hash of the last commit.
      * @param repository the remote repository which was pushed to.
@@ -136,7 +114,8 @@ public class LocalCIConnectorService {
         ProgrammingExerciseParticipation participation;
 
         try {
-            participation = getParticipationForRepository(exercise, repositoryTypeOrUserName, localVCRepositoryUrl.isPracticeRepository(), true);
+            participation = programmingExerciseParticipationService.getParticipationForRepository(exercise, repositoryTypeOrUserName, localVCRepositoryUrl.isPracticeRepository(),
+                    true);
         }
         catch (EntityNotFoundException e) {
             throw new LocalCIException("Could not find participation for repository " + repositoryTypeOrUserName + " of exercise " + exercise, e);
@@ -297,63 +276,5 @@ public class LocalCIConnectorService {
         commit.setMessage(revCommit.getFullMessage());
 
         return commit;
-    }
-
-    /**
-     * Get the participation for a given exercise and a repository type or user name. This method is used by the local VC system and by the local CI system to get the
-     * participation.
-     *
-     * @param exercise                 the exercise for which to get the participation.
-     * @param repositoryTypeOrUserName the repository type ("exercise", "solution", or "tests") or username (e.g. "artemis_test_user_1") as extracted from the repository URL.
-     * @param isPracticeRepository     whether the repository is a practice repository, i.e. the repository URL contains "-practice-".
-     * @param withSubmissions          whether submissions should be loaded with the participation. This is needed for the local CI system.
-     * @return the participation.
-     * @throws EntityNotFoundException if the participation could not be found.
-     */
-    public ProgrammingExerciseParticipation getParticipationForRepository(ProgrammingExercise exercise, String repositoryTypeOrUserName, boolean isPracticeRepository,
-            boolean withSubmissions) {
-
-        // For pushes to the tests repository, the solution repository is built first, and thus we need the solution participation.
-        if (repositoryTypeOrUserName.equals(RepositoryType.SOLUTION.toString()) || repositoryTypeOrUserName.equals(RepositoryType.TESTS.toString())) {
-            if (withSubmissions) {
-                return solutionParticipationRepository.findWithEagerResultsAndSubmissionsByProgrammingExerciseIdElseThrow(exercise.getId());
-            }
-            else {
-                return solutionParticipationRepository.findByProgrammingExerciseIdElseThrow(exercise.getId());
-            }
-        }
-
-        if (repositoryTypeOrUserName.equals(RepositoryType.TEMPLATE.toString())) {
-            if (withSubmissions) {
-                return templateParticipationRepository.findWithEagerResultsAndSubmissionsByProgrammingExerciseIdElseThrow(exercise.getId());
-            }
-            else {
-                return templateParticipationRepository.findByProgrammingExerciseIdElseThrow(exercise.getId());
-            }
-        }
-
-        if (exercise.isTeamMode()) {
-            // The repositoryTypeOrUserName is the team short name.
-            // For teams, there is no practice participation.
-            return programmingExerciseParticipationService.findTeamParticipationByExerciseAndTeamShortNameOrThrow(exercise, repositoryTypeOrUserName, withSubmissions);
-        }
-
-        // If the exercise is an exam exercise and the repository's owner is at least an editor, the repository could be a test run repository, or it could be the instructor's
-        // assignment repository.
-        // There is no way to tell from the repository URL, and only one participation will be created, even if both are used.
-        // This participation has "testRun = true" set if the test run was created first, and "testRun = false" set if the instructor's assignment repository was created first.
-        // If the exercise is an exam exercise, and the repository's owner is at least an editor, get the participation without regard for the testRun flag.
-        boolean isExamEditorRepository = exercise.isExamExercise()
-                && authorizationCheckService.isAtLeastEditorForExercise(exercise, userRepository.getUserByLoginElseThrow(repositoryTypeOrUserName));
-        if (isExamEditorRepository) {
-            if (withSubmissions) {
-                return studentParticipationRepository.findWithSubmissionsByExerciseIdAndStudentLoginOrThrow(exercise.getId(), repositoryTypeOrUserName);
-            }
-
-            return studentParticipationRepository.findByExerciseIdAndStudentLoginOrThrow(exercise.getId(), repositoryTypeOrUserName);
-        }
-
-        return programmingExerciseParticipationService.findStudentParticipationByExerciseAndStudentLoginAndTestRunOrThrow(exercise, repositoryTypeOrUserName, isPracticeRepository,
-                withSubmissions);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -132,6 +132,17 @@ public class LocalCIContainerService {
     }
 
     /**
+     * Retrieve an archive from a running Docker container.
+     *
+     * @param containerId the id of the container.
+     * @param path        the path to the file or directory to be retrieved.
+     * @return a {@link TarArchiveInputStream} that can be used to read the archive.
+     */
+    public TarArchiveInputStream getArchiveFromContainer(String containerId, String path) {
+        return new TarArchiveInputStream(dockerClient.copyArchiveFromContainerCmd(containerId, path).exec());
+    }
+
+    /**
      * Retrieve the commit hash of the latest commit to a given repository on a given container for a given branch.
      * This is the commit hash that was checked out by the build job.
      *
@@ -143,8 +154,8 @@ public class LocalCIContainerService {
      */
     public String getCommitHashOfBranch(String containerId, LocalCIBuildJobExecutionService.LocalCIBuildJobRepositoryType repositoryType, String branchName) throws IOException {
         // Get an input stream of the file in .git folder of the repository that contains the current commit hash of the branch.
-        TarArchiveInputStream repositoryTarInputStream = new TarArchiveInputStream(
-                dockerClient.copyArchiveFromContainerCmd(containerId, "/repositories/" + repositoryType.toString() + "-repository/.git/refs/heads/" + branchName).exec());
+        TarArchiveInputStream repositoryTarInputStream = getArchiveFromContainer(containerId,
+                "/repositories/" + repositoryType.toString() + "-repository/.git/refs/heads/" + branchName);
         repositoryTarInputStream.getNextTarEntry();
         String commitHash = IOUtils.toString(repositoryTarInputStream, StandardCharsets.UTF_8).replace("\n", "");
         repositoryTarInputStream.close();

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCPostPushHook.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCPostPushHook.java
@@ -2,7 +2,6 @@ package de.tum.in.www1.artemis.service.connectors.localvc;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Optional;
 
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.PostReceiveHook;
@@ -11,17 +10,16 @@ import org.eclipse.jgit.transport.ReceivePack;
 
 import de.tum.in.www1.artemis.exception.LocalCIException;
 import de.tum.in.www1.artemis.exception.VersionControlException;
-import de.tum.in.www1.artemis.service.connectors.localci.LocalCIConnectorService;
 
 /**
  * Contains an onPostReceive method that is called by JGit after a push has been received (i.e. after the pushed files were successfully written to disk).
  */
 public class LocalVCPostPushHook implements PostReceiveHook {
 
-    private final Optional<LocalCIConnectorService> localCIConnectorService;
+    private final LocalVCServletService localVCServletService;
 
-    public LocalVCPostPushHook(Optional<LocalCIConnectorService> localCIConnectorService) {
-        this.localCIConnectorService = localCIConnectorService;
+    public LocalVCPostPushHook(LocalVCServletService localVCServletService) {
+        this.localVCServletService = localVCServletService;
     }
 
     /**
@@ -62,7 +60,7 @@ public class LocalVCPostPushHook implements PostReceiveHook {
         Repository repository = receivePack.getRepository();
 
         try {
-            localCIConnectorService.orElseThrow().processNewPush(commitHash, repository);
+            localVCServletService.processNewPush(commitHash, repository);
         }
         catch (LocalCIException e) {
             // Return an error message to the user.

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
@@ -20,6 +20,7 @@ import de.tum.in.www1.artemis.domain.enumeration.RepositoryType;
 import de.tum.in.www1.artemis.domain.participation.*;
 import de.tum.in.www1.artemis.exception.VersionControlException;
 import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlService;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
@@ -43,9 +44,14 @@ public class ProgrammingExerciseParticipationService {
 
     private final GitService gitService;
 
+    private final AuthorizationCheckService authorizationCheckService;
+
+    private final UserRepository userRepository;
+
     public ProgrammingExerciseParticipationService(SolutionProgrammingExerciseParticipationRepository solutionParticipationRepository,
             TemplateProgrammingExerciseParticipationRepository templateParticipationRepository, ProgrammingExerciseStudentParticipationRepository studentParticipationRepository,
-            ParticipationRepository participationRepository, TeamRepository teamRepository, GitService gitService, Optional<VersionControlService> versionControlService) {
+            ParticipationRepository participationRepository, TeamRepository teamRepository, GitService gitService, Optional<VersionControlService> versionControlService,
+            AuthorizationCheckService authorizationCheckService, UserRepository userRepository) {
         this.studentParticipationRepository = studentParticipationRepository;
         this.solutionParticipationRepository = solutionParticipationRepository;
         this.templateParticipationRepository = templateParticipationRepository;
@@ -53,6 +59,8 @@ public class ProgrammingExerciseParticipationService {
         this.teamRepository = teamRepository;
         this.versionControlService = versionControlService;
         this.gitService = gitService;
+        this.authorizationCheckService = authorizationCheckService;
+        this.userRepository = userRepository;
     }
 
     /**
@@ -303,5 +311,62 @@ public class ProgrammingExerciseParticipationService {
 
         gitService.stageAllChanges(targetRepo);
         gitService.commitAndPush(targetRepo, "Reset Exercise", true, null);
+    }
+
+    /**
+     * Get the participation for a given exercise and a repository type or user name. This method is used by the local VC system and by the local CI system to get the
+     * participation.
+     *
+     * @param exercise                 the exercise for which to get the participation.
+     * @param repositoryTypeOrUserName the repository type ("exercise", "solution", or "tests") or username (e.g. "artemis_test_user_1") as extracted from the repository URL.
+     * @param isPracticeRepository     whether the repository is a practice repository, i.e. the repository URL contains "-practice-".
+     * @param withSubmissions          whether submissions should be loaded with the participation. This is needed for the local CI system.
+     * @return the participation.
+     * @throws EntityNotFoundException if the participation could not be found.
+     */
+    public ProgrammingExerciseParticipation getParticipationForRepository(ProgrammingExercise exercise, String repositoryTypeOrUserName, boolean isPracticeRepository,
+            boolean withSubmissions) {
+
+        // For pushes to the tests repository, the solution repository is built first, and thus we need the solution participation.
+        if (repositoryTypeOrUserName.equals(RepositoryType.SOLUTION.toString()) || repositoryTypeOrUserName.equals(RepositoryType.TESTS.toString())) {
+            if (withSubmissions) {
+                return solutionParticipationRepository.findWithEagerResultsAndSubmissionsByProgrammingExerciseIdElseThrow(exercise.getId());
+            }
+            else {
+                return solutionParticipationRepository.findByProgrammingExerciseIdElseThrow(exercise.getId());
+            }
+        }
+
+        if (repositoryTypeOrUserName.equals(RepositoryType.TEMPLATE.toString())) {
+            if (withSubmissions) {
+                return templateParticipationRepository.findWithEagerResultsAndSubmissionsByProgrammingExerciseIdElseThrow(exercise.getId());
+            }
+            else {
+                return templateParticipationRepository.findByProgrammingExerciseIdElseThrow(exercise.getId());
+            }
+        }
+
+        if (exercise.isTeamMode()) {
+            // The repositoryTypeOrUserName is the team short name.
+            // For teams, there is no practice participation.
+            return findTeamParticipationByExerciseAndTeamShortNameOrThrow(exercise, repositoryTypeOrUserName, withSubmissions);
+        }
+
+        // If the exercise is an exam exercise and the repository's owner is at least an editor, the repository could be a test run repository, or it could be the instructor's
+        // assignment repository.
+        // There is no way to tell from the repository URL, and only one participation will be created, even if both are used.
+        // This participation has "testRun = true" set if the test run was created first, and "testRun = false" set if the instructor's assignment repository was created first.
+        // If the exercise is an exam exercise, and the repository's owner is at least an editor, get the participation without regard for the testRun flag.
+        boolean isExamEditorRepository = exercise.isExamExercise()
+                && authorizationCheckService.isAtLeastEditorForExercise(exercise, userRepository.getUserByLoginElseThrow(repositoryTypeOrUserName));
+        if (isExamEditorRepository) {
+            if (withSubmissions) {
+                return studentParticipationRepository.findWithSubmissionsByExerciseIdAndStudentLoginOrThrow(exercise.getId(), repositoryTypeOrUserName);
+            }
+
+            return studentParticipationRepository.findByExerciseIdAndStudentLoginOrThrow(exercise.getId(), repositoryTypeOrUserName);
+        }
+
+        return findStudentParticipationByExerciseAndStudentLoginAndTestRunOrThrow(exercise, repositoryTypeOrUserName, isPracticeRepository, withSubmissions);
     }
 }


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Description
This PR improves the the way some of the services connected to local VC and local CI are connected, cleaning up the architecture. No functionality is added or taken away.

### Steps for Testing

## Important: This PR only affects the local VC and local CI system, so you need to deploy it on [Test Server 11](https://artemis-test11.artemis.in.tum.de/) test server for the "localvc" and "localci" profiles to be active.

Prerequisites:
- 1 Instructor
- 1 Student

1. Log in to Artemis as the instructor
2. Navigate to Course Management
3. Create a programming exercise and make sure the template and solution repository are correctly built.
4. Log in as the student, clone the repository for the exercise to your local machine.
5. Push and make sure your changes are built correctly.

#### Exam Mode Testing

Prerequisites:
- 1 Instructor
- 1 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student and make sure your submission via the online editor is built correctly.

### Review Progress

#### Performance Review
- [x] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [x] Test 1
- [x] Test 2

### Test Coverage
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [ArtemisGitServlet.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS4937-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.config.localvcci/ArtemisGitServlet.html) | 100% | ✅ |
| [JGitServletConfiguration.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS4937-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.config.localvcci/JGitServletConfiguration.html) | 100% | ✅ |
| [LocalCIBuildJobExecutionService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS4937-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.connectors.localci/LocalCIBuildJobExecutionService.html) | 96% | ✅ |
| [LocalCIConnectorService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS4937-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.connectors.localci/LocalCIConnectorService.html) | 85% | ✅ |
| [LocalCIContainerService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS4937-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.connectors.localci/LocalCIContainerService.html) | 81% | ✅ |
| [LocalVCPostPushHook.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS4937-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.connectors.localvc/LocalVCPostPushHook.html) | 90% | ✅ |
| [LocalVCServletService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS4937-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.connectors.localvc/LocalVCServletService.html) | 94% | ✅ |
| [ProgrammingExerciseParticipationService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS4937-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.programming/ProgrammingExerciseParticipationService.html) | 73% | ✅ |