### PR TITLE
`Development`: Fix flaky server test ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest.java
@@ -1027,7 +1027,7 @@ class ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest extends Abstr
         JSONParser jsonParser = new JSONParser();
         // replace plan.key in BAMBOO_BUILD_RESULT_REQUEST with buildPlanKey as well as the
         var buildResult = BAMBOO_BUILD_RESULT_REQUEST.replace("TEST201904BPROGRAMMINGEXERCISE6-STUDENT1", buildPlanKey).replace("2019-07-27T17:07:46.642Z[Zulu]",
-                ZonedDateTime.now() + "");
+                ZonedDateTime.now().toString());
         Object obj = jsonParser.parse(buildResult);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest.java
@@ -387,7 +387,7 @@ class ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest extends Abstr
         var latestSubmission = latestSubmissionOrEmpty.get();
         var latestResult = latestSubmission.getLatestResult();
         assertThat(latestResult).isNotNull();
-        assertThat(latestResult.getId()).isEqualTo(results.get(1).getId());
+        assertThat(latestResult.getId()).isEqualTo(results.get(0).getId());
     }
 
     /**
@@ -1025,8 +1025,9 @@ class ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest extends Abstr
 
     private BambooBuildResultNotificationDTO createBambooBuildResultNotificationDTO(String buildPlanKey) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        // replace plan.key in BAMBOO_BUILD_RESULT_REQUEST with buildPlanKey
-        var buildResult = BAMBOO_BUILD_RESULT_REQUEST.replace("TEST201904BPROGRAMMINGEXERCISE6-STUDENT1", buildPlanKey);
+        // replace plan.key in BAMBOO_BUILD_RESULT_REQUEST with buildPlanKey as well as the
+        var buildResult = BAMBOO_BUILD_RESULT_REQUEST.replace("TEST201904BPROGRAMMINGEXERCISE6-STUDENT1", buildPlanKey).replace("2019-07-27T17:07:46.642Z[Zulu]",
+                ZonedDateTime.now() + "");
         Object obj = jsonParser.parse(buildResult);
 
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
`ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest.shouldNotLinkTwoResultsToTheSameSubmission(IntegrationTestParticipationType) [3] participationType=SOLUTION` is flaky.

### Description
<!-- Describe your changes in detail -->
All build results sent to the server had the same build time. So the order of the results were non-deterministic. MySQL (and Postgres in most of the times) probably used the order of insertion into the database to determine the order instead.
This PR fixes the issue by including a valid build result time and fixes the test to use the correct result for validation.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2