### PR TITLE
`Development`: Fix postgres E2E file reference

### DIFF
--- a/.bamboo/E2E-tests/execute.sh
+++ b/.bamboo/E2E-tests/execute.sh
@@ -5,7 +5,7 @@ DB=$1
 if [ "$DB" = "mysql" ]; then
   COMPOSE_FILE="cypress-E2E-tests-mysql.yml"
 elif [ "$DB" = "postgresql" ]; then
-  COMPOSE_FILE="cypress-E2E-tests-postgresql.yml"
+  COMPOSE_FILE="cypress-E2E-tests-postgres.yml"
 else
   echo "Invalid database type. Please choose either mysql or postgresql."
   exit 1

--- a/src/test/cypress/e2e/course/CourseMessages.cy.ts
+++ b/src/test/cypress/e2e/course/CourseMessages.cy.ts
@@ -5,7 +5,7 @@ import { courseManagementRequest, courseMessages } from '../../support/artemis';
 import { convertModelAfterMultiPart } from '../../support/requests/CourseManagementRequests';
 import { ExamBuilder } from '../../support/requests/CourseManagementRequests';
 import { admin, instructor, studentOne, studentTwo, tutor, users } from '../../support/users';
-import { generateUUID, titleLowercase } from '../../support/utils';
+import { titleLowercase } from '../../support/utils';
 
 describe('Course messages', () => {
     let course: Course;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


### Description
<!-- Describe your changes in detail -->
Currently the file reference for the postgres E2E tests is wrong. This PR fixes that. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
