### PR TITLE
`Development`: Replace System.out.println() with Logger in server tests

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/TeamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TeamIntegrationTest.java
@@ -9,6 +9,8 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -51,6 +53,8 @@ class TeamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     private static final String TEST_PREFIX = "tit";
 
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
     @BeforeEach
     void initTestCase() {
         database.addUsers(TEST_PREFIX, NUMBER_OF_STUDENTS, 2, 0, 1);
@@ -91,7 +95,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         var teamAssignmentConfig = new TeamAssignmentConfig();
         teamAssignmentConfig.setExercise(exercise);
         assertThat(teamAssignmentConfig.getExercise()).isEqualTo(exercise);
-        System.out.println(teamAssignmentConfig);
+        log.debug(teamAssignmentConfig.toString());
         teamAssignmentConfig.setMinTeamSize(1);
         teamAssignmentConfig.setMaxTeamSize(10);
         exercise.setTeamAssignmentConfig(teamAssignmentConfig);

--- a/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
@@ -17,6 +17,8 @@ import org.gitlab4j.api.models.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -48,6 +50,8 @@ import de.tum.in.www1.artemis.service.connectors.gitlab.dto.GitLabPersonalAccess
 @Component
 @Profile("gitlab")
 public class GitlabRequestMockProvider {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Value("${artemis.version-control.default-branch:main}")
     protected String defaultBranch;
@@ -307,7 +311,7 @@ public class GitlabRequestMockProvider {
         final var mockedUserId = 1L;
         doReturn(mockedUserId).when(gitLabUserManagementService).getUserId(login);
         if (throwError) {
-            System.out.println("repositoryPath: " + repositoryPath + ", mockedUserId: " + mockedUserId);
+            log.debug("repositoryPath: {}, mockedUserId: {}", repositoryPath, mockedUserId);
             doThrow(new GitLabApiException("Bad Request", 400)).when(projectApi).addMember(repositoryPath, mockedUserId, DEVELOPER);
         }
         else {

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -1665,11 +1665,8 @@ class ProgrammingExerciseIntegrationTestService {
         var jplagZipArchive = request.getFile(path, HttpStatus.OK, database.getDefaultPlagiarismOptions());
         assertThat(jplagZipArchive).isNotNull();
         assertThat(jplagZipArchive).exists();
+
         try (ZipFile zipFile = new ZipFile(jplagZipArchive)) {
-            // var entries = zipFile.entries();
-            // while(entries.hasMoreElements()) {
-            // System.out.println(entries.nextElement().getName());
-            // }
             assertThat(zipFile.getEntry("overview.json")).isNotNull();
             assertThat(zipFile.getEntry("files/Submission-1.java/Submission-1.java")).isNotNull();
             assertThat(zipFile.getEntry("files/Submission-2.java/Submission-2.java")).isNotNull();

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -35,6 +35,8 @@ import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
@@ -89,6 +91,8 @@ import de.tum.in.www1.artemis.web.rest.dto.CourseForDashboardDTO;
  */
 @Service
 public class ProgrammingExerciseTestService {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Value("${artemis.version-control.default-branch:main}")
     protected String defaultBranch;
@@ -1930,7 +1934,7 @@ public class ProgrammingExerciseTestService {
             try (Git git = new Git(repository)) {
                 List<DiffEntry> diffs = git.diff().setNewTree(newTreeIter).setOldTree(oldTreeIter).call();
                 for (DiffEntry entry : diffs) {
-                    System.out.println("Entry: " + entry);
+                    log.debug("Entry: {}", entry.toString());
                 }
                 return diffs;
             }

--- a/src/test/java/de/tum/in/www1/artemis/quiz/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/quiz/QuizExerciseIntegrationTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
@@ -40,6 +42,8 @@ import de.tum.in.www1.artemis.web.websocket.QuizSubmissionWebsocketService;
 class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     private static final String TEST_PREFIX = "quizexerciseintegration";
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Autowired
     private QuizExerciseService quizExerciseService;
@@ -982,7 +986,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
         // calculate statistics
         quizExercise = request.get("/api/quiz-exercises/" + quizExercise.getId() + "/recalculate-statistics", HttpStatus.OK, QuizExercise.class);
 
-        System.out.println("QuizPointStatistic before re-evaluate: " + quizExercise.getQuizPointStatistic());
+        log.debug("QuizPointStatistic before re-evaluate: {}", quizExercise.getQuizPointStatistic());
 
         // check that the statistic is correct before any re-evaluate
         assertQuizPointStatisticsPointCounters(quizExercise, Map.of(0.0, pc30, 3.0, pc20, 4.0, pc20, 6.0, pc20, 7.0, pc10));
@@ -992,7 +996,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
                 QuizExercise.class, HttpStatus.OK);
         checkStatistics(quizExercise, quizExerciseWithReevaluatedStatistics);
 
-        System.out.println("QuizPointStatistic after re-evaluate (without changes): " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
+        log.debug("QuizPointStatistic after re-evaluate (without changes): {}", quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
 
         // remove wrong answer option and reevaluate
         var multipleChoiceQuestion = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
@@ -1010,7 +1014,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
         // one student should get a higher score
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().getPointCounters()).hasSameSizeAs(quizExercise.getQuizPointStatistic().getPointCounters());
-        System.out.println("QuizPointStatistic after 1st re-evaluate: " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
+        log.debug("QuizPointStatistic after 1st re-evaluate: {}", quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
 
         assertQuizPointStatisticsPointCounters(quizExerciseWithReevaluatedStatistics, Map.of(0.0, pc20, 3.0, pc20, 4.0, pc30, 6.0, pc20, 7.0, pc10));
 
@@ -1027,7 +1031,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
         // several students should get a higher score
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().getPointCounters()).hasSameSizeAs(quizExercise.getQuizPointStatistic().getPointCounters());
-        System.out.println("QuizPointStatistic after 2nd re-evaluate: " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
+        log.debug("QuizPointStatistic after 2nd re-evaluate: {}", quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
         assertQuizPointStatisticsPointCounters(quizExerciseWithReevaluatedStatistics, Map.of(2.0, pc20, 5.0, pc20, 6.0, pc50, 9.0, pc10));
 
         // delete a question and reevaluate
@@ -1041,7 +1045,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
         // max score should be less
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().getPointCounters()).hasSize(quizExercise.getQuizPointStatistic().getPointCounters().size() - 3);
-        System.out.println("QuizPointStatistic after 3rd re-evaluate: " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
+        log.debug("QuizPointStatistic after 3rd re-evaluate: {}", quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
         assertQuizPointStatisticsPointCounters(quizExerciseWithReevaluatedStatistics, Map.of(2.0, pc40, 6.0, pc60));
     }
 
@@ -1091,14 +1095,14 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
         // calculate statistics
         quizExercise = request.get("/api/quiz-exercises/" + quizExercise.getId() + "/recalculate-statistics", HttpStatus.OK, QuizExercise.class);
 
-        System.out.println("QuizPointStatistic before re-evaluate: " + quizExercise.getQuizPointStatistic());
+        log.debug("QuizPointStatistic before re-evaluate: {}", quizExercise.getQuizPointStatistic());
 
         // reevaluate without changing anything and check if statistics are still correct
         QuizExercise quizExerciseWithReevaluatedStatistics = request.putWithResponseBody("/api/quiz-exercises/" + quizExercise.getId() + "/re-evaluate/", quizExercise,
                 QuizExercise.class, HttpStatus.OK);
         checkStatistics(quizExercise, quizExerciseWithReevaluatedStatistics);
 
-        System.out.println("QuizPointStatistic after re-evaluate (without changes): " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
+        log.debug("QuizPointStatistic after re-evaluate (without changes): {}", quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
 
         // remove wrong answer option and reevaluate
         MultipleChoiceQuestion mc = (MultipleChoiceQuestion) quizExerciseWithReevaluatedStatistics.getQuizQuestions().get(0);
@@ -1110,7 +1114,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
         // one student should get a higher score
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().getPointCounters()).hasSameSizeAs(quizExercise.getQuizPointStatistic().getPointCounters());
 
-        System.out.println("QuizPointStatistic after 1st re-evaluate: " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
+        log.debug("QuizPointStatistic after 1st re-evaluate: {}", quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
 
         assertQuizPointStatisticsPointCounters(quizExerciseWithReevaluatedStatistics, Map.of(0.0, pc02, 3.0, pc02, 4.0, pc03, 6.0, pc02, 7.0, pc01));
 
@@ -1122,7 +1126,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
         // several students should get a higher score
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().getPointCounters()).hasSameSizeAs(quizExercise.getQuizPointStatistic().getPointCounters());
-        System.out.println("QuizPointStatistic after 2nd re-evaluate: " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
+        log.debug("QuizPointStatistic after 2nd re-evaluate: {}", quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
 
         assertQuizPointStatisticsPointCounters(quizExerciseWithReevaluatedStatistics, Map.of(2.0, pc02, 5.0, pc02, 6.0, pc05, 9.0, pc01));
 
@@ -1133,7 +1137,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
                 quizExerciseWithReevaluatedStatistics, QuizExercise.class, HttpStatus.OK);
 
         // max score should be less
-        System.out.println("QuizPointStatistic after 3rd re-evaluate: " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
+        log.debug("QuizPointStatistic after 3rd re-evaluate: {}", quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().getPointCounters()).hasSize(quizExercise.getQuizPointStatistic().getPointCounters().size() - 3);
 
         assertQuizPointStatisticsPointCounters(quizExerciseWithReevaluatedStatistics, Map.of(2.0, pc04, 6.0, pc06));
@@ -1906,22 +1910,22 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
             if (statistic instanceof MultipleChoiceQuestionStatistic mcStatistic) {
                 assertThat(mcStatistic.getAnswerCounters()).isNotEmpty();
                 for (var counter : mcStatistic.getAnswerCounters()) {
-                    System.out.println("AnswerCounters: " + counter.toString());
-                    System.out.println("MultipleChoiceQuestionStatistic: " + counter.getMultipleChoiceQuestionStatistic());
+                    log.debug("AnswerCounters: {}", counter.toString());
+                    log.debug("MultipleChoiceQuestionStatistic: {}", counter.getMultipleChoiceQuestionStatistic());
                 }
             }
             else if (statistic instanceof DragAndDropQuestionStatistic dndStatistic) {
                 assertThat(dndStatistic.getDropLocationCounters()).isNotEmpty();
                 for (var counter : dndStatistic.getDropLocationCounters()) {
-                    System.out.println("DropLocationCounters: " + counter.toString());
-                    System.out.println("DragAndDropQuestionStatistic: " + counter.getDragAndDropQuestionStatistic());
+                    log.debug("DropLocationCounters: {}", counter.toString());
+                    log.debug("DragAndDropQuestionStatistic: {}", counter.getDragAndDropQuestionStatistic());
                 }
             }
             else if (statistic instanceof ShortAnswerQuestionStatistic saStatistic) {
                 assertThat(saStatistic.getShortAnswerSpotCounters()).isNotEmpty();
                 for (var counter : saStatistic.getShortAnswerSpotCounters()) {
-                    System.out.println("ShortAnswerSpotCounters: " + counter.toString());
-                    System.out.println("ShortAnswerQuestionStatistic: " + counter.getShortAnswerQuestionStatistic());
+                    log.debug("ShortAnswerSpotCounters: {}", counter.toString());
+                    log.debug("ShortAnswerQuestionStatistic: {}", counter.getShortAnswerQuestionStatistic());
                 }
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -3892,23 +3892,23 @@ public class DatabaseUtilService {
 
             DragItem dragItem1 = ((DragAndDropQuestion) question).getDragItems().get(0);
             dragItem1.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dragItem1);
+            log.debug(dragItem1.toString());
             DragItem dragItem2 = ((DragAndDropQuestion) question).getDragItems().get(1);
             dragItem2.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dragItem2);
+            log.debug(dragItem2.toString());
             DragItem dragItem3 = ((DragAndDropQuestion) question).getDragItems().get(2);
             dragItem3.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dragItem3);
+            log.debug(dragItem3.toString());
 
             DropLocation dropLocation1 = ((DragAndDropQuestion) question).getDropLocations().get(0);
             dropLocation1.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dropLocation1);
+            log.debug(dropLocation1.toString());
             DropLocation dropLocation2 = ((DragAndDropQuestion) question).getDropLocations().get(1);
             dropLocation2.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dropLocation2);
+            log.debug(dropLocation2.toString());
             DropLocation dropLocation3 = ((DragAndDropQuestion) question).getDropLocations().get(2);
             dropLocation3.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dropLocation3);
+            log.debug(dropLocation3.toString());
 
             if (correct) {
                 submittedAnswer.addMappings(new DragAndDropMapping().dragItem(dragItem1).dropLocation(dropLocation1));
@@ -3963,23 +3963,23 @@ public class DatabaseUtilService {
 
             DragItem dragItem1 = ((DragAndDropQuestion) question).getDragItems().get(0);
             dragItem1.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dragItem1);
+            log.debug(dragItem1.toString());
             DragItem dragItem2 = ((DragAndDropQuestion) question).getDragItems().get(1);
             dragItem2.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dragItem2);
+            log.debug(dragItem2.toString());
             DragItem dragItem3 = ((DragAndDropQuestion) question).getDragItems().get(2);
             dragItem3.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dragItem3);
+            log.debug(dragItem3.toString());
 
             DropLocation dropLocation1 = ((DragAndDropQuestion) question).getDropLocations().get(0);
             dropLocation1.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dropLocation1);
+            log.debug(dropLocation1.toString());
             DropLocation dropLocation2 = ((DragAndDropQuestion) question).getDropLocations().get(1);
             dropLocation2.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dropLocation2);
+            log.debug(dropLocation2.toString());
             DropLocation dropLocation3 = ((DragAndDropQuestion) question).getDropLocations().get(2);
             dropLocation3.setQuestion((DragAndDropQuestion) question);
-            System.out.println(dropLocation3);
+            log.debug(dropLocation3.toString());
 
             submittedAnswer.addMappings(new DragAndDropMapping().dragItem(dragItem1).dropLocation(dropLocation1));
             submittedAnswer.addMappings(new DragAndDropMapping().dragItem(dragItem2).dropLocation(dropLocation3));
@@ -4143,8 +4143,8 @@ public class DatabaseUtilService {
         shortAnswerSpot1.addMappings(mapping1);
         assertThat(shortAnswerSolution1.getMappings()).isNotEmpty();
         assertThat(shortAnswerSpot1.getMappings()).isNotEmpty();
-        System.out.println(shortAnswerSolution1);
-        System.out.println(shortAnswerSpot1);
+        log.debug(shortAnswerSolution1.toString());
+        log.debug(shortAnswerSpot1.toString());
 
         var mapping2 = new ShortAnswerMapping().spot(sa.getSpots().get(1)).solution(sa.getSolutions().get(1));
         sa.addCorrectMapping(mapping1);
@@ -4155,8 +4155,8 @@ public class DatabaseUtilService {
         sa.setExplanation("Explanation");
         sa.setRandomizeOrder(true);
         // invoke some util methods
-        System.out.println("ShortAnswer: " + sa);
-        System.out.println("ShortAnswer.hashCode: " + sa.hashCode());
+        log.debug("ShortAnswer: {}", sa);
+        log.debug("ShortAnswer.hashCode: {}", sa.hashCode());
         sa.copyQuestionId();
         return sa;
     }
@@ -4209,8 +4209,8 @@ public class DatabaseUtilService {
         dnd.addCorrectMapping(mapping3);
         dnd.setExplanation("Explanation");
         // invoke some util methods
-        System.out.println("DnD: " + dnd);
-        System.out.println("DnD.hashCode: " + dnd.hashCode());
+        log.debug("DnD: {}", dnd);
+        log.debug("DnD.hashCode: {}", dnd.hashCode());
         dnd.copyQuestionId();
         return dnd;
     }
@@ -4227,8 +4227,8 @@ public class DatabaseUtilService {
         mc.getAnswerOptions().add(new AnswerOption().text("B").hint("H2").explanation("E2").isCorrect(false));
         mc.setExplanation("Explanation");
         // invoke some util methods
-        System.out.println("MC: " + mc);
-        System.out.println("MC.hashCode: " + mc.hashCode());
+        log.debug("MC: {}", mc);
+        log.debug("MC.hashCode: {}", mc.hashCode());
         mc.copyQuestionId();
         return mc;
     }


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] The changed server tests succeed locally and on bamboo.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
System.out.println() comes with more overhead than a logger. This is due to the fact that a logger only outputs when the output is free whereas System.out.println() interrupts the program until the output stream is free. Furthermore, using a Logger instead of System.out.println() is more consistent to the other tests.

### Description
In this PR, System.out.println() has been replaced with log.debug() for the server tests.
_Please note that there is still some occurrences of System.out.println() within the project, but those affect Programming Exercise templates and should not be changed._

### Steps for Testing
**Test changes only**

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2