### PR TITLE
`Development`: Prevent usage of anonymous users

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/security/SecurityUtils.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/SecurityUtils.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -60,7 +61,7 @@ public final class SecurityUtils {
     }
 
     private static String extractPrincipal(Authentication authentication) {
-        if (authentication == null) {
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
             return null;
         }
         else if (authentication.getPrincipal() instanceof UserDetails springSecurityUser) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There were some issues on production where there was an actual anonymous user created by Spring. We don't want such a user as we want a fully authenticated user wherever we use the identity of such.

### Description
<!-- Describe your changes in detail -->
Whenever retrieving the username to check for the existence of a user, we now return null for the anonymous user which prevents the usage of the very same.

Public endpoints and programming submissions still work, so unless tests fail there is nothing to manually review.