### PR TITLE
`General`: Use short date format in exercise overview across all window widths

### DIFF
--- a/src/main/webapp/app/overview/course-exercises/course-exercises.component.html
+++ b/src/main/webapp/app/overview/course-exercises/course-exercises.component.html
@@ -128,8 +128,8 @@
                 >
                     <fa-icon class="pe-3" [icon]="weeklyExercisesGrouped[weekKey].isCollapsed ? faAngleDown : faAngleUp"></fa-icon>
                     <span *ngIf="weeklyExercisesGrouped[weekKey].start && weeklyExercisesGrouped[weekKey].end">
-                        {{ weeklyExercisesGrouped[weekKey].start | artemisDate : 'long-date' }} -
-                        {{ weeklyExercisesGrouped[weekKey].end | artemisDate : 'long-date' }}
+                        {{ weeklyExercisesGrouped[weekKey].start | artemisDate : 'short-date' }} -
+                        {{ weeklyExercisesGrouped[weekKey].end | artemisDate : 'short-date' }}
                     </span>
                     <span *ngIf="!weeklyExercisesGrouped[weekKey].start || !weeklyExercisesGrouped[weekKey].end">
                         {{ 'artemisApp.courseOverview.exerciseList.noDateAssociated' | artemisTranslate }}

--- a/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
@@ -135,10 +135,10 @@ export class ArtemisDatePipe implements PipeTransform, OnDestroy {
         if (!long) {
             switch (locale) {
                 case 'de':
-                    format = 'DD.MM.YYYY';
+                    format = 'DD.MM.YY';
                     break;
                 default:
-                    format = 'YYYY-MM-DD';
+                    format = 'YY-MM-DD';
             }
         }
         return format;

--- a/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
@@ -135,10 +135,10 @@ export class ArtemisDatePipe implements PipeTransform, OnDestroy {
         if (!long) {
             switch (locale) {
                 case 'de':
-                    format = 'DD.MM.YY';
+                    format = 'DD.MM.YYYY';
                     break;
                 default:
-                    format = 'YY-MM-DD';
+                    format = 'YYYY-MM-DD';
             }
         }
         return format;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
We got a bug reported (resolves #6745 ) that on the exercise overview, the date format changes with different window sizes.
This is expected behavior, since the Artemis Date Pipe uses always "short-date" for mobile devices (regardless which format is used on desktop).
We discussed several options (read [slack-thread](https://ls1tum.slack.com/archives/C012NFRM76F/p1688637455467009) or PR comments for more information) and decided to use a consistent date-format for mobile and desktop widths in this particular case. This will resolve the reported issue #6745 .

### Technical Information
This PR changes the used desktop format in the exercise overview to `short-date` on desktop and since `short-date` is automatically used on mobile, it will be consistent across window widths.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Exercise

1. Log in to Artemis
2. Navigate to Exercise overview
3. Verify that the dates are displayed in this format (en: "YYYY-MM-DD", de: "DD.MM.YYYY") across all window widths

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
![image](https://github.com/ls1intum/Artemis/assets/78978542/2326f94d-30f6-4613-8185-8b6525ecbc41)

