### PR TITLE
`Communication`: Fix authorization error in courses without messaging

### DIFF
--- a/src/main/webapp/app/overview/course-overview.component.ts
+++ b/src/main/webapp/app/overview/course-overview.component.ts
@@ -104,7 +104,11 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
     }
 
     private setUpConversationService() {
-        if (isMessagingEnabled(this.course) && !this.conversationServiceInstantiated && this.messagesRouteLoaded) {
+        if (!isMessagingEnabled(this.course)) {
+            return;
+        }
+
+        if (!this.conversationServiceInstantiated && this.messagesRouteLoaded) {
             this.metisConversationService
                 .setUpConversationService(this.course!)
                 .pipe(takeUntil(this.ngUnsubscribe))

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -242,6 +242,8 @@ describe('CourseOverviewComponent', () => {
         const spy = jest.spyOn(metisConversationService, 'checkForUnreadMessages');
         metisConversationService._hasUnreadMessages$.next(hasNewMessages);
 
+        await component.ngOnInit();
+
         route.snapshot.firstChild!.routeConfig!.path = 'exercises';
         component.onSubRouteActivate({ controlConfiguration: undefined });
 

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -256,6 +256,22 @@ describe('CourseOverviewComponent', () => {
         });
     });
 
+    it('should not try to load message related data when not activated for course', () => {
+        const unreadMessagesSpy = jest.spyOn(metisConversationService, 'checkForUnreadMessages');
+        const setUpConversationServiceSpy = jest.spyOn(metisConversationService, 'setUpConversationService');
+
+        component.course = { courseInformationSharingConfiguration: CourseInformationSharingConfiguration.DISABLED };
+
+        const tabs = ['exercises', 'messages', 'exercises', 'messages'];
+        tabs.forEach((tab) => {
+            route.snapshot.firstChild!.routeConfig!.path = tab;
+            component.onSubRouteActivate({ controlConfiguration: undefined });
+        });
+
+        expect(unreadMessagesSpy).not.toHaveBeenCalled();
+        expect(setUpConversationServiceSpy).not.toHaveBeenCalled();
+    });
+
     it('should redirect to the registration page if the API endpoint returned a 403, but the user can register', fakeAsync(() => {
         // mock error response
         findOneForDashboardStub.mockReturnValue(


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix a bug when navigating into a course without messaging enabled

### Description
<!-- Describe your changes in detail -->
Currently the client always tried to check if there are unread messages, even when they were disabled in a course, which lead to an authorization error on the course page. This is now fixed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 2 users (instructors, students, ...) that are part in the courses
- 2 courses, one with messages enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. Check that you don't get an authorization error when navigating into the course without messaging
4. Check that you still see a red dot above the messaging tab when navigating into a course with messaging after you received a message there

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->