### PR TITLE
`Learning analytics`: Separate chart name and chart in course statistics to fix wrong line breaks

### DIFF
--- a/src/main/webapp/app/shared/statistics-graph/statistics-graph.component.html
+++ b/src/main/webapp/app/shared/statistics-graph/statistics-graph.component.html
@@ -1,8 +1,8 @@
 <div class="row d-flex justify-content-center">
-    <div class="col-xl-1">
+    <div>
         <h3>{{ chartName | artemisTranslate }}</h3>
     </div>
-    <div class="row col-xl-11">
+    <div>
         <fa-icon [icon]="faArrowLeft" size="2x" class="col-1 d-flex justify-content-end align-items-center px-0" role="button" (click)="switchTimeSpan(LEFT)"></fa-icon>
         <div #containerRef class="chart col-10 px-0">
             <ngx-charts-bar-vertical

--- a/src/main/webapp/app/shared/statistics-graph/statistics-graph.component.html
+++ b/src/main/webapp/app/shared/statistics-graph/statistics-graph.component.html
@@ -2,7 +2,7 @@
     <div>
         <h3>{{ chartName | artemisTranslate }}</h3>
     </div>
-    <div>
+    <div class="row">
         <fa-icon [icon]="faArrowLeft" size="2x" class="col-1 d-flex justify-content-end align-items-center px-0" role="button" (click)="switchTimeSpan(LEFT)"></fa-icon>
         <div #containerRef class="chart col-10 px-0">
             <ngx-charts-bar-vertical


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This is a PR to solve issue #6192 
### Description
<!-- Describe your changes in detail -->
The issue stems from the fact that on some screen sizes the chart name takes up less space than a word in width. Reducing font size doesn't make much sense(screenshot 2) but separating chart name and chart is a straightforward way(screenshot 3).
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Statistics
3. Check the chart names and charts are responsive

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
issue:
<img width="941" alt="original" src="https://github.com/ls1intum/Artemis/assets/60965100/e8478bf1-40a9-4154-a6c2-0caade5eada8">
reduce the font size:
<img width="928" alt="splitsmall" src="https://github.com/ls1intum/Artemis/assets/60965100/af88e9ac-23f6-4998-a899-3838d9fa8db3">
separate:
![image](https://github.com/ls1intum/Artemis/assets/60965100/94e7de7b-b3ec-452e-9ae4-44e5dfc3969b)
