### PR TITLE
`Development`: Fix flaky RepositoryIntegrationTest

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.exercise.programmingexercise;
 
 import static de.tum.in.www1.artemis.util.RequestUtilService.parameters;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
@@ -801,7 +802,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
             // Convert the time in the logs set up above to UTC and round it to milliseconds for comparison.
             ZonedDateTime expectedTime = ZonedDateTime.ofInstant(logs.get(i).getTime().truncatedTo(ChronoUnit.MILLIS).toInstant(), ZoneId.of("UTC"));
             ZonedDateTime actualTime = receivedLogs.get(i).getTime().truncatedTo(ChronoUnit.MILLIS);
-            assertThat(actualTime).isEqualTo(expectedTime);
+            assertThat(actualTime).isCloseTo(expectedTime, within(1, ChronoUnit.MILLIS));
         }
     }
 


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] The changed server tests succeed **locally** and on **Bamboo** and on **GitHub Actions**.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
In RepositoryIntegrationTest, some tests failed in combination with MySQL. Upon investigation, it turned out that actual date values were exactly 1 Millis higher than the expected date values in 50 % of all cases. The difference is likely due to a difference in behavior between rounding and truncating.

### Description
In this PR, I fixed the comparison of the date values mentioned above by allowing a difference of up to 1 Millis between the expected and actual date values.

### Steps for Testing
**Test changes only**

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2