### PR TITLE
`Development`: Enforce consistent usage of nullness annotations

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/RepositoryImpl.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/RepositoryImpl.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.artemis.repository;
 import java.io.Serializable;
 import java.util.Collections;
 
+import javax.annotation.Nullable;
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.*;
@@ -11,7 +12,6 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 public class RepositoryImpl<T, ID extends Serializable> extends SimpleJpaRepository<T, ID> {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCFetchFilter.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCFetchFilter.java
@@ -6,8 +6,8 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.NotNull;
 
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.filter.OncePerRequestFilter;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCPushFilter.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCPushFilter.java
@@ -6,8 +6,8 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.NotNull;
 
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.filter.OncePerRequestFilter;

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationService.java
@@ -5,7 +5,8 @@ import static de.tum.in.www1.artemis.service.notifications.NotificationSettingsC
 
 import java.util.List;
 
-import org.jetbrains.annotations.NotNull;
+import javax.validation.constraints.NotNull;
+
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 

--- a/src/test/java/de/tum/in/www1/artemis/AbstractArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractArchitectureTest.java
@@ -8,7 +8,7 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 
-public abstract class AbstractArchitectureTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
+public abstract class AbstractArchitectureTest {
 
     protected static final String ARTEMIS_PACKAGE = "de.tum.in.www1.artemis";
 

--- a/src/test/java/de/tum/in/www1/artemis/AbstractArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractArchitectureTest.java
@@ -8,7 +8,7 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 
-public abstract class AbstractArchitectureTest {
+public abstract class AbstractArchitectureTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     protected static final String ARTEMIS_PACKAGE = "de.tum.in.www1.artemis";
 

--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -81,7 +81,7 @@ class ArchitectureTest extends AbstractArchitectureTest {
     }
 
     private DescribedPredicate<? super JavaAnnotation<?>> resideInPackageAnnotation(String packageName) {
-        return equalTo(packageName).as("Annotation in package " + packageName).onResultOf(javaAnnotation -> javaAnnotation.getRawType().getPackageName());
+        return equalTo(packageName).as("Annotation in package " + packageName).onResultOf(annotation -> annotation.getRawType().getPackageName());
     }
 
     private ArchCondition<JavaMethod> notHaveAnyParameterAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> annotationPredicate) {

--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -62,9 +62,9 @@ class ArchitectureTest extends AbstractArchitectureTest {
         var nonNullPredicate = simpleNameAnnotation("NonNull");
         var nullablePredicate = and(not(resideInPackageAnnotation("javax.annotation")), simpleNameAnnotation("Nullable"));
 
-        Set<DescribedPredicate<? super JavaAnnotation<?>>> set = Set.of(notNullPredicate, nonNullPredicate, nullablePredicate);
+        Set<DescribedPredicate<? super JavaAnnotation<?>>> allPredicates = Set.of(notNullPredicate, nonNullPredicate, nullablePredicate);
 
-        for (var predicate : set) {
+        for (var predicate : allPredicates) {
             ArchRule units = noCodeUnits().should().beAnnotatedWith(predicate);
             ArchRule parameters = methods().should(notHaveAnyParameterAnnotatedWith(predicate));
 

--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis;
 
 import static com.tngtech.archunit.base.DescribedPredicate.*;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.*;
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.*;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 
@@ -90,8 +91,7 @@ class ArchitectureTest extends AbstractArchitectureTest {
             public void check(JavaMethod item, ConditionEvents events) {
                 boolean satisfied = item.getParameterAnnotations().stream().flatMap(Collection::stream).noneMatch(annotationPredicate);
                 if (!satisfied) {
-                    events.add(
-                            SimpleConditionEvent.violated(item, String.format("Method %s has parameter violating %s", item.getFullName(), annotationPredicate.getDescription())));
+                    events.add(violated(item, String.format("Method %s has parameter violating %s", item.getFullName(), annotationPredicate.getDescription())));
                 }
             }
         };

--- a/src/test/java/de/tum/in/www1/artemis/metis/AbstractConversationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/AbstractConversationTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.*;
 import java.util.Arrays;
 import java.util.Set;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -16,7 +15,6 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 import de.tum.in.www1.artemis.course.CourseUtilService;
-import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.CourseInformationSharingConfiguration;
 import de.tum.in.www1.artemis.domain.enumeration.DisplayPriority;
@@ -169,13 +167,11 @@ abstract class AbstractConversationTest extends AbstractSpringIntegrationBambooB
         }
     }
 
-    @NotNull
-    Course setCourseInformationSharingConfiguration(CourseInformationSharingConfiguration courseInformationSharingConfiguration) {
+    void setCourseInformationSharingConfiguration(CourseInformationSharingConfiguration courseInformationSharingConfiguration) {
         var persistedCourse = courseRepository.findByIdElseThrow(exampleCourseId);
         persistedCourse.setCourseInformationSharingConfiguration(courseInformationSharingConfiguration);
         persistedCourse = courseRepository.saveAndFlush(persistedCourse);
         assertThat(persistedCourse.getCourseInformationSharingConfiguration()).isEqualTo(courseInformationSharingConfiguration);
-        return persistedCourse;
     }
 
     ChannelDTO createChannel(boolean isPublicChannel, String name) throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/metis/PostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/PostIntegrationTest.java
@@ -11,8 +11,8 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotNull;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
There are many possibilites for defining nullness annotations in Java (see https://stackoverflow.com/questions/4963300/which-notnull-java-annotation-should-i-use).

We decided for Artemis to use `javax.validation.constraints.NotNull` and `javax.annotation.Nullable` (see #6019)

### Description
This PR adds an ArchUnit test that verifies the correct annotations. Since ArchUnit defines simple name matcher only for classes and not for Annotations, I implemented them myself.

### Steps for Testing
code review

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2