### PR TITLE
`Tutorial Groups`: Consistent Button Styles

### DIFF
--- a/src/main/webapp/app/course/tutorial-groups/tutorial-groups-management/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.html
+++ b/src/main/webapp/app/course/tutorial-groups/tutorial-groups-management/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.html
@@ -55,11 +55,9 @@
                         <label class="d-block">{{ 'artemisApp.dialogs.createChannel.channelForm.isPublicInput.label' | artemisTranslate }}</label>
                         <div class="btn-group" role="group">
                             <input formControlName="usePublicTutorialGroupChannels" type="radio" class="btn-check" id="public" autocomplete="off" checked [value]="true" />
-                            <label class="btn btn-outline-secondary" for="public">{{
-                                'artemisApp.dialogs.createChannel.channelForm.isPublicInput.public' | artemisTranslate
-                            }}</label>
+                            <label class="btn btn-outline-primary" for="public">{{ 'artemisApp.dialogs.createChannel.channelForm.isPublicInput.public' | artemisTranslate }}</label>
                             <input formControlName="usePublicTutorialGroupChannels" type="radio" class="btn-check" id="private" autocomplete="off" [value]="false" />
-                            <label class="btn btn-outline-secondary" for="private">{{
+                            <label class="btn btn-outline-primary" for="private">{{
                                 'artemisApp.dialogs.createChannel.channelForm.isPublicInput.private' | artemisTranslate
                             }}</label>
                         </div>

--- a/src/main/webapp/content/scss/themes/theme-default.scss
+++ b/src/main/webapp/content/scss/themes/theme-default.scss
@@ -39,9 +39,9 @@ html {
     color: $link-color;
 }
 
-.btn-check:checked + .btn,
-btn:hover {
-    color: white !important;
+// selects a label element with the class btn-check:checked + label.btn and sets the text color to white
+.btn-check:checked + label.btn {
+    color: white;
 }
 
 .btn-outline-primary:not(.list-group-item):hover {

--- a/src/main/webapp/content/scss/themes/theme-default.scss
+++ b/src/main/webapp/content/scss/themes/theme-default.scss
@@ -39,7 +39,7 @@ html {
     color: $link-color;
 }
 
-// selects a label element with the class btn-check:checked + label.btn and sets the text color to white
+// Making the style in bootstrap radio (class btn-check) consistent with other button styles
 .btn-check:checked + label.btn {
     color: white;
 }

--- a/src/main/webapp/content/scss/themes/theme-default.scss
+++ b/src/main/webapp/content/scss/themes/theme-default.scss
@@ -39,6 +39,11 @@ html {
     color: $link-color;
 }
 
+.btn-check:checked + .btn,
+btn:hover {
+    color: white !important;
+}
+
 .btn-outline-primary:not(.list-group-item):hover {
     color: black;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
This small PR resolves the feedback given to the PR by @pal03377 @SabrinaGlatz : https://github.com/ls1intum/Artemis/pull/6753

### Description and Steps for Testing
You can find the detailed description and steps for testing in the PR: https://github.com/ls1intum/Artemis/pull/6753





### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<img width="323" alt="image" src="https://github.com/ls1intum/Artemis/assets/24391701/a6b7ae4b-3863-423a-bc39-f0a74c6d62fd">
<img width="272" alt="image" src="https://github.com/ls1intum/Artemis/assets/24391701/7c3edfd2-d6f4-45a2-8538-0f6ce1120de0">


