### PR TITLE
`Development`: Remove presentation score from the course detail page

### DIFF
--- a/src/main/webapp/app/course/manage/detail/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.html
@@ -165,11 +165,6 @@
             <dd *ngIf="course.unenrollmentEnabled" id="course-unenrollment-end-date">
                 <span>{{ course.unenrollmentEndDate | artemisDate }}</span>
             </dd>
-            <dt><span jhiTranslate="artemisApp.course.presentationScoreEnabled.title">Presentation Score Enabled</span></dt>
-            <dd id="course-presentation-score-enabled">
-                <span *ngIf="course.presentationScore !== 0">{{ 'global.generic.yes' | artemisTranslate }}</span>
-                <span *ngIf="course.presentationScore === 0">{{ 'global.generic.no' | artemisTranslate }}</span>
-            </dd>
             <ng-container [jhiFeatureToggleLink]="FeatureToggle.TutorialGroups">
                 <dt>
                     <span>{{ 'artemisApp.forms.configurationForm.timeZoneInput.label' | artemisTranslate }} </span>


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
The "presentation score enabled" entry was removed from the course detail page in #6521 see [(diff file)](https://github.com/ls1intum/Artemis/pull/6521/files#diff-df441186d6a6d8e922e9e1a19a56eed877dd28855725a26b0dd209054140b409). However, it was  reintroduced in #6577 see [(diff file)](https://github.com/ls1intum/Artemis/pull/6577/files#diff-df441186d6a6d8e922e9e1a19a56eed877dd28855725a26b0dd209054140b409) (probably a mistake by Github's automatic merge)

### Description
In this PR, the "presentation score enabled" entry is being removed.

### Steps for Testing
1. Navigate to Course Detail Page.
2. Verify that there is no "presentation score enabled" entry.

### Review Progress
#### Code Review
- [x] Code Review 1
#### Manual Tests
- [x] Test 1



### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
After the changes (taken from the course detail page):
<img width="420" alt="Bildschirmfoto 2023-06-27 um 18 20 23" src="https://github.com/ls1intum/Artemis/assets/47261058/49bf9d26-68f9-400c-aa84-3b7bb74b2653">

Before the changes (taken from the course detail page):
<img width="420" alt="Bildschirmfoto 2023-06-27 um 18 19 57" src="https://github.com/ls1intum/Artemis/assets/47261058/d949a4d1-d2f7-4fbe-90f3-2b90014fc5dd">
