### PR TITLE
`Development`: Fix flaky server test on postgres

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -210,7 +210,7 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
     List<Long> countNumberOfFinishedAssessmentsByExamIdIgnoreTestRuns(@Param("examId") Long examId);
 
     @EntityGraph(type = LOAD, attributePaths = { "feedbacks" })
-    List<Result> findAllWithEagerFeedbackByAssessorIsNotNullAndParticipation_ExerciseIdAndCompletionDateIsNotNull(Long exerciseId);
+    Set<Result> findAllWithEagerFeedbackByAssessorIsNotNullAndParticipation_ExerciseIdAndCompletionDateIsNotNull(Long exerciseId);
 
     @Query("""
             SELECT COUNT(DISTINCT p) FROM Participation p JOIN p.results r

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseResultTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseResultTestService.java
@@ -151,15 +151,14 @@ public class ProgrammingExerciseResultTestService {
         feedback.setCredits(10.0);
 
         var resultsWithFeedback = resultRepository.findAllWithEagerFeedbackByAssessorIsNotNullAndParticipation_ExerciseIdAndCompletionDateIsNotNull(programmingExercise.getId());
-        var semiAutoResult = resultsWithFeedback.get(2);
+        var semiAutoResult = resultsWithFeedback.stream().filter(result -> result.getAssessmentType() == AssessmentType.SEMI_AUTOMATIC).findAny().orElseThrow();
         participationUtilService.addFeedbackToResult(feedback, semiAutoResult);
 
         // Assert that the results have been created successfully.
         resultsWithFeedback = resultRepository.findAllWithEagerFeedbackByAssessorIsNotNullAndParticipation_ExerciseIdAndCompletionDateIsNotNull(programmingExercise.getId());
         assertThat(resultsWithFeedback).hasSize(3);
-        assertThat(resultsWithFeedback.get(0).getAssessmentType()).isEqualTo(AssessmentType.MANUAL);
-        assertThat(resultsWithFeedback.get(1).getAssessmentType()).isEqualTo(AssessmentType.MANUAL);
-        assertThat(resultsWithFeedback.get(2).getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
+        assertThat(resultsWithFeedback).filteredOn(result -> result.getAssessmentType() == AssessmentType.MANUAL).hasSize(2);
+        assertThat(resultsWithFeedback).filteredOn(result -> result.getAssessmentType() == AssessmentType.SEMI_AUTOMATIC).hasSize(1);
 
         // Re-trigger the build. We create a notification with feedback of a successful test
         userUtilService.changeUser(userPrefix + "instructor1");


### PR DESCRIPTION

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
The test `shouldUpdateFeedbackInSemiAutomaticResult` is flaky on postgres.

### Description
The test relied on the order of a database request without specifing the sort order. I replaced the return value with a Set and used assertions that not rely on the exact order.

### Steps for Testing
code review

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
