### PR TITLE
`Programming exercises`: Fix resource cleanup when closing online editor

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
@@ -311,7 +311,7 @@ export class CodeEditorAceComponent implements AfterViewInit, OnChanges, OnDestr
             this.annotationChange.unsubscribe();
         }
         // remove all line widgets so that no old ones are displayed when the editor is opened again
-        if (this.editorSession && this.editorSession.widgetManager) {
+        if (this.editorSession?.widgetManager && this.editorSession?.lineWidgets) {
             for (const line of this.linesWithInlineFeedbackShown) {
                 const widget = this.editorSession.lineWidgets.find((w: any) => w?.el === this.getInlineFeedbackNode(line));
                 this.editorSession.widgetManager.removeLineWidget(widget);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
Sentry issue in our instance:
```
Uncaught (in promise): TypeError: this.editorSession.lineWidgets is null
ngOnDestroy@https://artemis.fim.uni-passau.de/default-src_main_webapp_app_exercises_programming_manage_instructions-editor_programming-exer-9ba431.7bb8e4c061d12c0b.js:1:57962
```

### Description
Checks that the `lineWidgets` are defined before accessing them. If they are not defined, then no widgets need to be cleaned up anyway.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor/Tutor
- 1 Programming Exercise with manual assessment and a student submission

Probably not necessary, code review should be enough.

1. Assess the student submission.
2. Add some general feedback at the bottom, no inline feedback.
3. Save and leave the page, no error should be logged in the console.
4. Go back to the assessment, this time add some inline feedback. Save/submit still works as expected.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
unchanged
