### PR TITLE
`Communication`: Initialize channel names for exercises, lectures, and exams on import

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/ChannelRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/ChannelRepository.java
@@ -1,7 +1,7 @@
 package de.tum.in.www1.artemis.repository.metis.conversation;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -60,7 +60,7 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
              AND channel.name = :#{#name}
              ORDER BY channel.name
             """)
-    Optional<Channel> findChannelByCourseIdAndName(@Param("courseId") Long courseId, @Param("name") String name);
+    Set<Channel> findChannelByCourseIdAndName(@Param("courseId") Long courseId, @Param("name") String name);
 
     @Query("""
              SELECT DISTINCT channel
@@ -70,7 +70,7 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
              AND channel.id <> :#{#channelId}
              ORDER BY channel.name
             """)
-    Optional<Channel> findChannelByCourseIdAndNameAndIdNot(@Param("courseId") Long courseId, @Param("name") String name, @Param("channelId") Long channelId);
+    Set<Channel> findChannelByCourseIdAndNameAndIdNot(@Param("courseId") Long courseId, @Param("name") String name, @Param("channelId") Long channelId);
 
     default Channel findByIdElseThrow(long channelId) {
         return this.findById(channelId).orElseThrow(() -> new EntityNotFoundException("Channel", channelId));

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
@@ -445,6 +445,11 @@ public class ChannelService {
         return defaultChannel;
     }
 
+    /**
+     * Determines whether duplicate channel names are allowed for the given channel
+     *
+     * @return true if the channel does not belong to a lecture/exercise/exam
+     */
     private boolean allowDuplicateChannelName(Channel channel) {
         return channel.getExercise() != null || channel.getLecture() != null || channel.getExam() != null;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
@@ -448,7 +448,7 @@ public class ChannelService {
     /**
      * Determines whether duplicate channel names are allowed for the given channel
      *
-     * @return true if the channel does not belong to a lecture/exercise/exam
+     * @return true if the channel does belong to a lecture/exercise/exam
      */
     private boolean allowDuplicateChannelName(Channel channel) {
         return channel.getExercise() != null || channel.getLecture() != null || channel.getExam() != null;

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
@@ -268,16 +268,16 @@ public class ChannelService {
             return;
         }
 
-        Optional<Channel> channelWithSameName;
+        Set<Channel> channelsWithSameName;
         if (channel.getId() != null) {
-            channelWithSameName = channelRepository.findChannelByCourseIdAndNameAndIdNot(courseId, channel.getName(), channel.getId());
+            channelsWithSameName = channelRepository.findChannelByCourseIdAndNameAndIdNot(courseId, channel.getName(), channel.getId());
         }
         else {
-            channelWithSameName = channelRepository.findChannelByCourseIdAndName(courseId, channel.getName());
+            channelsWithSameName = channelRepository.findChannelByCourseIdAndName(courseId, channel.getName());
         }
-        channelWithSameName.ifPresent(existingChannel -> {
-            throw new ChannelNameDuplicateException(existingChannel.getName());
-        });
+        if (!channelsWithSameName.isEmpty()) {
+            throw new ChannelNameDuplicateException(channel.getName());
+        }
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
@@ -263,6 +263,11 @@ public class ChannelService {
         if (channel.getName() != null && !channel.getName().matches(CHANNEL_NAME_REGEX)) {
             throw new BadRequestAlertException("Channel names can only contain lowercase letters, numbers, and dashes.", CHANNEL_ENTITY_NAME, "namePatternInvalid");
         }
+
+        if (this.allowDuplicateChannelName(channel)) {
+            return;
+        }
+
         Optional<Channel> channelWithSameName;
         if (channel.getId() != null) {
             channelWithSameName = channelRepository.findChannelByCourseIdAndNameAndIdNot(courseId, channel.getName(), channel.getId());
@@ -438,5 +443,9 @@ public class ChannelService {
         defaultChannel.setIsAnnouncementChannel(false);
         defaultChannel.setIsArchived(false);
         return defaultChannel;
+    }
+
+    private boolean allowDuplicateChannelName(Channel channel) {
+        return channel.getExercise() != null || channel.getLecture() != null || channel.getExam() != null;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupChannelManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupChannelManagementService.java
@@ -263,7 +263,7 @@ public class TutorialGroupChannelManagementService {
         if (channelName.length() == 20) {
             channelName = channelName.substring(0, 17);
         }
-        while (channelRepository.findChannelByCourseIdAndName(tutorialGroup.getCourse().getId(), channelName).isPresent() && channelName.length() <= 20) {
+        while (!channelRepository.findChannelByCourseIdAndName(tutorialGroup.getCourse().getId(), channelName).isEmpty() && channelName.length() <= 20) {
             channelName += ThreadLocalRandom.current().nextInt(0, 10);
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
@@ -243,10 +243,13 @@ public class LectureResource {
         authCheckService.checkHasAtLeastRoleForLectureElseThrow(Role.EDITOR, sourceLecture, user);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, destinationCourse, user);
 
-        final var result = lectureImportService.importLecture(sourceLecture, destinationCourse);
-        Channel createdChannel = channelService.createLectureChannel(result, "change-imported-lecture-" + result.getId());
-        channelService.registerUsersToChannelAsynchronously(true, result.getCourse(), createdChannel);
-        return ResponseEntity.created(new URI("/api/lectures/" + result.getId())).body(result);
+        final var savedLecture = lectureImportService.importLecture(sourceLecture, destinationCourse);
+
+        String channelName = generateChannelNameFromTitle(savedLecture.getTitle());
+        Channel createdChannel = channelService.createLectureChannel(savedLecture, channelName);
+
+        channelService.registerUsersToChannelAsynchronously(true, savedLecture.getCourse(), createdChannel);
+        return ResponseEntity.created(new URI("/api/lectures/" + savedLecture.getId())).body(savedLecture);
     }
 
     /**
@@ -370,5 +373,21 @@ public class LectureResource {
         log.debug("REST request to delete Lecture : {}", lectureId);
         lectureService.delete(lecture);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, lectureId.toString())).build();
+    }
+
+    /**
+     * Generates the channel name based on the lecture title and the "lecture-" prefix.
+     * It replaces alternating/consecutive occurrences of spaces and hyphens and limits length of the name to 30 characters.
+     *
+     * @param title title of the lecture
+     * @return the generated channel name
+     */
+    private static String generateChannelNameFromTitle(String title) {
+        String channelName = "lecture-" + title;
+        channelName = channelName.replaceAll("[-\\s]+", "-");
+        if (channelName.length() > 30) {
+            channelName = channelName.substring(0, 30);
+        }
+        return channelName;
     }
 }

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.html
@@ -28,7 +28,7 @@
                     channelNamePrefix="exam-"
                     [hideTitleLabel]="true"
                     [hideChannelName]="exam.testExam || (exam.id !== undefined && exam.channelName === undefined)"
-                    [initChannelName]="isImport"
+                    [initChannelName]="isImport || exam.id === undefined"
                 >
                 </jhi-title-channel-name>
             </div>

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.html
@@ -28,6 +28,7 @@
                     channelNamePrefix="exam-"
                     [hideTitleLabel]="true"
                     [hideChannelName]="exam.testExam || (exam.id !== undefined && exam.channelName === undefined)"
+                    [initChannelName]="isImport"
                 >
                 </jhi-title-channel-name>
             </div>

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
@@ -21,6 +21,7 @@
             [minTitleLength]="3"
             [emphasizeLabels]="true"
             [hideChannelName]="this.isExamMode || (!this.isImport && this.fileUploadExercise.channelName === undefined)"
+            [initChannelName]="isImport"
         ></jhi-title-channel-name>
         <div *ngIf="!isExamMode" class="form-group position-relative">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.categories">Categories</label>

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
@@ -20,8 +20,8 @@
             channelNamePrefix="exercise-"
             [minTitleLength]="3"
             [emphasizeLabels]="true"
-            [hideChannelName]="this.isExamMode || (!this.isImport && this.fileUploadExercise.channelName === undefined)"
-            [initChannelName]="isImport"
+            [hideChannelName]="isExamMode || (!isImport && fileUploadExercise.channelName === undefined)"
+            [initChannelName]="isImport || fileUploadExercise.id === undefined"
         ></jhi-title-channel-name>
         <div *ngIf="!isExamMode" class="form-group position-relative">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.categories">Categories</label>

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
@@ -21,7 +21,8 @@
             [(channelName)]="modelingExercise.channelName"
             channelNamePrefix="exercise-"
             [emphasizeLabels]="true"
-            [hideChannelName]="this.isExamMode || (!this.isImport && this.modelingExercise.channelName === undefined)"
+            [hideChannelName]="isExamMode || (!isImport && modelingExercise.channelName === undefined)"
+            [initChannelName]="isImport"
         ></jhi-title-channel-name>
         <div *ngIf="!isExamMode" class="form-group position-relative">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.categories">Categories</label>

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
@@ -22,7 +22,7 @@
             channelNamePrefix="exercise-"
             [emphasizeLabels]="true"
             [hideChannelName]="isExamMode || (!isImport && modelingExercise.channelName === undefined)"
-            [initChannelName]="isImport"
+            [initChannelName]="isImport || modelingExercise.id === undefined"
         ></jhi-title-channel-name>
         <div *ngIf="!isExamMode" class="form-group position-relative">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.categories">Categories</label>

--- a/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.html
@@ -12,6 +12,7 @@
         [hideTitleLabel]="true"
         [emphasizeLabels]="true"
         [hideChannelName]="isExamMode || (isEdit && programmingExercise.channelName === undefined)"
+        [initChannelName]="!isEdit"
     ></jhi-title-channel-name>
 </div>
 

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
@@ -34,7 +34,8 @@
                     (channelNameChange)="updateChannelName($event)"
                     channelNamePrefix="exercise-"
                     [emphasizeLabels]="true"
-                    [hideChannelName]="this.isExamMode || (!this.isImport && this.quizExercise.channelName === undefined)"
+                    [hideChannelName]="isExamMode || (!isImport && quizExercise.channelName === undefined)"
+                    [initChannelName]="isImport"
                 ></jhi-title-channel-name>
             </form>
 

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
@@ -35,7 +35,7 @@
                     channelNamePrefix="exercise-"
                     [emphasizeLabels]="true"
                     [hideChannelName]="isExamMode || (!isImport && quizExercise.channelName === undefined)"
-                    [initChannelName]="isImport"
+                    [initChannelName]="isImport || quizExercise.id === undefined"
                 ></jhi-title-channel-name>
             </form>
 

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
@@ -16,7 +16,8 @@
             channelNamePrefix="exercise-"
             [minTitleLength]="3"
             [emphasizeLabels]="true"
-            [hideChannelName]="this.isExamMode || (!this.isImport && this.textExercise.channelName === undefined)"
+            [hideChannelName]="isExamMode || (!isImport && textExercise.channelName === undefined)"
+            [initChannelName]="isImport"
         ></jhi-title-channel-name>
         <div *ngIf="!isExamMode" class="form-group position-relative">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.categories">Categories</label>

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
@@ -17,7 +17,7 @@
             [minTitleLength]="3"
             [emphasizeLabels]="true"
             [hideChannelName]="isExamMode || (!isImport && textExercise.channelName === undefined)"
-            [initChannelName]="isImport"
+            [initChannelName]="isImport || textExercise.id === undefined"
         ></jhi-title-channel-name>
         <div *ngIf="!isExamMode" class="form-group position-relative">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.categories">Categories</label>

--- a/src/main/webapp/app/lecture/lecture-update.component.html
+++ b/src/main/webapp/app/lecture/lecture-update.component.html
@@ -35,7 +35,8 @@
                     [(title)]="lecture.title"
                     [(channelName)]="lecture.channelName"
                     channelNamePrefix="lecture-"
-                    [hideChannelName]="this.lecture.id !== undefined && this.lecture.channelName === undefined"
+                    [hideChannelName]="lecture.id !== undefined && lecture.channelName === undefined"
+                    [initChannelName]="lecture.id === undefined"
                 ></jhi-title-channel-name>
                 <div class="form-group" id="field_description">
                     <label class="form-control-label" jhiTranslate="artemisApp.lecture.description" for="field_description">Description</label>

--- a/src/main/webapp/app/lecture/wizard-mode/lecture-wizard-title.component.html
+++ b/src/main/webapp/app/lecture/wizard-mode/lecture-wizard-title.component.html
@@ -2,7 +2,13 @@
     <h1><span jhiTranslate="artemisApp.lecture.wizardMode.steps.titleStepTitle">Title</span></h1>
     <p><span jhiTranslate="artemisApp.lecture.wizardMode.steps.titleStepMessage">Add a title and meaningful description to the new lecture.</span></p>
     <form name="editForm" role="form" novalidate>
-        <jhi-title-channel-name [(title)]="lecture.title" [(channelName)]="lecture.channelName" channelNamePrefix="lecture-"></jhi-title-channel-name>
+        <jhi-title-channel-name
+            [(title)]="lecture.title"
+            [(channelName)]="lecture.channelName"
+            channelNamePrefix="lecture-"
+            [hideChannelName]="lecture.id !== undefined && lecture.channelName === undefined"
+            [initChannelName]="lecture.id === undefined"
+        ></jhi-title-channel-name>
     </form>
     <div class="form-group" id="field_description">
         <label class="form-control-label" jhiTranslate="artemisApp.lecture.description" for="field_description">Description</label>

--- a/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
+++ b/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
@@ -27,6 +27,8 @@ export class TitleChannelNameComponent implements OnInit {
         }
 
         if (this.initChannelName) {
+            // Defer updating the channel name into the next change detection cycle to avoid the
+            // "NG0100: Expression has changed after it was checked" error
             setTimeout(() => {
                 let defaultChannelName = this.channelNamePrefix + (this.title ?? '');
                 defaultChannelName = defaultChannelName.replace(/[\s-]+/g, '-');

--- a/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
+++ b/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
@@ -16,6 +16,7 @@ export class TitleChannelNameComponent implements OnInit {
     @Input() emphasizeLabels = false;
     @Input() hideChannelName?: boolean;
     @Input() minTitleLength: number;
+    @Input() initChannelName = true;
 
     @Output() titleChange = new EventEmitter<string>();
     @Output() channelNameChange = new EventEmitter<string>();
@@ -23,6 +24,14 @@ export class TitleChannelNameComponent implements OnInit {
     ngOnInit(): void {
         if (!this.channelNamePrefix) {
             this.channelNamePrefix = '';
+        }
+
+        if (this.initChannelName) {
+            setTimeout(() => {
+                let defaultChannelName = this.channelNamePrefix + (this.title ?? '');
+                defaultChannelName = defaultChannelName.replace(/[\s-]+/g, '-');
+                this.formatChannelName(defaultChannelName);
+            });
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
@@ -86,7 +86,7 @@ class LectureIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJir
         channel.setIsAnnouncementChannel(false);
         channel.setIsPublic(true);
         channel.setIsArchived(false);
-        channel.setName("lecture" + UUID.randomUUID().toString().substring(0, 8));
+        channel.setName("lecture-channel");
         lecture.setTitle("Lecture " + lecture.getId()); // needed for search by title
         this.lecture1 = lectureRepository.save(lecture);
         channel.setLecture(this.lecture1);
@@ -184,7 +184,7 @@ class LectureIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJir
         Lecture originalLecture = lectureRepository.findById(lecture1.getId()).get();
         originalLecture.setTitle("Updated");
         originalLecture.setDescription("Updated");
-        String channelName = "test" + UUID.randomUUID().toString().substring(0, 8);
+        String channelName = "lecture-channel";
         // create channel with same name
         conversationUtilService.createChannel(originalLecture.getCourse(), channelName);
         originalLecture.setChannelName(channelName);

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
@@ -184,14 +184,17 @@ class LectureIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJir
         Lecture originalLecture = lectureRepository.findById(lecture1.getId()).get();
         originalLecture.setTitle("Updated");
         originalLecture.setDescription("Updated");
-        String uniqueChannelName = "test" + UUID.randomUUID().toString().substring(0, 8);
-        originalLecture.setChannelName(uniqueChannelName);
+        String channelName = "test" + UUID.randomUUID().toString().substring(0, 8);
+        // create channel with same name
+        conversationUtilService.createChannel(originalLecture.getCourse(), channelName);
+        originalLecture.setChannelName(channelName);
+        // lecture channel should be updated despite another channel with the same name
         Lecture updatedLecture = request.putWithResponseBody("/api/lectures", originalLecture, Lecture.class, HttpStatus.OK);
 
         Channel channel = channelRepository.findChannelByLectureId(updatedLecture.getId());
 
         assertThat(channel).isNotNull();
-        assertThat(channel.getName()).isEqualTo(uniqueChannelName);
+        assertThat(channel.getName()).isEqualTo(channelName);
         assertThat(updatedLecture.getTitle()).isEqualTo("Updated");
         assertThat(updatedLecture.getDescription()).isEqualTo("Updated");
     }

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
@@ -441,7 +441,7 @@ class LectureIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJir
 
         Channel channel = channelRepository.findChannelByLectureId(lecture.getId());
         assertThat(channel).isNotNull();
-        assertThat(channel.getName()).isEqualTo("change-imported-lecture-" + lecture.getId()); // default name of imported lecture channel
+        assertThat(channel.getName()).isEqualTo("lecture-" + lecture.getTitle().toLowerCase().replaceAll("[-\\s]+", "-")); // default name of imported lecture channel
 
         // Check that the conversation participants are added correctly to the lecture channel
         await().until(() -> {

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
@@ -18,6 +18,7 @@ import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.lecture.*;
 import de.tum.in.www1.artemis.domain.metis.ConversationParticipant;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
+import de.tum.in.www1.artemis.post.ConversationUtilService;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.repository.metis.ConversationParticipantRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
@@ -68,6 +69,9 @@ class LectureIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJir
     private Course course1;
 
     private Lecture lecture1;
+
+    @Autowired
+    private ConversationUtilService conversationUtilService;
 
     @BeforeEach
     void initTestCase() throws Exception {
@@ -137,6 +141,8 @@ class LectureIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJir
     void createLecture_correctRequestBody_shouldCreateLecture() throws Exception {
         Course course = courseRepository.findByIdElseThrow(this.course1.getId());
         courseUtilService.enableMessagingForCourse(course);
+
+        conversationUtilService.createChannel(course, "loremipsum");
 
         Lecture lecture = new Lecture();
         lecture.setTitle("loremIpsum");

--- a/src/test/java/de/tum/in/www1/artemis/metis/ChannelIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ChannelIntegrationTest.java
@@ -114,6 +114,9 @@ class ChannelIntegrationTest extends AbstractConversationTest {
         verifyMultipleParticipantTopicWebsocketSent(MetisCrudAction.CREATE, chat.getId(), loginNameWithoutPrefix);
         verifyNoParticipantTopicWebsocketSentExceptAction(MetisCrudAction.CREATE);
 
+        // cannot create channels with duplicate names
+        expectCreateBadRequest(channelDTO);
+
         // cleanup
         conversationRepository.deleteById(chat.getId());
     }

--- a/src/test/java/de/tum/in/www1/artemis/metis/ChannelIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ChannelIntegrationTest.java
@@ -309,6 +309,7 @@ class ChannelIntegrationTest extends AbstractConversationTest {
     void updateChannel_asUserWithChannelModerationRights_shouldUpdateChannel(boolean isPublicChannel) throws Exception {
         // given
         var channel = createChannel(isPublicChannel, TEST_PREFIX + "1");
+        var channelForDuplicateCheck = createChannel(isPublicChannel, TEST_PREFIX + "duplicate");
         var updateDTO = new ChannelDTO();
         updateDTO.setName(TEST_PREFIX + "2");
         updateDTO.setDescription("new description");
@@ -323,6 +324,9 @@ class ChannelIntegrationTest extends AbstractConversationTest {
         verifyMultipleParticipantTopicWebsocketSent(MetisCrudAction.UPDATE, channel.getId(), "instructor1", "tutor1");
         verifyNoParticipantTopicWebsocketSentExceptAction(MetisCrudAction.UPDATE);
         resetWebsocketMock();
+        // The channel name can not be modified if it matches another existing channel
+        updateDTO.setName(channelForDuplicateCheck.getName());
+        request.putWithResponseBody("/api/courses/" + exampleCourseId + "/channels/" + channel.getId(), updateDTO, ChannelDTO.class, HttpStatus.BAD_REQUEST);
 
         // channel moderators can also update the channel
         updateDTO.setName(TEST_PREFIX + "3");
@@ -333,6 +337,9 @@ class ChannelIntegrationTest extends AbstractConversationTest {
         this.assertChannelProperties(channel.getId(), updateDTO.getName(), updateDTO.getTopic(), updateDTO.getDescription(), isPublicChannel, false);
         verifyMultipleParticipantTopicWebsocketSent(MetisCrudAction.UPDATE, channel.getId(), "instructor1", "tutor1");
         verifyNoParticipantTopicWebsocketSentExceptAction(MetisCrudAction.UPDATE);
+        // The channel name can not be modified if it matches another existing channel
+        updateDTO.setName(channelForDuplicateCheck.getName());
+        request.putWithResponseBody("/api/courses/" + exampleCourseId + "/channels/" + channel.getId(), updateDTO, ChannelDTO.class, HttpStatus.BAD_REQUEST);
 
         // cleanup
         conversationRepository.deleteById(channel.getId());

--- a/src/test/java/de/tum/in/www1/artemis/post/ConversationUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/post/ConversationUtilService.java
@@ -341,7 +341,7 @@ public class ConversationUtilService {
         return conversationRepository.save(conversation);
     }
 
-    public static Channel createChannel(Course course, String channelName) {
+    public Channel createChannel(Course course, String channelName) {
         Channel channel = new Channel();
         channel.setCourse(course);
         channel.setName(channelName);
@@ -349,7 +349,7 @@ public class ConversationUtilService {
         channel.setIsAnnouncementChannel(false);
         channel.setIsArchived(false);
         channel.setDescription("Test channel");
-        return channel;
+        return conversationRepository.save(channel);
     }
 
     private ConversationParticipant createConversationParticipant(Conversation conversation, String userName) {

--- a/src/test/javascript/spec/component/shared/form/title-channel-name.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/form/title-channel-name.component.spec.ts
@@ -96,4 +96,25 @@ describe('TitleChannelNameComponent', () => {
 
         expect(component.channelName).toBe('prefix-');
     }));
+
+    it('remove consecutive/alternating hyphens and spaces from channel name on init', fakeAsync(() => {
+        component.channelNamePrefix = '-- ----p ---';
+        component.title = '-- -  t--- -- ';
+
+        component.ngOnInit();
+        tick();
+
+        expect(component.channelName).toBe('-p-t-');
+    }));
+
+    it("don't init channel name if not allowed", fakeAsync(() => {
+        component.channelNamePrefix = '-- ---- ---';
+        component.title = '-  --- -- ';
+        component.initChannelName = false;
+
+        component.ngOnInit();
+        tick();
+
+        expect(component.channelName).toBeUndefined();
+    }));
 });

--- a/src/test/javascript/spec/component/shared/form/title-channel-name.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/form/title-channel-name.component.spec.ts
@@ -1,10 +1,9 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, NgForm } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { TitleChannelNameComponent } from 'app/shared/form/title-channel-name/title-channel-name.component';
 import { ArtemisTestModule } from '../../../test.module';
-import { NgForm } from '@angular/forms';
 
 describe('TitleChannelNameComponent', () => {
     let component: TitleChannelNameComponent;
@@ -73,12 +72,28 @@ describe('TitleChannelNameComponent', () => {
         expect(component.channelName).toBe('new-0123-@()[]{}-!?.-_-$%&-too');
     }));
 
-    it('init prefix if undefined without influencing channel name', () => {
-        component.channelName = 'test';
-
+    it('init prefix if undefined', () => {
         component.ngOnInit();
 
         expect(component.channelNamePrefix).toBe('');
-        expect(component.channelName).toBe('test');
     });
+
+    it('init channel name based on prefix and title', fakeAsync(() => {
+        component.channelNamePrefix = 'prefix-';
+        component.title = 'test';
+
+        component.ngOnInit();
+        tick();
+
+        expect(component.channelName).toBe('prefix-test');
+    }));
+
+    it('init channel name based on prefix if title is undefined', fakeAsync(() => {
+        component.channelNamePrefix = 'prefix-';
+
+        component.ngOnInit();
+        tick();
+
+        expect(component.channelName).toBe('prefix-');
+    }));
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
(https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Course with messaging enabled

1. Create and import new lectures/exercises/exams and check if the channel name is properly initialized, i.e. prefix + formatted title (for lectures you have to actually click import, since there is no input field visible in the client due to no user interaction)
2. Import a lecture or exercise or exam with multiple consecutive hyphens/spaces in its name and check that the imported channel name does not contain multiple hyphens
3. Edit a lecture/exercise/exam and add multiple consecutive hyphens in its channel name, save, and check that the channel name is not automatically updated when you edit the lecture/exercise/exam again
4. Edit general channels on the messages tab: Duplicate channel names should **not** be allowed
5. Edit lecture/exercise/exam channel on the messages tab: Duplicate channel names should be allowed

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [title-channel-name.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5063-2/artifact/shared/Coverage-Report-Client-Tests/app/shared/form/title-channel-name/title-channel-name.component.ts.html) | 100% | ✅ |

#### Server

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [ChannelRepository.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5063-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.repository.metis.conversation/ChannelRepository.html) | 56% | ✅ |
| [ChannelService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5063-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.metis.conversation/ChannelService.html) | 94% | ✅ |
| [TutorialGroupChannelManagementService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5063-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.tutorialgroups/TutorialGroupChannelManagementService.html) | 83% | ✅ |
| [LectureResource.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5063-2/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.web.rest/LectureResource.html) | 97% | ✅ |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
The only visible change is that the channel name is initialized whenever you create or import a lecture/exercise/exam, and that unnecessary hyphens/spaces are removed from the automatically generated channel name.

#### Example 1: Lecture Creation
before:
<img width="807" alt="before" src="https://github.com/ls1intum/Artemis/assets/44754405/66d1a3e2-1eff-448b-8d85-f500df72549a">
after:
<img width="807" alt="after" src="https://github.com/ls1intum/Artemis/assets/44754405/5691f784-6e08-4a8f-9317-1d5fb2da2150">

#### Example 2: Exam Import with automatically generated channel name
<img width="688" alt="after" src="https://github.com/ls1intum/Artemis/assets/44754405/2aae3395-7024-48e2-8324-f97167ee6638">
