### PR TITLE
`Communication`: Fix broken exercise/lecture/exam channel names

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20230626170300_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230626170300_changelog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="keller" id="20230626170300">
+        <sql dbms="mysql">
+            UPDATE conversation c
+            SET name = REGEXP_REPLACE(name, '[-\\s]+', '-')
+            WHERE c.exercise_id IS NOT NULL OR c.lecture_id IS NOT NULL OR c.exam_id IS NOT NULL;
+        </sql>
+        <sql dbms="postgresql">
+            UPDATE conversation c
+            SET name = REGEXP_REPLACE(name, '[-\\s]+', '-', 'g')
+            WHERE c.exercise_id IS NOT NULL OR c.lecture_id IS NOT NULL OR c.exam_id IS NOT NULL;
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -41,6 +41,7 @@
     <include file="classpath:config/liquibase/changelog/20230525170100_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230613000000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230601154000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20230626170300_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command 'date '+%Y%m%d%H%M%S'' to get the current date and time in the correct format -->


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

# Do not deploy (database changes)

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There are some exercise/lecture/exam channels, that contain parts like '--' or ' - ' within the channel name. With this PR, such occurrences will be replaced with just '-' automatically.

### Description
<!-- Describe your changes in detail -->
This PR adds a migration script, that replaces all occurrences of '-' and ' ' within automatically generated exercise/lecture/exam channel names that match the regex [-\\s]+ with just a '-' for both PostgreSQL and MySQL databases.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- You need to test this locally, since you have to modify the database
- Some exercise/lecture/exam but also general channels, that contain combinations of '-' and ' ' within their name (Creating channels with ' ' in their name is not possible through the client, you have to change it in the database manually)

1. Restart the server to execute the migration script
2. Check that exercise/lecture/exam channel names have been changed correctly
3. Check that general channels have not been changed

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
