### PR TITLE
`Development`: Fix locked state for programming exercises started after exam start

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -1,5 +1,7 @@
 package de.tum.in.www1.artemis.service;
 
+import static de.tum.in.www1.artemis.service.scheduled.ProgrammingExerciseScheduleService.getExamProgrammingExerciseUnlockDate;
+
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -234,9 +236,10 @@ public class ParticipationService {
     }
 
     private StudentParticipation startProgrammingParticipation(ProgrammingExercise exercise, ProgrammingExerciseStudentParticipation participation, boolean setInitializationDate) {
-        // Step 1b) Lock the participation, if it is for an exam which has not started yet.
+        // Step 1b) Lock the participation, if it is for an upcoming exam (the participation gets created during the prepare exercise start step)
         // For course exercises, this is not necessary, as students can only create their participation after the start date.
-        if (exercise.isExamExercise() && !exercise.getExerciseGroup().getExam().isStarted()) {
+        // Also don't lock the participation if it's past the unlock date (the scheduled unlocking job already finished)
+        if (exercise.isExamExercise() && ZonedDateTime.now().isBefore(getExamProgrammingExerciseUnlockDate(exercise))) {
             participation.setLocked(true);
         }
         // Step 1c) configure the student repository (e.g. access right, etc.)

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.service;
 
-import static de.tum.in.www1.artemis.service.scheduled.ProgrammingExerciseScheduleService.getExamProgrammingExerciseUnlockDate;
-
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -236,12 +234,6 @@ public class ParticipationService {
     }
 
     private StudentParticipation startProgrammingParticipation(ProgrammingExercise exercise, ProgrammingExerciseStudentParticipation participation, boolean setInitializationDate) {
-        // Step 1b) Lock the participation, if it is for an upcoming exam (the participation gets created during the prepare exercise start step)
-        // For course exercises, this is not necessary, as students can only create their participation after the start date.
-        // Also don't lock the participation if it's past the unlock date (the scheduled unlocking job already finished)
-        if (exercise.isExamExercise() && ZonedDateTime.now().isBefore(getExamProgrammingExerciseUnlockDate(exercise))) {
-            participation.setLocked(true);
-        }
         // Step 1c) configure the student repository (e.g. access right, etc.)
         participation = configureRepository(exercise, participation);
         // Step 2a) create the build plan (based on the BASE build plan)

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -234,8 +234,9 @@ public class ParticipationService {
     }
 
     private StudentParticipation startProgrammingParticipation(ProgrammingExercise exercise, ProgrammingExerciseStudentParticipation participation, boolean setInitializationDate) {
-        // Step 1b) Lock the participation, if it is for an exam. For course exercises, this is not necessary, as students can only create their participation after the start date.
-        if (exercise.isExamExercise()) {
+        // Step 1b) Lock the participation, if it is for an exam which has not started yet.
+        // For course exercises, this is not necessary, as students can only create their participation after the start date.
+        if (exercise.isExamExercise() && !exercise.getExerciseGroup().getExam().isStarted()) {
             participation.setLocked(true);
         }
         // Step 1c) configure the student repository (e.g. access right, etc.)

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
@@ -496,11 +496,15 @@ public class StudentExamService {
                     }
                     generatedParticipations.add(participation);
                     // Unlock repository and participation only if the real exam starts within 5 minutes or if we have a test exam or test run
-                    if (exercise instanceof ProgrammingExercise programmingExercise && (studentExam.isTestRun() || studentExam.isTestExam()
-                            || ProgrammingExerciseScheduleService.getExamProgrammingExerciseUnlockDate(programmingExercise).isBefore(ZonedDateTime.now()))) {
-                        // Note: only unlock the programming exercise student repository for the affected user (Important: Do NOT invoke unlockAll)
-                        programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(programmingExercise,
-                                (ProgrammingExerciseStudentParticipation) participation);
+                    if (participation instanceof ProgrammingExerciseStudentParticipation programmingParticipation && exercise instanceof ProgrammingExercise programmingExercise) {
+                        if (studentExam.isTestRun() || studentExam.isTestExam()
+                                || ProgrammingExerciseScheduleService.getExamProgrammingExerciseUnlockDate(programmingExercise).isBefore(ZonedDateTime.now())) {
+                            // Note: only unlock the programming exercise student repository for the affected user (Important: Do NOT invoke unlockAll)
+                            programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(programmingExercise, programmingParticipation);
+                        }
+                        else {
+                            programmingExerciseParticipationService.lockStudentParticipation(programmingExercise, programmingParticipation);
+                        }
                     }
                     log.info("SUCCESS: Start exercise for student exam {} and exercise {} and student {}", studentExam.getId(), exercise.getId(),
                             student.getParticipantIdentifier());

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -618,8 +618,6 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
             ProgrammingExercise programmingExercise = createProgrammingExercise();
 
             participationUtilService.mockCreationOfExerciseParticipation(programmingExercise, versionControlService, continuousIntegrationService);
-            mockConnectorRequestsForStartParticipation(programmingExercise, student1.getLogin(), Set.of(student1), true);
-            mockConnectorRequestsForStartParticipation(programmingExercise, student2.getLogin(), Set.of(student2), true);
 
             createStudentExams(programmingExercise);
 
@@ -660,8 +658,6 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
             ProgrammingExercise programmingExercise = createProgrammingExercise();
 
             participationUtilService.mockCreationOfExerciseParticipation(programmingExercise, versionControlService, continuousIntegrationService);
-            mockConnectorRequestsForStartParticipation(programmingExercise, student1.getLogin(), Set.of(student1), true);
-            mockConnectorRequestsForStartParticipation(programmingExercise, student2.getLogin(), Set.of(student2), true);
 
             createStudentExams(programmingExercise);
 
@@ -675,7 +671,6 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
                 assertThat(participation.getSubmissions()).isEmpty();
                 // The participation should not get locked if it gets created after the exam already started
                 assertThat(((ProgrammingExerciseParticipation) participation).isLocked()).isFalse();
-                // TODO this currently gets invoked two times
                 verify(versionControlService, atLeast(1)).configureRepository(eq(programmingExercise), (ProgrammingExerciseStudentParticipation) eq(participation), eq(true));
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -48,9 +48,7 @@ import de.tum.in.www1.artemis.domain.metis.ConversationParticipant;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
-import de.tum.in.www1.artemis.domain.participation.Participation;
-import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
-import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
+import de.tum.in.www1.artemis.domain.participation.*;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismCase;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismVerdict;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
@@ -634,6 +632,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
                 // No initial submissions should be created for programming exercises
                 assertThat(participation.getSubmissions()).isEmpty();
                 assertThat(((ProgrammingExerciseParticipation) participation).isLocked()).isTrue();
+                verify(versionControlService, times(0)).configureRepository(eq(programmingExercise), (ProgrammingExerciseStudentParticipation) eq(participation), eq(true));
             }
         }
 
@@ -676,6 +675,8 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
                 assertThat(participation.getSubmissions()).isEmpty();
                 // The participation should not get locked if it gets created after the exam already started
                 assertThat(((ProgrammingExerciseParticipation) participation).isLocked()).isFalse();
+                // TODO this currently gets invoked two times
+                verify(versionControlService, atLeast(1)).configureRepository(eq(programmingExercise), (ProgrammingExerciseStudentParticipation) eq(participation), eq(true));
             }
         }
 

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -17,13 +17,15 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +49,7 @@ import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.participation.Participation;
+import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismCase;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismVerdict;
@@ -523,122 +526,189 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         request.delete("/api/courses/" + course1.getId() + "/exams/" + testExam1.getId() + "/students", HttpStatus.BAD_REQUEST);
     }
 
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testStartExercisesWithTextExercise() throws Exception {
+    // TODO IMPORTANT test more complex exam configurations (mixed exercise type, more variants and more registered students)
+    @Nested
+    class ExamStartTest {
 
-        doNothing().when(gitService).combineAllCommitsOfRepositoryIntoOne(any());
-        // TODO IMPORTANT test more complex exam configurations (mixed exercise type, more variants and more registered students)
+        private Set<User> registeredUsers;
 
-        // registering users
-        User student1 = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        User student2 = userUtilService.getUserByLogin(TEST_PREFIX + "student2");
-        var registeredUsers = Set.of(student1, student2);
-        exam2.setExamUsers(Set.of(new ExamUser()));
-        // setting dates
-        exam2.setStartDate(now().plusHours(2));
-        exam2.setEndDate(now().plusHours(3));
-        exam2.setVisibleDate(now().plusHours(1));
+        private final List<StudentExam> createdStudentExams = new ArrayList<>();
 
-        // creating exercise
-        ExerciseGroup exerciseGroup = exam2.getExerciseGroups().get(0);
+        private User student1;
 
-        TextExercise textExercise = TextExerciseFactory.generateTextExerciseForExam(exerciseGroup);
-        exerciseGroup.addExercise(textExercise);
-        exerciseGroupRepository.save(exerciseGroup);
-        textExercise = exerciseRepo.save(textExercise);
+        private User student2;
 
-        List<StudentExam> createdStudentExams = new ArrayList<>();
+        @BeforeEach
+        void init() throws Exception {
+            doNothing().when(gitService).combineAllCommitsOfRepositoryIntoOne(any());
 
-        // creating student exams
-        for (User user : registeredUsers) {
-            StudentExam studentExam = new StudentExam();
-            studentExam.addExercise(textExercise);
-            studentExam.setUser(user);
-            exam2.addStudentExam(studentExam);
-            createdStudentExams.add(studentExamRepository.save(studentExam));
+            // registering users
+            student1 = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
+            student2 = userUtilService.getUserByLogin(TEST_PREFIX + "student2");
+            registeredUsers = Set.of(student1, student2);
+            exam2.setExamUsers(Set.of(new ExamUser()));
+            // setting dates
+            exam2.setStartDate(now().plusHours(2));
+            exam2.setEndDate(now().plusHours(3));
+            exam2.setVisibleDate(now().plusHours(1));
         }
 
-        exam2 = examRepository.save(exam2);
-
-        // invoke start exercises
-        int noGeneratedParticipations = prepareExerciseStart(exam2);
-        verify(gitService, times(getNumberOfProgrammingExercises(exam2))).combineAllCommitsOfRepositoryIntoOne(any());
-        assertThat(noGeneratedParticipations).isEqualTo(exam2.getStudentExams().size());
-        List<Participation> studentParticipations = participationTestRepository.findByExercise_ExerciseGroup_Exam_Id(exam2.getId());
-
-        for (Participation participation : studentParticipations) {
-            assertThat(participation.getExercise()).isEqualTo(textExercise);
-            assertThat(participation.getExercise().getCourseViaExerciseGroupOrCourseMember()).isNotNull();
-            assertThat(participation.getExercise().getExerciseGroup()).isEqualTo(exam2.getExerciseGroups().get(0));
-            assertThat(participation.getSubmissions()).hasSize(1);
-            var textSubmission = (TextSubmission) participation.getSubmissions().iterator().next();
-            assertThat(textSubmission.getText()).isNull();
+        @AfterEach
+        void cleanup() {
+            // Cleanup of Bidirectional Relationships
+            for (StudentExam studentExam : createdStudentExams) {
+                exam2.removeStudentExam(studentExam);
+            }
+            examRepository.save(exam2);
         }
 
-        // Cleanup of Bidirectional Relationships
-        for (StudentExam studentExam : createdStudentExams) {
-            exam2.removeStudentExam(studentExam);
-        }
-        examRepository.save(exam2);
-    }
+        @Test
+        @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+        void testStartExercisesWithTextExercise() throws Exception {
+            // creating exercise
+            ExerciseGroup exerciseGroup = exam2.getExerciseGroups().get(0);
 
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testStartExercisesWithModelingExercise() throws Exception {
-        doNothing().when(gitService).combineAllCommitsOfRepositoryIntoOne(any());
-        // TODO IMPORTANT test more complex exam configurations (mixed exercise type, more variants and more registered students)
+            TextExercise textExercise = TextExerciseFactory.generateTextExerciseForExam(exerciseGroup);
+            exerciseGroup.addExercise(textExercise);
+            exerciseGroupRepository.save(exerciseGroup);
+            textExercise = exerciseRepo.save(textExercise);
 
-        // registering users
-        User student1 = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        User student2 = userUtilService.getUserByLogin(TEST_PREFIX + "student2");
-        var registeredUsers = Set.of(student1, student2);
-        exam2.setExamUsers(Set.of(new ExamUser()));
-        // setting dates
-        exam2.setStartDate(now().plusHours(2));
-        exam2.setEndDate(now().plusHours(3));
-        exam2.setVisibleDate(now().plusHours(1));
+            createStudentExams(textExercise);
 
-        // creating exercise
-        ModelingExercise modelingExercise = ModelingExerciseFactory.generateModelingExerciseForExam(DiagramType.ClassDiagram, exam2.getExerciseGroups().get(0));
-        exam2.getExerciseGroups().get(0).addExercise(modelingExercise);
-        exerciseGroupRepository.save(exam2.getExerciseGroups().get(0));
-        modelingExercise = exerciseRepo.save(modelingExercise);
+            List<Participation> studentParticipations = invokePrepareExerciseStart();
 
-        List<StudentExam> createdStudentExams = new ArrayList<>();
-
-        // creating student exams
-        for (User user : registeredUsers) {
-            StudentExam studentExam = new StudentExam();
-            studentExam.addExercise(modelingExercise);
-            studentExam.setUser(user);
-            exam2.addStudentExam(studentExam);
-            createdStudentExams.add(studentExamRepository.save(studentExam));
+            for (Participation participation : studentParticipations) {
+                assertThat(participation.getExercise()).isEqualTo(textExercise);
+                assertThat(participation.getExercise().getCourseViaExerciseGroupOrCourseMember()).isNotNull();
+                assertThat(participation.getExercise().getExerciseGroup()).isEqualTo(exam2.getExerciseGroups().get(0));
+                assertThat(participation.getSubmissions()).hasSize(1);
+                var textSubmission = (TextSubmission) participation.getSubmissions().iterator().next();
+                assertThat(textSubmission.getText()).isNull();
+            }
         }
 
-        exam2 = examRepository.save(exam2);
+        @Test
+        @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+        void testStartExercisesWithModelingExercise() throws Exception {
+            // creating exercise
+            ModelingExercise modelingExercise = ModelingExerciseFactory.generateModelingExerciseForExam(DiagramType.ClassDiagram, exam2.getExerciseGroups().get(0));
+            exam2.getExerciseGroups().get(0).addExercise(modelingExercise);
+            exerciseGroupRepository.save(exam2.getExerciseGroups().get(0));
+            modelingExercise = exerciseRepo.save(modelingExercise);
 
-        // invoke start exercises
-        int noGeneratedParticipations = prepareExerciseStart(exam2);
-        verify(gitService, times(getNumberOfProgrammingExercises(exam2))).combineAllCommitsOfRepositoryIntoOne(any());
-        assertThat(noGeneratedParticipations).isEqualTo(exam2.getStudentExams().size());
-        List<Participation> studentParticipations = participationTestRepository.findByExercise_ExerciseGroup_Exam_Id(exam2.getId());
+            createStudentExams(modelingExercise);
 
-        for (Participation participation : studentParticipations) {
-            assertThat(participation.getExercise()).isEqualTo(modelingExercise);
-            assertThat(participation.getExercise().getCourseViaExerciseGroupOrCourseMember()).isNotNull();
-            assertThat(participation.getExercise().getExerciseGroup()).isEqualTo(exam2.getExerciseGroups().get(0));
-            assertThat(participation.getSubmissions()).hasSize(1);
-            var textSubmission = (ModelingSubmission) participation.getSubmissions().iterator().next();
-            assertThat(textSubmission.getModel()).isNull();
-            assertThat(textSubmission.getExplanationText()).isNull();
+            List<Participation> studentParticipations = invokePrepareExerciseStart();
+
+            for (Participation participation : studentParticipations) {
+                assertThat(participation.getExercise()).isEqualTo(modelingExercise);
+                assertThat(participation.getExercise().getCourseViaExerciseGroupOrCourseMember()).isNotNull();
+                assertThat(participation.getExercise().getExerciseGroup()).isEqualTo(exam2.getExerciseGroups().get(0));
+                assertThat(participation.getSubmissions()).hasSize(1);
+                var modelingSubmission = (ModelingSubmission) participation.getSubmissions().iterator().next();
+                assertThat(modelingSubmission.getModel()).isNull();
+                assertThat(modelingSubmission.getExplanationText()).isNull();
+            }
         }
 
-        // Cleanup of Bidirectional Relationships
-        for (StudentExam studentExam : createdStudentExams) {
-            exam2.removeStudentExam(studentExam);
+        @Test
+        @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+        void testStartExerciseWithProgrammingExercise() throws Exception {
+            bitbucketRequestMockProvider.enableMockingOfRequests(true);
+            bambooRequestMockProvider.enableMockingOfRequests(true);
+
+            ProgrammingExercise programmingExercise = createProgrammingExercise();
+
+            participationUtilService.mockCreationOfExerciseParticipation(programmingExercise, versionControlService, continuousIntegrationService);
+            mockConnectorRequestsForStartParticipation(programmingExercise, student1.getLogin(), Set.of(student1), true);
+            mockConnectorRequestsForStartParticipation(programmingExercise, student2.getLogin(), Set.of(student2), true);
+
+            createStudentExams(programmingExercise);
+
+            var studentParticipations = invokePrepareExerciseStart();
+
+            for (Participation participation : studentParticipations) {
+                assertThat(participation.getExercise()).isEqualTo(programmingExercise);
+                assertThat(participation.getExercise().getCourseViaExerciseGroupOrCourseMember()).isNotNull();
+                assertThat(participation.getExercise().getExerciseGroup()).isEqualTo(exam2.getExerciseGroups().get(0));
+                // No initial submissions should be created for programming exercises
+                assertThat(participation.getSubmissions()).isEmpty();
+                assertThat(((ProgrammingExerciseParticipation) participation).isLocked()).isTrue();
+            }
         }
-        examRepository.save(exam2);
+
+        private static class ExamStartDateSource implements ArgumentsProvider {
+
+            @Override
+            public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+                return Stream.of(Arguments.of(ZonedDateTime.now().minusHours(1)), // after exam start
+                        Arguments.arguments(ZonedDateTime.now().plusMinutes(3)) // before exam start but after pe unlock date
+                );
+            }
+        }
+
+        @ParameterizedTest(name = "{displayName} [{index}]")
+        @ArgumentsSource(ExamStartDateSource.class)
+        @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+        void testStartExerciseWithProgrammingExercise_participationUnlocked(ZonedDateTime startDate) throws Exception {
+            exam2.setVisibleDate(ZonedDateTime.now().minusHours(2));
+            exam2.setStartDate(startDate);
+            examRepository.save(exam2);
+
+            bitbucketRequestMockProvider.enableMockingOfRequests(true);
+            bambooRequestMockProvider.enableMockingOfRequests(true);
+
+            ProgrammingExercise programmingExercise = createProgrammingExercise();
+
+            participationUtilService.mockCreationOfExerciseParticipation(programmingExercise, versionControlService, continuousIntegrationService);
+            mockConnectorRequestsForStartParticipation(programmingExercise, student1.getLogin(), Set.of(student1), true);
+            mockConnectorRequestsForStartParticipation(programmingExercise, student2.getLogin(), Set.of(student2), true);
+
+            createStudentExams(programmingExercise);
+
+            var studentParticipations = invokePrepareExerciseStart();
+
+            for (Participation participation : studentParticipations) {
+                assertThat(participation.getExercise()).isEqualTo(programmingExercise);
+                assertThat(participation.getExercise().getCourseViaExerciseGroupOrCourseMember()).isNotNull();
+                assertThat(participation.getExercise().getExerciseGroup()).isEqualTo(exam2.getExerciseGroups().get(0));
+                // No initial submissions should be created for programming exercises
+                assertThat(participation.getSubmissions()).isEmpty();
+                // The participation should not get locked if it gets created after the exam already started
+                assertThat(((ProgrammingExerciseParticipation) participation).isLocked()).isFalse();
+            }
+        }
+
+        private void createStudentExams(Exercise exercise) {
+            // creating student exams
+            for (User user : registeredUsers) {
+                StudentExam studentExam = new StudentExam();
+                studentExam.addExercise(exercise);
+                studentExam.setUser(user);
+                exam2.addStudentExam(studentExam);
+                createdStudentExams.add(studentExamRepository.save(studentExam));
+            }
+
+            exam2 = examRepository.save(exam2);
+        }
+
+        private ProgrammingExercise createProgrammingExercise() {
+            ProgrammingExercise programmingExercise = ProgrammingExerciseFactory.generateProgrammingExerciseForExam(exam2.getExerciseGroups().get(0));
+            programmingExercise = exerciseRepo.save(programmingExercise);
+            programmingExercise = programmingExerciseUtilService.addTemplateParticipationForProgrammingExercise(programmingExercise);
+            exam2.getExerciseGroups().get(0).addExercise(programmingExercise);
+            exerciseGroupRepository.save(exam2.getExerciseGroups().get(0));
+            return programmingExercise;
+        }
+
+        private List<Participation> invokePrepareExerciseStart() throws Exception {
+            // invoke start exercises
+            int noGeneratedParticipations = prepareExerciseStart(exam2);
+            verify(gitService, times(getNumberOfProgrammingExercises(exam2))).combineAllCommitsOfRepositoryIntoOne(any());
+            assertThat(noGeneratedParticipations).isEqualTo(exam2.getStudentExams().size());
+            return participationTestRepository.findByExercise_ExerciseGroup_Exam_Id(exam2.getId());
+        }
+
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/service/ParticipationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ParticipationServiceTest.java
@@ -22,7 +22,6 @@ import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.participation.Participant;
-import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programmingexercise.ProgrammingExerciseUtilService;
@@ -103,7 +102,7 @@ class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsGitlabTes
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testCreateParticipationForExternalSubmission() throws Exception {
         Optional<User> student = userRepository.findOneWithGroupsAndAuthoritiesByLogin(TEST_PREFIX + "student1");
-        mockCreationOfExerciseParticipation(false, null);
+        participationUtilService.mockCreationOfExerciseParticipation(false, null, programmingExercise, urlService, versionControlService, continuousIntegrationService);
 
         StudentParticipation participation = participationService.createParticipationWithEmptySubmissionIfNotExisting(programmingExercise, student.get(), SubmissionType.EXTERNAL);
         assertThat(participation).isNotNull();
@@ -135,7 +134,7 @@ class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsGitlabTes
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void canStartExerciseWithPracticeParticipationAfterDueDateChange() throws URISyntaxException {
         Participant participant = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        mockCreationOfExerciseParticipation(false, null);
+        participationUtilService.mockCreationOfExerciseParticipation(false, null, programmingExercise, urlService, versionControlService, continuousIntegrationService);
 
         programmingExercise.setDueDate(ZonedDateTime.now().minusHours(1));
         exerciseUtilService.updateExerciseDueDate(programmingExercise.getId(), ZonedDateTime.now().minusHours(1));
@@ -177,7 +176,8 @@ class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsGitlabTes
         Participant participant = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
         Result gradedResult = participationUtilService.addProgrammingParticipationWithResultForExercise(programmingExercise, TEST_PREFIX + "student1");
 
-        mockCreationOfExerciseParticipation(useGradedParticipation, gradedResult);
+        participationUtilService.mockCreationOfExerciseParticipation(useGradedParticipation, gradedResult, programmingExercise, urlService, versionControlService,
+                continuousIntegrationService);
 
         StudentParticipation studentParticipationReceived = participationService.startPracticeMode(programmingExercise, participant,
                 Optional.of((StudentParticipation) gradedResult.getParticipation()), useGradedParticipation);
@@ -232,24 +232,5 @@ class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsGitlabTes
         assertThat(buildLogEntryRepository.findById(studentSavedBuildLogs.get(0).getId())).isPresent();
         participationService.deleteResultsAndSubmissionsOfParticipation(studentParticipation.getId(), true);
         assertThat(buildLogEntryRepository.findById(studentSavedBuildLogs.get(0).getId())).isEmpty();
-    }
-
-    private void mockCreationOfExerciseParticipation(boolean useGradedParticipationOfResult, Result gradedResult) throws URISyntaxException {
-        doReturn(defaultBranch).when(versionControlService).getOrRetrieveBranchOfExercise(programmingExercise);
-        doReturn(defaultBranch).when(versionControlService).getOrRetrieveBranchOfStudentParticipation(any());
-        String templateRepoName;
-        if (useGradedParticipationOfResult) {
-            templateRepoName = urlService.getRepositorySlugFromRepositoryUrl(((ProgrammingExerciseStudentParticipation) gradedResult.getParticipation()).getVcsRepositoryUrl());
-        }
-        else {
-            templateRepoName = urlService.getRepositorySlugFromRepositoryUrl(programmingExercise.getVcsTemplateRepositoryUrl());
-        }
-        var someURL = new VcsRepositoryUrl("http://vcs.fake.fake");
-        doReturn(someURL).when(versionControlService).copyRepository(any(String.class), eq(templateRepoName), any(String.class), any(String.class), any(String.class));
-        doNothing().when(versionControlService).configureRepository(any(), any(), anyBoolean());
-        doReturn("buildPlanId").when(continuousIntegrationService).copyBuildPlan(any(), any(), any(), any(), any(), anyBoolean());
-        doNothing().when(continuousIntegrationService).configureBuildPlan(any(), any());
-        doNothing().when(continuousIntegrationService).performEmptySetupCommit(any());
-        doNothing().when(versionControlService).addWebHookForParticipation(any());
     }
 }


### PR DESCRIPTION
This PR fixes an edge case. While student participations in exams are generated before the exam start, it can happen in exceptional cases, that they are started after the exam start. Then the participation should not be locked.


### Steps for Testing
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a programming exercise

1. Add one student to the exam and prepare the exercise start (-> the created repository should be locked)
2. Wait until the exam start is less than 5 minutes away. The student repository should get automatically unlocked.
3. Add another student shortly and press the "prepare exercise start" button. The repository should already be unlocked.
4. Add another student but do NOT press "prepare exercise start". The student should be able to manually start the exercise and work with an unlocked repository.
5. Verify that all 3 students can perform the typical interactions with programming exercises (push, see results, etc)

To verify if a Repository is locked, open it on Bitbucket and navigate into Settings -> Permissions. When testing locally, also check that the locked boolean in the database is set correctly.