### PR TITLE
`Tutorial groups`: Fix missing translation on tutorial group detail page

### DIFF
--- a/src/main/webapp/i18n/en/tutorialGroups.json
+++ b/src/main/webapp/i18n/en/tutorialGroups.json
@@ -52,7 +52,7 @@
                 "utilizationHelpDetail": "Average attendance divided by capacity",
                 "averageAttendance": "Average attendance: {{ averageAttendance }}",
                 "averageAttendanceDetail": "Average Attendance",
-                "averageAttendanceDetailHelp": "Average attendance in the last three sessions. If no attendance is entered, the corresponding session is ignored and the calculation is performed with two or one session."
+                "averageAttendanceHelpDetail": "Average attendance in the last three sessions. If no attendance is entered, the corresponding session is ignored and the calculation is performed with two or one session."
             },
             "tutorialGroupSchedule": {
                 "dayOfWeek": "Day of Week",


### PR DESCRIPTION

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
In today's testing session we found a missing translation on the tutorial group detail page.

### Description
The requested translation key is called `averageAttendanceHelpDetail`, however, the English translation file used `averageAttendanceDetailHelp`. The german translation was already working.

### Steps for Testing
1. Nagivage to a tutorial group detail view as a student (course -> tutorial groups -> select a group)
2. Hover over the `Average Attendance` headline to read the tooltip
3. Verify that the translation works

### Review Progress

- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/5c6873b1-7aac-4691-8761-bd5908fdc482)

![grafik](https://github.com/ls1intum/Artemis/assets/26540346/be0e54db-5c74-4220-a48b-6d15ce79e4cd)


