### PR TITLE
`Development`: Fix flaky ParticipantScoreIntegrationTest

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.awaitility.Awaitility.await;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -213,6 +214,9 @@ class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationBambooBit
         }
         participations = studentParticipationRepository.findByExerciseIdAndStudentId(idOfIndividualTextExercise, idOfStudent1);
         assertThat(participations).isNotEmpty();
+
+        await().pollInterval(10, TimeUnit.MILLISECONDS).until(() -> participantScoreScheduleService.isIdle());
+
         for (StudentParticipation studentParticipation : participations) {
             request.delete("/api/participations/" + studentParticipation.getId(), HttpStatus.OK);
         }


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] The changed server tests succeed **locally** and on **Bamboo** and on **GitHub Actions**.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
In RepositoryIntegrationTest, some tests failed in combination with MySQL and Postgres. Upon investigation, it turned out that after creating submissions, the ParticipantScoreScheduleService calculates and adds scores to the participant_score table and associates them with a result. If at the same time, we try to delete the associated result, the tests fail since the association to the result in participation_score becomes invalid.

### Description
In this PR, a delay has been introduced that waits for the ParticipantScoreScheduleService to finish its' tasks before deleting participations and results.

### Steps for Testing
**Test changes only**

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2