### PR TITLE
`Development`: Avoid unnecessary fetching of course post tags if communication is not enabled

### DIFF
--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, Observable, ReplaySubject, map } from 'rxjs';
 import { HttpResponse } from '@angular/common/http';
 import { User } from 'app/core/user/user.model';
 import { AccountService } from 'app/core/auth/account.service';
-import { Course } from 'app/entities/course.model';
+import { Course, isCommunicationEnabled } from 'app/entities/course.model';
 import { Posting } from 'app/entities/metis/posting.model';
 import { Injectable, OnDestroy } from '@angular/core';
 import { AnswerPostService } from 'app/shared/metis/answer-post.service';
@@ -134,7 +134,9 @@ export class MetisService implements OnDestroy {
         if (course && (this.courseId === undefined || this.courseId !== course.id)) {
             this.courseId = course.id!;
             this.course = course;
-            this.updateCoursePostTags();
+            if (isCommunicationEnabled(course)) {
+                this.updateCoursePostTags();
+            }
         }
     }
 

--- a/src/test/javascript/spec/service/metis/metis.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/metis.service.spec.ts
@@ -39,6 +39,7 @@ import {
     metisUser2,
 } from '../../helpers/sample/metis-sample-data';
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
+import { ChannelDTO, ChannelSubType } from 'app/entities/metis/conversation/channel.model';
 
 describe('Metis Service', () => {
     let metisService: MetisService;
@@ -380,6 +381,29 @@ describe('Metis Service', () => {
         metisService.setCourse(course);
         const referenceRouterLink = metisService.getLinkForExam(metisExam.id!.toString());
         expect(referenceRouterLink).toBe(`/courses/${metisCourse.id}/exams/${metisExam.id!.toString()}`);
+    });
+
+    it('should determine the router link required for navigation based on the channel subtype', () => {
+        metisService.setCourse(course);
+        const channelDTO = new ChannelDTO();
+        channelDTO.subTypeReferenceId = 1;
+
+        channelDTO.subType = ChannelSubType.EXERCISE;
+        const exerciseRouterLink = metisService.getLinkForChannelSubType(channelDTO);
+
+        channelDTO.subType = ChannelSubType.LECTURE;
+        const lectureRouterLink = metisService.getLinkForChannelSubType(channelDTO);
+
+        channelDTO.subType = ChannelSubType.EXAM;
+        const examRouterLink = metisService.getLinkForChannelSubType(channelDTO);
+
+        channelDTO.subType = ChannelSubType.GENERAL;
+        const generalRouterLink = metisService.getLinkForChannelSubType(channelDTO);
+
+        expect(exerciseRouterLink).toBe(`/courses/${metisCourse.id}/exercises/1`);
+        expect(lectureRouterLink).toBe(`/courses/${metisCourse.id}/lectures/1`);
+        expect(examRouterLink).toBe(`/courses/${metisCourse.id}/exams/1`);
+        expect(generalRouterLink).toBeUndefined();
     });
 
     it('should determine the query param for a reference to a post with course-wide context', () => {

--- a/src/test/javascript/spec/service/metis/metis.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/metis.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Post } from 'app/entities/metis/post.model';
-import { Course } from 'app/entities/course.model';
+import { Course, CourseInformationSharingConfiguration } from 'app/entities/course.model';
 import { MockPostService } from '../../helpers/mocks/service/mock-post.service';
 import { MockAnswerPostService } from '../../helpers/mocks/service/mock-answer-post.service';
 import { MetisService } from 'app/shared/metis/metis.service';
@@ -301,6 +301,15 @@ describe('Metis Service', () => {
         const getCourseReturn = metisService.getCourse();
         expect(getCourseReturn).toEqual(course);
         expect(updateCoursePostTagsSpy).toHaveBeenCalledOnce();
+    });
+
+    it('should not update course post tags if communication is not enabled', () => {
+        const updateCoursePostTagsSpy = jest.spyOn(metisService, 'updateCoursePostTags');
+        course.courseInformationSharingConfiguration = CourseInformationSharingConfiguration.MESSAGING_ONLY;
+        metisService.setCourse(course);
+        const getCourseReturn = metisService.getCourse();
+        expect(getCourseReturn).toEqual(course);
+        expect(updateCoursePostTagsSpy).not.toHaveBeenCalled();
     });
 
     it('should set course when current course has different id', () => {

--- a/src/test/javascript/spec/service/metis/metis.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/metis.service.spec.ts
@@ -303,7 +303,7 @@ describe('Metis Service', () => {
         expect(updateCoursePostTagsSpy).toHaveBeenCalledOnce();
     });
 
-    it('should not update course post tags if communication is not enabled', () => {
+    it('should not fetch course post tags if communication is not enabled', () => {
         const updateCoursePostTagsSpy = jest.spyOn(metisService, 'updateCoursePostTags');
         course.courseInformationSharingConfiguration = CourseInformationSharingConfiguration.MESSAGING_ONLY;
         metisService.setCourse(course);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When loading an exercise or lecture page, the communication sidebar fetches course post tags even if only messaging but not communication is enabled. However, this is only allowed if communication is enabled.

### Description
<!-- Describe your changes in detail -->
When setting the course off for the MetisService, tags are only fetched if communication is enabled. I added client test to ensure this new check works.

I also added another (unrelated) client test, to improve the test coverage of the MetisService.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 User
- 1 Course with only messaging enabled

1. Visit a lecture or exercise page
2. There should be no "Bad Request" logs regarding communication

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
