### PR TITLE
`Exam mode`: Fix complaint text limit when course complaints are not active

### DIFF
--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.html
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.html
@@ -69,15 +69,14 @@
                     id="responseTextArea"
                     class="col-12 px-1"
                     rows="4"
-                    [maxlength]="this.course!.maxComplaintResponseTextLimit!"
+                    [maxlength]="maxComplaintResponseTextLimit"
                     [(ngModel)]="complaintResponse.responseText"
                     [readonly]="handled || isLockedForLoggedInUser"
                     [disabled]="handled || isLockedForLoggedInUser"
                     ondrop="return false;"
                 >
                 </textarea>
-                <jhi-textarea-counter [maxLength]="this.course!.maxComplaintResponseTextLimit!" [content]="complaintResponse.responseText" [visible]="!handled">
-                </jhi-textarea-counter>
+                <jhi-textarea-counter [maxLength]="maxComplaintResponseTextLimit" [content]="complaintResponse.responseText" [visible]="!handled"> </jhi-textarea-counter>
             </div>
             <div *ngIf="!handled && complaint.complaintType === ComplaintType.COMPLAINT" class="d-flex flex-wrap gap-1 justify-content-between mt-1">
                 <button
@@ -85,7 +84,7 @@
                     type="button"
                     class="btn btn-success btn-block"
                     (click)="respondToComplaint(true)"
-                    [disabled]="isLockedForLoggedInUser || complaintResponseTextLength() > this.course!.maxComplaintResponseTextLimit!"
+                    [disabled]="isLockedForLoggedInUser || complaintResponseTextLength() > maxComplaintResponseTextLimit"
                     title="{{ 'artemisApp.complaintResponse.updateAssessmentTooltip' | artemisTranslate }}"
                 >
                     {{ 'artemisApp.complaintResponse.updateAssessment' | artemisTranslate }}
@@ -95,7 +94,7 @@
                     type="button"
                     class="btn btn-danger btn-block"
                     (click)="respondToComplaint(false)"
-                    [disabled]="isLockedForLoggedInUser || complaintResponseTextLength() > this.course!.maxComplaintResponseTextLimit!"
+                    [disabled]="isLockedForLoggedInUser || complaintResponseTextLength() > maxComplaintResponseTextLimit"
                     title="{{ 'artemisApp.complaintResponse.rejectComplaintTooltip' | artemisTranslate }}"
                 >
                     {{ 'artemisApp.complaintResponse.rejectComplaint' | artemisTranslate }}

--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
@@ -54,7 +54,7 @@ export class ComplaintsForTutorComponent implements OnInit {
 
         this.maxComplaintResponseTextLimit = this.course!.maxComplaintResponseTextLimit ?? 0;
         if (!this.exercise?.course) {
-            // exam
+            // Exams should always allow at least 2000 characters
             this.maxComplaintResponseTextLimit = Math.max(2000, this.maxComplaintResponseTextLimit);
         }
 

--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
@@ -52,8 +52,8 @@ export class ComplaintsForTutorComponent implements OnInit {
     ngOnInit(): void {
         this.course = getCourseFromExercise(this.exercise!);
 
-        this.maxComplaintResponseTextLimit = this.course!.maxComplaintResponseTextLimit ?? 0;
-        if (!this.exercise?.course) {
+        this.maxComplaintResponseTextLimit = this.course?.maxComplaintResponseTextLimit ?? 0;
+        if (this.exercise?.exerciseGroup) {
             // Exams should always allow at least 2000 characters
             this.maxComplaintResponseTextLimit = Math.max(2000, this.maxComplaintResponseTextLimit);
         }

--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
@@ -39,6 +39,7 @@ export class ComplaintsForTutorComponent implements OnInit {
     lockedByCurrentUser = false;
     isLockedForLoggedInUser = false;
     course?: Course;
+    maxComplaintResponseTextLimit: number;
 
     constructor(
         private alertService: AlertService,
@@ -50,6 +51,12 @@ export class ComplaintsForTutorComponent implements OnInit {
 
     ngOnInit(): void {
         this.course = getCourseFromExercise(this.exercise!);
+
+        this.maxComplaintResponseTextLimit = this.course!.maxComplaintResponseTextLimit ?? 0;
+        if (!this.exercise?.course) {
+            // exam
+            this.maxComplaintResponseTextLimit = Math.max(2000, this.maxComplaintResponseTextLimit);
+        }
 
         if (this.complaint) {
             this.complaintText = this.complaint.complaintText;
@@ -147,10 +154,9 @@ export class ComplaintsForTutorComponent implements OnInit {
             this.alertService.error('artemisApp.complaintResponse.noText');
             return;
         }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-        if (this.complaintResponse.responseText.length > this.course?.maxComplaintResponseTextLimit!) {
+        if (this.complaintResponse.responseText.length > this.maxComplaintResponseTextLimit) {
             this.alertService.error('artemisApp.complaint.exceededComplaintResponseTextLimit', {
-                maxComplaintRespondTextLimit: this.course?.maxComplaintResponseTextLimit,
+                maxComplaintRespondTextLimit: this.maxComplaintResponseTextLimit,
             });
             return;
         }

--- a/src/main/webapp/app/complaints/form/complaints-form.component.html
+++ b/src/main/webapp/app/complaints/form/complaints-form.component.html
@@ -32,8 +32,8 @@
             </p>
 
             <div class="d-flex flex-column">
-                <textarea id="complainTextArea" class="col-12 px-1" rows="4" [maxLength]="this.course!.maxComplaintTextLimit!" [(ngModel)]="complaintText"> </textarea>
-                <jhi-textarea-counter [maxLength]="this.course!.maxComplaintTextLimit!" [content]="complaintText" [visible]="true"> </jhi-textarea-counter>
+                <textarea id="complainTextArea" class="col-12 px-1" rows="4" [maxLength]="this.maxComplaintTextLimit" [(ngModel)]="complaintText"> </textarea>
+                <jhi-textarea-counter [maxLength]="this.maxComplaintTextLimit" [content]="complaintText" [visible]="true"> </jhi-textarea-counter>
             </div>
 
             <div class="row">
@@ -41,7 +41,7 @@
                     <button
                         id="submit-complaint"
                         class="btn btn-primary"
-                        [disabled]="!complaintText || complaintTextLength() > this.course!.maxComplaintTextLimit!"
+                        [disabled]="!complaintText || complaintTextLength() > this.maxComplaintTextLimit"
                         (click)="createComplaint()"
                     >
                         {{ complaintType === ComplaintType.COMPLAINT ? ('artemisApp.complaint.submit' | artemisTranslate) : ('artemisApp.moreFeedback.button' | artemisTranslate) }}

--- a/src/main/webapp/app/complaints/form/complaints-form.component.ts
+++ b/src/main/webapp/app/complaints/form/complaints-form.component.ts
@@ -23,16 +23,23 @@ export class ComplaintsFormComponent implements OnInit {
     // eslint-disable-next-line @angular-eslint/no-output-native
     @Output() submit: EventEmitter<void> = new EventEmitter();
     maxComplaintsPerCourse = 1;
+    maxComplaintTextLimit: number;
     complaintText?: string;
-    ComplaintType = ComplaintType;
     course?: Course;
+
+    readonly ComplaintType = ComplaintType;
 
     constructor(private complaintService: ComplaintService, private alertService: AlertService) {}
 
     ngOnInit(): void {
         this.course = getCourseFromExercise(this.exercise);
         if (this.exercise.course) {
+            // only set the complaint limit for course exercises, there are unlimited complaints for exams
             this.maxComplaintsPerCourse = this.exercise.teamMode ? this.exercise.course.maxTeamComplaints! : this.exercise.course.maxComplaints!;
+            this.maxComplaintTextLimit = this.course!.maxComplaintTextLimit!;
+        } else {
+            // Complaints for exams should always allow at least 2000 characters. If the course limit is higher, the custom limit gets used.
+            this.maxComplaintTextLimit = Math.max(2000, this.course?.maxComplaintTextLimit ?? 0);
         }
     }
 
@@ -47,8 +54,8 @@ export class ComplaintsFormComponent implements OnInit {
         complaint.complaintType = this.complaintType;
 
         // TODO: Rethink global client error handling and adapt this line accordingly
-        if (complaint.complaintText !== undefined && this.course!.maxComplaintTextLimit! < complaint.complaintText!.length) {
-            this.alertService.error('artemisApp.complaint.exceededComplaintTextLimit', { maxComplaintTextLimit: this.course!.maxComplaintTextLimit! });
+        if (complaint.complaintText !== undefined && this.maxComplaintTextLimit < complaint.complaintText!.length) {
+            this.alertService.error('artemisApp.complaint.exceededComplaintTextLimit', { maxComplaintTextLimit: this.maxComplaintTextLimit! });
             return;
         }
 

--- a/src/main/webapp/app/complaints/form/complaints-form.component.ts
+++ b/src/main/webapp/app/complaints/form/complaints-form.component.ts
@@ -33,13 +33,13 @@ export class ComplaintsFormComponent implements OnInit {
 
     ngOnInit(): void {
         this.course = getCourseFromExercise(this.exercise);
+        this.maxComplaintTextLimit = this.course?.maxComplaintTextLimit ?? 0;
         if (this.exercise.course) {
             // only set the complaint limit for course exercises, there are unlimited complaints for exams
             this.maxComplaintsPerCourse = this.exercise.teamMode ? this.exercise.course.maxTeamComplaints! : this.exercise.course.maxComplaints!;
-            this.maxComplaintTextLimit = this.course!.maxComplaintTextLimit!;
         } else {
             // Complaints for exams should always allow at least 2000 characters. If the course limit is higher, the custom limit gets used.
-            this.maxComplaintTextLimit = Math.max(2000, this.course?.maxComplaintTextLimit ?? 0);
+            this.maxComplaintTextLimit = Math.max(2000, this.maxComplaintTextLimit);
         }
     }
 

--- a/src/main/webapp/app/course/manage/course-update.component.ts
+++ b/src/main/webapp/app/course/manage/course-update.component.ts
@@ -428,8 +428,8 @@ export class CourseUpdateComponent implements OnInit {
             this.courseForm.controls['maxComplaints'].setValue(0);
             this.courseForm.controls['maxTeamComplaints'].setValue(0);
             this.courseForm.controls['maxComplaintTimeDays'].setValue(0);
-            this.courseForm.controls['maxComplaintTextLimit'].setValue(0);
-            this.courseForm.controls['maxComplaintResponseTextLimit'].setValue(0);
+            this.courseForm.controls['maxComplaintTextLimit'].setValue(2000);
+            this.courseForm.controls['maxComplaintResponseTextLimit'].setValue(2000);
         }
     }
 

--- a/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { ComplaintService } from 'app/complaints/complaint.service';
 import { ComplaintResponseService } from 'app/complaints/complaint-response.service';
 import { ComplaintsForTutorComponent } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
+import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import { TextareaCounterComponent } from 'app/shared/textarea/textarea-counter.component';
 import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -265,6 +266,7 @@ describe('ComplaintsForTutorComponent', () => {
         const responseTextArea = complaintForTutorComponentFixture.debugElement.query(By.css('#responseTextArea')).nativeElement;
         responseTextArea.value = 'abcdefghijklmnopqrstuvwxyz';
         expect(responseTextArea.value).toHaveLength(26);
+        expect(complaintsForTutorComponent.maxComplaintResponseTextLimit).toBe(26);
 
         const rejectComplaintButton = complaintForTutorComponentFixture.debugElement.query(By.css('#rejectComplaintButton')).nativeElement;
         const acceptComplaintButton = complaintForTutorComponentFixture.debugElement.query(By.css('#acceptComplaintButton')).nativeElement;
@@ -316,6 +318,16 @@ describe('ComplaintsForTutorComponent', () => {
         const responseTextArea = complaintForTutorComponentFixture.debugElement.query(By.css('#responseTextArea')).nativeElement;
         expect(responseTextArea.maxLength).toBe(26);
     }));
+
+    it('should calculate the correct maximum text length for exam exercises', () => {
+        exercise.course = undefined;
+        exercise.exerciseGroup = { exam: { course: course } } as ExerciseGroup;
+
+        complaintForTutorComponentFixture.detectChanges();
+
+        // use the default value if the course would define a lower maximum for exam exercises
+        expect(complaintsForTutorComponent.maxComplaintResponseTextLimit).toBe(2000);
+    });
 
     it.each(['success', 'failure'])(
         'should handle %s after updating assessment after complaint',

--- a/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
@@ -289,7 +289,6 @@ describe('ComplaintsForTutorComponent', () => {
         unhandledComplaint.id = 1;
         unhandledComplaint.accepted = undefined;
         unhandledComplaint.complaintText = 'please check again';
-        unhandledComplaint.complaintResponse = undefined;
         unhandledComplaint.complaintResponse = new ComplaintResponse();
         unhandledComplaint.complaintResponse.id = 1;
         unhandledComplaint.complaintType = ComplaintType.COMPLAINT;

--- a/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
@@ -17,19 +17,13 @@ import { of } from 'rxjs';
 import { Course } from 'app/entities/course.model';
 import { Exercise } from 'app/entities/exercise.model';
 
-// Mock getCourseFromExercise(exercise) to get a course even if there isn't a course.
-jest.mock('app/entities/exercise.model', () => ({
-    getCourseFromExercise: () => {
-        const course = new Course();
-        course.maxComplaintResponseTextLimit = 26;
-        return course;
-    },
-}));
-
 describe('ComplaintsForTutorComponent', () => {
     let complaintsForTutorComponent: ComplaintsForTutorComponent;
     let complaintForTutorComponentFixture: ComponentFixture<ComplaintsForTutorComponent>;
     let injectedComplaintResponseService: ComplaintResponseService;
+
+    let course: Course;
+    let exercise: Exercise;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -42,6 +36,12 @@ describe('ComplaintsForTutorComponent', () => {
                 complaintForTutorComponentFixture = TestBed.createComponent(ComplaintsForTutorComponent);
                 complaintsForTutorComponent = complaintForTutorComponentFixture.componentInstance;
                 injectedComplaintResponseService = complaintForTutorComponentFixture.debugElement.injector.get(ComplaintResponseService);
+
+                course = new Course();
+                course.maxComplaintResponseTextLimit = 26;
+
+                exercise = { id: 11, isAtLeastInstructor: true, course: course } as Exercise;
+                complaintsForTutorComponent.exercise = exercise;
             });
     });
 
@@ -237,7 +237,6 @@ describe('ComplaintsForTutorComponent', () => {
         unhandledComplaint.id = 1;
         unhandledComplaint.accepted = undefined;
         unhandledComplaint.complaintText = 'please check again';
-        unhandledComplaint.complaintResponse = undefined;
         unhandledComplaint.complaintResponse = new ComplaintResponse();
         unhandledComplaint.complaintResponse.id = 1;
         unhandledComplaint.complaintType = ComplaintType.COMPLAINT;
@@ -338,7 +337,6 @@ describe('ComplaintsForTutorComponent', () => {
 
             complaintsForTutorComponent.complaint = unhandledComplaint;
             complaintsForTutorComponent.complaintResponse = newComplaintResponse;
-            complaintsForTutorComponent.exercise = { id: 11, isAtLeastInstructor: true } as Exercise;
 
             complaintsForTutorComponent.isLoading = false;
             complaintsForTutorComponent.handled = false;

--- a/src/test/javascript/spec/component/course/course-update.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-update.component.spec.ts
@@ -371,8 +371,8 @@ describe('Course Management Update Component', () => {
             expect(comp.courseForm.controls['maxComplaints'].value).toBe(0);
             expect(comp.courseForm.controls['maxTeamComplaints'].value).toBe(0);
             expect(comp.courseForm.controls['maxComplaintTimeDays'].value).toBe(0);
-            expect(comp.courseForm.controls['maxComplaintTextLimit'].value).toBe(0);
-            expect(comp.courseForm.controls['maxComplaintResponseTextLimit'].value).toBe(0);
+            expect(comp.courseForm.controls['maxComplaintTextLimit'].value).toBe(2000);
+            expect(comp.courseForm.controls['maxComplaintResponseTextLimit'].value).toBe(2000);
             expect(comp.complaintsEnabled).toBeFalse();
         });
     });


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.

### Motivation and Context
During the exam mode testing session we were unable to file complaints since the maximum input length was 0. This was the case because complaints were disabled in the course.

### Description
The exam complaints should always allow at least 2k characters. If the course defines a higher value (@dfuchss) this value is used instead.

### Steps for Testing
Prerequisites:
- 1 Student, 1 Instructor
- 1 Exam in Student Review phase

1. Check that a student is able to write an exam complaint.
2. Disable course complaints -> Exam complaints should be still possible
3. Add a higher complaint text limit -> the long text limit also applies for exam complaints.


### Review Progres

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
