### PR TITLE
`General`: Make markdown editor buttons more compact

### DIFF
--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
@@ -2,7 +2,7 @@
     <nav ngbNav #nav="ngbNav" class="nav-tabs" [destroyOnHide]="false" (navChange)="changeNavigation($event)">
         <!-- editor -->
         <ng-container ngbNavItem="editor_edit">
-            <a ngbNavLink class="btn-sm text-normal" *ngIf="showEditButton">{{ 'entity.action.edit' | artemisTranslate }}</a>
+            <a ngbNavLink class="btn-sm text-normal px-2 py-0 m-0" *ngIf="showEditButton">{{ 'entity.action.edit' | artemisTranslate }}</a>
             <ng-template ngbNavContent>
                 <div [ngStyle]="{ 'minHeight.px': minHeightEditor }" class="height-100 border-0 markdown-editor d-flex flex-column" [id]="uniqueMarkdownEditorId">
                     <jhi-ace-editor
@@ -37,14 +37,14 @@
         </ng-container>
         <!-- visual Mode -->
         <ng-container ngbNavItem="editor_visual">
-            <a ngbNavLink class="btn-sm text-normal" *ngIf="showVisualModeButton">{{ 'entity.action.visual' | artemisTranslate }}</a>
+            <a ngbNavLink class="btn-sm text-normal px-2 py-0 m-0" *ngIf="showVisualModeButton">{{ 'entity.action.visual' | artemisTranslate }}</a>
             <ng-template ngbNavContent>
                 <ng-content select="[#visual]"></ng-content>
             </ng-template>
         </ng-container>
         <!-- preview -->
         <ng-container ngbNavItem="editor_preview">
-            <a ngbNavLink class="btn-sm text-normal" *ngIf="showPreviewButton">{{ 'entity.action.preview' | artemisTranslate }}</a>
+            <a ngbNavLink class="btn-sm text-normal px-2 py-0 m-0" *ngIf="showPreviewButton">{{ 'entity.action.preview' | artemisTranslate }}</a>
             <ng-template ngbNavContent>
                 <ng-content select="[#preview]"></ng-content>
                 <div
@@ -65,7 +65,7 @@
                     <button
                         *ngFor="let command of defaultCommands | negatedTypeCheck : MultiOptionCommand"
                         type="button"
-                        class="btn btn-sm"
+                        class="btn btn-sm py-0"
                         (click)="command.execute()"
                         [ngbTooltip]="command.buttonTranslationString | artemisTranslate"
                     >
@@ -86,7 +86,12 @@
                     </div>
                     <ng-container *ngFor="let command of defaultCommands | typeCheck : MultiOptionCommand">
                         <div>
-                            <button [matMenuTriggerFor]="isTypeOfExerciseReferenceCommand(command) ? subMenuExercise : subMenuLecture" type="button" class="btn btn-sm ml-1">
+                            <button
+                                mat-button
+                                [matMenuTriggerFor]="isTypeOfExerciseReferenceCommand(command) ? subMenuExercise : subMenuLecture"
+                                type="button"
+                                class="btn btn-sm m-0 ml-1 py-0"
+                            >
                                 <span class="default-font-size">{{ command.buttonTranslationString | artemisTranslate }}</span>
                                 <fa-icon [icon]="faAngleDown" class="ms-1"></fa-icon>
                             </button>

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
@@ -86,8 +86,8 @@
                     </div>
                     <ng-container *ngFor="let command of defaultCommands | typeCheck : MultiOptionCommand">
                         <div>
-                            <button mat-button [matMenuTriggerFor]="isTypeOfExerciseReferenceCommand(command) ? subMenuExercise : subMenuLecture" type="button" class="ml-1">
-                                <span>{{ command.buttonTranslationString | artemisTranslate }}</span>
+                            <button [matMenuTriggerFor]="isTypeOfExerciseReferenceCommand(command) ? subMenuExercise : subMenuLecture" type="button" class="btn btn-sm ml-1">
+                                <span class="default-font-size">{{ command.buttonTranslationString | artemisTranslate }}</span>
                                 <fa-icon [icon]="faAngleDown" class="ms-1"></fa-icon>
                             </button>
                             <mat-menu #subMenuExercise="matMenu" type="button">

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.scss
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.scss
@@ -92,8 +92,8 @@
                 align-items: center;
             }
 
-            &-default > * {
-                margin-top: 5px;
+            .mat-mdc-button {
+                height: fit-content;
             }
         }
 

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.scss
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.scss
@@ -124,3 +124,7 @@
 .nested-slide {
     padding-left: 50px;
 }
+
+.default-font-size {
+    font-size: var(--bs-body-font-size);
+}

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.scss
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.scss
@@ -85,8 +85,6 @@
         }
 
         &__commands {
-            margin: 0 5px 5px 5px;
-
             &-default,
             &-domain {
                 display: flex;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The height of the buttons above the markdown editor for writing messages/posts are unnecessarily high.

### Description
<!-- Describe your changes in detail -->
I removed some margin and padding to reduce the height of the buttons.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- None

1. Log in to Artemis as any user
2. Check the markdown editor everywhere where you can write messages/posts

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
Same as develop
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
before:
<img width="758" alt="before" src="https://github.com/ls1intum/Artemis/assets/44754405/5c469c2b-4f63-4977-b039-8f22e33d5389">

after:
<img width="756" alt="after" src="https://github.com/ls1intum/Artemis/assets/44754405/38f60773-d17c-4264-aaf5-8b807f665329">
