### PR TITLE
`Development`: Replace .collect(Collectors.toList()) with .toList() or Collectors.toCollection()

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -167,28 +167,6 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
     <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable"/>
     <rule ref="category/java/codestyle.xml/UselessQualifiedThis"/>
     <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate" />
-    <rule name="DontUseCollectorsToList"
-          language="java"
-          message="Don't use Collectors.toList()"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
-        <description>
-            <![CDATA[
-                Collectors.toList() should not be used.
-                Use the .toList() for an unmodifiable list or .collect(Collectors.toCollection(ArrayList::new)) for a modifiable list.
-            ]]>
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="version" value="2.0"/>
-            <property name="xpath">
-                <value>
-                    <![CDATA[
-                        //PrimaryPrefix[Name[@Image = "Collectors.toList" or @Image = "toList"]]
-                    ]]>
-                </value>
-            </property>
-        </properties>
-    </rule>
 
     // all JSP rules
     <rule ref="category/jsp/bestpractices.xml"/>

--- a/src/main/java/de/tum/in/www1/artemis/security/OAuth2JWKSService.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/OAuth2JWKSService.java
@@ -5,7 +5,6 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +69,7 @@ public class OAuth2JWKSService {
         List<JWK> keys = new ArrayList<>(jwkSet.getKeys());
 
         if (jwkToRemove != null) {
-            keys = keys.stream().filter(jwk -> jwk != jwkToRemove).collect(Collectors.toList());
+            keys = keys.stream().filter(jwk -> jwk != jwkToRemove).toList();
         }
 
         generateAndAddKey(clientRegistration, keys);

--- a/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupService.java
@@ -285,7 +285,7 @@ public class TutorialGroupService {
      */
     public List<TutorialGroup> findAllForNotifications(User user) {
         return courseRepository.findAllActiveWithTutorialGroupsWhereUserIsRegisteredOrTutor(ZonedDateTime.now(), user.getId()).stream()
-                .flatMap(course -> course.getTutorialGroups().stream()).collect(Collectors.toList());
+                .flatMap(course -> course.getTutorialGroups().stream()).toList();
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -6,6 +6,8 @@ import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 
@@ -57,5 +59,11 @@ class ArchitectureTest {
         ArchRule noJunitJupiterAssertions = noClasses().should().dependOnClassesThat().haveNameMatching("org.junit.jupiter.api.Assertions");
 
         noJunitJupiterAssertions.check(testClasses);
+    }
+
+    @Test
+    void testNoCollectorsToList() {
+        ArchRule foo = noClasses().should().callMethod(Collectors.class, "toList").because("You should use .toList() or .collect(Collectors.toCollection(ArrayList::new)) instead");
+        foo.check(allClasses);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/metis/AnswerMessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/AnswerMessageIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,7 +49,7 @@ class AnswerMessageIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
 
         List<Post> existingPostsWithAnswers = existingPostsAndConversationPostsWithAnswers.stream().filter(post -> post.getConversation() == null).toList();
 
-        existingConversationPostsWithAnswers = existingPostsAndConversationPostsWithAnswers.stream().filter(post -> post.getConversation() != null).collect(Collectors.toList());
+        existingConversationPostsWithAnswers = existingPostsAndConversationPostsWithAnswers.stream().filter(post -> post.getConversation() != null).toList();
 
         // get all existing posts with answers in exercise context
         List<Post> existingPostsWithAnswersInExercise = existingPostsWithAnswers.stream()

--- a/src/test/java/de/tum/in/www1/artemis/metis/ChannelIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ChannelIntegrationTest.java
@@ -704,7 +704,7 @@ class ChannelIntegrationTest extends AbstractConversationTest {
         // then
         database.changeUser(testPrefix + "student1");
         var channels = request.getList("/api/courses/" + exampleCourseId + "/channels/overview", HttpStatus.OK, ChannelDTO.class);
-        assertThat(channels.stream().map(ChannelDTO::getId).collect(Collectors.toList())).contains(publicChannelWhereMember.getId(), publicChannelWhereNotMember.getId(),
+        assertThat(channels.stream().map(ChannelDTO::getId).toList()).contains(publicChannelWhereMember.getId(), publicChannelWhereNotMember.getId(),
                 privateChannelWhereMember.getId());
 
         // cleanup
@@ -728,7 +728,7 @@ class ChannelIntegrationTest extends AbstractConversationTest {
         // then
         database.changeUser(testPrefix + "instructor2");
         var channels = request.getList("/api/courses/" + exampleCourseId + "/channels/overview", HttpStatus.OK, ChannelDTO.class);
-        assertThat(channels.stream().map(ChannelDTO::getId).collect(Collectors.toList())).contains(publicChannelWhereMember.getId(), publicChannelWhereNotMember.getId(),
+        assertThat(channels.stream().map(ChannelDTO::getId).toList()).contains(publicChannelWhereMember.getId(), publicChannelWhereNotMember.getId(),
                 privateChannelWhereMember.getId(), privateChannelWhereNotMember.getId());
 
         // cleanup

--- a/src/test/java/de/tum/in/www1/artemis/metis/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/MessageIntegrationTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.ZonedDateTime;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -116,10 +115,10 @@ class MessageIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJir
         existingConversationPosts = existingPostsAndConversationPosts.stream().filter(post -> post.getConversation() != null).toList();
 
         // filter existing posts with exercise context
-        existingExercisePosts = existingPosts.stream().filter(coursePost -> (coursePost.getExercise() != null)).collect(Collectors.toList());
+        existingExercisePosts = existingPosts.stream().filter(coursePost -> (coursePost.getExercise() != null)).toList();
 
         // filter existing posts with lecture context
-        existingLecturePosts = existingPosts.stream().filter(coursePost -> (coursePost.getLecture() != null)).collect(Collectors.toList());
+        existingLecturePosts = existingPosts.stream().filter(coursePost -> (coursePost.getLecture() != null)).toList();
 
         course = existingExercisePosts.get(0).getExercise().getCourseViaExerciseGroupOrCourseMember();
 

--- a/src/test/java/de/tum/in/www1/artemis/metis/PostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/PostIntegrationTest.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -109,7 +108,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         existingPosts = existingPostsAndConversationPosts.stream().filter(post -> post.getConversation() == null).toList();
 
-        existingCoursePosts = existingPosts.stream().filter(coursePost -> (coursePost.getPlagiarismCase() == null)).collect(Collectors.toList());
+        existingCoursePosts = existingPosts.stream().filter(coursePost -> (coursePost.getPlagiarismCase() == null)).toList();
 
         // filter existing posts with exercise context
         existingExercisePosts = existingPosts.stream().filter(coursePost -> (coursePost.getExercise() != null)).toList();

--- a/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
@@ -932,7 +932,7 @@ public class CourseTestService {
 
         // Perform the request that is being tested here
         List<CourseForDashboardDTO> coursesForDashboard = request.getList("/api/courses/for-dashboard", HttpStatus.OK, CourseForDashboardDTO.class);
-        List<Course> courses = coursesForDashboard.stream().map(CourseForDashboardDTO::course).collect(Collectors.toList());
+        List<Course> courses = coursesForDashboard.stream().map(CourseForDashboardDTO::course).toList();
 
         Course activeCourse = coursesCreated.get(0);
         Course inactiveCourse = coursesCreated.get(1);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#5312 already replaced all occurrences of `Collectors.toList()`and tried to add a static code analysis rule. This rule was not executed and some occurrences got back into the code base.

### Description
<!-- Describe your changes in detail -->
This PR now adds another test that actually checks for these occurrences and replaces the not working check.
All occurrences of Collectors.toList() are also fixed.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2