### PR TITLE
`Exam mode`: Fix exam exercise name shown to students in breadcrumb

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExerciseRepository.java
@@ -179,7 +179,7 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
                      ELSE exercise.title
                 END AS title
             FROM Exercise exercise
-            LEFT JOIN fetch exercise.exerciseGroup exerciseGroup
+                LEFT JOIN exercise.exerciseGroup exerciseGroup
             WHERE exercise.id = :exerciseId
             """)
     @Cacheable(cacheNames = "exerciseTitle", key = "#exerciseId", unless = "#result == null")

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExerciseRepository.java
@@ -174,8 +174,8 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
      */
     @Query("""
             SELECT
-                CASE WHEN exercise.exerciseGroup IS NOT NULL
-                     THEN exercise.exerciseGroup.title
+                CASE WHEN exerciseGroup IS NOT NULL
+                     THEN exerciseGroup.title
                      ELSE exercise.title
                 END AS title
             FROM Exercise exercise

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExerciseRepository.java
@@ -173,9 +173,14 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
      * @return the name/title of the exercise or null if the exercise does not exist
      */
     @Query("""
-            SELECT e.title
-            FROM Exercise e
-            WHERE e.id = :exerciseId
+            SELECT
+                CASE WHEN exercise.exerciseGroup IS NOT NULL
+                     THEN exercise.exerciseGroup.title
+                     ELSE exercise.title
+                END AS title
+            FROM Exercise exercise
+            LEFT JOIN fetch exercise.exerciseGroup exerciseGroup
+            WHERE exercise.id = :exerciseId
             """)
     @Cacheable(cacheNames = "exerciseTitle", key = "#exerciseId", unless = "#result == null")
     String getExerciseTitle(@Param("exerciseId") Long exerciseId);

--- a/src/main/java/de/tum/in/www1/artemis/service/TitleCacheEvictionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TitleCacheEvictionService.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.artemis.service;
 import javax.persistence.EntityManagerFactory;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.hibernate.Hibernate;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.*;
 import org.hibernate.internal.SessionFactoryImpl;
@@ -102,7 +103,10 @@ public class TitleCacheEvictionService implements PostUpdateEventListener, PostD
             evictIdFromCache("exerciseHintTitle", combinedId);
         }
         else if (entity instanceof ExerciseGroup exerciseGroup) {
-            // TODO check for Hibernate.isInitialized and handle this case
+            if (!Hibernate.isInitialized(exerciseGroup.getExercises())) {
+                log.warn("Unable to clear title of exercises from exercise group {}: Exercises not initialized", exerciseGroup.getId());
+                return;
+            }
             var exercises = exerciseGroup.getExercises();
             for (Exercise exercise : exercises) {
                 evictIdFromCache("exerciseTitle", exercise.getId());

--- a/src/main/java/de/tum/in/www1/artemis/service/TitleCacheEvictionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TitleCacheEvictionService.java
@@ -17,6 +17,7 @@ import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.Organization;
 import de.tum.in.www1.artemis.domain.exam.Exam;
+import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.hestia.ExerciseHint;
 import de.tum.in.www1.artemis.domain.modeling.ApollonDiagram;
 
@@ -99,6 +100,13 @@ public class TitleCacheEvictionService implements PostUpdateEventListener, PostD
 
             var combinedId = hint.getExercise().getId() + "-" + hint.getId();
             evictIdFromCache("exerciseHintTitle", combinedId);
+        }
+        else if (entity instanceof ExerciseGroup exerciseGroup) {
+            // TODO check for Hibernate.isInitialized and handle this case
+            var exercises = exerciseGroup.getExercises();
+            for (Exercise exercise : exercises) {
+                evictIdFromCache("exerciseTitle", exercise.getId());
+            }
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -222,10 +222,6 @@ public class ExerciseResource {
     @GetMapping("exercises/{exerciseId}/title")
     @EnforceAtLeastStudent
     public ResponseEntity<String> getExerciseTitle(@PathVariable Long exerciseId) {
-        final var exercise = exerciseRepository.findByIdElseThrow(exerciseId);
-        if (authCheckService.isAtLeastTeachingAssistantForExercise(exercise)) {
-            return ResponseEntity.ok(exercise.getTitle());
-        }
         final var title = exerciseRepository.getExerciseTitle(exerciseId);
         return title == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(title);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -222,6 +222,10 @@ public class ExerciseResource {
     @GetMapping("exercises/{exerciseId}/title")
     @EnforceAtLeastStudent
     public ResponseEntity<String> getExerciseTitle(@PathVariable Long exerciseId) {
+        final var exercise = exerciseRepository.findByIdElseThrow(exerciseId);
+        if (authCheckService.isAtLeastTeachingAssistantForExercise(exercise)) {
+            return ResponseEntity.ok(exercise.getTitle());
+        }
         final var title = exerciseRepository.getExerciseTitle(exerciseId);
         return title == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(title);
     }

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
@@ -21,7 +21,7 @@
             >
                 <th scope="row">{{ i + 1 }}</th>
                 <td>
-                    <span *ngIf="exercise.title">{{ exercise.title }}</span>
+                    <span>{{ exercise?.exerciseGroup?.title ?? '-' }}</span>
                 </td>
                 <td>{{ exerciseService.isIncludedInScore(exercise) }}</td>
                 <td>

--- a/src/main/webapp/app/exercises/shared/exercise/exercise.service.ts
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise.service.ts
@@ -492,7 +492,13 @@ export class ExerciseService {
     }
 
     public sendExerciseTitleToTitleService(exercise: Exercise | undefined | null) {
-        this.entityTitleService.setTitle(EntityType.EXERCISE, [exercise?.id], exercise?.title);
+        // we only want to show the exercise group name as exercise name to the student for exam exercises.
+        // for tutors and more privileged users, we want to show the exercise title
+        if (exercise?.exerciseGroup && !exercise?.isAtLeastTutor) {
+            this.entityTitleService.setTitle(EntityType.EXERCISE, [exercise?.id], exercise?.exerciseGroup.title);
+        } else {
+            this.entityTitleService.setTitle(EntityType.EXERCISE, [exercise?.id], exercise?.title);
+        }
         if (exercise?.course) {
             this.entityTitleService.setTitle(EntityType.COURSE, [exercise.course.id], exercise.course.title);
         }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
@@ -704,6 +704,7 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJi
     void testGetExerciseTitleAsInstructor() throws Exception {
         // Only user and role matter, so we can re-use the logic
         testGetExerciseTitle();
+        testGetExamExerciseTitleIfAtLeastTutor();
     }
 
     @Test
@@ -711,23 +712,39 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJi
     void testGetExerciseTitleAsTeachingAssistant() throws Exception {
         // Only user and role matter, so we can re-use the logic
         testGetExerciseTitle();
+        testGetExamExerciseTitleIfAtLeastTutor();
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "user1", roles = "USER")
     void testGetExerciseTitleAsUser() throws Exception {
         // Only user and role matter, so we can re-use the logic
+        // course exercise
         testGetExerciseTitle();
+
+        // exam exercise
+        TextExercise textExercise = textExerciseUtilService.addCourseExamExerciseGroupWithOneTextExercise();
+        final String expectedTitle = textExercise.getExerciseGroup().getTitle();
+        final String title = request.get("/api/exercises/" + textExercise.getId() + "/title", HttpStatus.OK, String.class);
+        assertThat(title).isEqualTo(expectedTitle);
     }
 
     private void testGetExerciseTitle() throws Exception {
         Course courseWithOneReleasedTextExercise = textExerciseUtilService.addCourseWithOneReleasedTextExercise();
         Exercise exercise = (Exercise) courseWithOneReleasedTextExercise.getExercises().toArray()[0];
         exercise.setTitle("Test Exercise");
-        exerciseRepository.save(exercise);
+        exercise.setExerciseGroup(null);
+        exercise = exerciseRepository.save(exercise);
 
         final var title = request.get("/api/exercises/" + exercise.getId() + "/title", HttpStatus.OK, String.class);
         assertThat(title).isEqualTo(exercise.getTitle());
+    }
+
+    private void testGetExamExerciseTitleIfAtLeastTutor() throws Exception {
+        TextExercise textExercise = textExerciseUtilService.addCourseExamExerciseGroupWithOneTextExercise();
+        final String expectedTitle = textExercise.getTitle();
+        final String title = request.get("/api/exercises/" + textExercise.getId() + "/title", HttpStatus.OK, String.class);
+        assertThat(title).isEqualTo(expectedTitle);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
@@ -704,7 +704,7 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJi
     void testGetExerciseTitleAsInstructor() throws Exception {
         // Only user and role matter, so we can re-use the logic
         testGetExerciseTitle();
-        testGetExamExerciseTitleIfAtLeastTutor();
+        testGetExamExerciseTitle();
     }
 
     @Test
@@ -712,7 +712,7 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJi
     void testGetExerciseTitleAsTeachingAssistant() throws Exception {
         // Only user and role matter, so we can re-use the logic
         testGetExerciseTitle();
-        testGetExamExerciseTitleIfAtLeastTutor();
+        testGetExamExerciseTitle();
     }
 
     @Test
@@ -723,10 +723,7 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJi
         testGetExerciseTitle();
 
         // exam exercise
-        TextExercise textExercise = textExerciseUtilService.addCourseExamExerciseGroupWithOneTextExercise();
-        final String expectedTitle = textExercise.getExerciseGroup().getTitle();
-        final String title = request.get("/api/exercises/" + textExercise.getId() + "/title", HttpStatus.OK, String.class);
-        assertThat(title).isEqualTo(expectedTitle);
+        testGetExamExerciseTitle();
     }
 
     private void testGetExerciseTitle() throws Exception {
@@ -739,9 +736,9 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJi
         assertThat(title).isEqualTo(exercise.getTitle());
     }
 
-    private void testGetExamExerciseTitleIfAtLeastTutor() throws Exception {
+    private void testGetExamExerciseTitle() throws Exception {
         TextExercise textExercise = textExerciseUtilService.addCourseExamExerciseGroupWithOneTextExercise();
-        final String expectedTitle = textExercise.getTitle();
+        final String expectedTitle = textExercise.getExerciseGroup().getTitle();
         final String title = request.get("/api/exercises/" + textExercise.getId() + "/title", HttpStatus.OK, String.class);
         assertThat(title).isEqualTo(expectedTitle);
     }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
@@ -716,7 +716,7 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJi
     }
 
     @Test
-    @WithMockUser(username = TEST_PREFIX + "user1", roles = "USER")
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetExerciseTitleAsUser() throws Exception {
         // Only user and role matter, so we can re-use the logic
         // course exercise
@@ -733,7 +733,6 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJi
         Course courseWithOneReleasedTextExercise = textExerciseUtilService.addCourseWithOneReleasedTextExercise();
         Exercise exercise = (Exercise) courseWithOneReleasedTextExercise.getExercises().toArray()[0];
         exercise.setTitle("Test Exercise");
-        exercise.setExerciseGroup(null);
         exercise = exerciseRepository.save(exercise);
 
         final var title = request.get("/api/exercises/" + exercise.getId() + "/title", HttpStatus.OK, String.class);

--- a/src/test/javascript/spec/service/exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise.service.spec.ts
@@ -520,4 +520,23 @@ describe('Exercise Service', () => {
             method: 'PUT',
         });
     });
+
+    it('should correctly send the exercise name to the title service', () => {
+        const entityTitleService = TestBed.inject(EntityTitleService);
+        const examExerciseForStudent = { id: 1, title: 'exercise', exerciseGroup: { id: 1, title: 'exercise group' } } as Exercise;
+        const examExerciseForTutor = { ...examExerciseForStudent, isAtLeastTutor: true } as Exercise;
+        const courseExerciseForStudent = { ...examExerciseForStudent, exerciseGroup: undefined, course: { id: 2, title: 'course' } } as Exercise;
+        const courseExerciseForTutor = { ...courseExerciseForStudent, isAtLeastTutor: true } as Exercise;
+        const entityTitleServiceSpy = jest.spyOn(entityTitleService, 'setTitle');
+        service.sendExerciseTitleToTitleService(examExerciseForStudent);
+        expect(entityTitleServiceSpy).toHaveBeenCalledWith(EntityType.EXERCISE, [1], 'exercise group');
+        service.sendExerciseTitleToTitleService(examExerciseForTutor);
+        expect(entityTitleServiceSpy).toHaveBeenCalledWith(EntityType.EXERCISE, [1], 'exercise');
+        service.sendExerciseTitleToTitleService(courseExerciseForStudent);
+        expect(entityTitleServiceSpy).toHaveBeenCalledWith(EntityType.EXERCISE, [1], 'exercise');
+        expect(entityTitleServiceSpy).toHaveBeenCalledWith(EntityType.COURSE, [2], 'course');
+        service.sendExerciseTitleToTitleService(courseExerciseForTutor);
+        expect(entityTitleServiceSpy).toHaveBeenCalledWith(EntityType.EXERCISE, [1], 'exercise');
+        expect(entityTitleServiceSpy).toHaveBeenCalledWith(EntityType.COURSE, [2], 'course');
+    });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
Follow-up to #6873 to make the breadcrumbs consistent with the title shown for the exam exercise to students.

### Description
We now distinguish on the server side if the exercise name for the breadcrumb should be shown to a student or someone who is at least a tutor. In the former case, we show the exercise group name in the breadcrumb if it's an exam exercise, otherwise the normal exercise title. In the latter case, we always show the exercise title because for tutors the exercises should be distinguishable.
@Strohgelaender thanks for fixing the jpql query.

### Steps for Testing
- 1 Student
- 1 Tutor or user with more privileges
- 1 Exam

1. Participate in the exam and submit the exam
2. Grade the exam (also add an example solution for at least one exercise) and check that the exercise and not the exercise group name is shown in the breadcrumb.
3. Review your results as student and verify that the breadcrumb text for the exercise matches the exercise title you see
4. Review the example solution as student and verify the same
5. check the exercise names on the exam summary page at the top where the points are listed.

### Exam mode testing
Part of the normal testing steps

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [exercise.service.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5189/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/shared/exercise/exercise.service.ts.html) | 92.38% | ✅ |

#### Server

| Class/File | Line Coverage | Confirmation (assert/expect) |Comment|
|------------|--------------:|---------------------:|-------------------:|
| [ExerciseRepository.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5189/latest/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.repository/ExerciseRepository.html) | 76% | ✅ | cannot be directly covered|
| [TitleCacheEvictionService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5189/latest/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service/TitleCacheEvictionService.html) | 85% |  | |
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/ls1intum/Artemis/assets/84102468/820b34ba-f3c7-4c5b-be19-deb242a94814)
