### PR TITLE
`Development`: Change Response Status on Invalid Account Activation Key

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/open/PublicAccountResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/open/PublicAccountResource.java
@@ -34,7 +34,6 @@ import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.EmailAlreadyUsedException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
-import de.tum.in.www1.artemis.web.rest.errors.InternalServerErrorException;
 import de.tum.in.www1.artemis.web.rest.errors.LoginAlreadyUsedException;
 import de.tum.in.www1.artemis.web.rest.errors.PasswordViolatesRequirementsException;
 import de.tum.in.www1.artemis.web.rest.vm.KeyAndPasswordVM;
@@ -114,7 +113,7 @@ public class PublicAccountResource {
         }
         Optional<User> user = userService.activateRegistration(key);
         if (user.isEmpty()) {
-            throw new InternalServerErrorException("No user was found for this activation key");
+            throw new EntityNotFoundException("Activation key", key);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/open/PublicAccountResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/open/PublicAccountResource.java
@@ -103,7 +103,8 @@ public class PublicAccountResource {
      * {@code GET /activate} : activate the registered user.
      *
      * @param key the activation key.
-     * @throws RuntimeException {@code 500 (Internal Server Error)} if the user couldn't be activated.
+     * @throws AccessForbiddenException {@code 403 (Forbidden)} if the user registration is disabled
+     * @throws EntityNotFoundException {@code 404 (Not Found)} if the user provided an invalid activation key
      */
     @GetMapping("activate")
     @EnforceNothing

--- a/src/test/java/de/tum/in/www1/artemis/user/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/user/AccountResourceIntegrationTest.java
@@ -224,7 +224,7 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationBambooBitb
     void activateAccountNoUser() throws Exception {
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("key", "");
-        request.get("/api/public/activate", HttpStatus.INTERNAL_SERVER_ERROR, String.class, params);
+        request.get("/api/public/activate", HttpStatus.NOT_FOUND, String.class, params);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/user/AccountResourceWithGitLabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/user/AccountResourceWithGitLabIntegrationTest.java
@@ -247,7 +247,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         // Activate the user
         gitlabRequestMockProvider.mockActivateUser(user.getLogin(), true);
         String activationKey = registeredUser.get().getActivationKey();
-        request.get("/api/public/activate?key=" + activationKey, HttpStatus.INTERNAL_SERVER_ERROR, Void.class);
+        request.get("/api/public/activate?key=" + activationKey, HttpStatus.NOT_FOUND, Void.class);
         verify(gitlabRequestMockProvider.getMockedUserApi()).unblockUser(anyLong());
 
         assertThat(registeredUser.get().getActivationKey()).isNotNull();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style. 
#### Client
No changes affecting client side
#### Changes affecting Programming Exercises
No changes affecting programming exercises

### Motivation and Context
This is a small change to fix https://github.com/ls1intum/Artemis/issues/6691.
When the endpoint `/api/public/activate` is used with an invalid activation key, currently an InternalServerErrorException is thrown and response code 500 is returned to the user. Beside the fact that this error case is caused by user input and not anything the server did wrong, the thrown exception causes a large and overbearing stacktrace to be printed to the log, when in reality there is nothing to worry about. 

### Description
<!-- Describe your changes in detail -->
This PR changes the exception thrown to an EntityNotFoundException with response status 404, which I believe more accurately describes the situation at hand: no such activation key as described by the user could be found. The tests have also been adjusted to expect error code 404 and not 500.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Use the API endpoint `/api/public/activate` and set the path variable "key" to a random string that isn't a real activation key.
2. See that error code 404 is returned
3. See that no huge error stacktrace is printed to the log

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
Test coverage unchanged
