### PR TITLE
`Development`: Removed deprecated file upload endpoint

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
@@ -41,7 +41,6 @@ import de.tum.in.www1.artemis.service.FileService;
 import de.tum.in.www1.artemis.service.ResourceLoaderService;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
-import de.tum.in.www1.artemis.web.rest.lecture.AttachmentUnitResource;
 
 /**
  * REST controller for managing Files.
@@ -94,43 +93,6 @@ public class FileResource {
         this.authorizationCheckService = authorizationCheckService;
         this.examUserRepository = examUserRepository;
         this.slideRepository = slideRepository;
-    }
-
-    /**
-     * POST /fileUpload : Upload a new file.
-     *
-     * @param file         The file to save
-     * @param keepFileName specifies if original file name should be kept
-     * @return The path of the file
-     * @throws URISyntaxException if response path can't be converted into URI
-     * @deprecated Implement your own usage of {@link FileService#handleSaveFile(MultipartFile, boolean, boolean)} with a mixed multipart request instead. An example for this is
-     *             {@link AttachmentUnitResource#updateAttachmentUnit(Long, Long, AttachmentUnit, Attachment, MultipartFile, boolean, String)}
-     */
-    @Deprecated
-    @PostMapping("fileUpload")
-    @EnforceAtLeastTutor
-    public ResponseEntity<String> saveFile(@RequestParam(value = "file") MultipartFile file, @RequestParam(defaultValue = "false") boolean keepFileName) throws URISyntaxException {
-        log.debug("REST request to upload file : {}", file.getOriginalFilename());
-        String responsePath = fileService.handleSaveFile(file, keepFileName, false);
-
-        // return path for getting the file
-        String responseBody = "{\"path\":\"" + responsePath + "\"}";
-
-        return ResponseEntity.created(new URI(responsePath)).body(responseBody);
-
-    }
-
-    /**
-     * GET /files/temp/:filename : Get the temporary file with the given filename
-     *
-     * @param filename The filename of the file to get
-     * @return The requested file, or 404 if the file doesn't exist
-     */
-    @GetMapping("files/temp/{filename:.+}")
-    @EnforceAtLeastTutor
-    public ResponseEntity<byte[]> getTempFile(@PathVariable String filename) {
-        log.debug("REST request to get file : {}", filename);
-        return responseEntityForFilePath(FilePathService.getTempFilePath(), filename);
     }
 
     /**

--- a/src/main/webapp/app/shared/http/file-uploader.service.ts
+++ b/src/main/webapp/app/shared/http/file-uploader.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { MAX_FILE_SIZE } from 'app/shared/constants/input.constants';
 import { lastValueFrom } from 'rxjs';
-import { FILE_EXTENSIONS, MARKDOWN_FILE_EXTENSIONS } from 'app/shared/constants/file-extensions.constants';
+import { MARKDOWN_FILE_EXTENSIONS } from 'app/shared/constants/file-extensions.constants';
 
 export interface FileUploadResponse {
     path?: string;
@@ -15,39 +15,22 @@ type Options = {
 @Injectable({ providedIn: 'root' })
 export class FileUploaderService {
     readonly acceptedMarkdownFileExtensions = MARKDOWN_FILE_EXTENSIONS;
-    readonly acceptedFileExtensions = FILE_EXTENSIONS;
-
     constructor(private http: HttpClient) {}
 
     /**
-     * Uploads a generic file to the server.
-     */
-    uploadFile(file: Blob | File, fileName?: string, options?: Options): Promise<FileUploadResponse> {
-        return this.handleFileUpload('/api/fileUpload', this.acceptedFileExtensions, file, fileName, options);
-    }
-
-    /**
      * Uploads a file for the markdown editor to the server.
-     */
-    uploadMarkdownFile(file: Blob | File, fileName?: string, options?: Options): Promise<FileUploadResponse> {
-        return this.handleFileUpload('/api/markdown-file-upload', this.acceptedMarkdownFileExtensions, file, fileName, options);
-    }
-
-    /**
-     * Uploads a file to the server. It verifies the file extensions and file size.
-     * @param endpoint The API endpoint to upload the file to
-     * @param allowedExtensions The allowed extensions for the file
      * @param file The file to upload
      * @param fileName The name of the file
      * @param options The options dictionary (e.g, { keepFileName: true })
      * @return A promise with the response from the server or an error
-     * @private
      */
-    private handleFileUpload(endpoint: string, allowedExtensions: string[], file: Blob | File, fileName?: string, options?: Options): Promise<FileUploadResponse> {
+    uploadMarkdownFile(file: Blob | File, fileName?: string, options?: Options): Promise<FileUploadResponse> {
         const fileExtension = fileName ? fileName.split('.').pop()!.toLocaleLowerCase() : (file as File).name.split('.').pop()!.toLocaleLowerCase();
-        if (!allowedExtensions.includes(fileExtension)) {
+        if (!this.acceptedMarkdownFileExtensions.includes(fileExtension)) {
             return Promise.reject(
-                new Error('Unsupported file type! Only the following file extensions are allowed: ' + allowedExtensions.map((extension) => `.${extension}`).join(', ')),
+                new Error(
+                    'Unsupported file type! Only the following file extensions are allowed: ' + this.acceptedMarkdownFileExtensions.map((extension) => `.${extension}`).join(', '),
+                ),
             );
         }
 
@@ -58,6 +41,6 @@ export class FileUploaderService {
         const keepFileName = !!options?.keepFileName;
         const formData = new FormData();
         formData.append('file', file, fileName);
-        return lastValueFrom(this.http.post<FileUploadResponse>(endpoint + `?keepFileName=${keepFileName}`, formData));
+        return lastValueFrom(this.http.post<FileUploadResponse>(`/api/markdown-file-upload?keepFileName=${keepFileName}`, formData));
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
@@ -1,20 +1,32 @@
 package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.io.ByteArrayOutputStream;
 import java.time.ZonedDateTime;
+import java.util.Comparator;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.lecture.AttachmentUnit;
+import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
+import de.tum.in.www1.artemis.lecture.LectureFactory;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.user.UserUtilService;
@@ -37,6 +49,12 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Autowired
     private LectureUtilService lectureUtilService;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @BeforeEach
     void initTestCase() {
@@ -112,4 +130,136 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
     void testGetLecturePdfAttachmentsMerged_InvalidLectureId() throws Exception {
         request.get("/api/files/attachments/lecture/" + 999999999 + "/merge-pdf", HttpStatus.NOT_FOUND, byte[].class);
     }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void testGetLecturePdfAttachmentsMerged() throws Exception {
+        Lecture lecture = createLectureWithLectureUnits();
+        callAndCheckMergeResult(lecture, 5);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
+    void testGetLecturePdfAttachmentsMerged_TutorAccessToUnreleasedUnits() throws Exception {
+        Lecture lecture = createLectureWithLectureUnits();
+
+        adjustReleaseDateToFuture(lecture);
+
+        // The unit is hidden but a tutor can still see it
+        // -> the merged result should contain the unit
+        callAndCheckMergeResult(lecture, 5);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
+    void testGetLecturePdfAttachmentsMerged_NoAccessToUnreleasedUnits() throws Exception {
+        Lecture lecture = createLectureWithLectureUnits();
+
+        adjustReleaseDateToFuture(lecture);
+
+        // The test setup needs at least TA right for creating a lecture with files.
+        userUtilService.changeUser(TEST_PREFIX + "student1");
+
+        // The unit is hidden, students should not see it in the merged result
+        callAndCheckMergeResult(lecture, 2);
+    }
+
+    private void adjustReleaseDateToFuture(Lecture lecture) {
+        var attachment = lecture.getLectureUnits().stream().sorted(Comparator.comparing(LectureUnit::getId)).map(lectureUnit -> ((AttachmentUnit) lectureUnit).getAttachment())
+                .findFirst().orElseThrow();
+        attachment.setReleaseDate(ZonedDateTime.now().plusHours(2));
+        attachmentRepo.save(attachment);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
+    void testGetLecturePdfAttachmentsMerged_correctOrder() throws Exception {
+        Lecture lecture = createLectureWithLectureUnits();
+
+        // Change order of units
+        LectureUnit unit3 = lecture.getLectureUnits().get(2);
+        lecture.getLectureUnits().remove(unit3);
+        lecture.getLectureUnits().add(0, unit3);
+        lectureRepo.save(lecture);
+
+        // The test setup needs at least TA right for creating a lecture with files.
+        userUtilService.changeUser(TEST_PREFIX + "student1");
+
+        try (PDDocument mergedDoc = retrieveMergeResult(lecture)) {
+            assertThat(mergedDoc.getNumberOfPages()).isEqualTo(5);
+            PDPage firstPage = mergedDoc.getPage(0);
+            // Verify that attachment 3 (created with a special crop box in createLectureWithLectureUnits) was moved to the start
+            // and is now the first page of the merged pdf
+            assertThat(firstPage.getCropBox().getHeight()).isEqualTo(4);
+        }
+    }
+
+    private void callAndCheckMergeResult(Lecture lecture, int expectedPages) throws Exception {
+        try (PDDocument mergedDoc = retrieveMergeResult(lecture)) {
+            assertThat(mergedDoc.getNumberOfPages()).isEqualTo(expectedPages);
+        }
+    }
+
+    private PDDocument retrieveMergeResult(Lecture lecture) throws Exception {
+        byte[] receivedFile = request.get("/api/files/attachments/lecture/" + lecture.getId() + "/merge-pdf", HttpStatus.OK, byte[].class);
+
+        assertThat(receivedFile).isNotEmpty();
+        return PDDocument.load(receivedFile);
+    }
+
+    private Lecture createLectureWithLectureUnits() throws Exception {
+        String userLogin = userRepository.getUser().getLogin();
+        userUtilService.changeUser(TEST_PREFIX + "instructor1");
+
+        Lecture lecture = lectureUtilService.createCourseWithLecture(true);
+
+        lecture.setTitle("Test title");
+        lecture.setDescription("Test");
+        lecture.setStartDate(ZonedDateTime.now().minusHours(1));
+        lectureRepo.save(lecture);
+
+        // create pdf file 1
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(); PDDocument doc1 = new PDDocument()) {
+            doc1.addPage(new PDPage());
+            doc1.addPage(new PDPage());
+            doc1.addPage(new PDPage());
+            doc1.save(outputStream);
+            MockMultipartFile file1 = new MockMultipartFile("file", "file.pdf", "application/json", outputStream.toByteArray());
+            uploadAttachmentUnit(lecture.getId(), file1);
+        }
+
+        // create image file
+        MockMultipartFile file2 = new MockMultipartFile("file", "filename2.png", "application/json", "some text".getBytes());
+        uploadAttachmentUnit(lecture.getId(), file2);
+
+        // create pdf file 3
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(); PDDocument doc2 = new PDDocument()) {
+            // Add first page with extra cropBox to make it distinguishable in the later tests
+            PDPage page = new PDPage();
+            page.setCropBox(new PDRectangle(1, 2, 3, 4));
+            doc2.addPage(page);
+            doc2.addPage(new PDPage());
+            doc2.save(outputStream);
+            MockMultipartFile file3 = new MockMultipartFile("file", "filename3.pdf", "application/json", outputStream.toByteArray());
+            uploadAttachmentUnit(lecture.getId(), file3);
+        }
+
+        userUtilService.changeUser(userLogin);
+
+        return lectureRepo.findByIdWithLectureUnitsElseThrow(lecture.getId());
+    }
+
+    private void uploadAttachmentUnit(Long lectureId, MockMultipartFile file) throws Exception {
+        var attachmentUnit = new AttachmentUnit();
+        var attachment = LectureFactory.generateAttachment(null);
+        var attachmentUnitPart = new MockMultipartFile("attachmentUnit", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachmentUnit).getBytes());
+        var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachment).getBytes());
+
+        var builder = MockMvcRequestBuilders.multipart(HttpMethod.POST, "/api/lectures/" + lectureId + "/attachment-units").file(file).file(attachmentUnitPart).file(attachmentPart)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+        var result = request.getMvc().perform(builder).andExpect(status().is(HttpStatus.CREATED.value())).andReturn();
+
+        mapper.readValue(result.getResponse().getContentAsString(), AttachmentUnit.class);
+    }
+
 }

--- a/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
@@ -2,15 +2,8 @@ package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.file.Path;
 import java.time.ZonedDateTime;
-import java.util.Comparator;
-import java.util.List;
 
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,30 +13,15 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.enumeration.QuizMode;
 import de.tum.in.www1.artemis.domain.lecture.AttachmentUnit;
-import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
-import de.tum.in.www1.artemis.domain.quiz.DragAndDropQuestion;
-import de.tum.in.www1.artemis.domain.quiz.DragItem;
-import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
-import de.tum.in.www1.artemis.exercise.fileuploadexercise.FileUploadExerciseUtilService;
-import de.tum.in.www1.artemis.exercise.quizexercise.QuizExerciseUtilService;
-import de.tum.in.www1.artemis.lecture.LectureFactory;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
-import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.repository.*;
-import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.user.UserUtilService;
 
 class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     private static final String TEST_PREFIX = "fileintegration";
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private AttachmentRepository attachmentRepo;
@@ -52,46 +30,17 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
     private AttachmentUnitRepository attachmentUnitRepo;
 
     @Autowired
-    private QuizExerciseRepository quizExerciseRepository;
-
-    @Autowired
-    private QuizQuestionRepository quizQuestionRepository;
-
-    @Autowired
     private LectureRepository lectureRepo;
 
     @Autowired
     private UserUtilService userUtilService;
 
     @Autowired
-    private CourseUtilService courseUtilService;
-
-    @Autowired
-    private QuizExerciseUtilService quizExerciseUtilService;
-
-    @Autowired
-    private FileUploadExerciseUtilService fileUploadExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
-
-    @Autowired
     private LectureUtilService lectureUtilService;
 
     @BeforeEach
     void initTestCase() {
-        userUtilService.addUsers(TEST_PREFIX, 2, 2, 0, 1);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testSaveTempFile() throws Exception {
-        MockMultipartFile file = new MockMultipartFile("file", "file.png", "application/json", "some data".getBytes());
-        JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=false", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.CREATED);
-        String responsePath = response.get("path").asText();
-
-        String responseFile = request.get(responsePath, HttpStatus.OK, String.class);
-        assertThat(responseFile).isEqualTo("some data");
+        userUtilService.addUsers(TEST_PREFIX, 1, 1, 0, 1);
     }
 
     @Test
@@ -105,176 +54,6 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         assertThat(pythonReadme).isNotEmpty();
 
         request.get("/api/files/templates/randomnonexistingfile", HttpStatus.NOT_FOUND, String.class);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testGetCourseIcon() throws Exception {
-        Course course = courseUtilService.addEmptyCourse();
-        MockMultipartFile file = new MockMultipartFile("file", "icon.png", "application/json", "some data".getBytes());
-        JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=false", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.CREATED);
-        String responsePath = response.get("path").asText();
-        String iconPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, FilePathService.getCourseIconFilePath(), course.getId());
-
-        course.setCourseIcon(iconPath);
-        courseRepo.save(course);
-
-        String receivedIcon = request.get(iconPath, HttpStatus.OK, String.class);
-        assertThat(receivedIcon).isEqualTo("some data");
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testGetDragAndDropBackgroundFile() throws Exception {
-        Course course = courseUtilService.addEmptyCourse();
-        QuizExercise quizExercise = quizExerciseUtilService.createQuiz(course, ZonedDateTime.now(), null, QuizMode.SYNCHRONIZED);
-        DragAndDropQuestion dragAndDropQuestion = (DragAndDropQuestion) quizExercise.getQuizQuestions().get(1);
-        quizExerciseRepository.save(quizExercise);
-
-        MockMultipartFile file = new MockMultipartFile("file", "background.png", "application/json", "some data".getBytes());
-        JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=false", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.CREATED);
-        String responsePath = response.get("path").asText();
-        String backgroundPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, FilePathService.getDragAndDropBackgroundFilePath(), dragAndDropQuestion.getId());
-
-        dragAndDropQuestion.setBackgroundFilePath(backgroundPath);
-        courseRepo.save(course);
-        quizQuestionRepository.save(dragAndDropQuestion);
-
-        String receivedPath = request.get(backgroundPath, HttpStatus.OK, String.class);
-        assertThat(receivedPath).isEqualTo("some data");
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testGetDragItemFile() throws Exception {
-        Course course = courseUtilService.addEmptyCourse();
-        QuizExercise quizExercise = quizExerciseUtilService.createQuiz(course, ZonedDateTime.now(), null, QuizMode.SYNCHRONIZED);
-        DragAndDropQuestion dragAndDropQuestion = (DragAndDropQuestion) quizExercise.getQuizQuestions().get(1);
-        quizExerciseRepository.save(quizExercise);
-
-        DragItem dragItem = dragAndDropQuestion.getDragItems().get(0);
-        MockMultipartFile file = new MockMultipartFile("file", "background.png", "application/json", "some data".getBytes());
-        JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=false", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.CREATED);
-        String responsePath = response.get("path").asText();
-        String dragItemPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, FilePathService.getDragItemFilePath(), dragItem.getId());
-
-        dragItem.setPictureFilePath(dragItemPath);
-        courseRepo.save(course);
-        quizQuestionRepository.save(dragAndDropQuestion);
-
-        String receivedPath = request.get(dragItemPath, HttpStatus.OK, String.class);
-        assertThat(receivedPath).isEqualTo("some data");
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testGetFileUploadSubmission() throws Exception {
-        FileUploadSubmission fileUploadSubmission = createFileUploadSubmissionWithRealFile();
-        String receivedFile = request.get(fileUploadSubmission.getFilePath(), HttpStatus.OK, String.class);
-        assertThat(receivedFile).isEqualTo("some data");
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
-    void testGetFileUploadSubmissionAsTutor() throws Exception {
-        FileUploadSubmission fileUploadSubmission = createFileUploadSubmissionWithRealFile();
-
-        String receivedFile = request.get(fileUploadSubmission.getFilePath(), HttpStatus.OK, String.class);
-        assertThat(receivedFile).isEqualTo("some data");
-    }
-
-    private FileUploadSubmission createFileUploadSubmissionWithRealFile() throws Exception {
-        Course course = fileUploadExerciseUtilService.addCourseWithThreeFileUploadExercise();
-        FileUploadExercise fileUploadExercise = exerciseUtilService.findFileUploadExerciseWithTitle(course.getExercises(), "released");
-        FileUploadSubmission fileUploadSubmission = ParticipationFactory.generateFileUploadSubmission(true);
-        fileUploadSubmission = fileUploadExerciseUtilService.addFileUploadSubmission(fileUploadExercise, fileUploadSubmission, TEST_PREFIX + "student1");
-
-        MockMultipartFile file = new MockMultipartFile("file", "file.png", "application/json", "some data".getBytes());
-        JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=true", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.CREATED);
-        String responsePath = response.get("path").asText();
-        String filePath = fileService.manageFilesForUpdatedFilePath(null, responsePath,
-                FileUploadSubmission.buildFilePath(fileUploadExercise.getId(), fileUploadSubmission.getId()), fileUploadSubmission.getId(), true);
-
-        fileUploadSubmission.setFilePath(filePath);
-        return fileUploadSubmission;
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testGetLectureAttachment() throws Exception {
-        Attachment attachment = createLectureWithAttachment("attachment.pdf", HttpStatus.CREATED);
-        String attachmentPath = attachment.getLink();
-        String receivedAttachment = request.get(attachmentPath, HttpStatus.OK, String.class);
-        assertThat(receivedAttachment).isEqualTo("some data");
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
-    void testGetUnreleasedLectureAttachmentAsTutor() throws Exception {
-        Attachment attachment = createLectureWithAttachment("attachment.pdf", HttpStatus.CREATED);
-        String attachmentPath = attachment.getLink();
-        attachment.setReleaseDate(ZonedDateTime.now().plusDays(1));
-        String receivedAttachment = request.get(attachmentPath, HttpStatus.OK, String.class);
-        assertThat(receivedAttachment).isEqualTo("some data");
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testGetLectureAttachment_unsupportedFileType() throws Exception {
-        // this should return Unsupported file type
-        createLectureWithAttachment("attachment.abc", HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testGetLectureAttachment_mimeType() throws Exception {
-        Attachment attachment = createLectureWithAttachment("attachment.svg", HttpStatus.CREATED);
-        String attachmentPath = attachment.getLink();
-        String receivedAttachment = request.get(attachmentPath, HttpStatus.OK, String.class);
-        assertThat(receivedAttachment).isEqualTo("some data");
-    }
-
-    private Attachment createLectureWithAttachment(String filename, HttpStatus expectedStatus) throws Exception {
-        Lecture lecture = lectureUtilService.createCourseWithLecture(true);
-        lecture.setTitle("Test title");
-        lecture.setDescription("Test");
-        lecture.setStartDate(ZonedDateTime.now().minusHours(1));
-
-        Attachment attachment = LectureFactory.generateAttachment(ZonedDateTime.now());
-        attachment.setLecture(lecture);
-
-        // create file
-        MockMultipartFile file = new MockMultipartFile("file", filename, "application/json", "some data".getBytes());
-        // upload file
-        JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=true", file.getOriginalFilename(), "file", file, JsonNode.class, expectedStatus);
-        if (expectedStatus != HttpStatus.CREATED) {
-            return null;
-        }
-        String responsePath = response.get("path").asText();
-        // move file from temp folder to correct folder
-        var targetFolder = Path.of(FilePathService.getLectureAttachmentFilePath(), String.valueOf(lecture.getId())).toString();
-        String attachmentPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, targetFolder, lecture.getId(), true);
-
-        attachment.setLink(attachmentPath);
-        lecture.addAttachments(attachment);
-
-        lectureRepo.save(lecture);
-        attachmentRepo.save(attachment);
-        return attachment;
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testGetAttachmentUnit() throws Exception {
-        Lecture lecture = lectureUtilService.createCourseWithLecture(true);
-
-        MockMultipartFile file = new MockMultipartFile("file", "filename2.png", "application/json", "some data".getBytes());
-        AttachmentUnit attachmentUnit = uploadAttachmentUnit(file, HttpStatus.CREATED);
-        lectureUtilService.addLectureUnitsToLecture(lecture, List.of(attachmentUnit));
-
-        String attachmentPath = attachmentUnit.getAttachment().getLink();
-        String receivedAttachment = request.get(attachmentPath, HttpStatus.OK, String.class);
-        assertThat(receivedAttachment).isEqualTo("some data");
     }
 
     @Test
@@ -296,16 +75,6 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         attachmentUnitRepo.save(attachmentUnit);
 
         request.get(attachmentPath, HttpStatus.OK, String.class);
-    }
-
-    private AttachmentUnit createLectureWithAttachmentUnit() {
-        Lecture lecture = lectureUtilService.createCourseWithLecture(true);
-
-        AttachmentUnit attachmentUnit = lectureUtilService.createAttachmentUnit(true);
-        lecture.addLectureUnit(attachmentUnit);
-
-        lectureRepo.save(lecture);
-        return attachmentUnit;
     }
 
     @Test
@@ -339,181 +108,8 @@ class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
     }
 
     @Test
-    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void uploadFileAsStudentForbidden() throws Exception {
-        // create file
-        MockMultipartFile file = new MockMultipartFile("file", "image.png", "application/json", "some data".getBytes());
-        // upload file
-        request.postWithMultipartFile("/api/fileUpload?keepFileName=true", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.FORBIDDEN);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "student1", roles = "TA")
-    void uploadFileAsTutor() throws Exception {
-        // create file
-        MockMultipartFile file = new MockMultipartFile("file", "image.png", "application/json", "some data".getBytes());
-        // upload file
-        JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=true", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.CREATED);
-        String responsePath = response.get("path").asText();
-        assertThat(responsePath).contains("temp");
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void uploadFileUnsupportedFileExtension() throws Exception {
-        // create file
-        MockMultipartFile file = new MockMultipartFile("file", "something.exotic", "application/json", "some data".getBytes());
-        // upload file
-        request.postWithMultipartFile("/api/fileUpload?keepFileName=true", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     void testGetLecturePdfAttachmentsMerged_InvalidLectureId() throws Exception {
         request.get("/api/files/attachments/lecture/" + 999999999 + "/merge-pdf", HttpStatus.NOT_FOUND, byte[].class);
     }
-
-    @Test
-    @WithMockUser(username = "admin", roles = "ADMIN")
-    void testGetLecturePdfAttachmentsMerged() throws Exception {
-        Lecture lecture = createLectureWithLectureUnits();
-        callAndCheckMergeResult(lecture, 5);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
-    void testGetLecturePdfAttachmentsMerged_TutorAccessToUnreleasedUnits() throws Exception {
-        Lecture lecture = createLectureWithLectureUnits();
-
-        adjustReleaseDateToFuture(lecture);
-
-        // The unit is hidden but a tutor can still see it
-        // -> the merged result should contain the unit
-        callAndCheckMergeResult(lecture, 5);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
-    void testGetLecturePdfAttachmentsMerged_NoAccessToUnreleasedUnits() throws Exception {
-        Lecture lecture = createLectureWithLectureUnits();
-
-        adjustReleaseDateToFuture(lecture);
-
-        // The test setup needs at least TA right for creating a lecture with files.
-        userUtilService.changeUser(TEST_PREFIX + "student1");
-
-        // The unit is hidden, students should not see it in the merged result
-        callAndCheckMergeResult(lecture, 2);
-    }
-
-    private void adjustReleaseDateToFuture(Lecture lecture) {
-        var attachment = lecture.getLectureUnits().stream().sorted(Comparator.comparing(LectureUnit::getId)).map(lectureUnit -> ((AttachmentUnit) lectureUnit).getAttachment())
-                .findFirst().orElseThrow();
-        attachment.setReleaseDate(ZonedDateTime.now().plusHours(2));
-        attachmentRepo.save(attachment);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
-    void testGetLecturePdfAttachmentsMerged_correctOrder() throws Exception {
-        Lecture lecture = createLectureWithLectureUnits();
-
-        // Change order of units
-        LectureUnit unit3 = lecture.getLectureUnits().get(2);
-        lecture.getLectureUnits().remove(unit3);
-        lecture.getLectureUnits().add(0, unit3);
-        lectureRepo.save(lecture);
-
-        // The test setup needs at least TA right for creating a lecture with files.
-        userUtilService.changeUser(TEST_PREFIX + "student1");
-
-        try (PDDocument mergedDoc = retrieveMergeResult(lecture)) {
-            assertThat(mergedDoc.getNumberOfPages()).isEqualTo(5);
-            PDPage firstPage = mergedDoc.getPage(0);
-            // Verify that attachment 3 (created with a special crop box in createLectureWithLectureUnits) was moved to the start
-            // and is now the first page of the merged pdf
-            assertThat(firstPage.getCropBox().getHeight()).isEqualTo(4);
-        }
-    }
-
-    private void callAndCheckMergeResult(Lecture lecture, int expectedPages) throws Exception {
-        try (PDDocument mergedDoc = retrieveMergeResult(lecture)) {
-            assertThat(mergedDoc.getNumberOfPages()).isEqualTo(expectedPages);
-        }
-    }
-
-    private PDDocument retrieveMergeResult(Lecture lecture) throws Exception {
-        byte[] receivedFile = request.get("/api/files/attachments/lecture/" + lecture.getId() + "/merge-pdf", HttpStatus.OK, byte[].class);
-
-        assertThat(receivedFile).isNotEmpty();
-        return PDDocument.load(receivedFile);
-    }
-
-    private Lecture createLectureWithLectureUnits() throws Exception {
-        return createLectureWithLectureUnits(HttpStatus.CREATED);
-    }
-
-    private Lecture createLectureWithLectureUnits(HttpStatus expectedStatus) throws Exception {
-        Lecture lecture = lectureUtilService.createCourseWithLecture(true);
-
-        lecture.setTitle("Test title");
-        lecture.setDescription("Test");
-        lecture.setStartDate(ZonedDateTime.now().minusHours(1));
-        lectureRepo.save(lecture);
-
-        // create pdf file 1
-        AttachmentUnit unit1;
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(); PDDocument doc1 = new PDDocument()) {
-            doc1.addPage(new PDPage());
-            doc1.addPage(new PDPage());
-            doc1.addPage(new PDPage());
-            doc1.save(outputStream);
-            MockMultipartFile file1 = new MockMultipartFile("file", "file.pdf", "application/json", outputStream.toByteArray());
-            unit1 = uploadAttachmentUnit(file1, expectedStatus);
-        }
-
-        // create image file
-        MockMultipartFile file2 = new MockMultipartFile("file", "filename2.png", "application/json", "some text".getBytes());
-        AttachmentUnit unit2 = uploadAttachmentUnit(file2, expectedStatus);
-
-        // create pdf file 3
-        AttachmentUnit unit3;
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(); PDDocument doc2 = new PDDocument()) {
-            // Add first page with extra cropBox to make it distinguishable in the later tests
-            PDPage page = new PDPage();
-            page.setCropBox(new PDRectangle(1, 2, 3, 4));
-            doc2.addPage(page);
-            doc2.addPage(new PDPage());
-            doc2.save(outputStream);
-            MockMultipartFile file3 = new MockMultipartFile("file", "filename3.pdf", "application/json", outputStream.toByteArray());
-            unit3 = uploadAttachmentUnit(file3, expectedStatus);
-        }
-
-        lecture = lectureUtilService.addLectureUnitsToLecture(lecture, List.of(unit1, unit2, unit3));
-
-        return lecture;
-    }
-
-    private AttachmentUnit uploadAttachmentUnit(MockMultipartFile file, HttpStatus expectedStatus) throws Exception {
-
-        AttachmentUnit attachmentUnit = lectureUtilService.createAttachmentUnit(false);
-
-        // upload file
-        JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=true", file.getOriginalFilename(), "file", file, JsonNode.class, expectedStatus);
-        if (expectedStatus != HttpStatus.CREATED) {
-            return null;
-        }
-
-        String responsePath = response.get("path").asText();
-
-        // move file from temp folder to correct folder
-        var targetFolder = Path.of(FilePathService.getAttachmentUnitFilePath(), String.valueOf(attachmentUnit.getId())).toString();
-
-        String attachmentPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, targetFolder, attachmentUnit.getId(), true);
-        attachmentUnit.getAttachment().setLink(attachmentPath);
-        attachmentRepo.save(attachmentUnit.getAttachment());
-
-        return attachmentUnit;
-    }
-
 }

--- a/src/test/java/de/tum/in/www1/artemis/course/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/course/CourseTestService.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.IOException;
@@ -3090,6 +3092,11 @@ public class CourseTestService {
 
         var result = request.getMvc().perform(buildCreateCourse(course, "testIcon")).andExpect(status().isCreated()).andReturn();
         course = objectMapper.readValue(result.getResponse().getContentAsString(), Course.class);
+
+        assertThat(course.getCourseIcon()).as("Course icon got stored").isNotNull();
+        var imgResult = request.getMvc().perform(get(course.getCourseIcon())).andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM))
+                .andReturn();
+        assertThat(imgResult.getResponse().getContentAsByteArray()).isNotEmpty();
 
         var createdCourse = courseRepo.findByIdElseThrow(course.getId());
         assertThat(createdCourse.getCourseIcon()).as("Course icon got stored").isNotNull();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileuploadexercise/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileuploadexercise/FileUploadSubmissionIntegrationTest.java
@@ -1,6 +1,9 @@
 package de.tum.in.www1.artemis.exercise.fileuploadexercise;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -13,8 +16,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
@@ -169,6 +174,10 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationBambo
         var fileBytes = Files.readAllBytes(Path.of(actualFilePath));
         assertThat(fileBytes.length > 0).as("Stored file has content").isTrue();
         checkDetailsHidden(returnedSubmission, true);
+
+        MvcResult file = request.getMvc().perform(get(returnedSubmission.getFilePath())).andExpect(status().isOk()).andExpect(content().contentType(MediaType.IMAGE_PNG))
+                .andReturn();
+        assertThat(file.getResponse().getContentAsByteArray()).isEqualTo(validFile.getBytes());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quizexercise/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quizexercise/QuizExerciseIntegrationTest.java
@@ -2,7 +2,8 @@ package de.tum.in.www1.artemis.exercise.quizexercise;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.byLessThan;
-import static org.awaitility.Awaitility.await;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.security.Principal;
@@ -39,14 +40,10 @@ import de.tum.in.www1.artemis.domain.Team;
 import de.tum.in.www1.artemis.domain.TeamAssignmentConfig;
 import de.tum.in.www1.artemis.domain.enumeration.*;
 import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
-import de.tum.in.www1.artemis.domain.metis.ConversationParticipant;
-import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.quiz.*;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.*;
-import de.tum.in.www1.artemis.repository.metis.ConversationParticipantRepository;
-import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.ExerciseService;
 import de.tum.in.www1.artemis.service.QuizExerciseService;
@@ -98,12 +95,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @Autowired
-    private ChannelRepository channelRepository;
-
-    @Autowired
-    private ConversationParticipantRepository conversationParticipantRepository;
 
     @Autowired
     private UserUtilService userUtilService;
@@ -160,6 +151,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
     void testCreateQuizExercise(QuizMode quizMode) throws Exception {
         QuizExercise quizExercise = createQuizOnServer(ZonedDateTime.now().plusHours(5), null, quizMode);
         createdQuizAssert(quizExercise);
+        checkCreatedFiles(quizExercise);
     }
 
     @Test
@@ -167,6 +159,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
     void testCreateQuizExerciseForExam() throws Exception {
         QuizExercise quizExercise = createQuizOnServerForExam();
         createdQuizAssert(quizExercise);
+        checkCreatedFiles(quizExercise);
     }
 
     @Test
@@ -262,6 +255,28 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
             return objectMapper.readValue(result.getResponse().getContentAsString(), QuizExercise.class);
         }
         return null;
+    }
+
+    private void checkCreatedFiles(QuizExercise quizExercise) throws Exception {
+        List<DragAndDropQuestion> questions = quizExercise.getQuizQuestions().stream().filter(q -> q instanceof DragAndDropQuestion).map(q -> (DragAndDropQuestion) q).toList();
+        for (DragAndDropQuestion question : questions) {
+            if (question.getBackgroundFilePath() == null) {
+                continue;
+            }
+            checkCreatedFile(question.getBackgroundFilePath());
+            for (DragItem dragItem : question.getDragItems()) {
+                if (dragItem.getPictureFilePath() == null) {
+                    continue;
+                }
+                checkCreatedFile(dragItem.getPictureFilePath());
+            }
+        }
+    }
+
+    private void checkCreatedFile(String path) throws Exception {
+        MvcResult result = request.getMvc().perform(get(path)).andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM)).andReturn();
+        byte[] image = result.getResponse().getContentAsByteArray();
+        assertThat(image).isNotEmpty();
     }
 
     @Test
@@ -1132,7 +1147,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
     void importQuizExerciseToSameCourse() throws Exception {
         ZonedDateTime now = ZonedDateTime.now();
         QuizExercise quizExercise = quizExerciseUtilService.createQuiz(courseUtilService.addEmptyCourse(), now.plusHours(2), null, QuizMode.SYNCHRONIZED);
-        courseUtilService.enableMessagingForCourse(quizExercise.getCourseViaExerciseGroupOrCourseMember());
         quizExerciseService.handleDndQuizFileCreation(quizExercise,
                 List.of(new MockMultipartFile("files", "dragItemImage2.png", MediaType.IMAGE_PNG_VALUE, "dragItemImage".getBytes()),
                         new MockMultipartFile("files", "dragItemImage4.png", MediaType.IMAGE_PNG_VALUE, "dragItemImage".getBytes())));
@@ -1142,7 +1156,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
         assertThat(changedQuiz).isNotNull();
         changedQuiz.setTitle("New title");
         changedQuiz.setReleaseDate(now);
-        changedQuiz.setChannelName("testchannel-quiz");
 
         QuizExercise importedExercise = importQuizExerciseWithFiles(changedQuiz, changedQuiz.getId(), List.of(), HttpStatus.CREATED);
 
@@ -1153,16 +1166,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
                 .isEqualTo(quizExercise.getCourseViaExerciseGroupOrCourseMember().getId());
         assertThat(importedExercise.getCourseViaExerciseGroupOrCourseMember()).isEqualTo(quizExercise.getCourseViaExerciseGroupOrCourseMember());
         assertThat(importedExercise.getQuizQuestions()).as("Imported exercise has same number of questions").hasSameSizeAs(quizExercise.getQuizQuestions());
-
-        Channel channelDB = channelRepository.findChannelByExerciseId(importedExercise.getId());
-        assertThat(channelDB).isNotNull();
-        assertThat(channelDB.getName()).isEqualTo("testchannel-quiz");
-        // Check that the conversation participants are added correctly to the exercise channel
-        await().until(() -> {
-            SecurityUtils.setAuthorizationObject();
-            Set<ConversationParticipant> conversationParticipants = conversationParticipantRepository.findConversationParticipantByConversationId(channelDB.getId());
-            return conversationParticipants.size() == 4; // 1 student, 1 tutor, 1 instructor and 1 editor (see @BeforeEach)
-        });
     }
 
     /**
@@ -1178,14 +1181,11 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
                         new MockMultipartFile("files", "dragItemImage4.png", MediaType.IMAGE_PNG_VALUE, "dragItemImage".getBytes())));
         quizExerciseService.save(quizExercise);
 
-        courseUtilService.enableMessagingForCourse(quizExercise.getCourseViaExerciseGroupOrCourseMember());
-        quizExercise.setChannelName("testchannel-quiz" + UUID.randomUUID().toString().substring(0, 8));
+        Course course = courseUtilService.addEmptyCourse();
+        quizExercise.setCourse(course);
 
         QuizExercise importedExercise = importQuizExerciseWithFiles(quizExercise, quizExercise.getId(), List.of(), HttpStatus.CREATED);
-        assertThat(importedExercise.getCourseViaExerciseGroupOrCourseMember()).as("Quiz was imported for different course")
-                .isEqualTo(quizExercise.getCourseViaExerciseGroupOrCourseMember());
-        Channel channelDB = channelRepository.findChannelByExerciseId(importedExercise.getId());
-        assertThat(channelDB).isNotNull();
+        assertThat(importedExercise.getCourseViaExerciseGroupOrCourseMember()).as("Quiz was imported for different course").isEqualTo(course);
     }
 
     /**
@@ -1205,8 +1205,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
         QuizExercise importedExercise = importQuizExerciseWithFiles(quizExercise, quizExercise.getId(), List.of(), HttpStatus.CREATED);
         assertThat(importedExercise.getExerciseGroup()).as("Quiz was imported for different exercise group").isEqualTo(exerciseGroup);
-        Channel channelDB = channelRepository.findChannelByExerciseId(importedExercise.getId());
-        assertThat(channelDB).isNull();
     }
 
     /**
@@ -1239,7 +1237,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
                         new MockMultipartFile("files", "dragItemImage4.png", MediaType.IMAGE_PNG_VALUE, "dragItemImage".getBytes())));
         quizExerciseService.save(quizExercise);
         quizExercise.setCourse(course);
-        quizExercise.setChannelName("testchannel-quiz");
 
         QuizExercise importedExercise = importQuizExerciseWithFiles(quizExercise, quizExercise.getId(), List.of(), HttpStatus.CREATED);
         assertThat(importedExercise.getCourseViaExerciseGroupOrCourseMember()).isEqualTo(course);
@@ -1306,7 +1303,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
         Course course = courseUtilService.addEmptyCourse();
         changedQuiz.setCourse(course);
-        changedQuiz.setChannelName("testchannel-quiz");
         quizExerciseUtilService.setupTeamQuizExercise(changedQuiz, 1, 10);
 
         changedQuiz = importQuizExerciseWithFiles(changedQuiz, quizExercise.getId(), List.of(), HttpStatus.CREATED);
@@ -1353,7 +1349,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
         changedQuiz.setMode(ExerciseMode.INDIVIDUAL);
         Course course = courseUtilService.addEmptyCourse();
         changedQuiz.setCourse(course);
-        changedQuiz.setChannelName("testchannel-quiz");
 
         changedQuiz = importQuizExerciseWithFiles(changedQuiz, quizExercise.getId(), List.of(), HttpStatus.CREATED);
 
@@ -1382,7 +1377,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
         QuizExercise changedQuiz = quizExerciseRepository.findOneWithQuestionsAndStatistics(quizExercise.getId());
         assertThat(changedQuiz).isNotNull();
         changedQuiz.setQuizMode(QuizMode.INDIVIDUAL);
-        changedQuiz.setChannelName("testchannel-quiz");
 
         QuizExercise importedExercise = importQuizExerciseWithFiles(changedQuiz, quizExercise.getId(), List.of(), HttpStatus.CREATED);
 
@@ -1425,7 +1419,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
         MultipleChoiceQuestion question = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
         question.setExplanation("0".repeat(validityThreshold));
-        quizExercise.setChannelName("testchannel-quiz");
 
         createQuizExerciseWithFiles(quizExercise, HttpStatus.CREATED, true);
     }
@@ -1456,7 +1449,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
         MultipleChoiceQuestion question = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
         question.getAnswerOptions().get(0).setExplanation("0".repeat(validityThreshold));
-        quizExercise.setChannelName("testchannel-quiz");
 
         createQuizExerciseWithFiles(quizExercise, HttpStatus.CREATED, true);
     }
@@ -1572,22 +1564,11 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
     private QuizExercise createQuizOnServer(ZonedDateTime releaseDate, ZonedDateTime dueDate, QuizMode quizMode) throws Exception {
         QuizExercise quizExercise = quizExerciseUtilService.createQuiz(releaseDate, dueDate, quizMode);
         quizExercise.setDuration(3600);
-        quizExercise.setChannelName("channel-" + UUID.randomUUID().toString().substring(0, 8));
-        courseUtilService.enableMessagingForCourse(quizExercise.getCourseViaExerciseGroupOrCourseMember());
 
         QuizExercise quizExerciseServer = createQuizExerciseWithFiles(quizExercise, HttpStatus.CREATED, true);
         QuizExercise quizExerciseDatabase = quizExerciseRepository.findOneWithQuestionsAndStatistics(quizExerciseServer.getId());
         assertThat(quizExerciseServer).isNotNull();
         assertThat(quizExerciseDatabase).isNotNull();
-        Channel channelDB = channelRepository.findChannelByExerciseId(quizExerciseDatabase.getId());
-        assertThat(channelDB).isNotNull();
-
-        // Check that the conversation participants are added correctly to the exercise channel
-        await().until(() -> {
-            SecurityUtils.setAuthorizationObject();
-            Set<ConversationParticipant> conversationParticipants = conversationParticipantRepository.findConversationParticipantByConversationId(channelDB.getId());
-            return conversationParticipants.size() == 4; // 1 student, 1 tutor, 1 instructor and 1 editor (see @BeforeEach)
-        });
 
         checkQuizExercises(quizExercise, quizExerciseServer);
         checkQuizExercises(quizExercise, quizExerciseDatabase);
@@ -1621,9 +1602,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
         QuizExercise quizExerciseDatabase = quizExerciseRepository.findOneWithQuestionsAndStatistics(quizExerciseServer.getId());
         assertThat(quizExerciseServer).isNotNull();
         assertThat(quizExerciseDatabase).isNotNull();
-
-        Channel channelDB = channelRepository.findChannelByExerciseId(quizExercise.getId());
-        assertThat(channelDB).isNull();
 
         checkQuizExercises(quizExercise, quizExerciseServer);
         checkQuizExercises(quizExercise, quizExerciseDatabase);

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
@@ -2,6 +2,9 @@ package de.tum.in.www1.artemis.lecture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
@@ -71,6 +75,10 @@ class AttachmentResourceIntegrationTest extends AbstractSpringIntegrationBambooB
     void createAttachment() throws Exception {
         Attachment actualAttachment = request.postWithMultipartFile("/api/attachments", attachment, "attachment",
                 new MockMultipartFile("file", "test.txt", MediaType.TEXT_PLAIN_VALUE, "testContent".getBytes()), Attachment.class, HttpStatus.CREATED);
+        assertThat(actualAttachment.getLink()).isNotNull();
+        MvcResult file = request.getMvc().perform(get(actualAttachment.getLink())).andExpect(status().isOk()).andExpect(content().contentType(MediaType.TEXT_PLAIN_VALUE))
+                .andReturn();
+        assertThat(file.getResponse().getContentAsByteArray()).isNotEmpty();
         var expectedAttachment = attachmentRepository.findById(actualAttachment.getId()).orElseThrow();
         assertThat(actualAttachment).isEqualTo(expectedAttachment);
     }

--- a/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
@@ -439,6 +439,10 @@ public class RequestUtilService {
         return get(path, expectedStatus, responseType, params, new HttpHeaders());
     }
 
+    public File getFile(String path, HttpStatus expectedStatus) throws Exception {
+        return getFile(path, expectedStatus, new LinkedMultiValueMap<>());
+    }
+
     public File getFile(String path, HttpStatus expectedStatus, MultiValueMap<String, String> params) throws Exception {
         MvcResult res = mvc.perform(MockMvcRequestBuilders.get(new URI(path)).params(params).headers(new HttpHeaders())).andExpect(status().is(expectedStatus.value())).andReturn();
         restoreSecurityContext();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [X] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
#### Client
- [X] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
After replacing all uploads with multipart uploads, these two endpoints are not used anymore.

### Description
<!-- Describe your changes in detail -->
I removed the two endpoints from the server and all related tests. I also removed the endpoint from the client and simplified the corresponding service. I added some checks for the file retrieval to keep the test coverage stable.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

Confirm that the endpoints are not in use anymore.

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
