### PR TITLE
`Development`: Enforce websocket messaging service usage

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/QuizMessagingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizMessagingService.java
@@ -5,8 +5,6 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,13 +23,13 @@ public class QuizMessagingService {
 
     private final GroupNotificationService groupNotificationService;
 
-    private final SimpMessageSendingOperations messagingTemplate;
+    private final WebsocketMessagingService websocketMessagingService;
 
     public QuizMessagingService(MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter, GroupNotificationService groupNotificationService,
-            SimpMessageSendingOperations messagingTemplate) {
+            WebsocketMessagingService websocketMessagingService) {
         this.objectMapper = mappingJackson2HttpMessageConverter.getObjectMapper();
         this.groupNotificationService = groupNotificationService;
-        this.messagingTemplate = messagingTemplate;
+        this.websocketMessagingService = websocketMessagingService;
     }
 
     /**
@@ -45,7 +43,7 @@ public class QuizMessagingService {
         try {
             long start = System.currentTimeMillis();
             Class<?> view = quizExercise.viewForStudentsInQuizExercise(quizBatch);
-            byte[] payload = objectMapper.writerWithView(view).writeValueAsBytes(quizExercise);
+            String payload = objectMapper.writerWithView(view).writeValueAsString(quizExercise);
             // For each change we send the same message. The client needs to decide how to handle the date based on the quiz status
             if (quizExercise.isVisibleToStudents() && quizExercise.isCourseExercise()) {
                 // Create a group notification if actions is 'start-now'.
@@ -57,7 +55,7 @@ public class QuizMessagingService {
                 if ("start-batch".equals(quizChange) && quizBatch != null) {
                     destination = destination + "/" + quizBatch.getId();
                 }
-                messagingTemplate.send(destination, MessageBuilder.withPayload(payload).build());
+                websocketMessagingService.sendMessage(destination, payload);
                 log.info("Sent '{}' for quiz {} to all listening clients in {} ms", quizChange, quizExercise.getId(), System.currentTimeMillis() - start);
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizStatisticService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizStatisticService.java
@@ -6,7 +6,6 @@ import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.Result;
@@ -29,17 +28,17 @@ public class QuizStatisticService {
 
     private final QuizSubmissionRepository quizSubmissionRepository;
 
-    private final SimpMessageSendingOperations messagingTemplate;
+    private final WebsocketMessagingService websocketMessagingService;
 
-    public QuizStatisticService(StudentParticipationRepository studentParticipationRepository, ResultRepository resultRepository, SimpMessageSendingOperations messagingTemplate,
+    public QuizStatisticService(StudentParticipationRepository studentParticipationRepository, ResultRepository resultRepository,
             QuizPointStatisticRepository quizPointStatisticRepository, QuizQuestionStatisticRepository quizQuestionStatisticRepository,
-            QuizSubmissionRepository quizSubmissionRepository) {
+            QuizSubmissionRepository quizSubmissionRepository, WebsocketMessagingService websocketMessagingService) {
         this.studentParticipationRepository = studentParticipationRepository;
         this.resultRepository = resultRepository;
         this.quizPointStatisticRepository = quizPointStatisticRepository;
         this.quizQuestionStatisticRepository = quizQuestionStatisticRepository;
-        this.messagingTemplate = messagingTemplate;
         this.quizSubmissionRepository = quizSubmissionRepository;
+        this.websocketMessagingService = websocketMessagingService;
     }
 
     /**
@@ -140,7 +139,7 @@ public class QuizStatisticService {
             // notify users via websocket about new results for the statistics.
             // filters out solution information
             quiz.filterForStatisticWebsocket();
-            messagingTemplate.convertAndSend("/topic/statistic/" + quiz.getId(), quiz);
+            websocketMessagingService.sendMessage("/topic/statistic/" + quiz.getId(), quiz);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/SystemNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SystemNotificationService.java
@@ -3,7 +3,6 @@ package de.tum.in.www1.artemis.service;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.notification.SystemNotification;
@@ -16,13 +15,13 @@ public class SystemNotificationService {
 
     private static final String ENTITY_NAME = "systemNotification";
 
-    private final SimpMessageSendingOperations messagingTemplate;
-
     private final SystemNotificationRepository systemNotificationRepository;
 
-    public SystemNotificationService(SimpMessageSendingOperations messagingTemplate, SystemNotificationRepository systemNotificationRepository) {
-        this.messagingTemplate = messagingTemplate;
+    private final WebsocketMessagingService websocketMessagingService;
+
+    public SystemNotificationService(SystemNotificationRepository systemNotificationRepository, WebsocketMessagingService websocketMessagingService) {
         this.systemNotificationRepository = systemNotificationRepository;
+        this.websocketMessagingService = websocketMessagingService;
     }
 
     /**
@@ -41,7 +40,7 @@ public class SystemNotificationService {
      * Call this method after changing any system notification.
      */
     public void distributeActiveAndFutureNotificationsToClients() {
-        messagingTemplate.convertAndSend("/topic/system-notification", findAllActiveAndFutureSystemNotifications());
+        websocketMessagingService.sendMessage("/topic/system-notification", findAllActiveAndFutureSystemNotifications());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerMessageService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerMessageService.java
@@ -3,7 +3,6 @@ package de.tum.in.www1.artemis.service.metis;
 import java.util.Objects;
 import java.util.Set;
 
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.Course;
@@ -23,6 +22,7 @@ import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ConversationRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.service.metis.conversation.ConversationService;
 import de.tum.in.www1.artemis.service.metis.conversation.auth.ChannelAuthorizationService;
 import de.tum.in.www1.artemis.service.notifications.SingleUserNotificationService;
@@ -53,10 +53,10 @@ public class AnswerMessageService extends PostingService {
     @SuppressWarnings("PMD.ExcessiveParameterList")
     public AnswerMessageService(SingleUserNotificationService singleUserNotificationService, CourseRepository courseRepository, AuthorizationCheckService authorizationCheckService,
             UserRepository userRepository, AnswerPostRepository answerPostRepository, ConversationMessageRepository conversationMessageRepository,
-            ConversationService conversationService, ExerciseRepository exerciseRepository, LectureRepository lectureRepository, SimpMessageSendingOperations messagingTemplate,
+            ConversationService conversationService, ExerciseRepository exerciseRepository, LectureRepository lectureRepository,
             ConversationParticipantRepository conversationParticipantRepository, ChannelAuthorizationService channelAuthorizationService, PostRepository postRepository,
-            ConversationRepository conversationRepository) {
-        super(courseRepository, userRepository, exerciseRepository, lectureRepository, authorizationCheckService, messagingTemplate, conversationParticipantRepository);
+            ConversationRepository conversationRepository, WebsocketMessagingService websocketMessagingService) {
+        super(courseRepository, userRepository, exerciseRepository, lectureRepository, authorizationCheckService, conversationParticipantRepository, websocketMessagingService);
         this.answerPostRepository = answerPostRepository;
         this.conversationMessageRepository = conversationMessageRepository;
         this.conversationService = conversationService;

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerPostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerPostService.java
@@ -3,7 +3,6 @@ package de.tum.in.www1.artemis.service.metis;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.Course;
@@ -20,6 +19,7 @@ import de.tum.in.www1.artemis.repository.metis.ConversationParticipantRepository
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationService;
 import de.tum.in.www1.artemis.service.notifications.SingleUserNotificationService;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
@@ -41,9 +41,9 @@ public class AnswerPostService extends PostingService {
 
     protected AnswerPostService(CourseRepository courseRepository, AuthorizationCheckService authorizationCheckService, UserRepository userRepository,
             AnswerPostRepository answerPostRepository, PostRepository postRepository, ExerciseRepository exerciseRepository, LectureRepository lectureRepository,
-            GroupNotificationService groupNotificationService, SingleUserNotificationService singleUserNotificationService, SimpMessageSendingOperations messagingTemplate,
-            ConversationParticipantRepository conversationParticipantRepository) {
-        super(courseRepository, userRepository, exerciseRepository, lectureRepository, authorizationCheckService, messagingTemplate, conversationParticipantRepository);
+            GroupNotificationService groupNotificationService, SingleUserNotificationService singleUserNotificationService,
+            ConversationParticipantRepository conversationParticipantRepository, WebsocketMessagingService websocketMessagingService) {
+        super(courseRepository, userRepository, exerciseRepository, lectureRepository, authorizationCheckService, conversationParticipantRepository, websocketMessagingService);
         this.answerPostRepository = answerPostRepository;
         this.postRepository = postRepository;
         this.groupNotificationService = groupNotificationService;

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/ConversationMessagingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/ConversationMessagingService.java
@@ -10,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -29,6 +28,7 @@ import de.tum.in.www1.artemis.repository.metis.ConversationMessageRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationParticipantRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ConversationRepository;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.service.metis.conversation.ConversationService;
 import de.tum.in.www1.artemis.service.metis.conversation.auth.ChannelAuthorizationService;
 import de.tum.in.www1.artemis.web.rest.dto.PostContextFilter;
@@ -51,10 +51,10 @@ public class ConversationMessagingService extends PostingService {
     private final ConversationRepository conversationRepository;
 
     protected ConversationMessagingService(CourseRepository courseRepository, ExerciseRepository exerciseRepository, LectureRepository lectureRepository,
-            ConversationMessageRepository conversationMessageRepository, AuthorizationCheckService authorizationCheckService, SimpMessageSendingOperations messagingTemplate,
-            UserRepository userRepository, ConversationService conversationService, ConversationParticipantRepository conversationParticipantRepository,
-            ChannelAuthorizationService channelAuthorizationService, ConversationRepository conversationRepository) {
-        super(courseRepository, userRepository, exerciseRepository, lectureRepository, authorizationCheckService, messagingTemplate, conversationParticipantRepository);
+            ConversationMessageRepository conversationMessageRepository, AuthorizationCheckService authorizationCheckService, UserRepository userRepository,
+            ConversationService conversationService, ConversationParticipantRepository conversationParticipantRepository, ChannelAuthorizationService channelAuthorizationService,
+            ConversationRepository conversationRepository, WebsocketMessagingService websocketMessagingService) {
+        super(courseRepository, userRepository, exerciseRepository, lectureRepository, authorizationCheckService, conversationParticipantRepository, websocketMessagingService);
         this.conversationService = conversationService;
         this.conversationMessageRepository = conversationMessageRepository;
         this.channelAuthorizationService = channelAuthorizationService;

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
@@ -12,7 +12,6 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Lists;
@@ -35,6 +34,7 @@ import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.service.metis.similarity.PostSimilarityComparisonStrategy;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationService;
 import de.tum.in.www1.artemis.service.plagiarism.PlagiarismCaseService;
@@ -63,9 +63,9 @@ public class PostService extends PostingService {
 
     protected PostService(CourseRepository courseRepository, AuthorizationCheckService authorizationCheckService, UserRepository userRepository, PostRepository postRepository,
             ExerciseRepository exerciseRepository, LectureRepository lectureRepository, GroupNotificationService groupNotificationService,
-            PostSimilarityComparisonStrategy postContentCompareStrategy, SimpMessageSendingOperations messagingTemplate, PlagiarismCaseService plagiarismCaseService,
-            PlagiarismCaseRepository plagiarismCaseRepository, ConversationParticipantRepository conversationParticipantRepository) {
-        super(courseRepository, userRepository, exerciseRepository, lectureRepository, authorizationCheckService, messagingTemplate, conversationParticipantRepository);
+            PostSimilarityComparisonStrategy postContentCompareStrategy, PlagiarismCaseService plagiarismCaseService, PlagiarismCaseRepository plagiarismCaseRepository,
+            ConversationParticipantRepository conversationParticipantRepository, WebsocketMessagingService websocketMessagingService) {
+        super(courseRepository, userRepository, exerciseRepository, lectureRepository, authorizationCheckService, conversationParticipantRepository, websocketMessagingService);
         this.postRepository = postRepository;
         this.plagiarismCaseRepository = plagiarismCaseRepository;
         this.groupNotificationService = groupNotificationService;

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
@@ -7,8 +7,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
-
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -21,6 +19,7 @@ import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationParticipantRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.websocket.dto.metis.MetisCrudAction;
 import de.tum.in.www1.artemis.web.websocket.dto.metis.PostDTO;
@@ -39,22 +38,22 @@ public abstract class PostingService {
 
     protected final AuthorizationCheckService authorizationCheckService;
 
-    private final SimpMessageSendingOperations messagingTemplate;
+    private final WebsocketMessagingService websocketMessagingService;
 
     protected static final String METIS_POST_ENTITY_NAME = "metis.post";
 
     private static final String METIS_WEBSOCKET_CHANNEL_PREFIX = "/topic/metis/";
 
     protected PostingService(CourseRepository courseRepository, UserRepository userRepository, ExerciseRepository exerciseRepository, LectureRepository lectureRepository,
-            AuthorizationCheckService authorizationCheckService, SimpMessageSendingOperations messagingTemplate,
-            ConversationParticipantRepository conversationParticipantRepository) {
+            AuthorizationCheckService authorizationCheckService, ConversationParticipantRepository conversationParticipantRepository,
+            WebsocketMessagingService websocketMessagingService) {
         this.courseRepository = courseRepository;
         this.userRepository = userRepository;
         this.exerciseRepository = exerciseRepository;
         this.lectureRepository = lectureRepository;
         this.authorizationCheckService = authorizationCheckService;
-        this.messagingTemplate = messagingTemplate;
         this.conversationParticipantRepository = conversationParticipantRepository;
+        this.websocketMessagingService = websocketMessagingService;
     }
 
     /**
@@ -85,21 +84,21 @@ public abstract class PostingService {
 
         if (postDTO.post().getExercise() != null) {
             specificTopicName += "exercises/" + postDTO.post().getExercise().getId();
-            messagingTemplate.convertAndSend(specificTopicName, postDTO);
+            websocketMessagingService.sendMessage(specificTopicName, postDTO);
         }
         else if (postDTO.post().getLecture() != null) {
             specificTopicName += "lectures/" + postDTO.post().getLecture().getId();
-            messagingTemplate.convertAndSend(specificTopicName, postDTO);
+            websocketMessagingService.sendMessage(specificTopicName, postDTO);
         }
         else if (postDTO.post().getConversation() != null) {
             Set<ConversationParticipant> participants = this.conversationParticipantRepository
                     .findConversationParticipantByConversationId(postDTO.post().getConversation().getId());
-            participants.forEach(conversationParticipant -> messagingTemplate.convertAndSendToUser(conversationParticipant.getUser().getLogin(),
+            participants.forEach(conversationParticipant -> websocketMessagingService.sendMessageToUser(conversationParticipant.getUser().getLogin(),
                     genericTopicName + "/conversations/" + postDTO.post().getConversation().getId(), postDTO));
 
             return;
         }
-        messagingTemplate.convertAndSend(genericTopicName, postDTO);
+        websocketMessagingService.sendMessage(genericTopicName, postDTO);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -9,7 +9,6 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,6 +29,7 @@ import de.tum.in.www1.artemis.repository.metis.conversation.ConversationReposito
 import de.tum.in.www1.artemis.repository.metis.conversation.GroupChatRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.OneToOneChatRepository;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.metis.conversation.dtos.ConversationDTO;
@@ -51,8 +51,6 @@ public class ConversationService {
 
     private final ConversationParticipantRepository conversationParticipantRepository;
 
-    private final SimpMessageSendingOperations messagingTemplate;
-
     private final OneToOneChatRepository oneToOneChatRepository;
 
     private final PostRepository postRepository;
@@ -63,16 +61,18 @@ public class ConversationService {
 
     private final CourseRepository courseRepository;
 
+    private final WebsocketMessagingService websocketMessagingService;
+
     public ConversationService(ConversationDTOService conversationDTOService, UserRepository userRepository, ChannelRepository channelRepository,
-            ConversationParticipantRepository conversationParticipantRepository, ConversationRepository conversationRepository, SimpMessageSendingOperations messagingTemplate,
-            OneToOneChatRepository oneToOneChatRepository, PostRepository postRepository, GroupChatRepository groupChatRepository,
-            AuthorizationCheckService authorizationCheckService, CourseRepository courseRepository) {
+            ConversationParticipantRepository conversationParticipantRepository, ConversationRepository conversationRepository, OneToOneChatRepository oneToOneChatRepository,
+            PostRepository postRepository, GroupChatRepository groupChatRepository, AuthorizationCheckService authorizationCheckService, CourseRepository courseRepository,
+            WebsocketMessagingService websocketMessagingService) {
         this.conversationDTOService = conversationDTOService;
         this.userRepository = userRepository;
         this.channelRepository = channelRepository;
         this.conversationParticipantRepository = conversationParticipantRepository;
         this.conversationRepository = conversationRepository;
-        this.messagingTemplate = messagingTemplate;
+        this.websocketMessagingService = websocketMessagingService;
         this.oneToOneChatRepository = oneToOneChatRepository;
         this.postRepository = postRepository;
         this.groupChatRepository = groupChatRepository;
@@ -317,7 +317,7 @@ public class ConversationService {
         }
 
         var websocketDTO = new ConversationWebsocketDTO(dto, metisCrudAction);
-        messagingTemplate.convertAndSendToUser(user.getLogin(), conversationParticipantTopicName + user.getId(), websocketDTO);
+        websocketMessagingService.sendMessageToUser(user.getLogin(), conversationParticipantTopicName + user.getId(), websocketDTO);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationService.java
@@ -6,7 +6,6 @@ import static de.tum.in.www1.artemis.domain.notification.NotificationConstants.*
 import java.util.List;
 import java.util.Objects;
 
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.User;
@@ -17,6 +16,7 @@ import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.metis.conversation.GroupChat;
 import de.tum.in.www1.artemis.domain.notification.ConversationNotification;
 import de.tum.in.www1.artemis.repository.metis.conversation.ConversationNotificationRepository;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 
 /**
  * Service for sending notifications about new messages in conversations.
@@ -26,14 +26,14 @@ public class ConversationNotificationService {
 
     private final ConversationNotificationRepository conversationNotificationRepository;
 
-    private final SimpMessageSendingOperations messagingTemplate;
-
     private final GeneralInstantNotificationService generalInstantNotificationService;
 
-    public ConversationNotificationService(ConversationNotificationRepository conversationNotificationRepository, SimpMessageSendingOperations messagingTemplate,
-            GeneralInstantNotificationService generalInstantNotificationService) {
+    private final WebsocketMessagingService websocketMessagingService;
+
+    public ConversationNotificationService(ConversationNotificationRepository conversationNotificationRepository,
+            GeneralInstantNotificationService generalInstantNotificationService, WebsocketMessagingService websocketMessagingService) {
         this.conversationNotificationRepository = conversationNotificationRepository;
-        this.messagingTemplate = messagingTemplate;
+        this.websocketMessagingService = websocketMessagingService;
         this.generalInstantNotificationService = generalInstantNotificationService;
     }
 
@@ -79,7 +79,7 @@ public class ConversationNotificationService {
     private void sendNotificationViaWebSocket(ConversationNotification notification) {
         notification.getConversation().getConversationParticipants().stream().map(ConversationParticipant::getUser).filter(user -> !user.equals(notification.getAuthor()))
                 .forEach(user -> {
-                    messagingTemplate.convertAndSend(notification.getTopic(user.getId()), notification);
+                    websocketMessagingService.sendMessage(notification.getTopic(user.getId()), notification);
                 });
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/SingleUserNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/SingleUserNotificationService.java
@@ -11,7 +11,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.*;
@@ -29,6 +28,7 @@ import de.tum.in.www1.artemis.repository.SingleUserNotificationRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.ExerciseDateService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 
 @Service
 public class SingleUserNotificationService {
@@ -37,23 +37,23 @@ public class SingleUserNotificationService {
 
     private final UserRepository userRepository;
 
-    private final SimpMessageSendingOperations messagingTemplate;
-
     private final GeneralInstantNotificationService notificationService;
 
     private final NotificationSettingsService notificationSettingsService;
 
     private final StudentParticipationRepository studentParticipationRepository;
 
+    private final WebsocketMessagingService websocketMessagingService;
+
     public SingleUserNotificationService(SingleUserNotificationRepository singleUserNotificationRepository, UserRepository userRepository,
-            SimpMessageSendingOperations messagingTemplate, GeneralInstantNotificationService notificationService, NotificationSettingsService notificationSettingsService,
-            StudentParticipationRepository studentParticipationRepository) {
+            GeneralInstantNotificationService notificationService, NotificationSettingsService notificationSettingsService,
+            StudentParticipationRepository studentParticipationRepository, WebsocketMessagingService websocketMessagingService) {
         this.singleUserNotificationRepository = singleUserNotificationRepository;
         this.userRepository = userRepository;
-        this.messagingTemplate = messagingTemplate;
         this.notificationService = notificationService;
         this.notificationSettingsService = notificationSettingsService;
         this.studentParticipationRepository = studentParticipationRepository;
+        this.websocketMessagingService = websocketMessagingService;
     }
 
     /**
@@ -359,7 +359,7 @@ public class SingleUserNotificationService {
         boolean isWebappNotificationAllowed = notificationSettingsService.checkIfNotificationIsAllowedInCommunicationChannelBySettingsForGivenUser(notification,
                 notification.getRecipient(), WEBAPP);
         if (isWebappNotificationAllowed) {
-            messagingTemplate.convertAndSend(notification.getTopic(), notification);
+            websocketMessagingService.sendMessage(notification.getTopic(), notification);
         }
 
         prepareSingleUserInstantNotification(notification, notificationSubject, author);

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -15,7 +15,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import com.google.common.base.Strings;
@@ -53,8 +52,6 @@ public class ProgrammingExerciseGradingService {
 
     private final ProgrammingExerciseTestCaseRepository testCaseRepository;
 
-    private final SimpMessageSendingOperations messagingTemplate;
-
     private final ResultRepository resultRepository;
 
     private final StudentParticipationRepository studentParticipationRepository;
@@ -83,20 +80,22 @@ public class ProgrammingExerciseGradingService {
 
     private final FeedbackService feedbackService;
 
+    private final WebsocketMessagingService websocketMessagingService;
+
     public ProgrammingExerciseGradingService(StudentParticipationRepository studentParticipationRepository, ResultRepository resultRepository,
             Optional<ContinuousIntegrationResultService> continuousIntegrationResultService, Optional<VersionControlService> versionControlService,
-            ProgrammingExerciseFeedbackService programmingExerciseFeedbackService, SimpMessageSendingOperations messagingTemplate,
-            ProgrammingExerciseTestCaseRepository testCaseRepository, TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository,
+            ProgrammingExerciseFeedbackService programmingExerciseFeedbackService, ProgrammingExerciseTestCaseRepository testCaseRepository,
+            TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository,
             SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository, ProgrammingSubmissionRepository programmingSubmissionRepository,
             AuditEventRepository auditEventRepository, GroupNotificationService groupNotificationService, ResultService resultService, ExerciseDateService exerciseDateService,
             SubmissionPolicyService submissionPolicyService, ProgrammingExerciseRepository programmingExerciseRepository, BuildLogEntryService buildLogService,
-            StaticCodeAnalysisCategoryRepository staticCodeAnalysisCategoryRepository, FeedbackService feedbackService) {
+            StaticCodeAnalysisCategoryRepository staticCodeAnalysisCategoryRepository, FeedbackService feedbackService, WebsocketMessagingService websocketMessagingService) {
         this.studentParticipationRepository = studentParticipationRepository;
         this.continuousIntegrationResultService = continuousIntegrationResultService;
         this.resultRepository = resultRepository;
         this.versionControlService = versionControlService;
         this.programmingExerciseFeedbackService = programmingExerciseFeedbackService;
-        this.messagingTemplate = messagingTemplate;
+        this.websocketMessagingService = websocketMessagingService;
         this.testCaseRepository = testCaseRepository;
         this.templateProgrammingExerciseParticipationRepository = templateProgrammingExerciseParticipationRepository;
         this.solutionProgrammingExerciseParticipationRepository = solutionProgrammingExerciseParticipationRepository;
@@ -346,7 +345,7 @@ public class ProgrammingExerciseGradingService {
         if (haveTestCasesChanged) {
             // Notify the client about the updated testCases
             Set<ProgrammingExerciseTestCase> testCases = testCaseRepository.findByExerciseId(exercise.getId());
-            messagingTemplate.convertAndSend("/topic/programming-exercises/" + exercise.getId() + "/test-cases", testCases);
+            websocketMessagingService.sendMessage("/topic/programming-exercises/" + exercise.getId() + "/test-cases", testCases);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingMessagingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingMessagingService.java
@@ -4,7 +4,6 @@ import static de.tum.in.www1.artemis.config.Constants.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.*;
@@ -23,15 +22,12 @@ public class ProgrammingMessagingService {
 
     private final WebsocketMessagingService websocketMessagingService;
 
-    private final SimpMessageSendingOperations messagingTemplate;
-
     private final LtiNewResultService ltiNewResultService;
 
     public ProgrammingMessagingService(GroupNotificationService groupNotificationService, WebsocketMessagingService websocketMessagingService,
-            SimpMessageSendingOperations messagingTemplate, LtiNewResultService ltiNewResultService) {
+            LtiNewResultService ltiNewResultService) {
         this.groupNotificationService = groupNotificationService;
         this.websocketMessagingService = websocketMessagingService;
-        this.messagingTemplate = messagingTemplate;
         this.ltiNewResultService = ltiNewResultService;
     }
 
@@ -62,12 +58,12 @@ public class ProgrammingMessagingService {
             // Creating a deep copy of the submission and setting the exercise to null there is also not working, because 'java.time.ZoneRegion' is not open to external libraries
             // (like Jackson) so it cannot be serialized using 'objectMapper.readValue()'.
             // You could look into some kind of ProgrammingSubmissionDTO here that only gets the values set that the client actually needs.
-            studentParticipation.getStudents().forEach(user -> messagingTemplate.convertAndSendToUser(user.getLogin(), NEW_SUBMISSION_TOPIC, submission));
+            studentParticipation.getStudents().forEach(user -> websocketMessagingService.sendMessageToUser(user.getLogin(), NEW_SUBMISSION_TOPIC, submission));
         }
 
         if (submission.getParticipation() != null && submission.getParticipation().getExercise() != null && !(submission.getParticipation() instanceof StudentParticipation)) {
             var topicDestination = getExerciseTopicForTAAndAbove(submission.getParticipation().getExercise().getId());
-            messagingTemplate.convertAndSend(topicDestination, submission);
+            websocketMessagingService.sendMessage(topicDestination, submission);
         }
     }
 
@@ -83,11 +79,11 @@ public class ProgrammingMessagingService {
      */
     public void notifyUserAboutSubmissionError(Participation participation, BuildTriggerWebsocketError error) {
         if (participation instanceof StudentParticipation studentParticipation) {
-            studentParticipation.getStudents().forEach(user -> messagingTemplate.convertAndSendToUser(user.getLogin(), NEW_SUBMISSION_TOPIC, error));
+            studentParticipation.getStudents().forEach(user -> websocketMessagingService.sendMessageToUser(user.getLogin(), NEW_SUBMISSION_TOPIC, error));
         }
 
         if (participation != null && participation.getExercise() != null) {
-            messagingTemplate.convertAndSend(getExerciseTopicForTAAndAbove(participation.getExercise().getId()), error);
+            websocketMessagingService.sendMessage(getExerciseTopicForTAAndAbove(participation.getExercise().getId()), error);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/quiz/QuizScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/quiz/QuizScheduleService.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import com.hazelcast.config.Config;
@@ -42,6 +41,7 @@ import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.QuizMessagingService;
 import de.tum.in.www1.artemis.service.QuizStatisticService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.service.scheduled.cache.Cache;
 
 @Service
@@ -65,16 +65,16 @@ public class QuizScheduleService {
 
     private final QuizStatisticService quizStatisticService;
 
-    private final SimpMessageSendingOperations messagingTemplate;
-
     private final QuizCache quizCache;
 
     private final QuizExerciseRepository quizExerciseRepository;
 
-    public QuizScheduleService(SimpMessageSendingOperations messagingTemplate, StudentParticipationRepository studentParticipationRepository, UserRepository userRepository,
-            QuizSubmissionRepository quizSubmissionRepository, HazelcastInstance hazelcastInstance, QuizExerciseRepository quizExerciseRepository,
-            QuizMessagingService quizMessagingService, QuizStatisticService quizStatisticService) {
-        this.messagingTemplate = messagingTemplate;
+    private final WebsocketMessagingService websocketMessagingService;
+
+    public QuizScheduleService(StudentParticipationRepository studentParticipationRepository, UserRepository userRepository, QuizSubmissionRepository quizSubmissionRepository,
+            HazelcastInstance hazelcastInstance, QuizExerciseRepository quizExerciseRepository, QuizMessagingService quizMessagingService,
+            QuizStatisticService quizStatisticService, WebsocketMessagingService websocketMessagingService) {
+        this.websocketMessagingService = websocketMessagingService;
         this.studentParticipationRepository = studentParticipationRepository;
         this.userRepository = userRepository;
         this.quizSubmissionRepository = quizSubmissionRepository;
@@ -544,7 +544,7 @@ public class QuizScheduleService {
     private void sendQuizResultToUser(long quizExerciseId, StudentParticipation participation) {
         var user = participation.getParticipantIdentifier();
         removeUnnecessaryObjectsBeforeSendingToClient(participation);
-        messagingTemplate.convertAndSendToUser(user, "/topic/exercise/" + quizExerciseId + "/participation", participation);
+        websocketMessagingService.sendMessageToUser(user, "/topic/exercise/" + quizExerciseId + "/participation", participation);
     }
 
     private void removeUnnecessaryObjectsBeforeSendingToClient(StudentParticipation participation) {

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/QuizSubmissionWebsocketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/QuizSubmissionWebsocketService.java
@@ -9,16 +9,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 
 import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
 import de.tum.in.www1.artemis.exception.QuizSubmissionException;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
-import de.tum.in.www1.artemis.service.ParticipationService;
-import de.tum.in.www1.artemis.service.QuizExerciseService;
-import de.tum.in.www1.artemis.service.QuizSubmissionService;
+import de.tum.in.www1.artemis.service.*;
 
 @SuppressWarnings("unused")
 @Controller
@@ -26,23 +22,13 @@ public class QuizSubmissionWebsocketService {
 
     private static final Logger log = LoggerFactory.getLogger(QuizSubmissionWebsocketService.class);
 
-    private final QuizExerciseService quizExerciseService;
-
-    private final ParticipationService participationService;
-
     private final QuizSubmissionService quizSubmissionService;
 
-    private final SimpMessageSendingOperations messagingTemplate;
+    private final WebsocketMessagingService websocketMessagingService;
 
-    private final UserRepository userRepository;
-
-    public QuizSubmissionWebsocketService(QuizExerciseService quizExerciseService, ParticipationService participationService, SimpMessageSendingOperations messagingTemplate,
-            QuizSubmissionService quizSubmissionService, UserRepository userRepository) {
-        this.quizExerciseService = quizExerciseService;
-        this.participationService = participationService;
-        this.messagingTemplate = messagingTemplate;
+    public QuizSubmissionWebsocketService(QuizSubmissionService quizSubmissionService, WebsocketMessagingService websocketMessagingService) {
+        this.websocketMessagingService = websocketMessagingService;
         this.quizSubmissionService = quizSubmissionService;
-        this.userRepository = userRepository;
     }
 
     // TODO it would be nice to have some kind of startQuiz call that creates the participation with an initialization date. This should happen when the quiz is first shown
@@ -69,8 +55,8 @@ public class QuizSubmissionWebsocketService {
         }
         catch (QuizSubmissionException ex) {
             // send error message over websocket (use a thread to prevent that the outbound channel blocks the inbound channel (e.g. due a slow client))
-            new Thread(() -> messagingTemplate.convertAndSendToUser(principal.getName(), "/topic/quizExercise/" + exerciseId + "/submission", new WebsocketError(ex.getMessage())))
-                    .start();
+            new Thread(() -> websocketMessagingService.sendMessageToUser(principal.getName(), "/topic/quizExercise/" + exerciseId + "/submission",
+                    new WebsocketError(ex.getMessage()))).start();
         }
     }
 
@@ -83,7 +69,7 @@ public class QuizSubmissionWebsocketService {
      */
     private void sendSubmissionToUser(String username, Long exerciseId, QuizSubmission quizSubmission) {
         long start = System.nanoTime();
-        messagingTemplate.convertAndSendToUser(username, "/topic/quizExercise/" + exerciseId + "/submission", quizSubmission);
+        websocketMessagingService.sendMessageToUser(username, "/topic/quizExercise/" + exerciseId + "/submission", quizSubmission);
         log.info("WS.Outbound: Sent quiz submission to user {} in quiz {} in {} µs ", username, exerciseId, (System.nanoTime() - start) / 1000);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/team/ParticipationTeamWebsocketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/team/ParticipationTeamWebsocketService.java
@@ -14,7 +14,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.annotation.SubscribeMapping;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.simp.user.*;
@@ -34,6 +33,7 @@ import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.ModelingSubmissionService;
 import de.tum.in.www1.artemis.service.TextSubmissionService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.web.websocket.dto.OnlineTeamStudentDTO;
 import de.tum.in.www1.artemis.web.websocket.dto.SubmissionSyncPayload;
 
@@ -41,8 +41,6 @@ import de.tum.in.www1.artemis.web.websocket.dto.SubmissionSyncPayload;
 public class ParticipationTeamWebsocketService {
 
     private static final Logger log = LoggerFactory.getLogger(ParticipationTeamWebsocketService.class);
-
-    private final SimpMessageSendingOperations messagingTemplate;
 
     private final SimpUserRegistry simpUserRegistry;
 
@@ -62,10 +60,12 @@ public class ParticipationTeamWebsocketService {
 
     private final ModelingSubmissionService modelingSubmissionService;
 
-    public ParticipationTeamWebsocketService(SimpMessageSendingOperations messagingTemplate, SimpUserRegistry simpUserRegistry, UserRepository userRepository,
-            StudentParticipationRepository studentParticipationRepository, ExerciseRepository exerciseRepository, TextSubmissionService textSubmissionService,
-            ModelingSubmissionService modelingSubmissionService, HazelcastInstance hazelcastInstance) {
-        this.messagingTemplate = messagingTemplate;
+    private final WebsocketMessagingService websocketMessagingService;
+
+    public ParticipationTeamWebsocketService(SimpUserRegistry simpUserRegistry, UserRepository userRepository, StudentParticipationRepository studentParticipationRepository,
+            ExerciseRepository exerciseRepository, TextSubmissionService textSubmissionService, ModelingSubmissionService modelingSubmissionService,
+            HazelcastInstance hazelcastInstance, WebsocketMessagingService websocketMessagingService) {
+        this.websocketMessagingService = websocketMessagingService;
         this.simpUserRegistry = simpUserRegistry;
         this.userRepository = userRepository;
         this.studentParticipationRepository = studentParticipationRepository;
@@ -187,7 +187,7 @@ public class ParticipationTeamWebsocketService {
         sendOnlineTeamStudents(participationId);
 
         SubmissionSyncPayload payload = new SubmissionSyncPayload(submission, user);
-        messagingTemplate.convertAndSend(getDestination(participationId, topicPath), payload);
+        websocketMessagingService.sendMessage(getDestination(participationId, topicPath), payload);
     }
 
     /**
@@ -202,7 +202,7 @@ public class ParticipationTeamWebsocketService {
         final List<OnlineTeamStudentDTO> onlineTeamStudents = getSubscriberPrincipals(destination, exceptSessionID).stream()
                 .map(login -> new OnlineTeamStudentDTO(login, getValue(lastTypingTracker, participationId, login), lastActionTracker.get(participationId + "-" + login))).toList();
 
-        messagingTemplate.convertAndSend(destination, onlineTeamStudents);
+        websocketMessagingService.sendMessage(destination, onlineTeamStudents);
     }
 
     private void sendOnlineTeamStudents(Long participationId) {

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/team/TeamWebsocketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/team/TeamWebsocketService.java
@@ -4,37 +4,35 @@ import java.util.*;
 
 import javax.annotation.Nullable;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Team;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.web.websocket.dto.TeamAssignmentPayload;
 
 @Controller
 public class TeamWebsocketService {
 
-    private static final Logger log = LoggerFactory.getLogger(TeamWebsocketService.class);
-
-    private final SimpMessageSendingOperations messagingTemplate;
+    private final WebsocketMessagingService websocketMessagingService;
 
     private final String assignmentTopic = "/topic/team-assignments";
 
-    public TeamWebsocketService(SimpMessageSendingOperations messagingTemplate) {
-        this.messagingTemplate = messagingTemplate;
+    public TeamWebsocketService(WebsocketMessagingService websocketMessagingService) {
+        this.websocketMessagingService = websocketMessagingService;
     }
 
     /**
      * Sends out team assignment information for an exercise to students of a created/updated/deleted team
-     *
+     * <p>
      * Cases:
-     * 1. Team was created: sendTeamAssignmentUpdate(exercise, null, createdTeam);
-     * 2. Team was updated: sendTeamAssignmentUpdate(exercise, existingTeam, updatedTeam);
-     * 3. Team was deleted: sendTeamAssignmentUpdate(exercise, deletedTeam, null);
+     * <ol>
+     * <li>Team was created: sendTeamAssignmentUpdate(exercise, null, createdTeam);</li>
+     * <li>Team was updated: sendTeamAssignmentUpdate(exercise, existingTeam, updatedTeam);</li>
+     * <li>Team was deleted: sendTeamAssignmentUpdate(exercise, deletedTeam, null);</li>
+     * </ol>
      *
      * @param exercise                    Exercise for which the team assignment has been made
      * @param existingTeam                Team before the update (null when a team was created)
@@ -47,7 +45,7 @@ public class TeamWebsocketService {
             TeamAssignmentPayload payload = new TeamAssignmentPayload(exercise, null, List.of());
             Set<User> unassignedUsers = new HashSet<>(existingTeam.getStudents());
             unassignedUsers.removeAll(Optional.ofNullable(updatedTeam).map(Team::getStudents).orElse(Set.of()));
-            unassignedUsers.forEach(user -> messagingTemplate.convertAndSendToUser(user.getLogin(), assignmentTopic, payload));
+            unassignedUsers.forEach(user -> websocketMessagingService.sendMessageToUser(user.getLogin(), assignmentTopic, payload));
         }
 
         // Users in the updated team that were not yet part of the existing team were newly assigned => inform them
@@ -55,7 +53,7 @@ public class TeamWebsocketService {
             TeamAssignmentPayload payload = new TeamAssignmentPayload(exercise, updatedTeam, participationsOfUpdatedTeam);
             Set<User> assignedUsers = new HashSet<>(updatedTeam.getStudents());
             assignedUsers.removeAll(Optional.ofNullable(existingTeam).map(Team::getStudents).orElse(Set.of()));
-            assignedUsers.forEach(user -> messagingTemplate.convertAndSendToUser(user.getLogin(), assignmentTopic, payload));
+            assignedUsers.forEach(user -> websocketMessagingService.sendMessageToUser(user.getLogin(), assignmentTopic, payload));
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -11,11 +11,13 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
 
 import com.tngtech.archunit.base.DescribedPredicate;
-import com.tngtech.archunit.core.domain.JavaAnnotation;
-import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.*;
 import com.tngtech.archunit.lang.*;
+
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 
 class ArchitectureTest extends AbstractArchitectureTest {
 
@@ -72,6 +74,14 @@ class ArchitectureTest extends AbstractArchitectureTest {
             units.check(allClasses);
             parameters.check(allClasses);
         }
+    }
+
+    @Test
+    void testValidSimpMessageSendingOperationsUsage() {
+        ArchRule usage = fields().that().haveRawType(SimpMessageSendingOperations.class.getTypeName()).should().bePrivate().andShould()
+                .beDeclaredIn(WebsocketMessagingService.class)
+                .because("Classes should only use WebsocketMessagingService as a Facade and not SimpMessageSendingOperations directly");
+        usage.check(productionClasses);
     }
 
     // Custom Predicates for JavaAnnotations since ArchUnit only defines them for classes


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [X] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).groups for all new REST Calls (security).
- [X] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As discussed in the Developer's meeting 21.07.2023, we don't want to use the messaging template directly anymore but use the `WebsockerMessagingService` as a facade.

### Description
<!-- Describe your changes in detail -->
I added an architecture test to enforce this decision via tests and adapted all wrong usages

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [X] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
