### PR TITLE
`Exam mode`: Fix score rounding in feedback chart

### DIFF
--- a/src/main/webapp/app/exercises/shared/feedback/chart/feedback-chart.service.ts
+++ b/src/main/webapp/app/exercises/shared/feedback/chart/feedback-chart.service.ts
@@ -1,7 +1,7 @@
 import { Color, ScaleType } from '@swimlane/ngx-charts';
 import { NgxChartsMultiSeriesDataEntry } from 'app/shared/chart/ngx-charts-datatypes';
 import { FeedbackNode } from 'app/exercises/shared/feedback/node/feedback-node';
-import { Exercise } from 'app/entities/exercise.model';
+import { Exercise, getCourseFromExercise } from 'app/entities/exercise.model';
 import { roundScorePercentSpecifiedByCourseSettings } from 'app/shared/util/utils';
 import { Injectable } from '@angular/core';
 import { ChartData } from 'app/exercises/shared/feedback/chart/feedback-chart-data';
@@ -119,6 +119,6 @@ export class FeedbackChartService {
 
     private calculatePercentage = (node: FeedbackNode, exercise: Exercise) => {
         const appliedCredits = this.capCredits(node.credits ?? 0, node.maxCredits);
-        return roundScorePercentSpecifiedByCourseSettings(appliedCredits / exercise.maxPoints!, exercise.course);
+        return roundScorePercentSpecifiedByCourseSettings(appliedCredits / exercise.maxPoints!, getCourseFromExercise(exercise));
     };
 }


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
Fixes [ARTEMIS-Z7S](https://sentry.ase.in.tum.de/organizations/artemis/issues/32459/events/1c70a7a1d5a6464a89b66f552ee53f7b/?project=2) and [ARTEMIS-ZBF](https://sentry.ase.in.tum.de/organizations/artemis/issues/32579/events/86ce49e3b4964457aacc9e87a961771e/?project=2).

### Description
Rounding scores for exam exercises currently fails since `exercise.course` is accessed directly. Instead `getCourseFromExercise` must be used.

### Steps for Testing
(code changes are straight forward, I don't really think testing is needed)

You could change the course score accuracy value and then open the feedback detail view of an exam exercise. Verify that the values are rounded as specified.

### Review Progress

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
