### PR TITLE
`Development`: Extend and refactor authorization tests

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ClientForwardResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ClientForwardResource.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import de.tum.in.www1.artemis.security.annotations.EnforceNothing;
+import de.tum.in.www1.artemis.security.annotations.ManualConfig;
 
 @Controller
 public class ClientForwardResource {
@@ -15,6 +16,7 @@ public class ClientForwardResource {
      */
     @RequestMapping({ "{path:[^\\.]*}", "{path:^(?!websocket).*}/**/{path:[^\\.]*}" })
     @EnforceNothing
+    @ManualConfig
     public String forward() {
         return "forward:/";
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/OAuth2JWKSResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/OAuth2JWKSResource.java
@@ -9,6 +9,7 @@ import com.google.gson.GsonBuilder;
 
 import de.tum.in.www1.artemis.security.OAuth2JWKSService;
 import de.tum.in.www1.artemis.security.annotations.EnforceNothing;
+import de.tum.in.www1.artemis.security.annotations.ManualConfig;
 
 /**
  * REST controller to serve the public JWKSet related to all OAuth2 clients.
@@ -24,6 +25,7 @@ public class OAuth2JWKSResource {
 
     @GetMapping(".well-known/jwks.json")
     @EnforceNothing
+    @ManualConfig
     public ResponseEntity<String> getJwkSet() {
         String keysAsJson = new GsonBuilder().setPrettyPrinting().create().toJson(jwksService.getJwkSet().toPublicJWKSet().toJSONObject());
         return new ResponseEntity<>(keysAsJson, HttpStatus.OK);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminImprintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminImprintResource.java
@@ -1,4 +1,4 @@
-package de.tum.in.www1.artemis.web.rest;
+package de.tum.in.www1.artemis.web.rest.admin;
 
 import javax.ws.rs.BadRequestException;
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminPrivacyStatementResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminPrivacyStatementResource.java
@@ -1,4 +1,4 @@
-package de.tum.in.www1.artemis.web.rest;
+package de.tum.in.www1.artemis.web.rest.admin;
 
 import javax.ws.rs.BadRequestException;
 

--- a/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationTest.java
@@ -1,17 +1,28 @@
 package de.tum.in.www1.artemis.authorization;
 
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
+import de.tum.in.www1.artemis.security.annotations.*;
 
 /**
  * Contains the one automatic test covering all rest endpoints for authorization tests.
@@ -24,6 +35,21 @@ class AuthorizationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest
     @Autowired
     private AuthorizationTestService authorizationTestService;
 
+    private static final String ARTEMIS_PACKAGE = "de.tum.in.www1.artemis";
+
+    private static final String REST_BASE_PACKAGE = ARTEMIS_PACKAGE + ".web.rest";
+
+    private static final String REST_ADMIN_PACKAGE = REST_BASE_PACKAGE + ".admin";
+
+    private static final String REST_OPEN_PACKAGE = REST_BASE_PACKAGE + ".open";
+
+    private static JavaClasses productionClasses;
+
+    @BeforeAll
+    static void loadClasses() {
+        productionClasses = new ClassFileImporter().withImportOption(new ImportOption.DoNotIncludeTests()).importPackages(ARTEMIS_PACKAGE);
+    }
+
     @Test
     void testEndpoints() throws InvocationTargetException, IllegalAccessException {
         var requestMappingHandlerMapping = applicationContext.getBean("requestMappingHandlerMapping", RequestMappingHandlerMapping.class);
@@ -33,5 +59,47 @@ class AuthorizationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         authorizationTestService.testEndpoints(endpointMap);
+    }
+
+    @Test
+    void testNoPreAuthorizeOnRestControllers() {
+        ArchRule rule = noClasses().that().areAnnotatedWith(RestController.class).should().beAnnotatedWith(PreAuthorize.class).because(
+                "All endpoints should be secured directly using the Artemis enforcement annotations on the method definition. Refer to the server guidelines in our documentation.");
+        rule.check(productionClasses);
+    }
+
+    @Test
+    void testNoPreAuthorizeOnRestEndpoints() {
+        ArchRule rule = noMethods().that().areDeclaredInClassesThat().areAnnotatedWith(RestController.class).should().beAnnotatedWith(PreAuthorize.class)
+                .because("All endpoints should be secured using the Artemis enforcement annotations. Refer to the server guidelines in our documentation.");
+        rule.check(productionClasses);
+    }
+
+    @Test
+    void testEnforceAtLeastInstructorAnnotations() {
+        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastInstructor.class).should().beDeclaredInClassesThat().resideInAPackage(REST_BASE_PACKAGE + ".*").andShould()
+                .beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + ".*", REST_OPEN_PACKAGE + ".*");
+        rule.evaluate(productionClasses);
+    }
+
+    @Test
+    void testEnforceAtLeastEditorAnnotations() {
+        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastEditor.class).should().beDeclaredInClassesThat().resideInAPackage(REST_BASE_PACKAGE + ".*").andShould()
+                .beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + ".*", REST_OPEN_PACKAGE + ".*");
+        rule.evaluate(productionClasses);
+    }
+
+    @Test
+    void testEnforceAtLeastTutorAnnotations() {
+        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastTutor.class).should().beDeclaredInClassesThat().resideInAPackage(REST_BASE_PACKAGE + ".*").andShould()
+                .beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + ".*", REST_OPEN_PACKAGE + ".*");
+        rule.evaluate(productionClasses);
+    }
+
+    @Test
+    void testEnforceAtLeastStudentAnnotations() {
+        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastStudent.class).should().beDeclaredInClassesThat().resideInAPackage(REST_BASE_PACKAGE + ".*").andShould()
+                .beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + ".*", REST_OPEN_PACKAGE + ".*");
+        rule.evaluate(productionClasses);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationTest.java
@@ -76,30 +76,44 @@ class AuthorizationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest
     }
 
     @Test
+    void testEnforceAdminAnnotations() {
+        ArchRule rule = methods().that().areAnnotatedWith(EnforceAdmin.class).and().areNotAnnotatedWith(ManualConfig.class).should().beDeclaredInClassesThat()
+                .resideInAPackage(REST_ADMIN_PACKAGE + "..");
+        rule.check(productionClasses);
+    }
+
+    @Test
     void testEnforceAtLeastInstructorAnnotations() {
-        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastInstructor.class).should().beDeclaredInClassesThat().resideInAPackage(REST_BASE_PACKAGE + ".*").andShould()
-                .beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + ".*", REST_OPEN_PACKAGE + ".*");
-        rule.evaluate(productionClasses);
+        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastInstructor.class).and().areNotAnnotatedWith(ManualConfig.class).should().beDeclaredInClassesThat()
+                .resideInAPackage(REST_BASE_PACKAGE + "..").andShould().beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + "..", REST_OPEN_PACKAGE + "..");
+        rule.check(productionClasses);
     }
 
     @Test
     void testEnforceAtLeastEditorAnnotations() {
-        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastEditor.class).should().beDeclaredInClassesThat().resideInAPackage(REST_BASE_PACKAGE + ".*").andShould()
-                .beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + ".*", REST_OPEN_PACKAGE + ".*");
-        rule.evaluate(productionClasses);
+        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastEditor.class).and().areNotAnnotatedWith(ManualConfig.class).should().beDeclaredInClassesThat()
+                .resideInAnyPackage(REST_BASE_PACKAGE + "..").andShould().beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + "..", REST_OPEN_PACKAGE + "..");
+        rule.check(productionClasses);
     }
 
     @Test
     void testEnforceAtLeastTutorAnnotations() {
-        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastTutor.class).should().beDeclaredInClassesThat().resideInAPackage(REST_BASE_PACKAGE + ".*").andShould()
-                .beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + ".*", REST_OPEN_PACKAGE + ".*");
-        rule.evaluate(productionClasses);
+        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastTutor.class).and().areNotAnnotatedWith(ManualConfig.class).should().beDeclaredInClassesThat()
+                .resideInAPackage(REST_BASE_PACKAGE + "..").andShould().beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + "..", REST_OPEN_PACKAGE + "..");
+        rule.check(productionClasses);
     }
 
     @Test
     void testEnforceAtLeastStudentAnnotations() {
-        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastStudent.class).should().beDeclaredInClassesThat().resideInAPackage(REST_BASE_PACKAGE + ".*").andShould()
-                .beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + ".*", REST_OPEN_PACKAGE + ".*");
-        rule.evaluate(productionClasses);
+        ArchRule rule = methods().that().areAnnotatedWith(EnforceAtLeastStudent.class).and().areNotAnnotatedWith(ManualConfig.class).should().beDeclaredInClassesThat()
+                .resideInAPackage(REST_BASE_PACKAGE + "..").andShould().beDeclaredInClassesThat().resideOutsideOfPackages(REST_ADMIN_PACKAGE + "..", REST_OPEN_PACKAGE + "..");
+        rule.check(productionClasses);
+    }
+
+    @Test
+    void testEnforceNothingAnnotations() {
+        ArchRule rule = methods().that().areAnnotatedWith(EnforceNothing.class).and().areNotAnnotatedWith(ManualConfig.class).should().beDeclaredInClassesThat()
+                .resideInAPackage(REST_OPEN_PACKAGE + "..");
+        rule.check(productionClasses);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
After setting package and path rules for Admin and Public annotations, we should also enforce them via tests to make everyone's life easier.

### Description
<!-- Describe your changes in detail -->
I added tests to check for this and fixed some occurrences:

- I moved the `AdminPrivacyStatementResource` and the `AdminImprintResource`
- I excluded `ClientForwardResource.forward()` and `OAuth2JWKSResource.getJwkSet()` from the tests

Additionally, I implemented @JohannesStoehr's suggestions replacing some of the tests with ArchTests.

#### Code Review
- [x] Code Review 1
- [x] Code Review 2