### PR TITLE
`Development`: Remove spammy websocket subscriptions

### DIFF
--- a/src/main/webapp/app/shared/notification/notification.service.ts
+++ b/src/main/webapp/app/shared/notification/notification.service.ts
@@ -186,6 +186,10 @@ export class NotificationService {
                 this.subscribeToQuizUpdates(courses);
             }
         });
+        // TODO !!!!!!!!!!!!!!!!!!!
+        // TODO Re-enable / rewrite tests in notification.service.spec.ts, lines 303 and 317 (look for it.skip) when readding this
+        // TODO !!!!!!!!!!!!!!!!!!!
+        // TODO
         // TODO temporarily disabled because we should only subscribes once for all tutorial groups and once for all conversations
         // this.tutorialGroupsNotificationService.getTutorialGroupsForNotifications().subscribe((tutorialGroups) => {
         //     if (tutorialGroups) {

--- a/src/main/webapp/app/shared/notification/notification.service.ts
+++ b/src/main/webapp/app/shared/notification/notification.service.ts
@@ -186,16 +186,17 @@ export class NotificationService {
                 this.subscribeToQuizUpdates(courses);
             }
         });
-        this.tutorialGroupsNotificationService.getTutorialGroupsForNotifications().subscribe((tutorialGroups) => {
-            if (tutorialGroups) {
-                this.subscribeToTutorialGroupNotificationUpdates(tutorialGroups);
-            }
-        });
-        this.courseConversationsNotificationsService.getConversationsForNotifications().subscribe((conversations) => {
-            if (conversations) {
-                this.subscribeToConversationNotificationUpdates(conversations);
-            }
-        });
+        // TODO temporarily disabled because we should only subscribes once for all tutorial groups and once for all conversations
+        // this.tutorialGroupsNotificationService.getTutorialGroupsForNotifications().subscribe((tutorialGroups) => {
+        //     if (tutorialGroups) {
+        //         this.subscribeToTutorialGroupNotificationUpdates(tutorialGroups);
+        //     }
+        // });
+        // this.courseConversationsNotificationsService.getConversationsForNotifications().subscribe((conversations) => {
+        //     if (conversations) {
+        //         this.subscribeToConversationNotificationUpdates(conversations);
+        //     }
+        // });
         return this.notificationObserver;
     }
 

--- a/src/test/javascript/spec/service/notification.service.spec.ts
+++ b/src/test/javascript/spec/service/notification.service.spec.ts
@@ -300,7 +300,7 @@ describe('Notification Service', () => {
             // calls addNotificationToObserver i.e. calls next on subscribeToNotificationUpdates' ReplaySubject
         }));
 
-        it('should subscribe to tutorial group notification updates and receive new tutorial group notifications', fakeAsync(() => {
+        it.skip('should subscribe to tutorial group notification updates and receive new tutorial group notifications', fakeAsync(() => {
             getTutorialGroupsForNotificationsSpy = jest.spyOn(tutorialGroupNotificationService, 'getTutorialGroupsForNotifications').mockReturnValue(of([tutorialGroup]));
 
             notificationService.subscribeToNotificationUpdates().subscribe((notification) => {
@@ -314,7 +314,7 @@ describe('Notification Service', () => {
             wsNotificationSubject.next(tutorialGroupNotification);
         }));
 
-        it('should subscribe to conversation notification updates and receive new message notifications', fakeAsync(() => {
+        it.skip('should subscribe to conversation notification updates and receive new message notifications', fakeAsync(() => {
             getConversationsForNotificationsSpy = jest.spyOn(conversationNotificationService, 'getConversationsForNotifications').mockReturnValue(of([conversation]));
 
             notificationService.subscribeToNotificationUpdates().subscribe((notification) => {


### PR DESCRIPTION
This is a quick bandaid that disables some websocket subscriptions as they appear to overload the production broker.