### PR TITLE
`Development`: Fix code-style issue in server tests

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -63,7 +63,8 @@ class ArchitectureTest {
 
     @Test
     void testNoCollectorsToList() {
-        ArchRule toListUsage = noClasses().should().callMethod(Collectors.class, "toList").because("You should use .toList() or .collect(Collectors.toCollection(ArrayList::new)) instead");
+        ArchRule toListUsage = noClasses().should().callMethod(Collectors.class, "toList")
+                .because("You should use .toList() or .collect(Collectors.toCollection(ArrayList::new)) instead");
         toListUsage.check(allClasses);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
Currently, our tests contain a code-style issue that causes the corresponding GitHub Action to fail.

### Description
Fixed formatting of Architecture Test. Now neither spotless nor eslint show any warnings 👍 

### Steps for Testing
Check if the tests pass as expected and that the Github Action does not fail anymore.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
