### PR TITLE
`Development`: Fix flaky ExerciseScoresChartIntegrationTest

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExerciseScoresChartIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExerciseScoresChartIntegrationTest.java
@@ -109,7 +109,7 @@ class ExerciseScoresChartIntegrationTest extends AbstractSpringIntegrationBamboo
         // Creating result for team2
         Team team2 = teamRepository.findById(idOfTeam2).orElseThrow();
         participationUtilService.createParticipationSubmissionAndResult(idOfTeamTextExercise, team2, 10.0, 10.0, 90, true);
-
+        participantScoreScheduleService.executeScheduledTasks();
         await().until(() -> participantScoreRepository.findAllByExercise(textExercise).size() == 3);
         await().until(() -> participantScoreRepository.findAllByExercise(teamExercise).size() == 2);
     }

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExerciseScoresChartIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExerciseScoresChartIntegrationTest.java
@@ -109,6 +109,7 @@ class ExerciseScoresChartIntegrationTest extends AbstractSpringIntegrationBamboo
         // Creating result for team2
         Team team2 = teamRepository.findById(idOfTeam2).orElseThrow();
         participationUtilService.createParticipationSubmissionAndResult(idOfTeamTextExercise, team2, 10.0, 10.0, 90, true);
+
         participantScoreScheduleService.executeScheduledTasks();
         await().until(() -> participantScoreRepository.findAllByExercise(textExercise).size() == 3);
         await().until(() -> participantScoreRepository.findAllByExercise(teamExercise).size() == 2);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
ExerciseScoresChartIntegrationTest is flaky
### Description
<!-- Describe your changes in detail -->
participantScoreScheduleService.executeScheduledTasks is now invoked when preparing the test case.
Previously, it could happen that participant scores were missing because the schedule service didn't create them.

### Steps for Testing
Run the test e.g. 3000 times if you want but code review should be enough

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
