### PR TITLE
`Development`: Fix server start if notification relay is disabled

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/push_notifications/ApplePushNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/push_notifications/ApplePushNotificationService.java
@@ -22,7 +22,7 @@ public class ApplePushNotificationService extends PushNotificationService {
 
     private final PushNotificationDeviceConfigurationRepository repository;
 
-    @Value("${artemis.push-notification-relay:#{Optional.empty()}}")
+    @Value("${artemis.push-notification-relay:#{null}}")
     private Optional<String> relayServerBaseUrl;
 
     public ApplePushNotificationService(PushNotificationDeviceConfigurationRepository repository, RestTemplate restTemplate) {

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/push_notifications/FirebasePushNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/push_notifications/FirebasePushNotificationService.java
@@ -24,7 +24,7 @@ public class FirebasePushNotificationService extends PushNotificationService {
 
     private final PushNotificationDeviceConfigurationRepository repository;
 
-    @Value("${artemis.push-notification-relay:#{Optional.empty()}}")
+    @Value("${artemis.push-notification-relay:#{null}}")
     private Optional<String> relayServerBaseUrl;
 
     public FirebasePushNotificationService(PushNotificationDeviceConfigurationRepository pushNotificationDeviceConfigurationRepository, RestTemplate restTemplate) {
@@ -37,7 +37,6 @@ public class FirebasePushNotificationService extends PushNotificationService {
     void sendNotificationRequestsToEndpoint(List<RelayNotificationRequest> requests, String relayBaseUrl) {
         // The relay server accepts at most 500 messages per batch
         List<List<RelayNotificationRequest>> batches = Lists.partition(requests, 500);
-        ;
         var futures = batches.stream().map(batch -> CompletableFuture.runAsync(() -> sendSpecificNotificationRequestsToEndpoint(batch, relayBaseUrl))).toList()
                 .toArray(new CompletableFuture[0]);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
The Artemis server fails to start if the notification relay URL config (added in #6267) is missing.

### Description
Sets the default value for similar `Optional` config values as is done e.g. in https://github.com/ls1intum/Artemis/blob/4f326e30926a4b6b20ed41eb8c43370e27fede7f/src/main/java/de/tum/in/www1/artemis/config/SecurityConfiguration.java#L61

### Steps for Testing

1. Start Artemis locally.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2