### PR TITLE
`Tutorial Groups`: Ensure consistent button styles in tutorial group creation view

### DIFF
--- a/src/main/webapp/app/course/tutorial-groups/tutorial-groups-management/tutorial-groups/crud/tutorial-group-form/tutorial-group-form.component.html
+++ b/src/main/webapp/app/course/tutorial-groups/tutorial-groups-management/tutorial-groups/crud/tutorial-group-form/tutorial-group-form.component.html
@@ -37,10 +37,10 @@
                 <label class="d-block">{{ 'artemisApp.forms.tutorialGroupForm.isOnlineInput.label' | artemisTranslate }}</label>
                 <div class="btn-group" role="group">
                     <input formControlName="isOnline" type="radio" class="btn-check" id="online" autocomplete="off" checked [value]="true" />
-                    <label class="btn btn-secondary" for="online">{{ 'artemisApp.generic.online' | artemisTranslate }}</label>
+                    <label class="btn btn-outline-primary" for="online">{{ 'artemisApp.generic.online' | artemisTranslate }}</label>
 
                     <input formControlName="isOnline" type="radio" class="btn-check" id="offline" autocomplete="off" [value]="false" />
-                    <label class="btn btn-secondary" for="offline">{{ 'artemisApp.generic.offline' | artemisTranslate }}</label>
+                    <label class="btn btn-outline-primary" for="offline">{{ 'artemisApp.generic.offline' | artemisTranslate }}</label>
                 </div>
             </div>
             <!-- Teaching Assistant -->

--- a/src/main/webapp/content/scss/themes/theme-default.scss
+++ b/src/main/webapp/content/scss/themes/theme-default.scss
@@ -34,6 +34,7 @@ html {
 // Needed for highlighting code in the markdown editor
 @import 'node_modules/highlight.js/styles/vs.css';
 
+// Added to match the already existing style in theme-dark.scss
 .btn-outline-primary:not(.list-group-item) {
     color: $link-color;
 }

--- a/src/main/webapp/content/scss/themes/theme-default.scss
+++ b/src/main/webapp/content/scss/themes/theme-default.scss
@@ -33,3 +33,11 @@ html {
 
 // Needed for highlighting code in the markdown editor
 @import 'node_modules/highlight.js/styles/vs.css';
+
+.btn-outline-primary:not(.list-group-item) {
+    color: $link-color;
+}
+
+.btn-outline-primary:not(.list-group-item):hover {
+    color: black;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
This PR solves a small issue: https://github.com/ls1intum/Artemis/issues/6447
The problem pointed that regarding Mode picker and Language were already solved.

### Description
From the issue:
<img width="504" alt="image" src="https://github.com/ls1intum/Artemis/assets/24391701/47790b59-370f-4f74-83e5-92f688997b2c">
----------
I changed it to match the existing style (for Schedule) on that page regarding so that it is consistent.

**New Style:**
<img width="497" alt="image" src="https://github.com/ls1intum/Artemis/assets/24391701/31ce1239-0fda-4136-ab6b-543c3264f1eb">

**Matches the:** 
<img width="654" alt="image" src="https://github.com/ls1intum/Artemis/assets/24391701/3ebde77e-4231-4ee3-8670-c61dcdc58601">

**on the same page.**

### Steps for Testing
To Reproduce:
1. Go to Tutorial Groups
2. Create a New tutor group.



### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
