### PR TITLE
`Programming exercises`: Fix the position of the save button of the problem statement editor

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.scss
+++ b/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.scss
@@ -34,7 +34,7 @@
 
     &__save {
         position: absolute;
-        top: 1px;
+        top: -12px;
         right: 0;
     }
 

--- a/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.scss
+++ b/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.scss
@@ -34,7 +34,7 @@
 
     &__save {
         position: absolute;
-        top: -12px;
+        top: -16px;
         right: 0;
     }
 

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
@@ -73,7 +73,7 @@
                     </button>
                     <!--style command -->
                     <div *ngIf="headerCommands.length > 0" class="btn-group" ngbDropdown role="group" aria-label="Button group with nested dropdown">
-                        <button class="btn btn-sm" type="button" id="dropdownBasic1" ngbDropdownToggle>
+                        <button class="btn btn-sm px-2 py-0" type="button" id="dropdownBasic1" ngbDropdownToggle>
                             {{ 'artemisApp.multipleChoiceQuestion.editor.style' | artemisTranslate }}
                         </button>
                         <div class="dropdown-menu" ngbDropdownMenu>
@@ -170,19 +170,19 @@
                     </ng-container>
                     <!--color picker command -->
                     <div class="btn-group col-xs-6" *ngIf="colorCommands.length > 0">
-                        <div class="color-preview btn btn-sm" (click)="openColorSelector($event)">{{ 'artemisApp.markdownEditor.color' | artemisTranslate }}</div>
+                        <div class="color-preview btn btn-sm px-2 py-0" (click)="openColorSelector($event)">{{ 'artemisApp.markdownEditor.color' | artemisTranslate }}</div>
                         <jhi-color-selector [tagColors]="markdownColors" (selectedColor)="onSelectedColor($event)"></jhi-color-selector>
                     </div>
                     <!-- domain commands -->
                     <div class="markdown-editor__commands-domain" *ngIf="domainCommands && domainCommands.length != 0">
                         <ng-container *ngFor="let command of domainCommands | typeCheck : DomainTagCommand">
-                            <div *ngIf="command.displayCommandButton" class="btn btn-sm" (click)="command.execute()">
+                            <div *ngIf="command.displayCommandButton" class="btn btn-sm px-2 py-0" (click)="command.execute()">
                                 {{ command.buttonTranslationString | artemisTranslate }}
                             </div>
                         </ng-container>
                         <ng-container *ngFor="let command of domainCommands | typeCheck : DomainMultiOptionCommand">
                             <div ngbDropdown class="d-inline-block">
-                                <button class="btn btn-sm" type="button" ngbDropdownToggle>
+                                <button class="btn btn-sm px-2 py-0" type="button" ngbDropdownToggle>
                                     {{ command.buttonTranslationString | artemisTranslate }}
                                 </button>
                                 <div ngbDropdownMenu>
@@ -201,7 +201,7 @@
                         <button
                             *ngFor="let command of metaCommands"
                             type="button"
-                            class="btn btn-sm"
+                            class="btn btn-sm px-2 py-0"
                             (click)="command.execute()"
                             [ngbTooltip]="command.buttonTranslationString | artemisTranslate"
                         >

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
@@ -181,7 +181,7 @@
                             </div>
                         </ng-container>
                         <ng-container *ngFor="let command of domainCommands | typeCheck : DomainMultiOptionCommand">
-                            <div ngbDropdown class="d-inline-block">
+                            <div ngbDropdown class="btn-group">
                                 <button class="btn btn-sm px-2 py-0" type="button" ngbDropdownToggle>
                                     {{ command.buttonTranslationString | artemisTranslate }}
                                 </button>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With #6793 the height of the utility buttons from the markdown editor component got reduced. This caused the save button next to the problem statement editor for programming exercises to overlap with the text field.

### Description
<!-- Describe your changes in detail -->
I changed the position of the save button by moving it a few pixels upwards. Also, I reduced the height of the domain specific buttons like `Color`, `Formula`, and `Task` to make it consistent with all other places where the markdown editor is used.

The save button can overlap with other buttons, but this is an old issue that will not be fixed in this PR.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course programming exercise
- 1 Exam with a programming exercise

1. Edit the course programming exercise
2. Check that the save button does not overlap with the problem statement input field
3. Edit the exam programming exercise
4. Check that the save button does not overlap with the problem statement input field

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
Same as develop

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
before: 
![before](https://github.com/ls1intum/Artemis/assets/44754405/d37742ee-4420-4626-a63e-897671273313)

after:
<img width="1685" alt="after" src="https://github.com/ls1intum/Artemis/assets/44754405/ac86f080-be6e-4993-85ab-b5ab811adaf9">

