### PR TITLE
`Communication`: Improve error message alert when entering a duplicate channel name

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/errors/ChannelNameDuplicateException.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/errors/ChannelNameDuplicateException.java
@@ -24,7 +24,7 @@ public class ChannelNameDuplicateException extends BadRequestAlertException {
         Map<String, String> params = new HashMap<>();
         params.put("channelName", channelName);
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("skipAlert", true);
+        parameters.put("skipAlert", false);
         parameters.put("message", "artemisApp.errors." + ERROR_KEY);
         parameters.put("params", params);
         return parameters;

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/errors/ChannelNameDuplicateException.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/errors/ChannelNameDuplicateException.java
@@ -24,7 +24,6 @@ public class ChannelNameDuplicateException extends BadRequestAlertException {
         Map<String, String> params = new HashMap<>();
         params.put("channelName", channelName);
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("skipAlert", false);
         parameters.put("message", "artemisApp.errors." + ERROR_KEY);
         parameters.put("params", params);
         return parameters;

--- a/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts
@@ -197,7 +197,11 @@ export class ConversationInfoComponent implements OnInit, OnDestroy {
                     channel[propertyName] = updatedChannel[propertyName];
                     this.onChangePerformed();
                 },
-                error: (errorResponse: HttpErrorResponse) => onError(this.alertService, errorResponse),
+                error: (errorResponse: HttpErrorResponse) => {
+                    if (errorResponse.error?.skipAlert === true) {
+                        onError(this.alertService, errorResponse);
+                    }
+                },
             });
     }
 }

--- a/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts
@@ -198,7 +198,7 @@ export class ConversationInfoComponent implements OnInit, OnDestroy {
                     this.onChangePerformed();
                 },
                 error: (errorResponse: HttpErrorResponse) => {
-                    if (errorResponse.error?.skipAlert !== false) {
+                    if (errorResponse.error?.skipAlert) {
                         onError(this.alertService, errorResponse);
                     }
                 },

--- a/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts
@@ -198,7 +198,7 @@ export class ConversationInfoComponent implements OnInit, OnDestroy {
                     this.onChangePerformed();
                 },
                 error: (errorResponse: HttpErrorResponse) => {
-                    if (errorResponse.error?.skipAlert === true) {
+                    if (errorResponse.error?.skipAlert !== false) {
                         onError(this.alertService, errorResponse);
                     }
                 },

--- a/src/main/webapp/app/shared/metis/metis-conversation.service.ts
+++ b/src/main/webapp/app/shared/metis/metis-conversation.service.ts
@@ -169,7 +169,7 @@ export class MetisConversationService implements OnDestroy {
                 this.activeConversation = conversation.body!;
             }),
             catchError((res: HttpErrorResponse) => {
-                if (res.error?.skipAlert === false) {
+                if (!res.error?.skipAlert) {
                     return of(null);
                 }
 

--- a/src/main/webapp/app/shared/metis/metis-conversation.service.ts
+++ b/src/main/webapp/app/shared/metis/metis-conversation.service.ts
@@ -169,6 +169,10 @@ export class MetisConversationService implements OnDestroy {
                 this.activeConversation = conversation.body!;
             }),
             catchError((res: HttpErrorResponse) => {
+                if (res.error?.skipAlert === false) {
+                    return of(null);
+                }
+
                 onError(this.alertService, res);
                 if (res.error && res.error.title) {
                     this.alertService.addErrorAlert(res.error.title, res.error.message, res.error.params);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When renaming a channel on the messages tab and entering a name that already exists, the error message is very generic (Bad Request). 

### Description
<!-- Describe your changes in detail -->
The skipAlert field of the `ChannelNameDuplicateException` has now the value `false`. Therefore, the client now displays it properly. To avoid also displaying the "Bad Request" alert, I added a check, that prevents the generic alert from being shown if a more generic one has been already displayed due to `skipAlert=false`.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 General channels

1. Try to rename the first channel using the name of the other channel: An alert with a proper error message should be shown (see screenshots)
2. Switch the language: The alert should be properly translated
3. Rename the channel using a new name: No alert should be shown


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [conversation-info.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5163/latest/artifact/shared/Coverage-Report-Client-Tests/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts.html) | 90.69% | ✅ |
| [metis-conversation.service.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5163/latest/artifact/shared/Coverage-Report-Client-Tests/app/shared/metis/metis-conversation.service.ts.html) | 84.02% | ✅ |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
before:
<img width="1286" alt="before" src="https://github.com/ls1intum/Artemis/assets/44754405/a3d592a0-1887-40d2-8166-b940031600b6">

after:
<img width="1286" alt="after" src="https://github.com/ls1intum/Artemis/assets/44754405/4f52b268-a68e-419a-9c23-6365995629ae">
