### PR TITLE
`Development`: Improve use of verify in server tests

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/connectors/Lti10ServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/connectors/Lti10ServiceTest.java
@@ -110,8 +110,8 @@ class Lti10ServiceTest {
 
         lti10Service.performLaunch(launchRequest, exercise, onlineCourseConfiguration);
 
-        verify(ltiOutcomeUrlRepository, times(1)).findByUserAndExercise(user, exercise);
-        verify(ltiOutcomeUrlRepository, times(1)).save(any());
+        verify(ltiOutcomeUrlRepository).findByUserAndExercise(user, exercise);
+        verify(ltiOutcomeUrlRepository).save(any());
     }
 
     @Test
@@ -247,8 +247,8 @@ class Lti10ServiceTest {
         when(courseRepository.findByIdWithEagerOnlineCourseConfigurationElseThrow(exercise.getCourseViaExerciseGroupOrCourseMember().getId())).thenReturn(course);
 
         lti10Service.onNewResult(participation);
-        verify(resultRepository, times(1)).findFirstByParticipationIdOrderByCompletionDateDesc(27L);
-        verify(courseRepository, times(1)).findByIdWithEagerOnlineCourseConfigurationElseThrow(course.getId());
+        verify(resultRepository).findFirstByParticipationIdOrderByCompletionDateDesc(27L);
+        verify(courseRepository).findByIdWithEagerOnlineCourseConfigurationElseThrow(course.getId());
         verifyNoInteractions(client);
     }
 
@@ -274,9 +274,9 @@ class Lti10ServiceTest {
         when(client.execute(any())).thenReturn(response);
 
         lti10Service.onNewResult(participation);
-        verify(resultRepository, times(1)).findFirstByParticipationIdOrderByCompletionDateDesc(27L);
-        verify(courseRepository, times(1)).findByIdWithEagerOnlineCourseConfigurationElseThrow(course.getId());
-        verify(client, times(1)).execute(any());
+        verify(resultRepository).findFirstByParticipationIdOrderByCompletionDateDesc(27L);
+        verify(courseRepository).findByIdWithEagerOnlineCourseConfigurationElseThrow(course.getId());
+        verify(client).execute(any());
     }
 
     private void ltiOutcomeUrlRepositorySetup(User user) {

--- a/src/test/java/de/tum/in/www1/artemis/connectors/Lti13ServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/connectors/Lti13ServiceTest.java
@@ -288,7 +288,7 @@ class Lti13ServiceTest {
 
         lti13Service.buildLtiResponse(UriComponentsBuilder.newInstance(), mock(HttpServletResponse.class));
 
-        verify(ltiService, times(1)).buildLtiResponse(any(), any());
+        verify(ltiService).buildLtiResponse(any(), any());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/connectors/LtiNewResultServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/connectors/LtiNewResultServiceTest.java
@@ -70,7 +70,7 @@ class LtiNewResultServiceTest {
 
         ltiNewResultService.onNewResult(participation);
 
-        verify(lti10Service, times(1)).onNewResult(participation);
-        verify(lti13Service, times(1)).onNewResult(participation);
+        verify(lti10Service).onNewResult(participation);
+        verify(lti13Service).onNewResult(participation);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/connectors/LtiServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/connectors/LtiServiceTest.java
@@ -96,8 +96,8 @@ class LtiServiceTest {
 
         UriComponents uriComponents = uriComponentsBuilder.build();
 
-        verify(jwtCookieService, times(1)).buildLoginCookie(true);
-        verify(response, times(1)).addHeader(any(), any());
+        verify(jwtCookieService).buildLoginCookie(true);
+        verify(response).addHeader(any(), any());
 
         String initialize = uriComponents.getQueryParams().getFirst("initialize");
         String ltiSuccessLoginRequired = uriComponents.getQueryParams().getFirst("ltiSuccessLoginRequired");
@@ -118,8 +118,8 @@ class LtiServiceTest {
 
         UriComponents uriComponents = uriComponentsBuilder.build();
 
-        verify(jwtCookieService, times(1)).buildLogoutCookie();
-        verify(response, times(1)).addHeader(any(), any());
+        verify(jwtCookieService).buildLogoutCookie();
+        verify(response).addHeader(any(), any());
 
         String initialize = uriComponents.getQueryParams().getFirst("initialize");
         String ltiSuccessLoginRequired = uriComponents.getQueryParams().getFirst("ltiSuccessLoginRequired");
@@ -136,8 +136,8 @@ class LtiServiceTest {
         assertThat(user.getGroups()).contains(courseStudentGroupName);
         assertThat(user.getGroups()).contains(LtiService.LTI_GROUP_NAME);
 
-        verify(userCreationService, times(1)).saveUser(user);
-        verify(artemisAuthenticationProvider, times(1)).addUserToGroup(user, courseStudentGroupName);
+        verify(userCreationService).saveUser(user);
+        verify(artemisAuthenticationProvider).addUserToGroup(user, courseStudentGroupName);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -630,7 +630,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
                 // No initial submissions should be created for programming exercises
                 assertThat(participation.getSubmissions()).isEmpty();
                 assertThat(((ProgrammingExerciseParticipation) participation).isLocked()).isTrue();
-                verify(versionControlService, times(0)).configureRepository(eq(programmingExercise), (ProgrammingExerciseStudentParticipation) eq(participation), eq(true));
+                verify(versionControlService, never()).configureRepository(eq(programmingExercise), (ProgrammingExerciseStudentParticipation) eq(participation), eq(true));
             }
         }
 
@@ -3075,7 +3075,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         request.postListWithResponseBody("/api/courses/" + course1.getId() + "/exams/" + examWithProgramming.getId() + "/generate-student-exams", Optional.empty(),
                 StudentExam.class, HttpStatus.OK);
 
-        verify(gitService, times(0)).combineAllCommitsOfRepositoryIntoOne(any());
+        verify(gitService, never()).combineAllCommitsOfRepositoryIntoOne(any());
 
         // invoke prepare exercise start
         prepareExerciseStart(exam1);

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -1035,7 +1035,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         URI examUri = request.post("/api/courses/" + course1.getId() + "/exams", examE, HttpStatus.CREATED);
         Exam savedExam = request.get(String.valueOf(examUri), HttpStatus.OK, Exam.class);
         assertThat(savedExam.getTitle()).isEqualTo("Exam 123");
-        verify(examAccessService, times(1)).checkCourseAccessForInstructorElseThrow(course1.getId());
+        verify(examAccessService).checkCourseAccessForInstructorElseThrow(course1.getId());
 
         Channel channelFromDB = channelRepository.findChannelByExamId(savedExam.getId());
         assertThat(channelFromDB).isNotNull();
@@ -1080,7 +1080,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         Exam examA = ExamFactory.generateTestExam(course1);
         request.post("/api/courses/" + course1.getId() + "/exams", examA, HttpStatus.CREATED);
 
-        verify(examAccessService, times(1)).checkCourseAccessForInstructorElseThrow(course1.getId());
+        verify(examAccessService).checkCourseAccessForInstructorElseThrow(course1.getId());
     }
 
     @Test
@@ -1091,7 +1091,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         examB.setVisibleDate(examB.getStartDate());
         request.post("/api/courses/" + course1.getId() + "/exams", examB, HttpStatus.CREATED);
 
-        verify(examAccessService, times(1)).checkCourseAccessForInstructorElseThrow(course1.getId());
+        verify(examAccessService).checkCourseAccessForInstructorElseThrow(course1.getId());
     }
 
     @Test
@@ -1203,7 +1203,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         examWithProgrammingEx.setStartDate(examWithProgrammingEx.getStartDate().plusSeconds(1));
         examWithProgrammingEx.setWorkingTime(examWithProgrammingEx.getWorkingTime() - 1);
         request.put("/api/courses/" + examWithProgrammingEx.getCourse().getId() + "/exams", examWithProgrammingEx, HttpStatus.OK);
-        verify(instanceMessageSendService, times(1)).sendProgrammingExerciseSchedule(programmingEx.getId());
+        verify(instanceMessageSendService).sendProgrammingExerciseSchedule(programmingEx.getId());
     }
 
     @Test
@@ -1213,7 +1213,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         var examWithProgrammingEx = programmingEx.getExerciseGroup().getExam();
         examWithProgrammingEx.setVisibleDate(examWithProgrammingEx.getVisibleDate().plusSeconds(1));
         request.put("/api/courses/" + examWithProgrammingEx.getCourse().getId() + "/exams", examWithProgrammingEx, HttpStatus.OK);
-        verify(instanceMessageSendService, times(1)).sendProgrammingExerciseSchedule(programmingEx.getId());
+        verify(instanceMessageSendService).sendProgrammingExerciseSchedule(programmingEx.getId());
     }
 
     @Test
@@ -1224,7 +1224,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         examWithProgrammingEx.setStartDate(examWithProgrammingEx.getStartDate().plusSeconds(1));
         examWithProgrammingEx.setWorkingTime(examWithProgrammingEx.getWorkingTime() - 1);
         request.put("/api/courses/" + examWithProgrammingEx.getCourse().getId() + "/exams", examWithProgrammingEx, HttpStatus.OK);
-        verify(instanceMessageSendService, times(1)).sendProgrammingExerciseSchedule(programmingEx.getId());
+        verify(instanceMessageSendService).sendProgrammingExerciseSchedule(programmingEx.getId());
     }
 
     @Test
@@ -1235,7 +1235,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         examWithModelingEx.setEndDate(examWithModelingEx.getEndDate().plusSeconds(2));
         examWithModelingEx.setWorkingTime(examWithModelingEx.getWorkingTime() + 2);
         request.put("/api/courses/" + examWithModelingEx.getCourse().getId() + "/exams", examWithModelingEx, HttpStatus.OK);
-        verify(instanceMessageSendService, times(1)).sendModelingExerciseSchedule(modelingExercise.getId());
+        verify(instanceMessageSendService).sendModelingExerciseSchedule(modelingExercise.getId());
     }
 
     @Test
@@ -1291,7 +1291,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         assertThat(examRepository.findAllExercisesByExamId(Long.MAX_VALUE)).isEmpty();
 
         request.get("/api/courses/" + course1.getId() + "/exams/" + exam1.getId(), HttpStatus.OK, Exam.class);
-        verify(examAccessService, times(1)).checkCourseAndExamAccessForEditorElseThrow(course1.getId(), exam1.getId());
+        verify(examAccessService).checkCourseAndExamAccessForEditorElseThrow(course1.getId(), exam1.getId());
     }
 
     @Test
@@ -1315,7 +1315,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         Exam returnedExam = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "?withExerciseGroups=true", HttpStatus.OK, Exam.class);
 
         assertThat(returnedExam.getExerciseGroups()).anyMatch(groups -> groups.getExercises().stream().anyMatch(Exercise::getTestRunParticipationsExist));
-        verify(examAccessService, times(1)).checkCourseAndExamAccessForEditorElseThrow(course.getId(), exam.getId());
+        verify(examAccessService).checkCourseAndExamAccessForEditorElseThrow(course.getId(), exam.getId());
     }
 
     @Test
@@ -1323,7 +1323,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
     void testGetExamsForCourse_asInstructor() throws Exception {
 
         var exams = request.getList("/api/courses/" + course1.getId() + "/exams", HttpStatus.OK, Exam.class);
-        verify(examAccessService, times(1)).checkCourseAccessForTeachingAssistantElseThrow(course1.getId());
+        verify(examAccessService).checkCourseAccessForTeachingAssistantElseThrow(course1.getId());
 
         for (int i = 0; i < exams.size(); i++) {
             Exam exam = exams.get(i);
@@ -1380,7 +1380,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testDeleteEmptyExam_asInstructor() throws Exception {
         request.delete("/api/courses/" + course1.getId() + "/exams/" + exam1.getId(), HttpStatus.OK);
-        verify(examAccessService, times(1)).checkCourseAndExamAccessForInstructorElseThrow(course1.getId(), exam1.getId());
+        verify(examAccessService).checkCourseAndExamAccessForInstructorElseThrow(course1.getId(), exam1.getId());
     }
 
     @Test
@@ -1389,7 +1389,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         TextExercise textExercise = TextExerciseFactory.generateTextExerciseForExam(exam2.getExerciseGroups().get(0));
         exerciseRepo.save(textExercise);
         request.delete("/api/courses/" + course1.getId() + "/exams/" + exam2.getId(), HttpStatus.OK);
-        verify(examAccessService, times(1)).checkCourseAndExamAccessForInstructorElseThrow(course1.getId(), exam2.getId());
+        verify(examAccessService).checkCourseAndExamAccessForInstructorElseThrow(course1.getId(), exam2.getId());
     }
 
     @Test
@@ -1402,7 +1402,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testResetEmptyExam_asInstructor() throws Exception {
         request.delete("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/reset", HttpStatus.OK);
-        verify(examAccessService, times(1)).checkCourseAndExamAccessForInstructorElseThrow(course1.getId(), exam1.getId());
+        verify(examAccessService).checkCourseAndExamAccessForInstructorElseThrow(course1.getId(), exam1.getId());
     }
 
     @Test
@@ -1411,7 +1411,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         TextExercise textExercise = TextExerciseFactory.generateTextExerciseForExam(exam2.getExerciseGroups().get(0));
         exerciseRepo.save(textExercise);
         request.delete("/api/courses/" + course1.getId() + "/exams/" + exam2.getId() + "/reset", HttpStatus.OK);
-        verify(examAccessService, times(1)).checkCourseAndExamAccessForInstructorElseThrow(course1.getId(), exam2.getId());
+        verify(examAccessService).checkCourseAndExamAccessForInstructorElseThrow(course1.getId(), exam2.getId());
     }
 
     @Test
@@ -1682,7 +1682,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         exam.setVisibleDate(ZonedDateTime.now().minusHours(1).minusMinutes(5));
         StudentExam response = request.get("/api/courses/" + course1.getId() + "/exams/" + exam.getId() + "/start", HttpStatus.OK, StudentExam.class);
         assertThat(response.getExam()).isEqualTo(exam);
-        verify(examAccessService, times(1)).getExamInCourseElseThrow(course1.getId(), exam.getId());
+        verify(examAccessService).getExamInCourseElseThrow(course1.getId(), exam.getId());
     }
 
     @Test
@@ -1728,7 +1728,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         // the course students + our custom student99
         assertThat(exam.getExamUsers()).hasSize(numberOfStudentsInCourse + 1);
         assertThat(exam.getExamUsers()).contains(examUser99.get());
-        verify(examAccessService, times(1)).checkCourseAndExamAccessForInstructorElseThrow(course.getId(), exam.getId());
+        verify(examAccessService).checkCourseAndExamAccessForInstructorElseThrow(course.getId(), exam.getId());
 
         Channel channelFromDB = channelRepository.findChannelByExamId(exam.getId());
         assertThat(channelFromDB).isNotNull();
@@ -1794,7 +1794,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         // Should save new order
         request.put("/api/courses/" + course1.getId() + "/exams/" + exam.getId() + "/exercise-groups-order", orderedExerciseGroups, HttpStatus.OK);
-        verify(examAccessService, times(1)).checkCourseAndExamAccessForEditorElseThrow(course1.getId(), exam.getId());
+        verify(examAccessService).checkCourseAndExamAccessForEditorElseThrow(course1.getId(), exam.getId());
         List<ExerciseGroup> savedExerciseGroups = examRepository.findWithExerciseGroupsById(exam.getId()).get().getExerciseGroups();
         assertThat(savedExerciseGroups.get(0).getTitle()).isEqualTo("second");
         assertThat(savedExerciseGroups.get(1).getTitle()).isEqualTo("third");
@@ -1872,8 +1872,8 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         assertThat(numOfLockedExercises).isEqualTo(2);
 
-        verify(programmingExerciseScheduleService, times(1)).lockAllStudentRepositoriesAndParticipations(programmingExercise);
-        verify(programmingExerciseScheduleService, times(1)).lockAllStudentRepositoriesAndParticipations(programmingExercise2);
+        verify(programmingExerciseScheduleService).lockAllStudentRepositoriesAndParticipations(programmingExercise);
+        verify(programmingExerciseScheduleService).lockAllStudentRepositoriesAndParticipations(programmingExercise2);
     }
 
     @Test
@@ -1943,8 +1943,8 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         assertThat(numOfUnlockedExercises).isEqualTo(2);
 
-        verify(programmingExerciseScheduleService, times(1)).unlockAllStudentRepositoriesAndParticipations(programmingExercise);
-        verify(programmingExerciseScheduleService, times(1)).unlockAllStudentRepositoriesAndParticipations(programmingExercise2);
+        verify(programmingExerciseScheduleService).unlockAllStudentRepositoriesAndParticipations(programmingExercise);
+        verify(programmingExerciseScheduleService).unlockAllStudentRepositoriesAndParticipations(programmingExercise2);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -671,7 +671,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
                 assertThat(participation.getSubmissions()).isEmpty();
                 // The participation should not get locked if it gets created after the exam already started
                 assertThat(((ProgrammingExerciseParticipation) participation).isLocked()).isFalse();
-                verify(versionControlService, atLeast(1)).configureRepository(eq(programmingExercise), (ProgrammingExerciseStudentParticipation) eq(participation), eq(true));
+                verify(versionControlService, atLeastOnce()).configureRepository(eq(programmingExercise), (ProgrammingExerciseStudentParticipation) eq(participation), eq(true));
             }
         }
 

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExerciseGroupIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExerciseGroupIntegrationTest.java
@@ -108,7 +108,7 @@ class ExerciseGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         exerciseGroup = ExamFactory.generateExerciseGroup(true, exam2);
         exerciseGroup.setTitle("      ExerciseGroup 123       ");
         URI exerciseGroupUri = request.post("/api/courses/" + course1.getId() + "/exams/" + exam2.getId() + "/exerciseGroups", exerciseGroup, HttpStatus.CREATED);
-        verify(examAccessService, times(1)).checkCourseAndExamAccessForEditorElseThrow(course1.getId(), exam2.getId());
+        verify(examAccessService).checkCourseAndExamAccessForEditorElseThrow(course1.getId(), exam2.getId());
         ExerciseGroup savedExerciseGroup = request.get(String.valueOf(exerciseGroupUri), HttpStatus.OK, ExerciseGroup.class);
         assertThat(savedExerciseGroup.getTitle()).isEqualTo("ExerciseGroup 123");
 
@@ -121,7 +121,7 @@ class ExerciseGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         exerciseGroup.setExam(null);
         request.put("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exerciseGroups", exerciseGroup, HttpStatus.CONFLICT);
         request.put("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exerciseGroups", exerciseGroup1, HttpStatus.OK);
-        verify(examAccessService, times(1)).checkCourseAndExamAndExerciseGroupAccessElseThrow(Role.EDITOR, course1.getId(), exam1.getId(), exerciseGroup1);
+        verify(examAccessService).checkCourseAndExamAndExerciseGroupAccessElseThrow(Role.EDITOR, course1.getId(), exam1.getId(), exerciseGroup1);
     }
 
     @Test
@@ -129,7 +129,7 @@ class ExerciseGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
     void testGetExerciseGroup_asEditor() throws Exception {
         ExerciseGroup result = request.get("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exerciseGroups/" + exerciseGroup1.getId(), HttpStatus.OK,
                 ExerciseGroup.class);
-        verify(examAccessService, times(1)).checkCourseAndExamAndExerciseGroupAccessElseThrow(Role.EDITOR, course1.getId(), exam1.getId(), exerciseGroup1);
+        verify(examAccessService).checkCourseAndExamAndExerciseGroupAccessElseThrow(Role.EDITOR, course1.getId(), exam1.getId(), exerciseGroup1);
         assertThat(result.getExam()).isEqualTo(exam1);
     }
 
@@ -137,7 +137,7 @@ class ExerciseGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
     @WithMockUser(username = TEST_PREFIX + "editor1", roles = "EDITOR")
     void testGetExerciseGroupsForExam_asEditor() throws Exception {
         List<ExerciseGroup> result = request.getList("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exerciseGroups", HttpStatus.OK, ExerciseGroup.class);
-        verify(examAccessService, times(1)).checkCourseAndExamAccessForEditorElseThrow(course1.getId(), exam1.getId());
+        verify(examAccessService).checkCourseAndExamAccessForEditorElseThrow(course1.getId(), exam1.getId());
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getExercises()).hasSize(1);
         assertThat(result.get(0).getExercises()).contains(textExercise1);
@@ -148,7 +148,7 @@ class ExerciseGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testDeleteExerciseGroup_asInstructor() throws Exception {
         request.delete("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exerciseGroups/" + exerciseGroup1.getId(), HttpStatus.OK);
-        verify(examAccessService, times(1)).checkCourseAndExamAndExerciseGroupAccessElseThrow(Role.INSTRUCTOR, course1.getId(), exam1.getId(), exerciseGroup1);
+        verify(examAccessService).checkCourseAndExamAndExerciseGroupAccessElseThrow(Role.INSTRUCTOR, course1.getId(), exam1.getId(), exerciseGroup1);
         assertThat(textExerciseRepository.findById(textExercise1.getId())).isEmpty();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -749,7 +749,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
                 HttpStatus.OK);
         assertThat(result.getWorkingTime()).isEqualTo(newWorkingTime);
         assertThat(studentExamRepository.findById(studentExam1.getId()).get().getWorkingTime()).isEqualTo(newWorkingTime);
-        verify(messagingTemplate, times(1)).convertAndSend("/topic/studentExams/" + studentExam1.getId() + "/working-time-change-during-conduction", 10800);
+        verify(messagingTemplate).convertAndSend("/topic/studentExams/" + studentExam1.getId() + "/working-time-change-during-conduction", 10800);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitlabServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitlabServiceTest.java
@@ -3,7 +3,6 @@ package de.tum.in.www1.artemis.exercise.programmingexercise;
 import static de.tum.in.www1.artemis.exercise.programmingexercise.ProgrammingSubmissionConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.net.URISyntaxException;
@@ -115,7 +114,7 @@ class GitlabServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
         versionControlService.getOrRetrieveBranchOfParticipation(programmingExercise.getSolutionParticipation());
         versionControlService.getOrRetrieveBranchOfParticipation(programmingExercise.getSolutionParticipation());
 
-        verify(versionControlService, times(1)).getDefaultBranchOfRepository(any());
+        verify(versionControlService).getDefaultBranchOfRepository(any());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingAssessmentIntegrationTest.java
@@ -904,7 +904,7 @@ class ProgrammingAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         var responseParticipation = response.getParticipation();
         assertThat(responseParticipation.getIndividualDueDate()).isNull();
 
-        verify(programmingExerciseParticipationService, times(1)).unlockStudentRepositoryAndParticipation(programmingExercise, participation);
+        verify(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(programmingExercise, participation);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -1622,10 +1622,8 @@ class ProgrammingExerciseIntegrationTestService {
         final var endpoint = ProgrammingExerciseResourceEndpoints.LOCK_ALL_REPOSITORIES.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));
         request.put(ROOT + endpoint, null, HttpStatus.OK);
 
-        verify(versionControlService, times(1)).setRepositoryPermissionsToReadOnly(participation1.getVcsRepositoryUrl(), programmingExercise.getProjectKey(),
-                participation1.getStudents());
-        verify(versionControlService, times(1)).setRepositoryPermissionsToReadOnly(participation2.getVcsRepositoryUrl(), programmingExercise.getProjectKey(),
-                participation2.getStudents());
+        verify(versionControlService).setRepositoryPermissionsToReadOnly(participation1.getVcsRepositoryUrl(), programmingExercise.getProjectKey(), participation1.getStudents());
+        verify(versionControlService).setRepositoryPermissionsToReadOnly(participation2.getVcsRepositoryUrl(), programmingExercise.getProjectKey(), participation2.getStudents());
 
         userUtilService.changeUser(userPrefix + "instructor1");
 
@@ -1659,8 +1657,8 @@ class ProgrammingExerciseIntegrationTestService {
         final var endpoint = ProgrammingExerciseResourceEndpoints.UNLOCK_ALL_REPOSITORIES.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));
         request.put(ROOT + endpoint, null, HttpStatus.OK);
 
-        verify(versionControlService, times(1)).configureRepository(programmingExercise, participation1, true);
-        verify(versionControlService, times(1)).configureRepository(programmingExercise, participation2, true);
+        verify(versionControlService).configureRepository(programmingExercise, participation1, true);
+        verify(versionControlService).configureRepository(programmingExercise, participation2, true);
 
         userUtilService.changeUser(userPrefix + "instructor1");
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseRepositoryServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseRepositoryServiceTest.java
@@ -49,7 +49,7 @@ class ProgrammingExerciseRepositoryServiceTest extends AbstractSpringIntegration
 
         programmingExerciseRepositoryService.handleRepoAccessRightChanges(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
 
-        verify(instanceMessageSendService, times(1)).sendLockAllStudentRepositories(programmingExerciseBeforeUpdate.getId());
+        verify(instanceMessageSendService).sendLockAllStudentRepositories(programmingExerciseBeforeUpdate.getId());
     }
 
     @Test
@@ -59,7 +59,7 @@ class ProgrammingExerciseRepositoryServiceTest extends AbstractSpringIntegration
 
         programmingExerciseRepositoryService.handleRepoAccessRightChanges(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
 
-        verify(instanceMessageSendService, times(1)).sendUnlockAllStudentRepositoriesWithEarlierStartDateAndLaterDueDate(programmingExerciseBeforeUpdate.getId());
+        verify(instanceMessageSendService).sendUnlockAllStudentRepositoriesWithEarlierStartDateAndLaterDueDate(programmingExerciseBeforeUpdate.getId());
     }
 
     @Test
@@ -72,7 +72,7 @@ class ProgrammingExerciseRepositoryServiceTest extends AbstractSpringIntegration
 
         programmingExerciseRepositoryService.handleRepoAccessRightChanges(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
 
-        verify(instanceMessageSendService, times(1)).sendUnlockAllStudentRepositoriesAndParticipationsWithEarlierStartDateAndLaterDueDate(programmingExerciseBeforeUpdate.getId());
+        verify(instanceMessageSendService).sendUnlockAllStudentRepositoriesAndParticipationsWithEarlierStartDateAndLaterDueDate(programmingExerciseBeforeUpdate.getId());
     }
 
     @Test
@@ -83,7 +83,7 @@ class ProgrammingExerciseRepositoryServiceTest extends AbstractSpringIntegration
 
         programmingExerciseRepositoryService.handleRepoAccessRightChanges(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
 
-        verify(instanceMessageSendService, times(1)).sendLockAllStudentRepositoriesAndParticipationsWithEarlierDueDate(programmingExerciseBeforeUpdate.getId());
+        verify(instanceMessageSendService).sendLockAllStudentRepositoriesAndParticipationsWithEarlierDueDate(programmingExerciseBeforeUpdate.getId());
     }
 
     @Test
@@ -94,7 +94,7 @@ class ProgrammingExerciseRepositoryServiceTest extends AbstractSpringIntegration
 
         programmingExerciseRepositoryService.handleRepoAccessRightChanges(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
 
-        verify(instanceMessageSendService, times(1)).sendLockAllStudentRepositoriesAndParticipationsWithEarlierDueDate(programmingExerciseBeforeUpdate.getId());
+        verify(instanceMessageSendService).sendLockAllStudentRepositoriesAndParticipationsWithEarlierDueDate(programmingExerciseBeforeUpdate.getId());
     }
 
     @Test
@@ -106,7 +106,7 @@ class ProgrammingExerciseRepositoryServiceTest extends AbstractSpringIntegration
 
         programmingExerciseRepositoryService.handleRepoAccessRightChanges(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
 
-        verify(instanceMessageSendService, times(1)).sendLockAllStudentParticipationsWithEarlierDueDate(programmingExerciseBeforeUpdate.getId());
+        verify(instanceMessageSendService).sendLockAllStudentParticipationsWithEarlierDueDate(programmingExerciseBeforeUpdate.getId());
     }
 
     @Test
@@ -117,7 +117,7 @@ class ProgrammingExerciseRepositoryServiceTest extends AbstractSpringIntegration
 
         programmingExerciseRepositoryService.handleRepoAccessRightChanges(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
 
-        verify(instanceMessageSendService, times(1)).sendUnlockAllStudentRepositoriesAndParticipationsWithEarlierStartDateAndLaterDueDate(programmingExerciseBeforeUpdate.getId());
+        verify(instanceMessageSendService).sendUnlockAllStudentRepositoriesAndParticipationsWithEarlierStartDateAndLaterDueDate(programmingExerciseBeforeUpdate.getId());
     }
 
     @Test
@@ -130,7 +130,7 @@ class ProgrammingExerciseRepositoryServiceTest extends AbstractSpringIntegration
 
         programmingExerciseRepositoryService.handleRepoAccessRightChanges(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
 
-        verify(instanceMessageSendService, times(1)).sendUnlockAllStudentParticipationsWithEarlierStartDateAndLaterDueDate(programmingExerciseBeforeUpdate.getId());
+        verify(instanceMessageSendService).sendUnlockAllStudentParticipationsWithEarlierStartDateAndLaterDueDate(programmingExerciseBeforeUpdate.getId());
     }
 
     @Test
@@ -140,7 +140,7 @@ class ProgrammingExerciseRepositoryServiceTest extends AbstractSpringIntegration
 
         programmingExerciseRepositoryService.handleRepoAccessRightChanges(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
 
-        verify(instanceMessageSendService, times(1)).sendLockAllStudentRepositoriesAndParticipations(programmingExerciseBeforeUpdate.getId());
+        verify(instanceMessageSendService).sendLockAllStudentRepositoriesAndParticipations(programmingExerciseBeforeUpdate.getId());
     }
 
     @Test
@@ -151,6 +151,6 @@ class ProgrammingExerciseRepositoryServiceTest extends AbstractSpringIntegration
 
         programmingExerciseRepositoryService.handleRepoAccessRightChanges(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
 
-        verify(instanceMessageSendService, times(1)).sendUnlockAllStudentRepositoriesAndParticipationsWithEarlierStartDateAndLaterDueDate(programmingExerciseBeforeUpdate.getId());
+        verify(instanceMessageSendService).sendUnlockAllStudentRepositoriesAndParticipationsWithEarlierStartDateAndLaterDueDate(programmingExerciseBeforeUpdate.getId());
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseScheduleServiceTest.java
@@ -164,7 +164,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
         // Lock student repository must be called once per participation.
         verifyLockStudentRepositoryAndParticipationOperation(true, dueDateDelayMS);
         // Instructor build should have been triggered.
-        verify(programmingTriggerService, timeout(dueDateDelayMS).times(1)).triggerInstructorBuildForExercise(programmingExercise.getId());
+        verify(programmingTriggerService, timeout(dueDateDelayMS)).triggerInstructorBuildForExercise(programmingExercise.getId());
     }
 
     @Test
@@ -214,7 +214,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         // Lock student repository must be called once per participation.
         verifyLockStudentRepositoryAndParticipationOperation(true, delayMS * 2);
-        verify(programmingTriggerService, timeout(delayMS * 2).times(1)).triggerInstructorBuildForExercise(programmingExercise.getId());
+        verify(programmingTriggerService, timeout(delayMS * 2)).triggerInstructorBuildForExercise(programmingExercise.getId());
     }
 
     @Test
@@ -253,7 +253,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
         verifyLockStudentRepositoryAndParticipationOperation(true, delayMS);
-        verify(programmingTriggerService, timeout(5000).times(1)).triggerInstructorBuildForExercise(programmingExercise.getId());
+        verify(programmingTriggerService, timeout(5000)).triggerInstructorBuildForExercise(programmingExercise.getId());
     }
 
     @Test
@@ -295,7 +295,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
         verifyLockStudentRepositoryAndParticipationOperation(true, dueDateDelayMS);
         verify(programmingTriggerService, never()).triggerInstructorBuildForExercise(programmingExercise.getId());
         // has AFTER_DUE_DATE tests and no additional build after due date => update the scores to show those test cases in it
-        verify(programmingExerciseGradingService, timeout(5000).times(1)).updateResultsOnlyRegularDueDateParticipations(programmingExercise);
+        verify(programmingExerciseGradingService, timeout(5000)).updateResultsOnlyRegularDueDateParticipations(programmingExercise);
         // make sure to trigger the update only for participants who do not have got an individual due date
         verify(programmingExerciseGradingService, never()).updateAllResults(programmingExercise);
     }
@@ -317,7 +317,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
         Thread.sleep(dueDateDelayMS + SCHEDULER_TASK_TRIGGER_DELAY_MS);   // ok
 
         verifyLockStudentRepositoryAndParticipationOperation(true, dueDateDelayMS / 2);
-        verify(programmingTriggerService, timeout(dueDateDelayMS).times(1)).triggerInstructorBuildForExercise(programmingExercise.getId());
+        verify(programmingTriggerService, timeout(dueDateDelayMS)).triggerInstructorBuildForExercise(programmingExercise.getId());
         // has AFTER_DUE_DATE tests, but also buildAfterDueDate => do not update results, but use the results created on additional build run
         verify(programmingExerciseGradingService, never()).updateAllResults(programmingExercise);
     }
@@ -346,7 +346,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         verifyLockStudentRepositoryAndParticipationOperation(true, dueDateDelayMS / 2);
         if (hasBuildAndTestAfterDueDate) {
-            verify(programmingTriggerService, timeout(dueDateDelayMS).times(1)).triggerInstructorBuildForExercise(programmingExercise.getId());
+            verify(programmingTriggerService, timeout(dueDateDelayMS)).triggerInstructorBuildForExercise(programmingExercise.getId());
         }
         else {
             verify(programmingTriggerService, never()).triggerInstructorBuildForExercise(programmingExercise.getId());
@@ -366,7 +366,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
         programmingExerciseRepository.save(programmingExercise);
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
-        verify(gitService, timeout(5000).times(1)).combineAllCommitsOfRepositoryIntoOne(repositoryUrl);
+        verify(gitService, timeout(5000)).combineAllCommitsOfRepositoryIntoOne(repositoryUrl);
     }
 
     @Test
@@ -413,7 +413,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
-        verify(scheduleService, timeout(5000).times(1)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
+        verify(scheduleService, timeout(5000)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
         verify(scheduleService, never()).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE), any());
 
         Thread.sleep(delayMS + SCHEDULER_TASK_TRIGGER_DELAY_MS);      // ok
@@ -429,7 +429,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         // after build and test date: no individual build and test actions are scheduled
         verify(programmingTriggerService, never()).triggerBuildForParticipations(List.of(participationIndividualDueDate));
-        verify(programmingTriggerService, timeout(2 * SCHEDULER_TASK_TRIGGER_DELAY_MS).times(1)).triggerInstructorBuildForExercise(programmingExercise.getId());
+        verify(programmingTriggerService, timeout(2 * SCHEDULER_TASK_TRIGGER_DELAY_MS)).triggerInstructorBuildForExercise(programmingExercise.getId());
     }
 
     @Test
@@ -447,9 +447,8 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
         // special scheduling for both lock and build and test
-        verify(scheduleService, timeout(5000).times(1)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
-        verify(scheduleService, timeout(5000).times(1)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE),
-                any());
+        verify(scheduleService, timeout(5000)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
+        verify(scheduleService, timeout(5000)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE), any());
     }
 
     @Test
@@ -470,10 +469,10 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
-        verify(scheduleService, timeout(5000).times(1)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
+        verify(scheduleService, timeout(5000)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
         verify(scheduleService, never()).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE), any());
 
-        verify(scheduleService, timeout(5000).times(1)).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
+        verify(scheduleService, timeout(5000)).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
         verify(scheduleService, never()).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE), any(Runnable.class));
     }
 
@@ -494,10 +493,10 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
-        verify(scheduleService, timeout(5000).times(1)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
+        verify(scheduleService, timeout(5000)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
         verify(scheduleService, never()).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE), any());
 
-        verify(scheduleService, timeout(5000).times(1)).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
+        verify(scheduleService, timeout(5000)).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
         verify(scheduleService, never()).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE), any(Runnable.class));
 
         // remove due date and schedule again
@@ -532,8 +531,8 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
-        verify(scheduleService, timeout(5000).times(1)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
-        verify(scheduleService, timeout(5000).times(1)).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
+        verify(scheduleService, timeout(5000)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
+        verify(scheduleService, timeout(5000)).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
 
         // remove individual due date and schedule again
         participationIndividualDueDate.setIndividualDueDate(null);
@@ -544,7 +543,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
         // called twice: first time when removing potential old schedules before scheduling, second time only cancelling
         verify(scheduleService, timeout(5000).times(2)).cancelScheduledTaskForParticipationLifecycle(programmingExercise.getId(), participationIndividualDueDate.getId(),
                 ParticipationLifecycle.DUE);
-        verify(scheduleService, timeout(5000).times(1)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
+        verify(scheduleService, timeout(5000)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
     }
 
     @Test
@@ -561,8 +560,8 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
-        verify(scheduleService, timeout(5000).times(1)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
-        verify(scheduleService, timeout(5000).times(1)).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
+        verify(scheduleService, timeout(5000)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
+        verify(scheduleService, timeout(5000)).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
 
         // change individual due date and schedule again
         participationIndividualDueDate.setIndividualDueDate(plusMillis(now, 3 * delayMS));
@@ -592,10 +591,10 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
-        verify(scheduleService, timeout(5000).times(1)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
+        verify(scheduleService, timeout(5000)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
         verify(scheduleService, never()).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE), any());
 
-        verify(scheduleService, timeout(5000).times(1)).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
+        verify(scheduleService, timeout(5000)).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
         verify(scheduleService, never()).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE), any(Runnable.class));
 
         // change exercise due date and schedule again
@@ -626,7 +625,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
-        verify(scheduleService, timeout(5000).times(1)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
+        verify(scheduleService, timeout(5000)).scheduleParticipationTask(eq(participationIndividualDueDate), eq(ParticipationLifecycle.DUE), any());
         verify(scheduleService, never()).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
     }
 
@@ -646,10 +645,10 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
         instanceMessageReceiveService.processScheduleProgrammingExercise(programmingExercise.getId());
 
         verify(scheduleService, never()).scheduleTask(eq(programmingExercise), eq(ExerciseLifecycle.DUE), any(Runnable.class));
-        verify(scheduleService, timeout(5000).times(1)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.RELEASE);
-        verify(scheduleService, timeout(5000).times(1)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.DUE);
-        verify(scheduleService, timeout(5000).times(1)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE);
-        verify(scheduleService, timeout(5000).times(1)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.ASSESSMENT_DUE);
+        verify(scheduleService, timeout(5000)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.RELEASE);
+        verify(scheduleService, timeout(5000)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.DUE);
+        verify(scheduleService, timeout(5000)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE);
+        verify(scheduleService, timeout(5000)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.ASSESSMENT_DUE);
     }
 
     @Test
@@ -669,7 +668,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         instanceMessageReceiveService.processExamWorkingTimeChangeDuringConduction(studentExam.getId());
 
-        verify(versionControlService, timeout(200).times(1)).setRepositoryPermissionsToReadOnly(participation.getVcsRepositoryUrl(), examExercise.getProjectKey(),
+        verify(versionControlService, timeout(200)).setRepositoryPermissionsToReadOnly(participation.getVcsRepositoryUrl(), examExercise.getProjectKey(),
                 participation.getStudents());
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestCaseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestCaseServiceTest.java
@@ -185,8 +185,8 @@ class ProgrammingExerciseTestCaseServiceTest extends AbstractSpringIntegrationBa
         }
         assertThat(updatedProgrammingExercise.getTestCasesChanged()).isTrue();
 
-        verify(groupNotificationService, times(1)).notifyEditorAndInstructorGroupsAboutChangedTestCasesForProgrammingExercise(updatedProgrammingExercise);
-        verify(websocketMessagingService, times(1)).sendMessage("/topic/programming-exercises/" + programmingExercise.getId() + "/test-cases-changed", true);
+        verify(groupNotificationService).notifyEditorAndInstructorGroupsAboutChangedTestCasesForProgrammingExercise(updatedProgrammingExercise);
+        verify(websocketMessagingService).sendMessage("/topic/programming-exercises/" + programmingExercise.getId() + "/test-cases-changed", true);
     }
 
     @Test
@@ -220,8 +220,8 @@ class ProgrammingExerciseTestCaseServiceTest extends AbstractSpringIntegrationBa
 
         assertThat(testCaseRepository.findById(testCase.getId()).get().getWeight()).isEqualTo(400);
         assertThat(updatedProgrammingExercise.getTestCasesChanged()).isTrue();
-        verify(groupNotificationService, times(1)).notifyEditorAndInstructorGroupsAboutChangedTestCasesForProgrammingExercise(updatedProgrammingExercise);
-        verify(websocketMessagingService, times(1)).sendMessage("/topic/programming-exercises/" + programmingExercise.getId() + "/test-cases-changed", true);
+        verify(groupNotificationService).notifyEditorAndInstructorGroupsAboutChangedTestCasesForProgrammingExercise(updatedProgrammingExercise);
+        verify(websocketMessagingService).sendMessage("/topic/programming-exercises/" + programmingExercise.getId() + "/test-cases-changed", true);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest.java
@@ -889,7 +889,7 @@ class ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest extends Abstr
         createdResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(createdResult.getId()).get();
 
         // Student should receive a result over WebSocket, the exam not over (grace period still active)
-        verify(messagingTemplate, times(1)).convertAndSendToUser(eq(user.getLogin()), eq(NEW_RESULT_TOPIC), isA(Result.class));
+        verify(messagingTemplate).convertAndSendToUser(eq(user.getLogin()), eq(NEW_RESULT_TOPIC), isA(Result.class));
 
         // Assert that the submission is illegal
         assertThat(submission.getParticipation().getId()).isEqualTo(participation.getId());

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingSubmissionIntegrationTest.java
@@ -268,9 +268,8 @@ class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         assertThat(optionalUpdatedProgrammingExercise).isPresent();
         ProgrammingExercise updatedProgrammingExercise = optionalUpdatedProgrammingExercise.get();
         assertThat(updatedProgrammingExercise.getTestCasesChanged()).isFalse();
-        verify(groupNotificationService, times(1)).notifyEditorAndInstructorGroupAboutExerciseUpdate(updatedProgrammingExercise,
-                Constants.TEST_CASES_CHANGED_RUN_COMPLETED_NOTIFICATION);
-        verify(websocketMessagingService, times(1)).sendMessage("/topic/programming-exercises/" + exercise.getId() + "/test-cases-changed", false);
+        verify(groupNotificationService).notifyEditorAndInstructorGroupAboutExerciseUpdate(updatedProgrammingExercise, Constants.TEST_CASES_CHANGED_RUN_COMPLETED_NOTIFICATION);
+        verify(websocketMessagingService).sendMessage("/topic/programming-exercises/" + exercise.getId() + "/test-cases-changed", false);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/metis/AbstractConversationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/AbstractConversationTest.java
@@ -134,7 +134,7 @@ abstract class AbstractConversationTest extends AbstractSpringIntegrationBambooB
     void verifyParticipantTopicWebsocketSent(MetisCrudAction crudAction, Long conversationId, String userLoginsWithoutPrefix) {
         var receivingUser = userUtilService.getUserByLogin(testPrefix + userLoginsWithoutPrefix);
         var topic = ConversationService.getConversationParticipantTopicName(exampleCourseId) + receivingUser.getId();
-        verify(messagingTemplate, times(1)).convertAndSendToUser(eq(testPrefix + userLoginsWithoutPrefix), eq(topic),
+        verify(messagingTemplate).convertAndSendToUser(eq(testPrefix + userLoginsWithoutPrefix), eq(topic),
                 argThat((argument) -> argument instanceof ConversationWebsocketDTO && ((ConversationWebsocketDTO) argument).metisCrudAction().equals(crudAction)
                         && ((ConversationWebsocketDTO) argument).conversation().getId().equals(conversationId)));
 

--- a/src/test/java/de/tum/in/www1/artemis/metis/PostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/PostIntegrationTest.java
@@ -248,7 +248,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         PostContextFilter postContextFilter = new PostContextFilter(courseId);
         postContextFilter.setExerciseIds(new Long[] { firstExerciseId });
         assertThat(postsBelongingToFirstExercise).hasSameSizeAs(postRepository.findPosts(postContextFilter, null, false, null));
-        verify(groupNotificationService, times(0)).notifyAllGroupsAboutNewPostForExercise(any(), any());
+        verify(groupNotificationService, never()).notifyAllGroupsAboutNewPostForExercise(any(), any());
 
     }
 
@@ -326,7 +326,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         // assertThat(existingPostsAndConversationPosts.size()).isEqualTo(postRepository.count());
 
         assertThat(postRepository.findPosts(postContextFilter, null, false, null)).hasSize(numberOfPostsBefore);
-        verify(groupNotificationService, times(0)).notifyAllGroupsAboutNewAnnouncement(any(), any());
+        verify(groupNotificationService, never()).notifyAllGroupsAboutNewAnnouncement(any(), any());
     }
 
     @Test
@@ -360,7 +360,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         request.postWithResponseBody("/api/courses/" + courseId + "/posts", existingPostToSave, Post.class, HttpStatus.BAD_REQUEST);
         assertThat(postRepository.findPosts(postContextFilter, null, false, null)).hasSize(sizeBefore);
-        verify(groupNotificationService, times(0)).notifyAllGroupsAboutNewPostForExercise(any(), any());
+        verify(groupNotificationService, never()).notifyAllGroupsAboutNewPostForExercise(any(), any());
     }
 
     @Test
@@ -373,7 +373,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         postToSave.setCourseWideContext(CourseWideContext.RANDOM);
 
         request.postWithResponseBody("/api/courses/" + courseId + "/posts", postToSave, Post.class, HttpStatus.BAD_REQUEST);
-        verify(groupNotificationService, times(0)).notifyAllGroupsAboutNewCoursePost(any(), any());
+        verify(groupNotificationService, never()).notifyAllGroupsAboutNewCoursePost(any(), any());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/metis/PostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/PostIntegrationTest.java
@@ -195,7 +195,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         PostContextFilter postContextFilter = new PostContextFilter(courseId);
         postContextFilter.setExerciseIds(new Long[] { firstExerciseId });
         assertThat(postsBelongingToFirstExercise).hasSize(postRepository.findPosts(postContextFilter, null, false, null).getSize() - 1);
-        verify(groupNotificationService, times(1)).notifyAllGroupsAboutNewPostForExercise(createdPost, course);
+        verify(groupNotificationService).notifyAllGroupsAboutNewPostForExercise(createdPost, course);
     }
 
     @Test
@@ -266,7 +266,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         PostContextFilter postContextFilter = new PostContextFilter(courseId);
         postContextFilter.setLectureIds(new Long[] { firstLectureId });
         assertThat(postsBelongingToFirstLecture).hasSize(postRepository.findPosts(postContextFilter, null, false, null).getSize() - 1);
-        verify(groupNotificationService, times(1)).notifyAllGroupsAboutNewPostForLecture(createdPost, course);
+        verify(groupNotificationService).notifyAllGroupsAboutNewPostForLecture(createdPost, course);
     }
 
     @Test
@@ -285,7 +285,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         List<Post> updatedCourseWidePosts = postRepository.findPosts(postContextFilter, null, false, null).stream().filter(post -> post.getCourseWideContext() != null).toList();
         assertThat(existingCourseWidePosts).hasSize(updatedCourseWidePosts.size() - 1);
-        verify(groupNotificationService, times(1)).notifyAllGroupsAboutNewCoursePost(createdPost, course);
+        verify(groupNotificationService).notifyAllGroupsAboutNewCoursePost(createdPost, course);
     }
 
     @Test
@@ -307,7 +307,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         List<Post> updatedCourseWidePosts = postRepository.findPosts(postContextFilter, null, false, null).stream().filter(post -> post.getCourseWideContext() != null).toList();
         assertThat(postRepository.findPosts(postContextFilter, null, false, null)).hasSize(numberOfPostsBefore + 1);
-        verify(groupNotificationService, times(1)).notifyAllGroupsAboutNewAnnouncement(createdPost, course);
+        verify(groupNotificationService).notifyAllGroupsAboutNewAnnouncement(createdPost, course);
     }
 
     @Test
@@ -346,7 +346,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         List<Post> updatedPlagiarismCasePosts = postRepository.findPostsByPlagiarismCaseId(plagiarismCase.getId());
         assertThat(updatedPlagiarismCasePosts).hasSize(1);
-        verify(singleUserNotificationService, times(1)).notifyUserAboutNewPlagiarismCase(any(), any());
+        verify(singleUserNotificationService).notifyUserAboutNewPlagiarismCase(any(), any());
     }
 
     @Test
@@ -396,7 +396,7 @@ class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         // if error occurs during parsing markdown to html, the content will be replaced by an empty string
         expectedPost.setContent("");
 
-        verify(groupNotificationService, times(1)).notifyAllGroupsAboutNewPostForExercise(expectedPost, course);
+        verify(groupNotificationService).notifyAllGroupsAboutNewPostForExercise(expectedPost, course);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/notification/GroupNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/GroupNotificationServiceTest.java
@@ -241,7 +241,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
     void testNotifyAboutExerciseUpdate_futureReleaseDate() {
         exercise.setReleaseDate(FUTURE_TIME);
         groupNotificationService.notifyAboutExerciseUpdate(exercise, NOTIFICATION_TEXT);
-        verify(groupNotificationService, times(0)).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(exercise, NOTIFICATION_TEXT);
+        verify(groupNotificationService, never()).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(exercise, NOTIFICATION_TEXT);
     }
 
     /**
@@ -261,7 +261,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
     void testNotifyAboutExerciseUpdate_correctReleaseDate_courseExercise() {
         exercise.setReleaseDate(CURRENT_TIME);
         groupNotificationService.notifyAboutExerciseUpdate(exercise, null);
-        verify(groupNotificationService, times(0)).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(any(), any());
+        verify(groupNotificationService, never()).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(any(), any());
         groupNotificationService.notifyAboutExerciseUpdate(exercise, NOTIFICATION_TEXT);
         verify(groupNotificationService).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(any(), any());
     }

--- a/src/test/java/de/tum/in/www1/artemis/notification/GroupNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/GroupNotificationServiceTest.java
@@ -231,7 +231,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
     @Test
     void testNotifyAboutExerciseUpdate_undefinedReleaseDate() {
         groupNotificationService.notifyAboutExerciseUpdate(exercise, NOTIFICATION_TEXT);
-        verify(groupNotificationService, times(1)).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(exercise, NOTIFICATION_TEXT);
+        verify(groupNotificationService).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(exercise, NOTIFICATION_TEXT);
     }
 
     /**
@@ -251,7 +251,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
     void testNotifyAboutExerciseUpdate_correctReleaseDate_examExercise() {
         examExercise.setReleaseDate(CURRENT_TIME);
         groupNotificationService.notifyAboutExerciseUpdate(examExercise, null);
-        verify(groupNotificationService, times(1)).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(any(), any());
+        verify(groupNotificationService).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(any(), any());
     }
 
     /**
@@ -263,7 +263,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
         groupNotificationService.notifyAboutExerciseUpdate(exercise, null);
         verify(groupNotificationService, times(0)).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(any(), any());
         groupNotificationService.notifyAboutExerciseUpdate(exercise, NOTIFICATION_TEXT);
-        verify(groupNotificationService, times(1)).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(any(), any());
+        verify(groupNotificationService).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(any(), any());
     }
 
     /// CheckNotificationForExerciseRelease
@@ -274,7 +274,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
     @Test
     void testCheckNotificationForExerciseRelease_undefinedReleaseDate() {
         groupNotificationScheduleService.checkNotificationsForNewExercise(exercise);
-        verify(groupNotificationService, timeout(1500).times(1)).notifyAllGroupsAboutReleasedExercise(any());
+        verify(groupNotificationService, timeout(1500)).notifyAllGroupsAboutReleasedExercise(any());
     }
 
     /**
@@ -284,7 +284,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
     void testCheckNotificationForExerciseRelease_currentOrPastReleaseDate() {
         exercise.setReleaseDate(CURRENT_TIME);
         groupNotificationScheduleService.checkNotificationsForNewExercise(exercise);
-        verify(groupNotificationService, timeout(1500).times(1)).notifyAllGroupsAboutReleasedExercise(any());
+        verify(groupNotificationService, timeout(1500)).notifyAllGroupsAboutReleasedExercise(any());
     }
 
     /**
@@ -294,7 +294,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
     void testCheckNotificationForExerciseRelease_futureReleaseDate() {
         exercise.setReleaseDate(FUTURE_TIME);
         groupNotificationScheduleService.checkNotificationsForNewExercise(exercise);
-        verify(instanceMessageSendService, timeout(1500).times(1)).sendExerciseReleaseNotificationSchedule(any());
+        verify(instanceMessageSendService, timeout(1500)).sendExerciseReleaseNotificationSchedule(any());
     }
 
     /// CheckAndCreateAppropriateNotificationsWhenUpdatingExercise
@@ -312,7 +312,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
 
         groupNotificationScheduleService.checkAndCreateAppropriateNotificationsWhenUpdatingExercise(exercise, updatedExercise, NOTIFICATION_TEXT);
 
-        verify(groupNotificationService, times(1)).notifyAboutExerciseUpdate(any(), any());
+        verify(groupNotificationService).notifyAboutExerciseUpdate(any(), any());
 
         // Exercise Released Notifications
         verify(groupNotificationService, times(expectNotifyAboutExerciseReleaseNow ? 1 : 0)).notifyAllGroupsAboutReleasedExercise(any());

--- a/src/test/java/de/tum/in/www1/artemis/notification/NotificationScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/NotificationScheduleServiceTest.java
@@ -85,7 +85,7 @@ class NotificationScheduleServiceTest extends AbstractSpringIntegrationBambooBit
         instanceMessageReceiveService.processScheduleExerciseReleasedNotification(exercise.getId());
         await().until(() -> notificationRepository.count() > sizeBefore);
         verify(groupNotificationService, timeout(4000)).notifyAllGroupsAboutReleasedExercise(exercise);
-        verify(mailService, timeout(4000).atLeast(1)).sendNotification(any(), anyList(), any());
+        verify(mailService, timeout(4000).atLeastOnce()).sendNotification(any(), anyList(), any());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/notification/NotificationScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/NotificationScheduleServiceTest.java
@@ -84,7 +84,7 @@ class NotificationScheduleServiceTest extends AbstractSpringIntegrationBambooBit
         notificationSettingRepository.save(new NotificationSetting(user, true, true, true, NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_RELEASED));
         instanceMessageReceiveService.processScheduleExerciseReleasedNotification(exercise.getId());
         await().until(() -> notificationRepository.count() > sizeBefore);
-        verify(groupNotificationService, timeout(4000).times(1)).notifyAllGroupsAboutReleasedExercise(exercise);
+        verify(groupNotificationService, timeout(4000)).notifyAllGroupsAboutReleasedExercise(exercise);
         verify(mailService, timeout(4000).atLeast(1)).sendNotification(any(), anyList(), any());
     }
 
@@ -108,7 +108,7 @@ class NotificationScheduleServiceTest extends AbstractSpringIntegrationBambooBit
         instanceMessageReceiveService.processScheduleAssessedExerciseSubmittedNotification(exercise.getId());
 
         await().until(() -> notificationRepository.count() > sizeBefore);
-        verify(singleUserNotificationService, timeout(4000).times(1)).notifyUsersAboutAssessedExerciseSubmission(exercise);
-        verify(javaMailSender, timeout(4000).times(1)).send(any(MimeMessage.class));
+        verify(singleUserNotificationService, timeout(4000)).notifyUsersAboutAssessedExerciseSubmission(exercise);
+        verify(javaMailSender, timeout(4000)).send(any(MimeMessage.class));
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/notification/SingleUserNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/SingleUserNotificationServiceTest.java
@@ -248,7 +248,7 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationBambooB
 
         assertThat(notificationRepository.findAll()).as("The notification should have been saved to the DB").hasSize(1);
         // no web app notification or email should be sent
-        verify(messagingTemplate, times(0)).convertAndSend(any());
+        verify(messagingTemplate, never()).convertAndSend(any());
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/notification/SingleUserNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/SingleUserNotificationServiceTest.java
@@ -312,7 +312,7 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationBambooB
     void testCheckNotificationForAssessmentExerciseSubmission_undefinedAssessmentDueDate() {
         exercise = TextExerciseFactory.generateTextExercise(null, null, null, course);
         singleUserNotificationService.checkNotificationForAssessmentExerciseSubmission(exercise, user, result);
-        verify(singleUserNotificationService, times(1)).checkNotificationForAssessmentExerciseSubmission(exercise, user, result);
+        verify(singleUserNotificationService).checkNotificationForAssessmentExerciseSubmission(exercise, user, result);
     }
 
     /**
@@ -378,7 +378,7 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationBambooB
         singleUserNotificationService.notifyUserAboutNewPlagiarismCase(plagiarismCase, user);
         verifyRepositoryCallWithCorrectNotification(NEW_PLAGIARISM_CASE_STUDENT_TITLE);
         ArgumentCaptor<MimeMessage> mimeMessageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
-        verify(javaMailSender, timeout(1000).times(1)).send(mimeMessageCaptor.capture());
+        verify(javaMailSender, timeout(1000)).send(mimeMessageCaptor.capture());
         assertThat(mimeMessageCaptor.getValue().getSubject()).isEqualTo("New Plagiarism Case: Exercise \"" + exerciseTitle + "\" in the course \"" + course.getTitle() + "\"");
     }
 
@@ -393,7 +393,7 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationBambooB
         singleUserNotificationService.notifyUserAboutPlagiarismCaseVerdict(plagiarismCase, user);
         verifyRepositoryCallWithCorrectNotification(PLAGIARISM_CASE_VERDICT_STUDENT_TITLE);
         ArgumentCaptor<MimeMessage> mimeMessageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
-        verify(javaMailSender, timeout(1000).times(1)).send(mimeMessageCaptor.capture());
+        verify(javaMailSender, timeout(1000)).send(mimeMessageCaptor.capture());
         assertThat(mimeMessageCaptor.getValue().getSubject()).isEqualTo(PLAGIARISM_CASE_VERDICT_STUDENT_TITLE);
     }
 
@@ -404,17 +404,17 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationBambooB
         List<Notification> capturedNotifications = notificationRepository.findAll();
         assertThat(capturedNotifications).as("Notification should not have been saved").hasSize(notificationsBefore);
         // notification should be sent
-        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/user/" + user.getId() + "/notifications"), (Object) any());
+        verify(messagingTemplate).convertAndSend(eq("/topic/user/" + user.getId() + "/notifications"), (Object) any());
     }
 
     @Test
     void testConversationNotificationsGroupChatCreation() {
         int notificationsBefore = (int) notificationRepository.count();
         singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(groupChat, user, userTwo, CONVERSATION_CREATE_GROUP_CHAT);
-        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/user/" + user.getId() + "/notifications"), (Object) any());
+        verify(messagingTemplate).convertAndSend(eq("/topic/user/" + user.getId() + "/notifications"), (Object) any());
 
         singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(groupChat, userThree, userTwo, CONVERSATION_CREATE_GROUP_CHAT);
-        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/user/" + userThree.getId() + "/notifications"), (Object) any());
+        verify(messagingTemplate).convertAndSend(eq("/topic/user/" + userThree.getId() + "/notifications"), (Object) any());
 
         List<Notification> capturedNotifications = notificationRepository.findAll();
         assertThat(capturedNotifications).as("Both notifications should have been saved").hasSize(notificationsBefore + 2);
@@ -428,7 +428,7 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationBambooB
     @MethodSource("getNotificationTypesAndTitlesParametersForGroupChat")
     void testConversationNotificationsGroupChatAddAndRemoveUsers(NotificationType notificationType, String expectedTitle) {
         singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(groupChat, user, userTwo, notificationType);
-        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/user/" + user.getId() + "/notifications"), (Object) any());
+        verify(messagingTemplate).convertAndSend(eq("/topic/user/" + user.getId() + "/notifications"), (Object) any());
 
         verifyRepositoryCallWithCorrectNotification(expectedTitle);
     }
@@ -437,7 +437,7 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationBambooB
     @MethodSource("getNotificationTypesAndTitlesParametersForChannel")
     void testConversationNotificationsChannel(NotificationType notificationType, String expectedTitle) {
         singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(channel, user, userTwo, notificationType);
-        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/user/" + user.getId() + "/notifications"), (Object) any());
+        verify(messagingTemplate).convertAndSend(eq("/topic/user/" + user.getId() + "/notifications"), (Object) any());
 
         verifyRepositoryCallWithCorrectNotification(expectedTitle);
     }
@@ -456,7 +456,7 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationBambooB
         answerPost.setPost(post);
 
         singleUserNotificationService.notifyUserAboutNewMessageReply(answerPost, user, userTwo);
-        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/user/" + user.getId() + "/notifications"), (Object) any());
+        verify(messagingTemplate).convertAndSend(eq("/topic/user/" + user.getId() + "/notifications"), (Object) any());
 
         verifyRepositoryCallWithCorrectNotification(MESSAGE_REPLY_IN_CONVERSATION_TITLE);
     }
@@ -539,7 +539,7 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationBambooB
      * Checks if an email was created and send
      */
     private void verifyEmail() {
-        verify(javaMailSender, timeout(1000).times(1)).send(any(MimeMessage.class));
+        verify(javaMailSender, timeout(1000)).send(any(MimeMessage.class));
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
@@ -532,7 +532,7 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         assertThat(response.getResults()).allMatch(result1 -> result.getAssessmentType() == AssessmentType.SEMI_AUTOMATIC);
         assertThat(response.getIndividualDueDate()).isNotNull().isBefore(ZonedDateTime.now());
 
-        verify(programmingExerciseParticipationService, times(1)).lockStudentRepositoryAndParticipation(programmingExercise, participation);
+        verify(programmingExerciseParticipationService).lockStudentRepositoryAndParticipation(programmingExercise, participation);
     }
 
     @Test
@@ -902,8 +902,8 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         assertThat(response).hasSize(1);
         assertThat(response.get(0).getIndividualDueDate()).isEqualToIgnoringNanos(participation.getIndividualDueDate());
 
-        verify(programmingExerciseScheduleService, times(1)).updateScheduling(exercise);
-        verify(programmingExerciseParticipationService, times(1)).unlockStudentRepositoryAndParticipation(exercise, participation);
+        verify(programmingExerciseScheduleService).updateScheduling(exercise);
+        verify(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(exercise, participation);
         verify(programmingExerciseParticipationService, never()).unlockStudentRepositoryAndParticipation(exercise, participation2);
     }
 
@@ -966,9 +966,9 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
                 StudentParticipation.class, HttpStatus.OK);
 
         assertThat(response).hasSize(1);
-        verify(programmingExerciseScheduleService, times(1)).updateScheduling(exercise);
+        verify(programmingExerciseScheduleService).updateScheduling(exercise);
         // make sure the student repo is unlocked as the due date is in the future
-        verify(programmingExerciseParticipationService, times(1)).unlockStudentRepositoryAndParticipation(exercise, participation);
+        verify(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(exercise, participation);
     }
 
     @Test
@@ -992,9 +992,9 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
                 StudentParticipation.class, HttpStatus.OK);
 
         assertThat(response).hasSize(1);
-        verify(programmingExerciseScheduleService, times(1)).updateScheduling(exercise);
+        verify(programmingExerciseScheduleService).updateScheduling(exercise);
         // student repo should be locked as due date is in the past
-        verify(programmingExerciseParticipationService, times(1)).lockStudentRepositoryAndParticipation(exercise, participation);
+        verify(programmingExerciseParticipationService).lockStudentRepositoryAndParticipation(exercise, participation);
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/security/lti/Lti13TokenRetrieverTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/security/lti/Lti13TokenRetrieverTest.java
@@ -122,8 +122,8 @@ class Lti13TokenRetrieverTest {
 
         String token = lti13TokenRetriever.getToken(clientRegistration, Scopes.AGS_SCORE);
 
-        verify(oAuth2JWKSService, times(1)).getJWK(clientRegistration.getRegistrationId());
-        verify(restTemplate, times(1)).exchange(any(), eq(String.class));
+        verify(oAuth2JWKSService).getJWK(clientRegistration.getRegistrationId());
+        verify(restTemplate).exchange(any(), eq(String.class));
 
         assertThat(token).isNull();
     }
@@ -138,8 +138,8 @@ class Lti13TokenRetrieverTest {
 
         String token = lti13TokenRetriever.getToken(clientRegistration, Scopes.AGS_SCORE);
 
-        verify(oAuth2JWKSService, times(1)).getJWK(clientRegistration.getRegistrationId());
-        verify(restTemplate, times(1)).exchange(any(), eq(String.class));
+        verify(oAuth2JWKSService).getJWK(clientRegistration.getRegistrationId());
+        verify(restTemplate).exchange(any(), eq(String.class));
 
         assertThat(token).isNull();
     }
@@ -156,8 +156,8 @@ class Lti13TokenRetrieverTest {
 
         String token = lti13TokenRetriever.getToken(clientRegistration, Scopes.AGS_SCORE);
 
-        verify(oAuth2JWKSService, times(1)).getJWK(clientRegistration.getRegistrationId());
-        verify(restTemplate, times(1)).exchange(any(), eq(String.class));
+        verify(oAuth2JWKSService).getJWK(clientRegistration.getRegistrationId());
+        verify(restTemplate).exchange(any(), eq(String.class));
 
         assertThat(token).isEqualTo("result");
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/EmailSummaryServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/EmailSummaryServiceTest.java
@@ -131,8 +131,8 @@ class EmailSummaryServiceTest extends AbstractSpringIntegrationBambooBitbucketJi
         weeklyEmailSummaryService.prepareEmailSummariesForUsers(Set.of(userWithActivatedWeeklySummaries));
 
         ArgumentCaptor<Set<Exercise>> captor = ArgumentCaptor.forClass(Set.class);
-        verify(mailService, timeout(5000).times(1)).sendWeeklySummaryEmail(eq(userWithActivatedWeeklySummaries), captor.capture());
-        verify(javaMailSender, timeout(5000).times(1)).send(any(MimeMessage.class));
+        verify(mailService, timeout(5000)).sendWeeklySummaryEmail(eq(userWithActivatedWeeklySummaries), captor.capture());
+        verify(javaMailSender, timeout(5000)).send(any(MimeMessage.class));
 
         Set<Exercise> capturedExerciseSet = captor.getValue();
         assertThat(capturedExerciseSet).as("Weekly summary should contain exercises that were released yesterday and are not yet due.")

--- a/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/GitlabCIServiceTest.java
@@ -181,8 +181,8 @@ class GitlabCIServiceTest extends AbstractSpringIntegrationGitlabCIGitlabSamlTes
 
         verify(gitlab, atLeastOnce()).getPipelineApi();
         verify(gitlab.getPipelineApi(), atLeastOnce()).createPipelineTrigger(any(), anyString());
-        verify(gitlab.getPipelineApi(), times(1)).triggerPipeline(eq(urlService.getRepositoryPathFromRepositoryUrl(participation.getVcsRepositoryUrl())), any(Trigger.class),
-                anyString(), isNull());
+        verify(gitlab.getPipelineApi()).triggerPipeline(eq(urlService.getRepositoryPathFromRepositoryUrl(participation.getVcsRepositoryUrl())), any(Trigger.class), anyString(),
+                isNull());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/service/JenkinsJobServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/JenkinsJobServiceTest.java
@@ -83,7 +83,7 @@ class JenkinsJobServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
         // This call shall not fail, since the job will be created ..
         jenkinsJobService.createJobInFolder(validDocument, "JenkinsFolder", "JenkinsJob");
         // Create Job should be invoked on JenkinsServer
-        verify(jenkinsServer, times(1)).createJob(any(FolderJob.class), eq("JenkinsJob"), eq("JenkinsConfigStringMock"), any());
+        verify(jenkinsServer).createJob(any(FolderJob.class), eq("JenkinsJob"), eq("JenkinsConfigStringMock"), any());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/service/JenkinsServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/JenkinsServiceTest.java
@@ -223,7 +223,7 @@ class JenkinsServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
         continuousIntegrationService.recreateBuildPlansForExercise(programmingExercise);
 
-        verify(jenkinsServer, times(1)).createFolder(eq(null), eq(programmingExercise.getProjectKey()), any());
+        verify(jenkinsServer).createFolder(eq(null), eq(programmingExercise.getProjectKey()), any());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/service/ParticipationTeamWebsocketServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ParticipationTeamWebsocketServiceTest.java
@@ -73,7 +73,7 @@ class ParticipationTeamWebsocketServiceTest extends AbstractSpringIntegrationBam
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testSubscribeToParticipationTeamWebsocketTopic() {
         participationTeamWebsocketService.subscribe(participation.getId(), getStompHeaderAccessorMock("fakeSessionId"));
-        verify(messagingTemplate, times(1)).convertAndSend(websocketTopic(participation), List.of());
+        verify(messagingTemplate).convertAndSend(websocketTopic(participation), List.of());
         assertThat(participationTeamWebsocketService.getDestinationTracker()).as("Session was added to destination tracker.").hasSize(1);
         assertThat(participationTeamWebsocketService.getDestinationTracker()).as("Destination in tracker is correct.").containsValue(websocketTopic(participation));
     }
@@ -82,7 +82,7 @@ class ParticipationTeamWebsocketServiceTest extends AbstractSpringIntegrationBam
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testTriggerSendOnlineTeamMembers() {
         participationTeamWebsocketService.triggerSendOnlineTeamStudents(participation.getId());
-        verify(messagingTemplate, times(1)).convertAndSend(websocketTopic(participation), List.of());
+        verify(messagingTemplate).convertAndSend(websocketTopic(participation), List.of());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/service/WeeklyEmailSummaryScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/WeeklyEmailSummaryScheduleServiceTest.java
@@ -62,7 +62,7 @@ class WeeklyEmailSummaryScheduleServiceTest {
 
         weeklyEmailSummaryService.scheduleEmailSummariesOnStartUp();
 
-        verify(schedulerSpy, times(1)).scheduleAtFixedRate(any(), instantCaptor.capture(), eq(Duration.ofDays(7)));
+        verify(schedulerSpy).scheduleAtFixedRate(any(), instantCaptor.capture(), eq(Duration.ofDays(7)));
         LocalDateTime capturedTriggerTime = LocalDateTime.ofInstant(instantCaptor.getValue(), zoneOffset);
         assertThat(capturedTriggerTime).as("The initial trigger for weekly summaries should be on the soonest Friday. (I.e. next Friday or today (if Friday))")
                 .isAfterOrEqualTo(LocalDateTime.now());

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationServiceTest.java
@@ -102,7 +102,7 @@ class ConversationNotificationServiceTest extends AbstractSpringIntegrationBambo
         post = conversationMessageRepository.save(post);
 
         conversationNotificationService.notifyAboutNewMessage(post);
-        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/conversation/" + post.getConversation().getId() + "/notifications"), (Object) any());
+        verify(messagingTemplate).convertAndSend(eq("/topic/conversation/" + post.getConversation().getId() + "/notifications"), (Object) any());
         verifyRepositoryCallWithCorrectNotification(NEW_MESSAGE_TITLE);
 
         var participants = conversationParticipantRepository.findConversationParticipantByConversationId(oneToOneChat.getId());

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationServiceTest.java
@@ -74,9 +74,9 @@ class GeneralInstantNotificationServiceTest {
 
         generalInstantNotificationService.sendNotification(notification, student1, null);
 
-        verify(applePushNotificationService, times(1)).sendNotification(notification, student1, null);
-        verify(firebasePushNotificationService, times(1)).sendNotification(notification, student1, null);
-        verify(mailService, times(1)).sendNotification(notification, student1, null);
+        verify(applePushNotificationService).sendNotification(notification, student1, null);
+        verify(firebasePushNotificationService).sendNotification(notification, student1, null);
+        verify(mailService).sendNotification(notification, student1, null);
     }
 
     /**
@@ -91,8 +91,8 @@ class GeneralInstantNotificationServiceTest {
 
         generalInstantNotificationService.sendNotification(notification, student1, null);
 
-        verify(applePushNotificationService, times(1)).sendNotification(notification, student1, null);
-        verify(firebasePushNotificationService, times(1)).sendNotification(notification, student1, null);
+        verify(applePushNotificationService).sendNotification(notification, student1, null);
+        verify(firebasePushNotificationService).sendNotification(notification, student1, null);
         verify(mailService, times(0)).sendNotification(notification, student1, null);
     }
 
@@ -110,7 +110,7 @@ class GeneralInstantNotificationServiceTest {
 
         verify(applePushNotificationService, times(0)).sendNotification(notification, student1, null);
         verify(firebasePushNotificationService, times(0)).sendNotification(notification, student1, null);
-        verify(mailService, times(1)).sendNotification(notification, student1, null);
+        verify(mailService).sendNotification(notification, student1, null);
     }
 
     /**
@@ -129,9 +129,9 @@ class GeneralInstantNotificationServiceTest {
 
         generalInstantNotificationService.sendNotification(notification, studentList, null);
 
-        verify(applePushNotificationService, times(1)).sendNotification(notification, studentList, null);
-        verify(firebasePushNotificationService, times(1)).sendNotification(notification, studentList, null);
-        verify(mailService, times(1)).sendNotification(notification, studentList, null);
+        verify(applePushNotificationService).sendNotification(notification, studentList, null);
+        verify(firebasePushNotificationService).sendNotification(notification, studentList, null);
+        verify(mailService).sendNotification(notification, studentList, null);
     }
 
     @Test
@@ -146,9 +146,9 @@ class GeneralInstantNotificationServiceTest {
 
         generalInstantNotificationService.sendNotification(notification, studentList, null);
 
-        verify(applePushNotificationService, times(1)).sendNotification(notification, studentList, null);
-        verify(firebasePushNotificationService, times(1)).sendNotification(notification, studentList, null);
-        verify(mailService, times(1)).sendNotification(notification, Collections.singletonList(student1), null);
+        verify(applePushNotificationService).sendNotification(notification, studentList, null);
+        verify(firebasePushNotificationService).sendNotification(notification, studentList, null);
+        verify(mailService).sendNotification(notification, Collections.singletonList(student1), null);
     }
 
     @Test
@@ -163,8 +163,8 @@ class GeneralInstantNotificationServiceTest {
 
         generalInstantNotificationService.sendNotification(notification, studentList, null);
 
-        verify(applePushNotificationService, times(1)).sendNotification(notification, Collections.singletonList(student1), null);
-        verify(firebasePushNotificationService, times(1)).sendNotification(notification, Collections.singletonList(student1), null);
-        verify(mailService, times(1)).sendNotification(notification, studentList, null);
+        verify(applePushNotificationService).sendNotification(notification, Collections.singletonList(student1), null);
+        verify(firebasePushNotificationService).sendNotification(notification, Collections.singletonList(student1), null);
+        verify(mailService).sendNotification(notification, studentList, null);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationServiceTest.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.service.notifications;
 
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.times;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -93,7 +92,7 @@ class GeneralInstantNotificationServiceTest {
 
         verify(applePushNotificationService).sendNotification(notification, student1, null);
         verify(firebasePushNotificationService).sendNotification(notification, student1, null);
-        verify(mailService, times(0)).sendNotification(notification, student1, null);
+        verify(mailService, never()).sendNotification(notification, student1, null);
     }
 
     /**
@@ -108,8 +107,8 @@ class GeneralInstantNotificationServiceTest {
 
         generalInstantNotificationService.sendNotification(notification, student1, null);
 
-        verify(applePushNotificationService, times(0)).sendNotification(notification, student1, null);
-        verify(firebasePushNotificationService, times(0)).sendNotification(notification, student1, null);
+        verify(applePushNotificationService, never()).sendNotification(notification, student1, null);
+        verify(firebasePushNotificationService, never()).sendNotification(notification, student1, null);
         verify(mailService).sendNotification(notification, student1, null);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/MailServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/MailServiceTest.java
@@ -87,7 +87,7 @@ class MailServiceTest {
     @Test
     void testSendEmail() {
         mailService.sendEmail(student1, subject, content, false, true);
-        verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+        verify(javaMailSender).send(any(MimeMessage.class));
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/push_notifications/AppleFirebasePushNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/push_notifications/AppleFirebasePushNotificationServiceTest.java
@@ -87,8 +87,8 @@ class AppleFirebasePushNotificationServiceTest {
         firebasePushNotificationService.sendNotification(notification, student, null);
 
         // Then
-        verify(appleRestTemplateMock, timeout(1000).times(1)).postForObject(anyString(), any(HttpEntity.class), eq(String.class));
-        verify(firebaseRestTemplateMock, timeout(1000).times(1)).postForObject(anyString(), any(HttpEntity.class), eq(String.class));
+        verify(appleRestTemplateMock, timeout(1000)).postForObject(anyString(), any(HttpEntity.class), eq(String.class));
+        verify(firebaseRestTemplateMock, timeout(1000)).postForObject(anyString(), any(HttpEntity.class), eq(String.class));
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
@@ -3,8 +3,7 @@ package de.tum.in.www1.artemis.tutorialgroups;
 import static de.tum.in.www1.artemis.domain.enumeration.tutorialgroups.TutorialGroupRegistrationType.INSTRUCTOR_REGISTRATION;
 import static de.tum.in.www1.artemis.tutorialgroups.AbstractTutorialGroupIntegrationTest.RandomTutorialGroupGenerator.generateRandomTitle;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
 import java.util.*;
@@ -912,7 +911,7 @@ class TutorialGroupIntegrationTest extends AbstractTutorialGroupIntegrationTest 
             verify(singleUserNotificationService).notifyTutorAboutRegistrationToTutorialGroup(tutorialGroup, student3, responsibleUser);
         }
         else {
-            verify(singleUserNotificationService, times(0)).notifyTutorAboutRegistrationToTutorialGroup(tutorialGroup, student3, responsibleUser);
+            verify(singleUserNotificationService, never()).notifyTutorAboutRegistrationToTutorialGroup(tutorialGroup, student3, responsibleUser);
         }
 
         asserTutorialGroupChannelIsCorrectlyConfigured(tutorialGroup);
@@ -940,7 +939,7 @@ class TutorialGroupIntegrationTest extends AbstractTutorialGroupIntegrationTest 
             verify(singleUserNotificationService).notifyTutorAboutDeregistrationFromTutorialGroup(tutorialGroup, student1, responsibleUser);
         }
         else {
-            verify(singleUserNotificationService, times(0)).notifyTutorAboutDeregistrationFromTutorialGroup(tutorialGroup, student1, responsibleUser);
+            verify(singleUserNotificationService, never()).notifyTutorAboutDeregistrationFromTutorialGroup(tutorialGroup, student1, responsibleUser);
         }
         asserTutorialGroupChannelIsCorrectlyConfigured(tutorialGroup);
 

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
@@ -3,7 +3,8 @@ package de.tum.in.www1.artemis.tutorialgroups;
 import static de.tum.in.www1.artemis.domain.enumeration.tutorialgroups.TutorialGroupRegistrationType.INSTRUCTOR_REGISTRATION;
 import static de.tum.in.www1.artemis.tutorialgroups.AbstractTutorialGroupIntegrationTest.RandomTutorialGroupGenerator.generateRandomTitle;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.util.*;

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
@@ -593,7 +593,7 @@ class TutorialGroupIntegrationTest extends AbstractTutorialGroupIntegrationTest 
         var tutorialGroup = tutorialGroupRepository.findByIdWithTeachingAssistantAndRegistrationsAndSessions(exampleOneTutorialGroupId).get();
         assertThat(tutorialGroup.getRegistrations().stream().map(TutorialGroupRegistration::getStudent)).contains(student3);
         assertThat(notFoundStudents).containsExactly(studentNotInCourse);
-        verify(singleUserNotificationService, times(1)).notifyStudentAboutRegistrationToTutorialGroup(tutorialGroup, student3, instructor1);
+        verify(singleUserNotificationService).notifyStudentAboutRegistrationToTutorialGroup(tutorialGroup, student3, instructor1);
         asserTutorialGroupChannelIsCorrectlyConfigured(tutorialGroup);
 
         // remove registration of student 6 again
@@ -907,9 +907,9 @@ class TutorialGroupIntegrationTest extends AbstractTutorialGroupIntegrationTest 
                 new LinkedMultiValueMap<>());
         var tutorialGroup = tutorialGroupRepository.findByIdWithTeachingAssistantAndRegistrationsAndSessions(exampleOneTutorialGroupId).get();
         assertThat(tutorialGroup.getRegistrations().stream().map(TutorialGroupRegistration::getStudent)).contains(student3);
-        verify(singleUserNotificationService, times(1)).notifyStudentAboutRegistrationToTutorialGroup(tutorialGroup, student3, responsibleUser);
+        verify(singleUserNotificationService).notifyStudentAboutRegistrationToTutorialGroup(tutorialGroup, student3, responsibleUser);
         if (expectTutorNotification) {
-            verify(singleUserNotificationService, times(1)).notifyTutorAboutRegistrationToTutorialGroup(tutorialGroup, student3, responsibleUser);
+            verify(singleUserNotificationService).notifyTutorAboutRegistrationToTutorialGroup(tutorialGroup, student3, responsibleUser);
         }
         else {
             verify(singleUserNotificationService, times(0)).notifyTutorAboutRegistrationToTutorialGroup(tutorialGroup, student3, responsibleUser);
@@ -935,9 +935,9 @@ class TutorialGroupIntegrationTest extends AbstractTutorialGroupIntegrationTest 
         request.delete(getTutorialGroupsPath(exampleCourseId) + exampleOneTutorialGroupId + "/deregister/" + student1.getLogin(), HttpStatus.NO_CONTENT);
         TutorialGroup tutorialGroup = tutorialGroupRepository.findByIdWithTeachingAssistantAndRegistrationsAndSessions(exampleOneTutorialGroupId).get();
         assertThat(tutorialGroup.getRegistrations().stream().map(TutorialGroupRegistration::getStudent)).doesNotContain(student1);
-        verify(singleUserNotificationService, times(1)).notifyStudentAboutDeregistrationFromTutorialGroup(tutorialGroup, student1, responsibleUser);
+        verify(singleUserNotificationService).notifyStudentAboutDeregistrationFromTutorialGroup(tutorialGroup, student1, responsibleUser);
         if (expectTutorNotification) {
-            verify(singleUserNotificationService, times(1)).notifyTutorAboutDeregistrationFromTutorialGroup(tutorialGroup, student1, responsibleUser);
+            verify(singleUserNotificationService).notifyTutorAboutDeregistrationFromTutorialGroup(tutorialGroup, student1, responsibleUser);
         }
         else {
             verify(singleUserNotificationService, times(0)).notifyTutorAboutDeregistrationFromTutorialGroup(tutorialGroup, student1, responsibleUser);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
While working on another PR about server tests, I noticed that there are some bad practices and redundancies related to `verify` that could be improved.

### Description
<!-- Describe your changes in detail -->
In this PR I make `verify` statements shorter and more readable by: 
1. Omitting `times(1)` since this is default behavior
2. Using `atleastOnce()` instead of `atLeast(1)`
3. Replacing `times(0)` with `never()`


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged
