### PR TITLE
`Development`: Fix broken links of generate code coverage script and an error

### DIFF
--- a/supporting_scripts/generate_code_cov_table/generate_code_cov_table.py
+++ b/supporting_scripts/generate_code_cov_table/generate_code_cov_table.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
-base_url = "https://bamboo.ase.in.tum.de/"
+base_url = "https://bamboo.ase.in.tum.de"
 project_key = "ARTEMIS"
 plan_key = "TESTS"
 repo_path = "../.."  # relative to this file
@@ -31,39 +31,26 @@ def environ_or_required(key, required=True):
     )
 
 
+def get_client_tests_cov_report_url(build_id):
+    return f"{base_url}/browse/{project_key}-{plan_key}{build_id}/latest/artifact/shared/Coverage-Report-Client-Tests"
+
+
+def get_server_tests_cov_report_url(build_id):
+    return f"{base_url}/browse/{project_key}-{plan_key}{build_id}/latest/artifact/shared/Coverage-Report-Server-Tests"
+
+
 def get_latest_build_id(username, password, branch_name):
     bamboo_branch_name = branch_name.replace("origin/", "").replace("/", "-")
     url = f"{base_url}/rest/api/latest/plan/{project_key}-{plan_key}/branch/{bamboo_branch_name}.json"
     response = requests.get(url, auth=(username, password))
     if response.status_code == 200:
         branch = json.loads(response.content)
-        return int(branch["shortKey"].replace("TESTS", ""))
+        return int(branch["shortKey"].replace(plan_key, ""))
     elif response.status_code == 404:
         logging.error(f"Branch {branch_name} not found in Bamboo")
         sys.exit(1)
     else:
         logging.error(f"Error accessing Bamboo with status code {response.status_code}")
-        sys.exit(1)
-
-    branch = json.loads(response.content)
-    return int(branch["shortKey"].replace("TESTS", ""))
-
-
-def get_latest_build_number(username, password, build_id):
-    url = f"{base_url}/rest/api/latest/result/{project_key}-{plan_key}{build_id}.json"
-    response = requests.get(url, auth=(username, password))
-    data = json.loads(response.content)
-    return int(data["results"]["result"][0]["number"])
-
-
-def get_code_cov_report_url(username, password, key):
-    url = f"{base_url}/rest/api/latest/result/{key}.json?expand=artifacts"
-    response = requests.get(url, auth=(username, password))
-    data = json.loads(response.content)
-    try:
-        return data["artifacts"]["artifact"][1]["link"]["href"] # second artifact is the code coverage report
-    except IndexError:
-        logging.warning(f"Code coverage report not found for {key}, please wait for the tests to finish and try again")
         sys.exit(1)
 
 
@@ -74,7 +61,17 @@ def get_branch_name():
 
 def get_changed_files(branch_name, base_branch_name="origin/develop"):
     repo = git.Repo(repo_path)
-    branch_head = repo.commit(branch_name)
+    try:
+        branch_head = repo.commit(branch_name)
+    except Exception as e:
+        if "did not resolve to an object" in str(e):
+            logging.error(f"Branch {branch_name} does not exist")
+            if "origin/" in branch_name:
+                sys.exit(1)
+            logging.info("Trying to fetch branch from remote")
+            branch_name = f"origin/{branch_name}"
+            branch_head = repo.commit(branch_name)
+
     branch_base = repo.merge_base(branch_name, base_branch_name)[0]
     diff_index = branch_head.diff(branch_base, create_patch=False)
     file_names = [item.a_path for item in diff_index]
@@ -99,9 +96,10 @@ def filter_files(file_names):
     return client_file_names, server_file_names
 
 
-def get_client_line_coverage(username, password, key, file_name):
-    report_url = get_code_cov_report_url(username, password, key)
-    file_report_url = report_url.replace("index", file_name)
+def get_client_line_coverage(username, password, build_id, file_name):
+    report_url = get_client_tests_cov_report_url(build_id)
+    file_report_url = f"{report_url}/{file_name}.html"
+    logging.debug(f"GET {file_report_url}")
     response = requests.get(file_report_url, auth=(username, password))
 
     soup = BeautifulSoup(response.content, "html.parser")
@@ -115,14 +113,15 @@ def get_client_line_coverage(username, password, key, file_name):
     return file_name, file_report_url, line_coverage
 
 
-def get_server_line_coverage(username, password, key, file_name):
-    report_url = get_code_cov_report_url(username, password, key)
+def get_server_line_coverage(username, password, build_id, file_name):
+    report_url = get_server_tests_cov_report_url(build_id)
     path, class_name = file_name.replace(".java", "").rsplit("/", 1)
     package = path.replace("/", ".")
     file_name = file_name[len("de/tum/in/www1/") :]
     report_name = f"{package}/{class_name}"
 
-    file_report_url = report_url.replace("index", report_name)
+    file_report_url = f"{report_url}/{report_name}.html"
+    logging.debug(f"GET {file_report_url}")
     response = requests.get(file_report_url, auth=(username, password))
 
     soup = BeautifulSoup(response.content, "html.parser")
@@ -172,10 +171,7 @@ def main(argv):
         "--base-branch-name", default="origin/develop", help="Name of the Git base branch (default: origin/develop)"
     )
     parser.add_argument(
-        "--build-id", default=None, help="Build ID of the Bamboo build (ARTEMIS-TESTS{BUILD_ID}-JAVATEST-{BUILD_NUMBER})"
-    )
-    parser.add_argument(
-        "--build-number", default=None, help="Build number (ARTEMIS-TESTS{BUILD_ID}-JAVATEST-{BUILD_NUMBER})"
+        "--build-id", default=None, help="Build ID of the Bamboo build (ARTEMIS-TESTS{BUILD_ID})"
     )
     parser.add_argument(
         "--verbose", action="store_true", help="Enable verbose logging"
@@ -200,24 +196,16 @@ def main(argv):
     if args.build_id is None:
         args.build_id = get_latest_build_id(args.username, args.password, args.branch_name)
         logging.info(f"Using latest build ID: {args.build_id}")
-    if args.build_number is None:
-        args.build_number = get_latest_build_number(args.username, args.password, args.build_id)
-        logging.info(f"Using latest build number: {args.build_number}")
-
-    project_key = "ARTEMIS-TESTS"
-
-    server_key = f"{project_key}{args.build_id}-JAVATEST-{args.build_number}"
-    client_key = f"{project_key}{args.build_id}-TSTEST-{args.build_number}"
 
     file_names = get_changed_files(args.branch_name, args.base_branch_name)
     client_file_names, server_file_names = filter_files(file_names)
 
     client_cov = [
-        get_client_line_coverage(args.username, args.password, client_key, file_name)
+        get_client_line_coverage(args.username, args.password, args.build_id, file_name)
         for file_name in tqdm(client_file_names, desc="Fetching client coverage", unit="files")
     ]
     server_cov = [
-        get_server_line_coverage(args.username, args.password, server_key, file_name)
+        get_server_line_coverage(args.username, args.password, args.build_id, file_name)
         for file_name in tqdm(server_file_names, desc="Fetching server coverage", unit="files")
     ]
 

--- a/supporting_scripts/generate_code_cov_table/generate_code_cov_table.py
+++ b/supporting_scripts/generate_code_cov_table/generate_code_cov_table.py
@@ -110,6 +110,9 @@ def get_client_line_coverage(username, password, build_id, file_name):
             line_coverage_strong = coverage_divs[3].find("span", {"class": "strong"})
             line_coverage = line_coverage_strong.text.replace("%", "").strip()
         logging.debug(f"Coverage for {file_name} -> line coverage: {line_coverage}")
+    elif response.status_code != 404:
+        logging.error(f"Error accessing {file_report_url} with status code {response.status_code}")
+        sys.exit(1)
 
     return file_name, file_report_url, line_coverage
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

@maximiliansoelch pointed out that the links in the coverage table break after a new build, the links should be stable and point to the latest coverage report.

Additionally, @dearjasmina had an issue or error with running the script for the branch `6596-plagiarism-enhance-navigation-to-plagiarism-cases-from-detection-page`: 
`Ref '6596-plagiarism-enhance-navigation-to-plagiarism-cases-from-detection-page' did not resolve to an object` I'm getting the same error, but probably because I have not checked it out locally. To fix this confusion it should automatically use the remote branch.

### Description
<!-- Describe your changes in detail -->

Removed the build number from the url and replaced it with `/latest` to always point to the latest build. I did not know about this before but it is way more convenient and reduces the amount of requests.

When a branch cannot be found locally it automatically tries to use the remote branch, this is less confusing when you don't have the branch checked out or there is an issue with the local branch (e.g. `6596-plagiarism-enhance-navigation-to-plagiarism-cases-from-detection-page`)

Lastly, it no longer links to the coverage page (`Page not found`) when the file has been deleted and marks it as deleted in the table.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Follow the instructions in `artemis/supporting_scripts/generate_code_cov_table/README.md`
2. Test if the script works as expected with any open PR's branch 
3. Check if the links are stable/work

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
Unchanged 

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

N/A