### PR TITLE
`Programming exercise`: Improve anonymize option in export repository dialog

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/DataExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/DataExportService.java
@@ -208,12 +208,11 @@ public class DataExportService {
         createSubmissionsResultsExport(programmingExercise, exerciseDir);
         RepositoryExportOptionsDTO repositoryExportOptions = new RepositoryExportOptionsDTO();
         repositoryExportOptions.setExportAllParticipants(false);
-        repositoryExportOptions.setAnonymizeStudentCommits(false);
+        repositoryExportOptions.setAnonymizeRepository(false);
         repositoryExportOptions.setFilterLateSubmissions(false);
         repositoryExportOptions.setCombineStudentCommits(false);
         repositoryExportOptions.setFilterLateSubmissionsIndividualDueDate(false);
         repositoryExportOptions.setExcludePracticeSubmissions(false);
-        repositoryExportOptions.setHideStudentNameInZippedFolder(false);
         repositoryExportOptions.setNormalizeCodeStyle(true);
         var listOfProgrammingExerciseParticipations = programmingExercise.getStudentParticipations().stream()
                 .filter(studentParticipation -> studentParticipation instanceof ProgrammingExerciseStudentParticipation)

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -225,7 +225,7 @@ public class ProgrammingExerciseExportService {
             var studentParticipations = studentParticipationRepository.findByExerciseId(exercise.getId()).stream()
                     .map(studentParticipation -> (ProgrammingExerciseStudentParticipation) studentParticipation).sorted(Comparator.comparing(DomainObject::getId)).toList();
             var exportOptions = new RepositoryExportOptionsDTO();
-            exportOptions.setHideStudentNameInZippedFolder(false);
+            exportOptions.setAnonymizeRepository(false);
 
             // Export student repositories and add them to list
             var exportedStudentRepositoryFiles = exportStudentRepositories(exercise, studentParticipations, exportOptions, outputDir, outputDir, exportErrors).stream()
@@ -639,10 +639,10 @@ public class ProgrammingExerciseExportService {
 
             if (repositoryExportOptions.isCombineStudentCommits()) {
                 log.debug("Combining commits for participation {}", participation);
-                gitService.combineAllStudentCommits(repository, programmingExercise, repositoryExportOptions.isAnonymizeStudentCommits());
+                gitService.combineAllStudentCommits(repository, programmingExercise, repositoryExportOptions.isAnonymizeRepository());
             }
 
-            if (repositoryExportOptions.isAnonymizeStudentCommits()) {
+            if (repositoryExportOptions.isAnonymizeRepository()) {
                 log.debug("Anonymizing commits for participation {}", participation);
                 gitService.anonymizeStudentCommits(repository, programmingExercise);
             }
@@ -659,7 +659,7 @@ public class ProgrammingExerciseExportService {
             }
 
             log.debug("Create temporary zip file for repository {}", repository.getLocalPath().toString());
-            return gitService.zipRepositoryWithParticipation(repository, outputDir.toString(), repositoryExportOptions.isHideStudentNameInZippedFolder());
+            return gitService.zipRepositoryWithParticipation(repository, outputDir.toString(), repositoryExportOptions.isAnonymizeRepository());
         }
         catch (GitAPIException | GitException ex) {
             log.error("Failed to create zip for participation id {} with exercise id {} because of the following exception ", participation.getId(),

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseExportImportResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseExportImportResource.java
@@ -411,7 +411,7 @@ public class ProgrammingExerciseExportImportResource {
 
         // Only instructors or higher may override the anonymization setting
         if (!authCheckService.isAtLeastInstructorForExercise(programmingExercise, null)) {
-            repositoryExportOptions.setAnonymizeStudentCommits(true);
+            repositoryExportOptions.setAnonymizeRepository(true);
         }
 
         if (repositoryExportOptions.getFilterLateSubmissionsDate() == null) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/RepositoryExportOptionsDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/RepositoryExportOptionsDTO.java
@@ -24,11 +24,9 @@ public class RepositoryExportOptionsDTO {
 
     private boolean combineStudentCommits;
 
-    private boolean anonymizeStudentCommits;
+    private boolean anonymizeRepository;
 
     private boolean normalizeCodeStyle;
-
-    private boolean hideStudentNameInZippedFolder;
 
     public boolean isExportAllParticipants() {
         return exportAllParticipants;
@@ -86,12 +84,12 @@ public class RepositoryExportOptionsDTO {
         this.combineStudentCommits = combineStudentCommits;
     }
 
-    public boolean isAnonymizeStudentCommits() {
-        return anonymizeStudentCommits;
+    public boolean isAnonymizeRepository() {
+        return anonymizeRepository;
     }
 
-    public void setAnonymizeStudentCommits(boolean anonymizeStudentCommits) {
-        this.anonymizeStudentCommits = anonymizeStudentCommits;
+    public void setAnonymizeRepository(boolean anonymizeRepository) {
+        this.anonymizeRepository = anonymizeRepository;
     }
 
     public boolean isNormalizeCodeStyle() {
@@ -100,13 +98,5 @@ public class RepositoryExportOptionsDTO {
 
     public void setNormalizeCodeStyle(boolean normalizeCodeStyle) {
         this.normalizeCodeStyle = normalizeCodeStyle;
-    }
-
-    public boolean isHideStudentNameInZippedFolder() {
-        return this.hideStudentNameInZippedFolder;
-    }
-
-    public void setHideStudentNameInZippedFolder(boolean hideStudentNameInZippedFolder) {
-        this.hideStudentNameInZippedFolder = hideStudentNameInZippedFolder;
     }
 }

--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.html
@@ -100,9 +100,9 @@
         <ng-container *ngIf="isAtLeastInstructor">
             <div class="checkbox">
                 <label class="control-label">
-                    <input class="form-check-input" type="checkbox" name="anonymizeStudentCommits" [(ngModel)]="this.repositoryExportOptions.anonymizeStudentCommits" checked />
-                    <strong jhiTranslate="artemisApp.programmingExercise.export.anonymizeStudentCommits.title">Anonymize all of the student's commits</strong>
-                    <jhi-help-icon text="artemisApp.programmingExercise.export.anonymizeStudentCommits.tooltip"></jhi-help-icon>
+                    <input class="form-check-input" type="checkbox" name="anonymizeRepository" [(ngModel)]="this.repositoryExportOptions.anonymizeRepository" checked />
+                    <strong jhiTranslate="artemisApp.programmingExercise.export.anonymizeRepository.title">Anonymize repository</strong>
+                    <jhi-help-icon text="artemisApp.programmingExercise.export.anonymizeRepository.tooltip"></jhi-help-icon>
                 </label>
             </div>
         </ng-container>

--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.ts
@@ -47,9 +47,8 @@ export class ProgrammingAssessmentRepoExportDialogComponent implements OnInit {
             excludePracticeSubmissions: false,
             addParticipantName: true,
             combineStudentCommits: true,
-            anonymizeStudentCommits: false,
+            anonymizeRepository: false,
             normalizeCodeStyle: false, // disabled by default because it is rather unstable
-            hideStudentNameInZippedFolder: false,
         };
         this.isRepoExportForMultipleExercises = this.programmingExercises.length > 1;
         this.isAtLeastInstructor = this.programmingExercises.every((exercise) => exercise.isAtLeastInstructor);
@@ -71,7 +70,7 @@ export class ProgrammingAssessmentRepoExportDialogComponent implements OnInit {
             if (this.participationIdList?.length) {
                 // We anonymize the assessment process ("double-blind").
                 this.repositoryExportOptions.addParticipantName = false;
-                this.repositoryExportOptions.hideStudentNameInZippedFolder = true;
+                this.repositoryExportOptions.anonymizeRepository = true;
                 this.repoExportService.exportReposByParticipations(exercise.id, this.participationIdList, this.repositoryExportOptions).subscribe({
                     next: this.handleExportRepoResponse,
                     error: () => {

--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export.service.ts
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export.service.ts
@@ -10,9 +10,8 @@ export type RepositoryExportOptions = {
     excludePracticeSubmissions: boolean;
     addParticipantName: boolean;
     combineStudentCommits: boolean;
-    anonymizeStudentCommits: boolean;
+    anonymizeRepository: boolean;
     normalizeCodeStyle: boolean;
-    hideStudentNameInZippedFolder: boolean;
 };
 
 @Injectable({ providedIn: 'root' })

--- a/src/main/webapp/app/orion/assessment/orion-assessment.service.ts
+++ b/src/main/webapp/app/orion/assessment/orion-assessment.service.ts
@@ -72,9 +72,8 @@ export class OrionAssessmentService {
             excludePracticeSubmissions: false,
             addParticipantName: false,
             combineStudentCommits: true,
-            anonymizeStudentCommits: true,
+            anonymizeRepository: true,
             normalizeCodeStyle: false,
-            hideStudentNameInZippedFolder: true,
         };
         this.programmingSubmissionService.lockAndGetProgrammingSubmissionParticipation(submissionId, correctionRound).subscribe((programmingSubmission) => {
             this.repositoryExportService.exportReposByParticipations(exerciseId, [programmingSubmission.participation!.id!], exportOptions).subscribe((response) => {

--- a/src/main/webapp/i18n/de/programmingExercise.json
+++ b/src/main/webapp/i18n/de/programmingExercise.json
@@ -339,9 +339,9 @@
                     "title": "Alle Änderungen in einem Commit zusammenfassen",
                     "tooltip": "Fasst alle Commits eines Studierenden in einem einzigen Commit für leichtere Korrektur zusammen"
                 },
-                "anonymizeStudentCommits": {
-                    "title": "Alle Änderungen von Studierenden anonymisieren",
-                    "tooltip": "Verberge die Namen der Studierenden in Commits für eine unvoreingenommene Bewertung"
+                "anonymizeRepository": {
+                    "title": "Repository anonymisieren",
+                    "tooltip": "Verberge die Namen der Studierenden in Commits und Ordnernamen für eine unvoreingenommene Bewertung"
                 },
                 "normalizeCodeStyle": {
                     "title": "Code-Style normalisieren",

--- a/src/main/webapp/i18n/en/programmingExercise.json
+++ b/src/main/webapp/i18n/en/programmingExercise.json
@@ -335,9 +335,9 @@
                     "title": "Combine changes into one commit",
                     "tooltip": "Squashes all commits of a student into a single commit for easier review"
                 },
-                "anonymizeStudentCommits": {
-                    "title": "Anonymize all of the student's commits",
-                    "tooltip": "Hide student names in commit messages for unbiased evaluation"
+                "anonymizeRepository": {
+                    "title": "Anonymize repository",
+                    "tooltip": "Hide student names in commit messages and directory name for unbiased evaluation"
                 },
                 "normalizeCodeStyle": {
                     "title": "Normalize code style",

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -531,7 +531,7 @@ class ProgrammingExerciseIntegrationTestService {
         repositoryExportOptions.setFilterLateSubmissions(true);
         repositoryExportOptions.setExcludePracticeSubmissions(false);
         repositoryExportOptions.setCombineStudentCommits(true);
-        repositoryExportOptions.setAnonymizeStudentCommits(true);
+        repositoryExportOptions.setAnonymizeRepository(true);
         repositoryExportOptions.setAddParticipantName(true);
         repositoryExportOptions.setNormalizeCodeStyle(true);
         return repositoryExportOptions;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -471,7 +471,8 @@ class ProgrammingExerciseIntegrationTestService {
 
         // Checks
         assertThat(entries).anyMatch(entry -> entry.endsWith("Test.java"));
-        Optional<Path> extractedRepo1 = entries.stream().filter(entry -> entry.toString().endsWith(Path.of("student1", ".git").toString())).findFirst();
+        Optional<Path> extractedRepo1 = entries.stream()
+                .filter(entry -> entry.toString().endsWith(Path.of("-" + String.valueOf(participation1.getId()) + "-student-submission.git", ".git").toString())).findFirst();
         assertThat(extractedRepo1).isPresent();
         try (Git downloadedGit = Git.open(extractedRepo1.get().toFile())) {
             RevCommit commit = downloadedGit.log().setMaxCount(1).call().iterator().next();

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-repo-export-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-repo-export-dialog.component.spec.ts
@@ -105,7 +105,7 @@ describe('ProgrammingAssessmentRepoExportDialogComponent', () => {
         comp.exportRepos();
         tick();
         expect(comp.repositoryExportOptions.addParticipantName).toBeFalse();
-        expect(comp.repositoryExportOptions.hideStudentNameInZippedFolder).toBeTrue();
+        expect(comp.repositoryExportOptions.anonymizeRepository).toBeTrue();
         expect(comp.exportInProgress).toBeFalse();
         expect(exportReposStub).toHaveBeenCalledOnce();
     }));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] ~~I added multiple integration tests (Spring) related to the features (with a high test coverage).~~
- [x] ~~I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).~~
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] ~~Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.~~
- [x] ~~I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).~~
- [x] ~~I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).~~
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Currently there is no way to also hide the student's name when exporting the programming exercise repositories, there only is a option for anonymizing student's commits. The anonymization option should include hiding the student's name so it is actually anonymized and can be handed out for example as evaluation data for [Athena](https://github.com/ls1intum/Athena).

### Description
<!-- Describe your changes in detail -->

Renamed `Anonymize all of the student's commits` to `Anonymize repository` in the programming exercise's **Export Repository** dialog. This option now also hides the student's names from the directories in the downloaded zip file, in addition to anonymizing the commits.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1-2 Students
- 1 Programming Exercise with submissions

1. Log in to Artemis as instructor
2. Navigate to Course Management
3. Go to the detail view of a Programming Exercise
4. Press **Scores** button to get to the scores page
5. Make sure to have at least 1 participation listed, ideally more
6. Press **Export** -> **Download Repos** button
7. Check `Or download the repositories of all students` and `Anonymize repository` in the **Export Repository** dialog
8. Press **Export** and unzip the downloaded zip
9. Make sure that the student names are now hidden (replaced by **student-submission**), e.g. `themisTest-Sorting-17779-student-submission.git.zip`
10. Repeat export with unchecked `Anonymize repository` and check if student names are there

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

Unchanged

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Renamed `Anonymize all of the student's commits` to `Anonymize repository`:**

| Before | After |
|------------|--------------|
| <img width="809" alt="image" src="https://github.com/ls1intum/Artemis/assets/5898705/e132c6df-6839-4a6e-934c-903d0952da9e"> | <img width="809" alt="image" src="https://github.com/ls1intum/Artemis/assets/5898705/8024fe11-6f12-4902-bbb7-36a0f8d057bc"> |

Unzipped repos with `Anonymize repository` set to true (student usernames are now hidden 🎉 )
<img width="390" alt="image" src="https://github.com/ls1intum/Artemis/assets/5898705/d71e0d33-1196-4d96-9bab-fb943ea250ed">
