### PR TITLE
`Development`: Fix flaky file upload integration tests

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/CourseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/CourseRepository.java
@@ -135,19 +135,6 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             """)
     List<Course> findAllActiveWithTutorialGroupsWhereUserIsRegisteredOrTutor(@Param("now") ZonedDateTime now, @Param("userId") Long userId);
 
-    // Note: this is currently only used for testing purposes
-    @Query("""
-            SELECT DISTINCT c
-            FROM Course c
-                LEFT JOIN FETCH c.exercises exercises
-                LEFT JOIN FETCH c.lectures lectures
-                LEFT JOIN FETCH lectures.attachments
-                LEFT JOIN FETCH exercises.categories
-            WHERE (c.startDate <= :now OR c.startDate IS NULL)
-                AND (c.endDate >= :now OR c.endDate IS NULL)
-                """)
-    List<Course> findAllActiveWithEagerExercisesAndLectures(@Param("now") ZonedDateTime now);
-
     @EntityGraph(type = LOAD, attributePaths = { "exercises", "exercises.categories", "exercises.teamAssignmentConfig" })
     Course findWithEagerExercisesById(long courseId);
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileuploadexercise/FileUploadExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileuploadexercise/FileUploadExerciseUtilService.java
@@ -70,10 +70,7 @@ public class FileUploadExerciseUtilService {
 
     public List<FileUploadExercise> createFileUploadExercisesWithCourse() {
         Course course = CourseFactory.generateCourse(null, pastTimestamp, futureFutureTimestamp, new HashSet<>(), "tumuser", "tutor", "editor", "instructor");
-        int courseSizeBefore = courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now()).size();
-        courseRepo.save(course);
-        List<Course> courseRepoContent = courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now());
-        assertThat(courseRepoContent).as("a course got stored").hasSize(courseSizeBefore + 1);
+        course = courseRepo.save(course);
 
         FileUploadExercise releasedFileUploadExercise = FileUploadExerciseFactory.generateFileUploadExercise(pastTimestamp, futureTimestamp, futureFutureTimestamp, "png,pdf",
                 course);
@@ -107,10 +104,7 @@ public class FileUploadExerciseUtilService {
             String editorGroupName, String instructorGroupName) {
         Course course = CourseFactory.generateCourse(null, pastTimestamp, futureFutureTimestamp, new HashSet<>(), studentGroupName, teachingAssistantGroupName, editorGroupName,
                 instructorGroupName);
-        int courseSizeBefore = courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now()).size();
-        courseRepo.save(course);
-        List<Course> courseRepoContent = courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now());
-        assertThat(courseRepoContent).as("a course got stored").hasSize(courseSizeBefore + 1);
+        course = courseRepo.save(course);
 
         FileUploadExercise releasedFileUploadExercise = FileUploadExerciseFactory.generateFileUploadExercise(pastTimestamp, futureTimestamp, futureFutureTimestamp, "png,pdf",
                 course);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`FileUploadAssessmentIntegrationTest.testUpdateFileUploadAssessmentAfterComplaint_studentHidden()` and
`FileUploadSubmissionIntegrationTest.saveExercise_afterDueDateWithParticipationStartAfterDueDate_allowed()` are flaky.

### Description
<!-- Describe your changes in detail -->
The assertions that were flaky, were testing the `CourseRepository.findAllActiveWithEagerExercisesAndLectures()` method that was only used within the server-test files (or the `CourseRespository.save()` method, depending on how you look at it). Since both cases do not make sense to assert, I deleted the method and the according assertions.

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
