### PR TITLE
`Programming exercises`: Fix wrong participation state message when not submitting

### DIFF
--- a/src/main/webapp/app/overview/submission-result-status.component.html
+++ b/src/main/webapp/app/overview/submission-result-status.component.html
@@ -24,7 +24,7 @@
             <span class="text-body-secondary" *ngIf="uninitialized">{{ 'artemisApp.courseOverview.exerciseList.userNotStartedExercise' | artemisTranslate }}</span>
             <span class="text-body-secondary" *ngIf="exerciseMissedDueDate">{{ 'artemisApp.courseOverview.exerciseList.exerciseMissedDueDate' | artemisTranslate }}</span>
             <span class="text-body-secondary" *ngIf="notSubmitted">{{ 'artemisApp.courseOverview.exerciseList.exerciseNotSubmitted' | artemisTranslate }}</span>
-            <span class="text-body-secondary" *ngIf="studentParticipation?.initializationState === InitializationState.FINISHED">{{
+            <span class="text-body-secondary" *ngIf="!notSubmitted && studentParticipation?.initializationState === InitializationState.FINISHED">{{
                 'artemisApp.courseOverview.exerciseList.userSubmitted' | artemisTranslate
             }}</span>
             <span class="text-body-secondary" *ngIf="studentParticipation?.initializationState === InitializationState.INITIALIZED && exercise.type === ExerciseType.QUIZ">{{
@@ -40,7 +40,7 @@
             <span class="text-body-secondary" *ngIf="uninitialized">{{ 'artemisApp.courseOverview.exerciseList.userNotStartedExerciseShort' | artemisTranslate }}</span>
             <span class="text-body-secondary" *ngIf="exerciseMissedDueDate">{{ 'artemisApp.courseOverview.exerciseList.exerciseMissedDueDateShort' | artemisTranslate }}</span>
             <span class="text-body-secondary" *ngIf="notSubmitted">{{ 'artemisApp.courseOverview.exerciseList.exerciseNotSubmittedShort' | artemisTranslate }}</span>
-            <span class="text-body-secondary" *ngIf="studentParticipation?.initializationState === InitializationState.FINISHED">{{
+            <span class="text-body-secondary" *ngIf="!notSubmitted && studentParticipation?.initializationState === InitializationState.FINISHED">{{
                 'artemisApp.courseOverview.exerciseList.userSubmittedShort' | artemisTranslate
             }}</span>
             <span class="text-body-secondary" *ngIf="studentParticipation?.initializationState === InitializationState.INITIALIZED && exercise.type === ExerciseType.QUIZ">{{


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
When a student starts a programming exercise but never submits anything, a misleading submission status is shown: 

![grafik](https://github.com/ls1intum/Artemis/assets/26540346/077a0217-46c5-442a-8d2d-9f3bd88b3e8d)

### Description
A finished participation state means not necessarily that a submission was done, but only that no more submissions are possible. We now check if submissions are present.

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Programming Exercise

1. Start the PE but don't submit anything
2. Wait until the deadline passed
3. Cleanup the student build plan (or wait until the scheduled job does it for you) to create a finished participation
4. Check the status message

### Review Progress

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
now: 
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/e1c3d24e-a444-49c5-a0d6-3397baaaf14a)

