### PR TITLE
`Development`: Track number of server starts in server Integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         java-version: '${{ env.java }}'
         cache: 'gradle'
     - name: Check current dir
-      run: ls -a
+      run: ls -a supporting_scripts
     - name: Java Tests
       run: ./gradlew --console=plain test jacocoTestReport -x webapp jacocoTestCoverageVerification | tee tests.log
     - name: "Codacy: Report coverage"
@@ -88,7 +88,7 @@ jobs:
         reporter: java-junit
     - name: Number of Server Starts
       if: success() || failure()
-      run: bash /supporting_scripts/test.sh
+      run: bash supporting_scripts/test.sh
 
   server-tests-mysql:
       needs: [ server-tests ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,6 @@ jobs:
         distribution: 'temurin'
         java-version: '${{ env.java }}'
         cache: 'gradle'
-    - name: Check current dir
-      run: ls -a supporting_scripts
     - name: Java Tests
       run: ./gradlew --console=plain test jacocoTestReport -x webapp jacocoTestCoverageVerification | tee tests.log
     - name: "Codacy: Report coverage"
@@ -88,7 +86,7 @@ jobs:
         reporter: java-junit
     - name: Number of Server Starts
       if: success() || failure()
-      run: bash supporting_scripts/test.sh
+      run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-tests-mysql:
       needs: [ server-tests ]
@@ -132,7 +130,7 @@ jobs:
                 reporter: java-junit
           - name: Number of Server Starts
             if: success() || failure()
-            run: cat tests.log | grep "Interactive Learning with Individual Feedback" | wc -l
+            run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-tests-postgres:
       needs: [ server-tests ]
@@ -176,7 +174,7 @@ jobs:
                 reporter: java-junit
           - name: Number of Server Starts
             if: success() || failure()
-            run: cat tests.log | grep "Interactive Learning with Individual Feedback" | wc -l
+            run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         reporter: java-junit
     - name: Number of Server Starts
       if: success() || failure()
-      run: cat tests.log | grep "Interactive Learning with Individual Feedback" | wc -l
+      run: bash /supporting_scripts/test.sh
 
   server-tests-mysql:
       needs: [ server-tests ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         java-version: '${{ env.java }}'
         cache: 'gradle'
     - name: Java Tests
-      run: ./gradlew --console=plain test jacocoTestReport -x webapp jacocoTestCoverageVerification
+      run: ./gradlew --console=plain test jacocoTestReport -x webapp jacocoTestCoverageVerification | tee tests.log
     - name: "Codacy: Report coverage"
       uses: codacy/codacy-coverage-reporter-action@master
       with:
@@ -84,6 +84,9 @@ jobs:
         name: H2 Tests
         path: build/test-results/test/*.xml
         reporter: java-junit
+    - name: Number of Server Starts
+      if: success() || failure()
+      run: grep ':: Interactive Learning with Individual Feedback ::' tests.log | wc -l
 
   server-tests-mysql:
       needs: [ server-tests ]
@@ -125,6 +128,9 @@ jobs:
                 name: MySQL Tests
                 path: build/test-results/test/*.xml
                 reporter: java-junit
+          - name: Number of Server Starts
+            if: success() || failure()
+            run: grep ':: Interactive Learning with Individual Feedback ::' tests.log | wc -l
 
   server-tests-postgres:
       needs: [ server-tests ]
@@ -166,6 +172,9 @@ jobs:
                 name: PostgreSQL Tests
                 path: build/test-results/test/*.xml
                 reporter: java-junit
+          - name: Number of Server Starts
+            if: success() || failure()
+            run: grep ':: Interactive Learning with Individual Feedback ::' tests.log | wc -l
 
   server-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,8 @@ jobs:
         distribution: 'temurin'
         java-version: '${{ env.java }}'
         cache: 'gradle'
+    - name: Check current dir
+      run: ls -a
     - name: Java Tests
       run: ./gradlew --console=plain test jacocoTestReport -x webapp jacocoTestCoverageVerification | tee tests.log
     - name: "Codacy: Report coverage"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         reporter: java-junit
     - name: Number of Server Starts
       if: success() || failure()
-      run: grep ':: Interactive Learning with Individual Feedback ::' tests.log | wc -l
+      run: grep ":\:\ Interactive Learning with Individual Feedback :\:\" tests.log | wc -l
 
   server-tests-mysql:
       needs: [ server-tests ]
@@ -130,7 +130,7 @@ jobs:
                 reporter: java-junit
           - name: Number of Server Starts
             if: success() || failure()
-            run: grep ':: Interactive Learning with Individual Feedback ::' tests.log | wc -l
+            run: grep ":\:\ Interactive Learning with Individual Feedback :\:\" tests.log | wc -l
 
   server-tests-postgres:
       needs: [ server-tests ]
@@ -174,7 +174,7 @@ jobs:
                 reporter: java-junit
           - name: Number of Server Starts
             if: success() || failure()
-            run: grep ':: Interactive Learning with Individual Feedback ::' tests.log | wc -l
+            run: grep ":\:\ Interactive Learning with Individual Feedback :\:\" tests.log | wc -l
 
   server-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         reporter: java-junit
     - name: Number of Server Starts
       if: success() || failure()
-      run: grep ":\:\ Interactive Learning with Individual Feedback :\:\" tests.log | wc -l
+      run: cat tests.log | grep "Interactive Learning with Individual Feedback" | wc -l
 
   server-tests-mysql:
       needs: [ server-tests ]
@@ -130,7 +130,7 @@ jobs:
                 reporter: java-junit
           - name: Number of Server Starts
             if: success() || failure()
-            run: grep ":\:\ Interactive Learning with Individual Feedback :\:\" tests.log | wc -l
+            run: cat tests.log | grep "Interactive Learning with Individual Feedback" | wc -l
 
   server-tests-postgres:
       needs: [ server-tests ]
@@ -174,7 +174,7 @@ jobs:
                 reporter: java-junit
           - name: Number of Server Starts
             if: success() || failure()
-            run: grep ":\:\ Interactive Learning with Individual Feedback :\:\" tests.log | wc -l
+            run: cat tests.log | grep "Interactive Learning with Individual Feedback" | wc -l
 
   server-style:
     runs-on: ubuntu-latest

--- a/supporting_scripts/extract_number_of_server_starts.sh
+++ b/supporting_scripts/extract_number_of_server_starts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-numberOfStarts=$(grep ":: Interactive Learning with Individual Feedback ::" ../tests.log | wc -l)
+numberOfStarts=$(grep ":: Interactive Learning with Individual Feedback ::" tests.log | wc -l)
 echo "Number of Server Starts: $numberOfStarts"
 
 if [[ $numberOfStarts -gt 4 ]]

--- a/supporting_scripts/extract_number_of_server_starts.sh
+++ b/supporting_scripts/extract_number_of_server_starts.sh
@@ -9,7 +9,7 @@ then
   exit 1
 fi
 
-if [[ $numberOfStarts -gt 2 ]]
+if [[ $numberOfStarts -gt 4 ]]
 then
   echo "The number of Server Starts should not be greater than 4!"
   exit 1

--- a/supporting_scripts/extract_number_of_server_starts.sh
+++ b/supporting_scripts/extract_number_of_server_starts.sh
@@ -9,7 +9,7 @@ then
   exit 1
 fi
 
-if [[ $numberOfStarts -gt 4 ]]
+if [[ $numberOfStarts -gt 2 ]]
 then
   echo "The number of Server Starts should not be greater than 4!"
   exit 1

--- a/supporting_scripts/extract_number_of_server_starts.sh
+++ b/supporting_scripts/extract_number_of_server_starts.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-numberOfStarts=$(grep ":: Interactive Learning with Individual Feedback ::" tests.log | wc -l)
+numberOfStarts=$(grep ":: Powered by Spring Boot[^:]* ::" tests.log | wc -l)
 echo "Number of Server Starts: $numberOfStarts"
+
+if [[ $numberOfStarts -lt 1 ]]
+then
+  echo "Something went wrong, there should be at least one Server Start!"
+  exit 1
+fi
 
 if [[ $numberOfStarts -gt 4 ]]
 then

--- a/supporting_scripts/test.sh
+++ b/supporting_scripts/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+variable=$(grep "Interactive Learning with Individual Feedback" tests.log | wc -l)
+echo $variable
+
+if [[ $variable -gt 4 ]]
+then
+  echo "The number of Server Starts is greater than 4"
+else
+  echo "The number of Server Starts is not greater than 4"
+fi

--- a/supporting_scripts/test.sh
+++ b/supporting_scripts/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-variable=$(grep "Interactive Learning with Individual Feedback" tests.log | wc -l)
+variable=$(grep "Interactive Learning with Individual Feedback" ../tests.log | wc -l)
 echo $variable
 
 if [[ $variable -gt 4 ]]

--- a/supporting_scripts/test.sh
+++ b/supporting_scripts/test.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-variable=$(grep "Interactive Learning with Individual Feedback" ../tests.log | wc -l)
-echo $variable
+numberOfStarts=$(grep ":: Interactive Learning with Individual Feedback ::" ../tests.log | wc -l)
+echo "Number of Server Starts: $numberOfStarts"
 
-if [[ $variable -gt 4 ]]
+if [[ $numberOfStarts -gt 4 ]]
 then
-  echo "The number of Server Starts is greater than 4"
-else
-  echo "The number of Server Starts is not greater than 4"
+  echo "The number of Server Starts should not be greater than 4!"
+  exit 1
 fi


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Restarting the server when the tests are run is very time expensive and we want to ensure it does not happen too often. If it does, the newly added task `Number of Server Starts` fails.

### Description
<!-- Describe your changes in detail -->
This PR adds a task tracking how many times the server has been started in tests. The task fails if the server has been started more than 4 times. Additionally, the number of starts is printed to the console.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
