### PR TITLE
`Assessment`: Fix submissions breadcrumb

### DIFF
--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -544,6 +544,11 @@ export class NavbarComponent implements OnInit, OnDestroy {
                     this.addTranslationAsCrumb(currentPath, segment);
                 }
                 break;
+            case 'submissions':
+                // only a scores list exists, no special one for submissions
+                const updatedLink = currentPath.replace('/submissions/', '/scores/');
+                this.addTranslationAsCrumb(updatedLink, 'submissions');
+                break;
             default:
                 // Special cases:
                 if (this.lastRouteUrlSegment === 'user-management') {

--- a/src/test/javascript/spec/component/shared/navbar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/navbar.component.spec.ts
@@ -420,7 +420,7 @@ describe('NavbarComponent', () => {
             const submissionsCrumb = {
                 label: 'artemisApp.exercise.submissions',
                 translate: true,
-                uri: '/course-management/1/text-exercises/2/submissions/',
+                uri: '/course-management/1/text-exercises/2/scores/',
             } as MockBreadcrumb;
 
             const conflictCrumb = {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Closes #6676.

In #6110 the submissions table was removed and merged with the scores table. Therefore, the link to the submissions table in the breadcrumbs during the manual assessment of an exercise no longer works.

### Description
Updates the breadcrumbs to redirect to the scores page instead.

### Steps for Testing
Prerequisites:
- 1 Instructor/Tutor
- 1 Exercise with manual grading enabled (doesn’t matter if text/programming/file) and at least one student submission

1. Go to the manual assessment for the exercise. (Either via Assessment Dashboard, or the scores on the exercise details page).
2. Check that the breadcrumb for ‘Submissions’ (see screenshot in #6676) works and redirects to the ‘Scores’ table for the exercise.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| `navbar.component.ts` | changed lines covered| ✅                           |

### Screenshots
<img width="1728" alt="Bildschirmfoto 2023-06-06 um 19 35 41" src="https://github.com/ls1intum/Artemis/assets/53149143/b094c674-d501-4080-9469-3068228ca3ac">
