### PR TITLE
`General`: Unify header padding

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-participation-page.component.scss
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-participation-page.component.scss
@@ -5,7 +5,6 @@
     $top-border-radius: 3px;
 
     min-height: unset;
-    padding: 15px 25px;
     margin: $margin $margin 0 $margin;
     background-color: var(--header-participation-page-info-bar-background);
     border-top-left-radius: $top-border-radius;

--- a/src/main/webapp/app/overview/header-course.component.html
+++ b/src/main/webapp/app/overview/header-course.component.html
@@ -1,4 +1,4 @@
-<div class="course-info-bar course-info-bar--header" [ngStyle]="{ backgroundColor: course.color || ARTEMIS_DEFAULT_COLOR }" id="course-detail-info-bar">
+<div class="course-info-bar" [ngStyle]="{ backgroundColor: course.color || ARTEMIS_DEFAULT_COLOR }" id="course-detail-info-bar">
     <div class="row">
         <div class="col general-info">
             <h3 id="course-header-title" class="fw-medium" [class.mb-0]="!courseDescription">{{ course.title }}</h3>

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -702,7 +702,7 @@ Course Info Bar
 ========================================================================== */
 .course-info-bar {
     background-color: $artemis-dark;
-    padding: 1rem 1rem;
+    padding: 0.5rem 1rem;
     margin: -1rem -1rem 0 -1rem;
     display: flex;
     color: $white;

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -702,7 +702,7 @@ Course Info Bar
 ========================================================================== */
 .course-info-bar {
     background-color: $artemis-dark;
-    padding: 0.5rem 0.5rem;
+    padding: 1rem 1rem;
     margin: -1rem -1rem 0 -1rem;
     display: flex;
     color: $white;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Improve and unify the appearance of ui elements in Artemis to have a more consistent design.

### Description
<!-- Describe your changes in detail -->
The course header was not aligned with the other components around it and had a smaller padding on the left/right side than other ui elements. This is now unified to a common distance.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Text/Modelingexercise

1. Log in to Artemis
2. Check different headers in Artemis that they have a consistent padding. These include:
- The course header in the student and the course management view
- An exercise header
- The participation header when working on/viewing a submission in a text/modeling exercise
- The assessment dashboard
- Lecture detail page
3. Click around and look if there are any other headers that have a too small/large padding

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before (for example the breadcrumbs and the title in the header are misaligned):
<img width="1728" alt="Bildschirmfoto 2023-07-11 um 10 15 01" src="https://github.com/ls1intum/Artemis/assets/38322605/677e0985-700d-444c-85fc-7e3d421d6cdb">

After (with and without a course icon on the right):
<img width="1728" alt="Bildschirmfoto 2023-07-11 um 10 29 39" src="https://github.com/ls1intum/Artemis/assets/38322605/41b2fb1c-9e79-4639-8eeb-a3c90c5d7e92">
<img width="1728" alt="Bildschirmfoto 2023-07-11 um 10 30 04" src="https://github.com/ls1intum/Artemis/assets/38322605/6c2cabba-d9ab-4325-a49d-da0ab01a2435">