### PR TITLE
`Programming exercises`: Fix participation for users with "git" in their login

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/VcsRepositoryUrl.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/VcsRepositoryUrl.java
@@ -83,10 +83,13 @@ public class VcsRepositoryUrl {
         }
         else { // e.g. http(s) or ssh
             String path = getURI().getPath();
-            path = path.replaceAll(".git$", "");
+            // remove .git (which might be used at the end)
+            path = path.replaceAll("\\.git$", "");
             path = path.replaceAll("/$", "");
             path = path.replaceAll("^/.*scm", "");
-            path = path.replaceAll("^/.*git", "");
+            // TODO: this seems to be somehow necessary for LOCAL VCS, however it breaks with usernames such ab123git (because they will include a '.' before)
+            // Therefore, we temporarily disable this replacement until we find out what the actual needed replacement would be
+            // path = path.replaceAll("^/.*git", "");
             return path;
         }
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/UrlServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/UrlServiceTest.java
@@ -17,15 +17,18 @@ import de.tum.in.www1.artemis.exception.VersionControlException;
 
 class UrlServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
-    private final VcsRepositoryUrl repositoryUrl1 = new VcsRepositoryUrl("https://ab123cd@bitbucket.ase.in.tum.de/scm/EIST2016RME/RMEXERCISE-ab123cd");
+    private final VcsRepositoryUrl repositoryUrl1 = new VcsRepositoryUrl("https://ab12cde@bitbucket.ase.in.tum.de/scm/EIST2016RME/RMEXERCISE-ab12cde");
 
-    private final VcsRepositoryUrl repositoryUrl2 = new VcsRepositoryUrl("https://ab123cd@repobruegge.in.tum.de/scm/EIST2016RME/RMEXERCISE-ab123cd.git");
+    private final VcsRepositoryUrl repositoryUrl2 = new VcsRepositoryUrl("https://ab12cde@repobruegge.in.tum.de/scm/EIST2016RME/RMEXERCISE-ab12cde.git");
 
     private final VcsRepositoryUrl repositoryUrl3 = new VcsRepositoryUrl("https://artemistest2gitlab.ase.in.tum.de/TESTADAPTER/testadapter-exercise.git");
 
     private final VcsRepositoryUrl repositoryUrl4 = new VcsRepositoryUrl("https://username@artemistest2gitlab.ase.in.tum.de/FTCSCAGRADING1/ftcscagrading1-username");
 
-    private final VcsRepositoryUrl repositoryUrl5 = new VcsRepositoryUrl("ssh://git@bitbucket.ase.in.tum.de:7999/eist20l06e03/eist20l06e03-ab123cd.git");
+    private final VcsRepositoryUrl repositoryUrl5 = new VcsRepositoryUrl("ssh://git@bitbucket.ase.in.tum.de:7999/eist20l06e03/eist20l06e03-ab12cde.git");
+
+    // special case which recently did not work
+    private final VcsRepositoryUrl repositoryUrl6 = new VcsRepositoryUrl("https://ab12cde@bitbucket.ase.in.tum.de/scm/EIST2016RME/RMEXERCISE-ab12git");
 
     private final VcsRepositoryUrl fileRepositoryUrl1 = new VcsRepositoryUrl(new File("C:/Users/Admin/AppData/Local/Temp/studentOriginRepo1644180397872264950"));
 
@@ -43,9 +46,9 @@ class UrlServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
     @Test
     void testGetRepositorySlugFromRepositoryUrl() {
         String repoSlug = urlService.getRepositorySlugFromRepositoryUrl(repositoryUrl1);
-        assertThat(repoSlug).isEqualTo("RMEXERCISE-ab123cd");
+        assertThat(repoSlug).isEqualTo("RMEXERCISE-ab12cde");
         repoSlug = urlService.getRepositorySlugFromRepositoryUrl(repositoryUrl2);
-        assertThat(repoSlug).isEqualTo("RMEXERCISE-ab123cd");
+        assertThat(repoSlug).isEqualTo("RMEXERCISE-ab12cde");
         repoSlug = urlService.getRepositorySlugFromRepositoryUrl(repositoryUrl3);
         assertThat(repoSlug).isEqualTo("testadapter-exercise");
         repoSlug = urlService.getRepositorySlugFromRepositoryUrl(repositoryUrl4);
@@ -58,9 +61,9 @@ class UrlServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
     @Test
     void testGetRepositoryPathFromRepositoryUrl() {
         String repoSlug = urlService.getRepositoryPathFromRepositoryUrl(repositoryUrl1);
-        assertThat(repoSlug).isEqualTo("EIST2016RME/RMEXERCISE-ab123cd");
+        assertThat(repoSlug).isEqualTo("EIST2016RME/RMEXERCISE-ab12cde");
         repoSlug = urlService.getRepositoryPathFromRepositoryUrl(repositoryUrl2);
-        assertThat(repoSlug).isEqualTo("EIST2016RME/RMEXERCISE-ab123cd");
+        assertThat(repoSlug).isEqualTo("EIST2016RME/RMEXERCISE-ab12cde");
         repoSlug = urlService.getRepositoryPathFromRepositoryUrl(repositoryUrl3);
         assertThat(repoSlug).isEqualTo("TESTADAPTER/testadapter-exercise");
         repoSlug = urlService.getRepositoryPathFromRepositoryUrl(repositoryUrl4);
@@ -87,11 +90,12 @@ class UrlServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     @Test
     void testGetFolderNameForRepositoryUrl() {
-        assertThat(repositoryUrl1.folderNameForRepositoryUrl()).isEqualTo("/EIST2016RME/RMEXERCISE-ab123cd");
-        assertThat(repositoryUrl2.folderNameForRepositoryUrl()).isEqualTo("/EIST2016RME/RMEXERCISE-ab123cd");
+        assertThat(repositoryUrl1.folderNameForRepositoryUrl()).isEqualTo("/EIST2016RME/RMEXERCISE-ab12cde");
+        assertThat(repositoryUrl2.folderNameForRepositoryUrl()).isEqualTo("/EIST2016RME/RMEXERCISE-ab12cde");
         assertThat(repositoryUrl3.folderNameForRepositoryUrl()).isEqualTo("/TESTADAPTER/testadapter-exercise");
         assertThat(repositoryUrl4.folderNameForRepositoryUrl()).isEqualTo("/FTCSCAGRADING1/ftcscagrading1-username");
-        assertThat(repositoryUrl5.folderNameForRepositoryUrl()).isEqualTo("/eist20l06e03/eist20l06e03-ab123cd");
+        assertThat(repositoryUrl5.folderNameForRepositoryUrl()).isEqualTo("/eist20l06e03/eist20l06e03-ab12cde");
+        assertThat(repositoryUrl6.folderNameForRepositoryUrl()).isEqualTo("/EIST2016RME/RMEXERCISE-ab12git");
         assertThat(fileRepositoryUrl1.folderNameForRepositoryUrl()).isEqualTo("studentOriginRepo1644180397872264950");
         assertThat(fileRepositoryUrl2.folderNameForRepositoryUrl()).isEqualTo("studentTeamOriginRepo420037178325056205");
     }
@@ -100,11 +104,11 @@ class UrlServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
     void testUserIndependentRepositoryUrl() {
         var solutionProgrammingExerciseParticipation = new SolutionProgrammingExerciseParticipation();
         solutionProgrammingExerciseParticipation.setRepositoryUrl(repositoryUrl1.toString());
-        assertThat(solutionProgrammingExerciseParticipation.getUserIndependentRepositoryUrl()).isEqualTo("https://bitbucket.ase.in.tum.de/scm/EIST2016RME/RMEXERCISE-ab123cd");
+        assertThat(solutionProgrammingExerciseParticipation.getUserIndependentRepositoryUrl()).isEqualTo("https://bitbucket.ase.in.tum.de/scm/EIST2016RME/RMEXERCISE-ab12cde");
 
         var templateProgrammingExerciseParticipation = new TemplateProgrammingExerciseParticipation();
         templateProgrammingExerciseParticipation.setRepositoryUrl(repositoryUrl2.toString());
-        assertThat(templateProgrammingExerciseParticipation.getUserIndependentRepositoryUrl()).isEqualTo("https://repobruegge.in.tum.de/scm/EIST2016RME/RMEXERCISE-ab123cd.git");
+        assertThat(templateProgrammingExerciseParticipation.getUserIndependentRepositoryUrl()).isEqualTo("https://repobruegge.in.tum.de/scm/EIST2016RME/RMEXERCISE-ab12cde.git");
 
         var studentParticipation1 = new ProgrammingExerciseStudentParticipation();
         studentParticipation1.setRepositoryUrl(repositoryUrl3.toString());


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
A student reported that starting programming exercises does not work for them. After further investigation it was discovered that the issue comes from the fact that their login contained "git", which caused a bug during the cloning process.

### Description
When creating the folder name for the cloned repo, everything from the start to "git" was replaced by the empty string. This was added in #6262 but there does not seam to be a reason for this replacement, so it is deactivated for now.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student with "git" in the login. You can locally create a new user to test this out
- 1 Programming Exercise

1. Log in to Artemis
2. Check if participating (starting and submitting something is enough) in the exercise with that special student is possible

### Review Progress

#### Performance Review
- [x] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->