### PR TITLE
`Development`: Fix flaky GitServiceTest

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitServiceTest.java
@@ -110,12 +110,6 @@ class GitServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         assertThat(gitService.getOriginHead(repo)).isEqualTo(defaultBranch);
     }
 
-    // TODO Remove this method (just here to temporarily isolate flaky test)
-    // @RepeatedTest(1000)
-    void testPushSourceToTargetRepoWithoutBranchFlaky() throws GitAPIException, IOException {
-        this.testPushSourceToTargetRepoWithoutBranch("someOtherName");
-    }
-
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @ValueSource(strings = { "master", "main", "someOtherName" })
     void testPushSourceToTargetRepoWithoutBranch(String defaultBranch) throws GitAPIException, IOException {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitServiceTest.java
@@ -110,6 +110,12 @@ class GitServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         assertThat(gitService.getOriginHead(repo)).isEqualTo(defaultBranch);
     }
 
+    // TODO Remove this method (just here to temporarily isolate flaky test)
+    // @RepeatedTest(1000)
+    void testPushSourceToTargetRepoWithoutBranchFlaky() throws GitAPIException, IOException {
+        this.testPushSourceToTargetRepoWithoutBranch("someOtherName");
+    }
+
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @ValueSource(strings = { "master", "main", "someOtherName" })
     void testPushSourceToTargetRepoWithoutBranch(String defaultBranch) throws GitAPIException, IOException {

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -99,26 +99,35 @@ public class GitUtilService {
     }
 
     public void deleteRepos() {
-        try {
-            if (remoteRepo != null) {
-                remoteRepo.close();
-            }
-            if (localRepo != null) {
-                localRepo.close();
-            }
-            if (localGit != null) {
-                localGit.close();
-            }
-            if (remoteGit != null) {
-                remoteGit.close();
-            }
-            FileUtils.deleteDirectory(localPath.toFile());
-            FileUtils.deleteDirectory(remotePath.toFile());
-            localRepo = null;
-            remoteRepo = null;
+        if (remoteRepo != null) {
+            remoteRepo.close();
         }
-        catch (IOException ignored) {
+        if (localRepo != null) {
+            localRepo.close();
         }
+        if (localGit != null) {
+            localGit.close();
+        }
+        if (remoteGit != null) {
+            remoteGit.close();
+        }
+        while (FileUtils.isDirectory(localPath.toFile())) {
+            try {
+                FileUtils.deleteDirectory(localPath.toFile());
+            }
+            catch (IOException ignored) {
+            }
+        }
+        localRepo = null;
+
+        while (FileUtils.isDirectory(remotePath.toFile())) {
+            try {
+                FileUtils.deleteDirectory(remotePath.toFile());
+            }
+            catch (IOException ignored) {
+            }
+        }
+        remoteRepo = null;
     }
 
     public void deleteRepo(REPOS repo) {

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -113,28 +113,31 @@ public class GitUtilService {
         if (remoteGit != null) {
             remoteGit.close();
         }
-        while (FileUtils.isDirectory(localPath.toFile())) {
-            try {
-                FileUtils.deleteDirectory(localPath.toFile());
-            }
-            catch (IOException ignored) {
-            }
-        }
-        localRepo = null;
 
-        for (int i = 0; i < 10 && FileUtils.isDirectory(remotePath.toFile()); i++) {
-            try {
-                FileUtils.deleteDirectory(remotePath.toFile());
-            }
-            catch (IOException ignored) {
-            }
+        try {
+            tryToDeleteDirectory(localPath);
+            localRepo = null;
+            tryToDeleteDirectory(remotePath);
+            remoteRepo = null;
         }
+        catch (Exception e) {
+            fail("Failed while deleting the repositories", e);
+        }
+    }
 
-        if (FileUtils.isDirectory(remotePath.toFile())) {
-            fail("Could not delete directory with path " + remotePath);
+    private void tryToDeleteDirectory(Path path) throws Exception {
+        if (FileUtils.isDirectory(path.toFile())) {
+            FileUtils.deleteDirectory(path.toFile());
         }
 
-        remoteRepo = null;
+        for (int i = 0; i < 10 && FileUtils.isDirectory(path.toFile()); i++) {
+            Thread.sleep(10);
+            FileUtils.deleteDirectory(path.toFile());
+        }
+
+        if (FileUtils.isDirectory(path.toFile())) {
+            fail("Could not delete directory with path " + path);
+        }
     }
 
     public void deleteRepo(REPOS repo) {

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -1,5 +1,7 @@
 package de.tum.in.www1.artemis.util;
 
+import static org.assertj.core.api.Fail.fail;
+
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -120,13 +122,18 @@ public class GitUtilService {
         }
         localRepo = null;
 
-        while (FileUtils.isDirectory(remotePath.toFile())) {
+        for (int i = 0; i < 10 && FileUtils.isDirectory(remotePath.toFile()); i++) {
             try {
                 FileUtils.deleteDirectory(remotePath.toFile());
             }
             catch (IOException ignored) {
             }
         }
+
+        if (FileUtils.isDirectory(remotePath.toFile())) {
+            fail("Could not delete directory with path " + remotePath);
+        }
+
         remoteRepo = null;
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -126,13 +126,13 @@ public class GitUtilService {
     }
 
     private void tryToDeleteDirectory(Path path) throws Exception {
-        if (FileUtils.isDirectory(path.toFile())) {
-            FileUtils.deleteDirectory(path.toFile());
-        }
-
         for (int i = 0; i < 10 && FileUtils.isDirectory(path.toFile()); i++) {
-            Thread.sleep(10);
-            FileUtils.deleteDirectory(path.toFile());
+            try {
+                FileUtils.deleteDirectory(path.toFile());
+            }
+            catch (IOException e) {
+                Thread.sleep(10);
+            }
         }
 
         if (FileUtils.isDirectory(path.toFile())) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
`GitServiceTest.testPushSourceToTargetRepoWithoutBranch(String) [3]` is flaky.

### Description
<!-- Describe your changes in detail -->
When deleting the directory of the repositories it might (VERY RARELY) happen, that a file is currently still locked by the OS. Hence, the directory was only partially deleted.
We now try to delete the directory until this process completed successfully.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

