### PR TITLE
`Development`: Fix flaky message group test

### DIFF
--- a/src/test/cypress/e2e/course/CourseMessages.cy.ts
+++ b/src/test/cypress/e2e/course/CourseMessages.cy.ts
@@ -362,7 +362,9 @@ describe('Course messages', () => {
             it('student should be able to write message in group chat', () => {
                 cy.login(studentOne, `/courses/${course.id}/messages?conversationId=${groupChat.id}`);
                 const messageText = 'Student Test Message';
+                cy.wait(2000);
                 courseMessages.writeMessage(messageText);
+                cy.wait(2000);
                 courseMessages.save().then((interception) => {
                     const message = interception.response!.body;
                     courseMessages.checkMessage(message.id, messageText);
@@ -374,7 +376,7 @@ describe('Course messages', () => {
                 const messageText = 'Student Edit Test Message';
                 courseManagementRequest.createCourseMessage(course, groupChat.id!, 'groupChat', messageText).then((response) => {
                     const message = response.body;
-                    const newMessage = 'Edited Text';
+                    const newMessage = ' Edited Text';
                     courseMessages.editMessage(message.id, newMessage);
                     courseMessages.checkMessage(message.id, newMessage);
                     courseMessages.checkMessage(message.id, 'edited by');

--- a/src/test/cypress/support/pageobjects/course/CourseMessages.ts
+++ b/src/test/cypress/support/pageobjects/course/CourseMessages.ts
@@ -124,6 +124,7 @@ export class CourseMessagesPage {
 
     editMessage(messageId: number, message: string) {
         this.getSinglePost(messageId).find('.editIcon').click();
+        cy.wait(500);
         this.getSinglePost(messageId).find('.markdown-editor').find('.ace_editor').click().type(message, { delay: 8 });
         cy.intercept(PUT, BASE_API + 'courses/*/messages/*').as('updateMessage');
         this.getSinglePost(messageId).find('#save').click();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the `student should be able to write message in group chat` fails. 

### Description
<!-- Describe your changes in detail -->
This PR fixes the flaky test by giving the input some seconds

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
