### PR TITLE
`Communication`: Improve performance by reducing the notification size when creating messages

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Channel.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Channel.java
@@ -169,6 +169,7 @@ public class Channel extends Conversation {
 
     @Override
     public void hideDetails() {
+        // the following values are sometimes not needed when sending payloads to the client, so we allow to remove them
         setLecture(null);
         setExam(null);
         setExercise(null);

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Channel.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Channel.java
@@ -166,4 +166,12 @@ public class Channel extends Conversation {
     public String getHumanReadableNameForReceiver(User sender) {
         return getName();
     }
+
+    @Override
+    public void hideDetails() {
+        setLecture(null);
+        setExam(null);
+        setExercise(null);
+        super.hideDetails();
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Channel.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Channel.java
@@ -167,6 +167,9 @@ public class Channel extends Conversation {
         return getName();
     }
 
+    /**
+     * hide the details of the object, can be invoked before sending it as payload in a REST response or websocket message
+     */
     @Override
     public void hideDetails() {
         // the following values are sometimes not needed when sending payloads to the client, so we allow to remove them

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
@@ -108,8 +108,8 @@ public abstract class Conversation extends DomainObject {
     public abstract String getHumanReadableNameForReceiver(User sender);
 
     public void hideDetails() {
-        getConversationParticipants().clear();
-        getPosts().clear();
+        setConversationParticipants(new HashSet<>());
+        setPosts(new HashSet<>());
         setCourse(null);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
@@ -110,6 +110,7 @@ public abstract class Conversation extends DomainObject {
     public void hideDetails() {
         setConversationParticipants(new HashSet<>());
         setPosts(new HashSet<>());
-        setCourse(null);
+        // TODO: this information is still needed in some places, we need to identify those and then set it to null
+        // setCourse(null);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
@@ -107,6 +107,9 @@ public abstract class Conversation extends DomainObject {
      */
     public abstract String getHumanReadableNameForReceiver(User sender);
 
+    /**
+     * hide the details of the object, can be invoked before sending it as payload in a REST response or websocket message
+     */
     public void hideDetails() {
         // the following values are sometimes not needed when sending payloads to the client, so we allow to remove them
         setConversationParticipants(new HashSet<>());

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
@@ -32,6 +32,7 @@ public abstract class Conversation extends DomainObject {
 
     @ManyToOne
     @JoinColumn(name = "creator_id")
+    @JsonIncludeProperties({ "id", "name" })
     private User creator;
 
     @JsonIgnoreProperties("conversation")

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
@@ -106,4 +106,10 @@ public abstract class Conversation extends DomainObject {
      * @return returns a human-readable name for this conversation, which can be used in notifications or emails.
      */
     public abstract String getHumanReadableNameForReceiver(User sender);
+
+    public void hideDetails() {
+        getConversationParticipants().clear();
+        getPosts().clear();
+        setCourse(null);
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
@@ -108,6 +108,7 @@ public abstract class Conversation extends DomainObject {
     public abstract String getHumanReadableNameForReceiver(User sender);
 
     public void hideDetails() {
+        // the following values are sometimes not needed when sending payloads to the client, so we allow to remove them
         setConversationParticipants(new HashSet<>());
         setPosts(new HashSet<>());
         // TODO: this information is still needed in some places, we need to identify those and then set it to null

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/ConversationNotificationFactory.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/ConversationNotificationFactory.java
@@ -11,6 +11,7 @@ public class ConversationNotificationFactory {
     /**
      * Creates a ConversationNotification for the given conversation and notification type.
      *
+     * @param courseId          the id of the course
      * @param message           the message for which the notification is created
      * @param notificationType  the type of the notification
      * @param notificationText  text of the notification
@@ -18,16 +19,15 @@ public class ConversationNotificationFactory {
      * @param placeholderValues values for the placeholders in the notification text
      * @return the created notification
      */
-    public static ConversationNotification createConversationMessageNotification(Post message, NotificationType notificationType, String notificationText,
+    public static ConversationNotification createConversationMessageNotification(Long courseId, Post message, NotificationType notificationType, String notificationText,
             boolean textIsPlaceholder, String[] placeholderValues) {
         String title = findCorrespondingNotificationTitleOrThrow(notificationType);
         var notification = new ConversationNotification(message.getAuthor(), message, message.getConversation(), title, notificationText, textIsPlaceholder, placeholderValues);
-        setNotificationTarget(notification);
+        setNotificationTarget(courseId, notification);
         return notification;
     }
 
-    private static void setNotificationTarget(ConversationNotification notification) {
-        Long courseId = notification.getMessage().getConversation().getCourse().getId();
+    private static void setNotificationTarget(Long courseId, ConversationNotification notification) {
         NotificationTarget notificationTarget = createConversationMessageTarget(notification.getMessage(), courseId);
         notification.setTransientAndStringTarget(notificationTarget);
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/PushNotificationDeviceConfigurationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/PushNotificationDeviceConfigurationRepository.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.repository;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -28,10 +29,10 @@ public interface PushNotificationDeviceConfigurationRepository extends JpaReposi
     @Query("""
             SELECT p FROM PushNotificationDeviceConfiguration p
             WHERE p.expirationDate > now()
-                AND p.owner IN :userList
+                AND p.owner IN :users
                 AND p.deviceType = :deviceType
             """)
-    List<PushNotificationDeviceConfiguration> findByUserIn(@Param("userList") List<User> userList, @Param("deviceType") PushNotificationDeviceType deviceType);
+    List<PushNotificationDeviceConfiguration> findByUserIn(@Param("users") Set<User> users, @Param("deviceType") PushNotificationDeviceType deviceType);
 
     /**
      * Cleans up the old/expired push notifications device configurations

--- a/src/main/java/de/tum/in/www1/artemis/repository/PushNotificationDeviceConfigurationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/PushNotificationDeviceConfigurationRepository.java
@@ -22,7 +22,7 @@ import de.tum.in.www1.artemis.domain.push_notification.PushNotificationDeviceTyp
 public interface PushNotificationDeviceConfigurationRepository extends JpaRepository<PushNotificationDeviceConfiguration, PushNotificationDeviceConfigurationId> {
 
     /**
-     * @param userList   a list of users you want the deviceTokens for.
+     * @param users      a list of users you want the deviceTokens for.
      * @param deviceType the device type you want the deviceTokens to be found for. Either Firebase or APNS.
      * @return Finds all the deviceTokens for a specific deviceType for a list of users.
      */

--- a/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
@@ -538,7 +538,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * Get students by given course
      *
      * @param course object
-     * @return list of students for given course
+     * @return students for given course
      */
     default Set<User> getStudents(Course course) {
         return findAllInGroupWithAuthorities(course.getStudentGroupName());
@@ -548,7 +548,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * Get tutors by given course
      *
      * @param course object
-     * @return list of tutors for given course
+     * @return tutors for given course
      */
     default Set<User> getTutors(Course course) {
         return findAllInGroupWithAuthorities(course.getTeachingAssistantGroupName());
@@ -558,7 +558,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * Get editors by given course
      *
      * @param course object
-     * @return list of editors for given course
+     * @return editors for given course
      */
     default Set<User> getEditors(Course course) {
         return findAllInGroupWithAuthorities(course.getEditorGroupName());
@@ -568,7 +568,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * Get all instructors for a given course
      *
      * @param course The course for which to fetch all instructors
-     * @return A list of all users that have the role of instructor in the course
+     * @return instructors for the given course
      */
     default Set<User> getInstructors(Course course) {
         return findAllInGroupWithAuthorities(course.getInstructorGroupName());
@@ -579,7 +579,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      *
      * @param groupName     The group by which all users should get filtered
      * @param excludedUsers The users that should get ignored/excluded
-     * @return A list of filtered users
+     * @return users who are in the given group except the excluded ones
      */
     default Set<User> findAllUserInGroupAndNotIn(String groupName, Collection<User> excludedUsers) {
         // For an empty list, we have to use another query, because Hibernate builds an invalid query with empty lists

--- a/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
@@ -109,10 +109,10 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
 
     @EntityGraph(type = LOAD, attributePaths = { "groups", "authorities" })
     @Query("SELECT user FROM User user WHERE user.isDeleted = false AND :#{#groupName} MEMBER OF user.groups")
-    List<User> findAllInGroupWithAuthorities(@Param("groupName") String groupName);
+    Set<User> findAllInGroupWithAuthorities(@Param("groupName") String groupName);
 
     @Query("SELECT user FROM User user WHERE user.isDeleted = false AND :#{#groupName} MEMBER OF user.groups")
-    List<User> findAllInGroup(@Param("groupName") String groupName);
+    Set<User> findAllInGroup(@Param("groupName") String groupName);
 
     /**
      * Searches for users in a group by their login or full name.
@@ -329,7 +329,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
 
     @EntityGraph(type = LOAD, attributePaths = { "groups" })
     @Query("SELECT user FROM User user WHERE user.isDeleted = false AND :#{#groupName} MEMBER OF user.groups AND user NOT IN :#{#ignoredUsers}")
-    List<User> findAllInGroupContainingAndNotIn(@Param("groupName") String groupName, @Param("ignoredUsers") Set<User> ignoredUsers);
+    Set<User> findAllInGroupContainingAndNotIn(@Param("groupName") String groupName, @Param("ignoredUsers") Set<User> ignoredUsers);
 
     @Query("""
             SELECT DISTINCT team.students AS student
@@ -540,7 +540,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * @param course object
      * @return list of students for given course
      */
-    default List<User> getStudents(Course course) {
+    default Set<User> getStudents(Course course) {
         return findAllInGroupWithAuthorities(course.getStudentGroupName());
     }
 
@@ -550,7 +550,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * @param course object
      * @return list of tutors for given course
      */
-    default List<User> getTutors(Course course) {
+    default Set<User> getTutors(Course course) {
         return findAllInGroupWithAuthorities(course.getTeachingAssistantGroupName());
     }
 
@@ -560,7 +560,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * @param course object
      * @return list of editors for given course
      */
-    default List<User> getEditors(Course course) {
+    default Set<User> getEditors(Course course) {
         return findAllInGroupWithAuthorities(course.getEditorGroupName());
     }
 
@@ -570,7 +570,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * @param course The course for which to fetch all instructors
      * @return A list of all users that have the role of instructor in the course
      */
-    default List<User> getInstructors(Course course) {
+    default Set<User> getInstructors(Course course) {
         return findAllInGroupWithAuthorities(course.getInstructorGroupName());
     }
 
@@ -581,7 +581,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * @param excludedUsers The users that should get ignored/excluded
      * @return A list of filtered users
      */
-    default List<User> findAllUserInGroupAndNotIn(String groupName, Collection<User> excludedUsers) {
+    default Set<User> findAllUserInGroupAndNotIn(String groupName, Collection<User> excludedUsers) {
         // For an empty list, we have to use another query, because Hibernate builds an invalid query with empty lists
         if (!excludedUsers.isEmpty()) {
             return findAllInGroupContainingAndNotIn(groupName, new HashSet<>(excludedUsers));

--- a/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/ConversationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/ConversationRepository.java
@@ -31,7 +31,7 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
     // This is used only for testing purposes
     List<Conversation> findAllByCourseId(long courseId);
 
-    @EntityGraph(type = LOAD, attributePaths = { "conversationParticipants" })
+    @EntityGraph(type = LOAD, attributePaths = { "conversationParticipants.user" })
     Optional<Conversation> findWithConversationParticipantsById(long conversationId);
 
     default Conversation findWithConversationParticipantsByIdElseThrow(long conversationId) {

--- a/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/ConversationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/ConversationRepository.java
@@ -14,7 +14,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.metis.conversation.Conversation;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
@@ -24,10 +23,6 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
     @Transactional // ok because of delete
     @Modifying
     void deleteById(long conversationId);
-
-    @Transactional // ok because of delete
-    @Modifying
-    void deleteAllByCreator(User creator);
 
     @Transactional // ok because of delete
     @Modifying

--- a/src/main/java/de/tum/in/www1/artemis/service/CompetencyProgressService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CompetencyProgressService.java
@@ -88,7 +88,7 @@ public class CompetencyProgressService {
         else {
             throw new IllegalArgumentException("Learning object must be either LectureUnit or Exercise");
         }
-        updateProgressByLearningObject(learningObject, new HashSet<>(userRepository.getStudents(course)));
+        updateProgressByLearningObject(learningObject, userRepository.getStudents(course));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/ComplaintService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ComplaintService.java
@@ -75,7 +75,7 @@ public class ComplaintService {
         // checking if it is allowed to create a complaint
         if (examId.isPresent()) {
             final Exam exam = examRepository.findByIdElseThrow(examId.getAsLong());
-            final List<User> instructors = userRepository.getInstructors(exam.getCourse());
+            final Set<User> instructors = userRepository.getInstructors(exam.getCourse());
             boolean examTestRun = instructors.stream().anyMatch(instructor -> instructor.getLogin().equals(principal.getName()));
             if (!examTestRun && !isTimeOfComplaintValid(exam)) {
                 throw new BadRequestAlertException("You cannot submit a complaint after the student review period", ENTITY_NAME, "afterStudentReviewPeriod");

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -808,7 +808,7 @@ public class CourseService {
      * @return list of users
      */
     @NotNull
-    public ResponseEntity<List<User>> getAllUsersInGroup(Course course, String groupName) {
+    public ResponseEntity<Set<User>> getAllUsersInGroup(Course course, String groupName) {
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
         var usersInGroup = userRepository.findAllInGroup(groupName);
         usersInGroup.forEach(user -> {
@@ -1014,7 +1014,7 @@ public class CourseService {
      *
      * @param usersInGroup user whose variables are removed
      */
-    private void removeUserVariables(List<User> usersInGroup) {
+    private void removeUserVariables(Iterable<User> usersInGroup) {
         usersInGroup.forEach(user -> {
             user.setLastNotificationRead(null);
             user.setActivationKey(null);

--- a/src/main/java/de/tum/in/www1/artemis/service/TutorLeaderboardService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TutorLeaderboardService.java
@@ -86,7 +86,7 @@ public class TutorLeaderboardService {
     }
 
     @NotNull
-    private List<TutorLeaderboardDTO> aggregateTutorLeaderboardData(List<User> tutors, List<TutorLeaderboardAssessments> assessments, List<TutorLeaderboardComplaints> complaints,
+    private List<TutorLeaderboardDTO> aggregateTutorLeaderboardData(Set<User> tutors, List<TutorLeaderboardAssessments> assessments, List<TutorLeaderboardComplaints> complaints,
             List<TutorLeaderboardMoreFeedbackRequests> feedbackRequests, List<TutorLeaderboardComplaintResponses> complaintResponses,
             List<TutorLeaderboardAnsweredMoreFeedbackRequests> answeredFeedbackRequests, boolean isExam) {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/WebsocketMessagingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/WebsocketMessagingService.java
@@ -10,8 +10,6 @@ import java.util.concurrent.Executor;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -59,9 +57,8 @@ public class WebsocketMessagingService {
      *
      * @param topic   the destination to which subscription the message should be sent
      * @param message a prebuild message that should be sent to the destination (topic)
-     * @return a future that can be used to check if the message was sent successfully or null if an error occurs
+     * @return a future that can be used to check if the message was sent successfully or resulted in an exception
      */
-    @Nullable
     public CompletableFuture<Void> sendMessage(String topic, Message<?> message) {
         try {
             return CompletableFuture.runAsync(() -> messagingTemplate.send(topic, message), asyncExecutor);
@@ -69,8 +66,8 @@ public class WebsocketMessagingService {
         // Note: explicitly catch ALL kinds of exceptions here and do NOT rethrow, because the actual task should NEVER be interrupted when the server cannot send WS messages
         catch (Exception ex) {
             log.error("Error when sending message {} to topic {}", message, topic, ex);
+            return CompletableFuture.failedFuture(ex);
         }
-        return null;
     }
 
     /**
@@ -79,9 +76,8 @@ public class WebsocketMessagingService {
      *
      * @param topic   the destination to which subscription the message should be sent
      * @param message any object that should be sent to the destination (topic), this will typically get transformed into json
-     * @return a future that can be used to check if the message was sent successfully or null if an error occurs
+     * @return a future that can be used to check if the message was sent successfully or resulted in an exception
      */
-    @Nullable
     public CompletableFuture<Void> sendMessage(String topic, Object message) {
         try {
             return CompletableFuture.runAsync(() -> messagingTemplate.convertAndSend(topic, message), asyncExecutor);
@@ -89,8 +85,8 @@ public class WebsocketMessagingService {
         // Note: explicitly catch ALL kinds of exceptions here and do NOT rethrow, because the actual task should NEVER be interrupted when the server cannot send WS messages
         catch (Exception ex) {
             log.error("Error when sending message {} to topic {}", message, topic, ex);
+            return CompletableFuture.failedFuture(ex);
         }
-        return null;
     }
 
     /**
@@ -100,9 +96,8 @@ public class WebsocketMessagingService {
      * @param user    the user that should receive the message.
      * @param topic   the destination to send the message to
      * @param payload the payload to send
-     * @return a future that can be used to check if the message was sent successfully or null if an error occurs
+     * @return a future that can be used to check if the message was sent successfully or resulted in an exception
      */
-    @Nullable
     public CompletableFuture<Void> sendMessageToUser(String user, String topic, Object payload) {
         try {
             return CompletableFuture.runAsync(() -> messagingTemplate.convertAndSendToUser(user, topic, payload), asyncExecutor);
@@ -110,8 +105,8 @@ public class WebsocketMessagingService {
         // Note: explicitly catch ALL kinds of exceptions here and do NOT rethrow, because the actual task should NEVER be interrupted when the server cannot send WS messages
         catch (Exception ex) {
             log.error("Error when sending message {} on topic {} to user {}", payload, topic, user, ex);
+            return CompletableFuture.failedFuture(ex);
         }
-        return null;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
@@ -430,7 +430,7 @@ public class GitLabService extends AbstractVersionControlService {
      * @param exercise    the exercise
      * @param accessLevel the access level to give
      */
-    private void addUsersToExerciseGroup(List<User> users, ProgrammingExercise exercise, AccessLevel accessLevel) {
+    private void addUsersToExerciseGroup(Set<User> users, ProgrammingExercise exercise, AccessLevel accessLevel) {
         for (final var user : users) {
             try {
                 final var userId = gitLabUserManagementService.getUserId(user.getLogin());

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabUserManagementService.java
@@ -140,7 +140,7 @@ public class GitLabUserManagementService implements VcsUserManagementService {
         log.info("Update Gitlab permissions for programming exercises: {}", programmingExercises.stream().map(ProgrammingExercise::getProjectKey).toList());
         // TODO: in case we update a tutor group / role here, the tutor should NOT get access to exam exercises before the exam has finished
 
-        final List<User> allUsers = userRepository.findAllInGroupWithAuthorities(oldInstructorGroup);
+        final Set<User> allUsers = userRepository.findAllInGroupWithAuthorities(oldInstructorGroup);
         allUsers.addAll(userRepository.findAllInGroupWithAuthorities(oldEditorGroup));
         allUsers.addAll(userRepository.findAllInGroupWithAuthorities(oldTeachingAssistantGroup));
         allUsers.addAll(userRepository.findAllUserInGroupAndNotIn(updatedCourse.getInstructorGroupName(), allUsers));

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamRegistrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamRegistrationService.java
@@ -333,7 +333,7 @@ public class ExamRegistrationService {
      */
     public void addAllStudentsOfCourseToExam(Long courseId, Exam exam) {
         Course course = courseRepository.findByIdElseThrow(courseId);
-        var students = userRepository.getStudents(course);
+        var students = new ArrayList<>(userRepository.getStudents(course));
 
         Map<String, Object> userData = new HashMap<>();
         userData.put("exam", exam.getTitle());

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamRegistrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamRegistrationService.java
@@ -310,9 +310,8 @@ public class ExamRegistrationService {
         examUserRepository.deleteAllById(registeredExamUsers.stream().map(ExamUser::getId).toList());
 
         var students = userRepository.getStudents(exam.getCourse());
-        Set<User> studentSet = new HashSet<>(students);
 
-        channelService.deregisterUsersFromExamChannel(studentSet, exam.getId());
+        channelService.deregisterUsersFromExamChannel(students, exam.getId());
 
         // remove all students exams
         Set<StudentExam> studentExams = studentExamRepository.findAllWithoutTestRunsWithExercisesByExamId(exam.getId());

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerMessageService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerMessageService.java
@@ -191,7 +191,7 @@ public class AnswerMessageService extends PostingService {
         Post updatedMessage = answerMessage.getPost();
         updatedMessage.removeAnswerPost(answerMessage);
         updatedMessage.setConversation(conversation);
-        broadcastForPost(new PostDTO(updatedMessage, MetisCrudAction.UPDATE), course);
+        broadcastForPost(new PostDTO(updatedMessage, MetisCrudAction.UPDATE), course, null);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerPostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerPostService.java
@@ -179,7 +179,7 @@ public class AnswerPostService extends PostingService {
         // delete
         answerPostRepository.deleteById(answerPostId);
 
-        broadcastForPost(new PostDTO(post, MetisCrudAction.UPDATE), course);
+        broadcastForPost(new PostDTO(post, MetisCrudAction.UPDATE), course, null);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
@@ -104,7 +104,7 @@ public class PostService extends PostingService {
             post.setDisplayPriority(DisplayPriority.PINNED);
             Post savedPost = postRepository.save(post);
             sendNotification(savedPost, course);
-            broadcastForPost(new PostDTO(savedPost, MetisCrudAction.CREATE), course);
+            broadcastForPost(new PostDTO(savedPost, MetisCrudAction.CREATE), course, null);
             return savedPost;
         }
         Post savedPost = postRepository.save(post);
@@ -114,7 +114,7 @@ public class PostService extends PostingService {
             plagiarismCaseService.savePostForPlagiarismCaseAndNotifyStudent(savedPost.getPlagiarismCase().getId(), savedPost);
         }
         else {
-            broadcastForPost(new PostDTO(savedPost, MetisCrudAction.CREATE), course);
+            broadcastForPost(new PostDTO(savedPost, MetisCrudAction.CREATE), course, null);
             sendNotification(savedPost, course);
         }
 
@@ -149,7 +149,7 @@ public class PostService extends PostingService {
         if (contextHasChanged) {
             // in case the context changed, a post is moved from one context (page) to another
             // i.e., it has to be treated as deleted post in the old context
-            broadcastForPost(new PostDTO(existingPost, MetisCrudAction.DELETE), course);
+            broadcastForPost(new PostDTO(existingPost, MetisCrudAction.DELETE), course, null);
         }
 
         boolean hasContentChanged = !existingPost.getContent().equals(post.getContent());
@@ -184,11 +184,11 @@ public class PostService extends PostingService {
         if (contextHasChanged) {
             // in case the context changed, a post is moved from one context (page) to another
             // i.e., it has to be treated as newly created post in the new context
-            broadcastForPost(new PostDTO(updatedPost, MetisCrudAction.CREATE), course);
+            broadcastForPost(new PostDTO(updatedPost, MetisCrudAction.CREATE), course, null);
         }
         else {
             // in case the context did not change we emit with trigger a post update via websocket
-            broadcastForPost(new PostDTO(updatedPost, MetisCrudAction.UPDATE), course);
+            broadcastForPost(new PostDTO(updatedPost, MetisCrudAction.UPDATE), course, null);
         }
         return updatedPost;
     }
@@ -219,7 +219,7 @@ public class PostService extends PostingService {
         post.addReaction(reaction);
         Post updatedPost = postRepository.save(post);
         updatedPost.setConversation(post.getConversation());
-        broadcastForPost(new PostDTO(updatedPost, MetisCrudAction.UPDATE), course);
+        broadcastForPost(new PostDTO(updatedPost, MetisCrudAction.UPDATE), course, null);
     }
 
     /**
@@ -317,7 +317,7 @@ public class PostService extends PostingService {
 
         // delete
         postRepository.deleteById(postId);
-        broadcastForPost(new PostDTO(post, MetisCrudAction.DELETE), course);
+        broadcastForPost(new PostDTO(post, MetisCrudAction.DELETE), course, null);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
@@ -79,6 +79,12 @@ public abstract class PostingService {
      * @param course  course the posting belongs to
      */
     protected void broadcastForPost(PostDTO postDTO, Course course) {
+
+        // reduce the payload of the websocket message: this is important to avoid overloading the involved subsystems
+        if (postDTO.post().getConversation() != null) {
+            postDTO.post().getConversation().hideDetails();
+        }
+
         String specificTopicName = METIS_WEBSOCKET_CHANNEL_PREFIX;
         String genericTopicName = METIS_WEBSOCKET_CHANNEL_PREFIX + "courses/" + course.getId();
 

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
@@ -99,7 +99,6 @@ public abstract class PostingService {
         }
         else if (postDTO.post().getConversation() != null) {
             if (recipients == null) {
-                // TODO: should we filter the author of the post?
                 recipients = this.conversationParticipantRepository.findConversationParticipantByConversationId(postDTO.post().getConversation().getId()).stream()
                         .map(ConversationParticipant::getUser).collect(Collectors.toSet());
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
@@ -99,6 +99,7 @@ public abstract class PostingService {
         }
         else if (postDTO.post().getConversation() != null) {
             if (recipients == null) {
+                // send to all participants of the conversation
                 recipients = this.conversationParticipantRepository.findConversationParticipantByConversationId(postDTO.post().getConversation().getId()).stream()
                         .map(ConversationParticipant::getUser).collect(Collectors.toSet());
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/ReactionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/ReactionService.java
@@ -133,7 +133,7 @@ public class ReactionService {
             updatedPost.removeAnswerPost(updatedAnswerPost);
             updatedPost.addAnswerPost(updatedAnswerPost);
         }
-        postService.broadcastForPost(new PostDTO(updatedPost, MetisCrudAction.UPDATE), course);
+        postService.broadcastForPost(new PostDTO(updatedPost, MetisCrudAction.UPDATE), course, null);
         reactionRepository.deleteById(reactionId);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -212,14 +212,10 @@ public class ConversationService {
      * Notify all members of a conversation about a new message in the conversation
      *
      * @param conversation conversation which members to notify about the new message (except the author)
-     * @param author       author of the new message to filter out
+     * @param recipients   users to which the notification should be sent
      */
-    public void notifyAllConversationMembersAboutNewMessage(Conversation conversation, User author) {
-        var usersToContact = conversationParticipantRepository.findConversationParticipantByConversationId(conversation.getId()).stream().map(ConversationParticipant::getUser)
-                .collect(Collectors.toSet());
-        // filter out the author of the message
-        usersToContact.remove(author);
-        broadcastOnConversationMembershipChannel(conversation.getCourse(), MetisCrudAction.NEW_MESSAGE, conversation, usersToContact);
+    public void notifyAllConversationMembersAboutNewMessage(Conversation conversation, Set<User> recipients) {
+        broadcastOnConversationMembershipChannel(conversation.getCourse(), MetisCrudAction.NEW_MESSAGE, conversation, recipients);
     }
 
     /**
@@ -264,11 +260,11 @@ public class ConversationService {
      * @param course          the course in which the conversation is located
      * @param metisCrudAction the action that was performed
      * @param conversation    the conversation that was affected
-     * @param usersToMessage  the users to be messaged
+     * @param recipients      the users to be messaged
      */
-    public void broadcastOnConversationMembershipChannel(Course course, MetisCrudAction metisCrudAction, Conversation conversation, Set<User> usersToMessage) {
+    public void broadcastOnConversationMembershipChannel(Course course, MetisCrudAction metisCrudAction, Conversation conversation, Set<User> recipients) {
         String conversationParticipantTopicName = getConversationParticipantTopicName(course.getId());
-        usersToMessage.forEach(user -> sendToConversationMembershipChannel(metisCrudAction, conversation, user, conversationParticipantTopicName));
+        recipients.forEach(user -> sendToConversationMembershipChannel(metisCrudAction, conversation, user, conversationParticipantTopicName));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -214,8 +214,8 @@ public class ConversationService {
      * @param conversation conversation which members to notify about the new message (except the author)
      * @param recipients   users to which the notification should be sent
      */
-    public void notifyAllConversationMembersAboutNewMessage(Conversation conversation, Set<User> recipients) {
-        broadcastOnConversationMembershipChannel(conversation.getCourse(), MetisCrudAction.NEW_MESSAGE, conversation, recipients);
+    public void notifyAllConversationMembersAboutNewMessage(Course course, Conversation conversation, Set<User> recipients) {
+        broadcastOnConversationMembershipChannel(course, MetisCrudAction.NEW_MESSAGE, conversation, recipients);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -211,6 +211,7 @@ public class ConversationService {
     /**
      * Notify all members of a conversation about a new message in the conversation
      *
+     * @param course       the course in which the conversation takes place
      * @param conversation conversation which members to notify about the new message (except the author)
      * @param recipients   users to which the notification should be sent
      */

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.NotificationType;
-import de.tum.in.www1.artemis.domain.metis.ConversationParticipant;
 import de.tum.in.www1.artemis.domain.metis.Post;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.metis.conversation.GroupChat;
@@ -68,15 +67,12 @@ public class ConversationNotificationService {
 
     private void saveAndSend(ConversationNotification notification, Set<User> recipients) {
         conversationNotificationRepository.save(notification);
-        sendNotificationViaWebSocket(notification);
+        sendNotificationViaWebSocket(notification, recipients);
 
         generalInstantNotificationService.sendNotification(notification, recipients, null);
     }
 
-    private void sendNotificationViaWebSocket(ConversationNotification notification) {
-        notification.getConversation().getConversationParticipants().stream().map(ConversationParticipant::getUser).filter(user -> !user.equals(notification.getAuthor()))
-                .forEach(user -> {
-                    websocketMessagingService.sendMessage(notification.getTopic(user.getId()), notification);
-                });
+    private void sendNotificationViaWebSocket(ConversationNotification notification, Set<User> recipients) {
+        recipients.forEach(user -> websocketMessagingService.sendMessage(notification.getTopic(user.getId()), notification));
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationService.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import org.springframework.stereotype.Service;
 
+import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.NotificationType;
 import de.tum.in.www1.artemis.domain.metis.Post;
@@ -39,8 +40,10 @@ public class ConversationNotificationService {
      * Notify registered students about new message
      *
      * @param createdMessage the new message
+     * @param recipients     the users which should be notified about the new message
+     * @param course         the course in which the message was posted
      */
-    public void notifyAboutNewMessage(Post createdMessage, Set<User> recipients, String courseTitle) {
+    public void notifyAboutNewMessage(Post createdMessage, Set<User> recipients, Course course) {
         String notificationText;
         String[] placeholders;
         String conversationName = createdMessage.getConversation().getHumanReadableNameForReceiver(createdMessage.getAuthor());
@@ -48,20 +51,20 @@ public class ConversationNotificationService {
         // add channel/groupChat/oneToOneChat string to placeholders for notification to distinguish in mobile client
         if (createdMessage.getConversation() instanceof Channel channel) {
             notificationText = NEW_MESSAGE_CHANNEL_TEXT;
-            placeholders = new String[] { courseTitle, createdMessage.getContent(), createdMessage.getCreationDate().toString(), channel.getName(),
+            placeholders = new String[] { course.getTitle(), createdMessage.getContent(), createdMessage.getCreationDate().toString(), channel.getName(),
                     createdMessage.getAuthor().getName(), "channel" };
         }
         else if (createdMessage.getConversation() instanceof GroupChat groupChat) {
             notificationText = NEW_MESSAGE_GROUP_CHAT_TEXT;
-            placeholders = new String[] { courseTitle, createdMessage.getContent(), createdMessage.getCreationDate().toString(), createdMessage.getAuthor().getName(),
+            placeholders = new String[] { course.getTitle(), createdMessage.getContent(), createdMessage.getCreationDate().toString(), createdMessage.getAuthor().getName(),
                     conversationName, "groupChat" };
         }
         else {
             notificationText = NEW_MESSAGE_DIRECT_TEXT;
-            placeholders = new String[] { courseTitle, createdMessage.getContent(), createdMessage.getCreationDate().toString(), createdMessage.getAuthor().getName(),
+            placeholders = new String[] { course.getTitle(), createdMessage.getContent(), createdMessage.getCreationDate().toString(), createdMessage.getAuthor().getName(),
                     conversationName, "oneToOneChat" };
         }
-        var notification = createConversationMessageNotification(createdMessage, NotificationType.CONVERSATION_NEW_MESSAGE, notificationText, true, placeholders);
+        var notification = createConversationMessageNotification(course.getId(), createdMessage, NotificationType.CONVERSATION_NEW_MESSAGE, notificationText, true, placeholders);
         saveAndSend(notification, recipients);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationService.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.service.notifications;
 import static de.tum.in.www1.artemis.service.notifications.NotificationSettingsCommunicationChannel.EMAIL;
 import static de.tum.in.www1.artemis.service.notifications.NotificationSettingsCommunicationChannel.PUSH;
 
-import java.util.List;
+import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
@@ -79,7 +79,7 @@ public class GeneralInstantNotificationService implements InstantNotificationSer
      */
     @Async
     @Override
-    public void sendNotification(Notification notification, List<User> users, Object notificationSubject) {
+    public void sendNotification(Notification notification, Set<User> users, Object notificationSubject) {
         SecurityUtils.setAuthorizationObject();
 
         var emailRecipients = filterRecipients(notification, users, EMAIL);
@@ -103,7 +103,7 @@ public class GeneralInstantNotificationService implements InstantNotificationSer
      * @return filtered user list
      */
     @NotNull
-    private List<User> filterRecipients(Notification notification, List<User> users, NotificationSettingsCommunicationChannel channel) {
+    private Set<User> filterRecipients(Notification notification, Set<User> users, NotificationSettingsCommunicationChannel channel) {
         return notificationSettingsService.filterUsersByNotificationIsAllowedInCommunicationChannelBySettings(notification, users, channel);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/GroupNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/GroupNotificationService.java
@@ -7,6 +7,7 @@ import static de.tum.in.www1.artemis.domain.notification.NotificationConstants.L
 
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -329,7 +330,7 @@ public class GroupNotificationService {
 
         // checks if this notification type has email support
         if (notificationSettingsService.checkNotificationTypeForInstantNotificationSupport(type)) {
-            List<User> groupNotificationReceivers = findGroupNotificationReceivers(notification, author);
+            Set<User> groupNotificationReceivers = findGroupNotificationReceivers(notification, author);
 
             if (!groupNotificationReceivers.isEmpty()) {
                 notificationService.sendNotification(notification, groupNotificationReceivers, notificationSubject);
@@ -357,23 +358,23 @@ public class GroupNotificationService {
      * @param notification which information should also be propagated via email
      * @param author       the author will be excluded if not null
      */
-    private List<User> findGroupNotificationReceivers(GroupNotification notification, User author) {
+    private Set<User> findGroupNotificationReceivers(GroupNotification notification, User author) {
         Course course = notification.getCourse();
         GroupNotificationType groupType = notification.getType();
-        List<User> foundUsers;
+        Set<User> foundUsers;
         switch (groupType) {
             case STUDENT -> foundUsers = userRepository.getStudents(course);
             case INSTRUCTOR -> foundUsers = userRepository.getInstructors(course);
             case EDITOR -> foundUsers = userRepository.getEditors(course);
             case TA -> foundUsers = userRepository.getTutors(course);
-            default -> foundUsers = Collections.emptyList();
+            default -> foundUsers = Collections.emptySet();
         }
 
         if (author == null) {
             return foundUsers;
         }
         else {
-            return foundUsers.stream().filter((user) -> !Objects.equals(user.getId(), author.getId())).toList();
+            return foundUsers.stream().filter((user) -> !Objects.equals(user.getId(), author.getId())).collect(Collectors.toSet());
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/InstantNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/InstantNotificationService.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.service.notifications;
 
-import java.util.List;
+import java.util.Set;
 
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.notification.Notification;
@@ -27,5 +27,5 @@ public interface InstantNotificationService {
      * @param users               who should be contacted
      * @param notificationSubject that is used to provide further information (e.g. exercise, attachment, post, etc.)
      */
-    void sendNotification(Notification notification, List<User> users, Object notificationSubject);
+    void sendNotification(Notification notification, Set<User> users, Object notificationSubject);
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/MailService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/MailService.java
@@ -5,7 +5,6 @@ import static de.tum.in.www1.artemis.domain.notification.NotificationTargetFacto
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -185,7 +184,7 @@ public class MailService implements InstantNotificationService {
      */
     @Override
     @Async
-    public void sendNotification(Notification notification, List<User> users, Object notificationSubject) {
+    public void sendNotification(Notification notification, Set<User> users, Object notificationSubject) {
         users.forEach(user -> sendNotification(notification, user, notificationSubject));
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/NotificationSettingsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/NotificationSettingsService.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.NotificationSetting;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.NotificationType;
@@ -170,7 +171,7 @@ public class NotificationSettingsService {
      */
     public boolean checkIfNotificationIsAllowedInCommunicationChannelBySettingsForGivenUser(Notification notification, User user,
             NotificationSettingsCommunicationChannel communicationChannel) {
-        List<User> users = filterUsersByNotificationIsAllowedInCommunicationChannelBySettings(notification, Collections.singletonList(user), communicationChannel);
+        Set<User> users = filterUsersByNotificationIsAllowedInCommunicationChannelBySettings(notification, Set.of(user), communicationChannel);
         return !users.isEmpty();
     }
 
@@ -182,12 +183,12 @@ public class NotificationSettingsService {
      * @param communicationChannel which channel to use (e.g. email or webapp or push)
      * @return filtered user list
      */
-    public List<User> filterUsersByNotificationIsAllowedInCommunicationChannelBySettings(Notification notification, List<User> users,
+    public Set<User> filterUsersByNotificationIsAllowedInCommunicationChannelBySettings(Notification notification, Set<User> users,
             NotificationSettingsCommunicationChannel communicationChannel) {
         NotificationType type = findCorrespondingNotificationType(notification.getTitle());
 
         Set<NotificationSetting> decidedNotificationSettings = notificationSettingRepository
-                .findAllNotificationSettingsForRecipientsWithId(users.stream().map(user -> user.getId()).toList());
+                .findAllNotificationSettingsForRecipientsWithId(users.stream().map(DomainObject::getId).toList());
         Set<NotificationSetting> notificationSettings = new HashSet<>(decidedNotificationSettings);
 
         return users.stream().filter(user -> {
@@ -203,7 +204,7 @@ public class NotificationSettingsService {
 
             Set<NotificationType> deactivatedTypes = findDeactivatedNotificationTypes(communicationChannel, notificationSettings);
             return !deactivatedTypes.contains(type);
-        }).toList();
+        }).collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/TutorialGroupNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/TutorialGroupNotificationService.java
@@ -4,7 +4,6 @@ import static de.tum.in.www1.artemis.domain.enumeration.NotificationType.TUTORIA
 import static de.tum.in.www1.artemis.domain.enumeration.NotificationType.TUTORIAL_GROUP_UPDATED;
 import static de.tum.in.www1.artemis.domain.notification.TutorialGroupNotificationFactory.createTutorialGroupNotification;
 
-import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -74,7 +73,7 @@ public class TutorialGroupNotificationService {
         if (notificationSettingsService.checkNotificationTypeForInstantNotificationSupport(notification.notificationType)) {
             var usersToMail = findUsersToNotify(notification, notifyTutor);
             if (!usersToMail.isEmpty()) {
-                notificationService.sendNotification(notification, new ArrayList<>(usersToMail), notification.getTutorialGroup());
+                notificationService.sendNotification(notification, usersToMail, notification.getTutorialGroup());
             }
         }
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/push_notifications/PushNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/push_notifications/PushNotificationService.java
@@ -3,10 +3,7 @@ package de.tum.in.www1.artemis.service.notifications.push_notifications;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.time.Instant;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 import javax.crypto.Cipher;
@@ -116,7 +113,7 @@ public abstract class PushNotificationService implements InstantNotificationServ
      */
     @Override
     public final void sendNotification(Notification notification, User user, Object notificationSubject) {
-        sendNotification(notification, Collections.singletonList(user), notificationSubject);
+        sendNotification(notification, Set.of(user), notificationSubject);
     }
 
     /**
@@ -130,7 +127,7 @@ public abstract class PushNotificationService implements InstantNotificationServ
      */
     @Override
     @Async
-    public void sendNotification(Notification notification, List<User> users, Object notificationSubject) {
+    public void sendNotification(Notification notification, Set<User> users, Object notificationSubject) {
         final Optional<String> relayServerBaseUrl = getRelayBaseUrl();
 
         if (relayServerBaseUrl.isEmpty()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserService.java
@@ -9,7 +9,6 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -572,7 +571,7 @@ public class UserService {
      */
     public void removeGroupFromUsers(String groupName) {
         log.info("Remove group {} from users", groupName);
-        List<User> users = userRepository.findAllInGroupWithAuthorities(groupName);
+        Set<User> users = userRepository.findAllInGroupWithAuthorities(groupName);
         log.info("Found {} users with group {}", users.size(), groupName);
         for (User user : users) {
             user.getGroups().remove(groupName);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -802,7 +802,7 @@ public class CourseResource {
      */
     @GetMapping("courses/{courseId}/students")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<User>> getAllStudentsInCourse(@PathVariable Long courseId) {
+    public ResponseEntity<Set<User>> getAllStudentsInCourse(@PathVariable Long courseId) {
         log.debug("REST request to get all students in course : {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         return courseService.getAllUsersInGroup(course, course.getStudentGroupName());
@@ -886,7 +886,7 @@ public class CourseResource {
      */
     @GetMapping("courses/{courseId}/tutors")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<User>> getAllTutorsInCourse(@PathVariable Long courseId) {
+    public ResponseEntity<Set<User>> getAllTutorsInCourse(@PathVariable Long courseId) {
         log.debug("REST request to get all tutors in course : {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         return courseService.getAllUsersInGroup(course, course.getTeachingAssistantGroupName());
@@ -900,7 +900,7 @@ public class CourseResource {
      */
     @GetMapping("courses/{courseId}/editors")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<User>> getAllEditorsInCourse(@PathVariable Long courseId) {
+    public ResponseEntity<Set<User>> getAllEditorsInCourse(@PathVariable Long courseId) {
         log.debug("REST request to get all editors in course : {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         return courseService.getAllUsersInGroup(course, course.getEditorGroupName());
@@ -914,7 +914,7 @@ public class CourseResource {
      */
     @GetMapping("courses/{courseId}/instructors")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<User>> getAllInstructorsInCourse(@PathVariable Long courseId) {
+    public ResponseEntity<Set<User>> getAllInstructorsInCourse(@PathVariable Long courseId) {
         log.debug("REST request to get all instructors in course : {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         return courseService.getAllUsersInGroup(course, course.getInstructorGroupName());

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
@@ -56,6 +56,12 @@ public class ConversationMessageResource {
     @EnforceAtLeastStudent
     public ResponseEntity<Post> createMessage(@PathVariable Long courseId, @Valid @RequestBody Post post) throws URISyntaxException {
         Post createdMessage = conversationMessagingService.createMessage(courseId, post);
+
+        // reduce the payload of the response / websocket message: this is important to avoid overloading the involved subsystems
+        if (createdMessage.getConversation() != null) {
+            createdMessage.getConversation().hideDetails();
+        }
+
         // creation of message posts should not trigger entity creation alert
         conversationNotificationService.notifyAboutNewMessage(createdMessage);
         return ResponseEntity.created(new URI("/api/courses/" + courseId + "/messages/" + createdMessage.getId())).body(createdMessage);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
@@ -20,7 +20,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import de.tum.in.www1.artemis.domain.metis.Post;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastStudent;
 import de.tum.in.www1.artemis.service.metis.ConversationMessagingService;
-import de.tum.in.www1.artemis.service.notifications.ConversationNotificationService;
 import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 import de.tum.in.www1.artemis.web.rest.dto.PostContextFilter;
 import io.swagger.annotations.ApiParam;
@@ -37,11 +36,8 @@ public class ConversationMessageResource {
 
     private final ConversationMessagingService conversationMessagingService;
 
-    private final ConversationNotificationService conversationNotificationService;
-
-    public ConversationMessageResource(ConversationNotificationService conversationNotificationService, ConversationMessagingService conversationMessagingService) {
+    public ConversationMessageResource(ConversationMessagingService conversationMessagingService) {
         this.conversationMessagingService = conversationMessagingService;
-        this.conversationNotificationService = conversationNotificationService;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
@@ -56,14 +56,6 @@ public class ConversationMessageResource {
     @EnforceAtLeastStudent
     public ResponseEntity<Post> createMessage(@PathVariable Long courseId, @Valid @RequestBody Post post) throws URISyntaxException {
         Post createdMessage = conversationMessagingService.createMessage(courseId, post);
-
-        // reduce the payload of the response / websocket message: this is important to avoid overloading the involved subsystems
-        if (createdMessage.getConversation() != null) {
-            createdMessage.getConversation().hideDetails();
-        }
-
-        // creation of message posts should not trigger entity creation alert
-        conversationNotificationService.notifyAboutNewMessage(createdMessage);
         return ResponseEntity.created(new URI("/api/courses/" + courseId + "/messages/" + createdMessage.getId())).body(createdMessage);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ChannelDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ChannelDTO.java
@@ -1,8 +1,11 @@
 package de.tum.in.www1.artemis.web.rest.metis.conversation.dtos;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.metis.conversation.ChannelSubType;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ChannelDTO extends ConversationDTO {
 
     private String name;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ConversationDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ConversationDTO.java
@@ -67,7 +67,7 @@ public class ConversationDTO {
         // default constructor
     }
 
-    // TODO: in json, this value is inserted twice
+    // TODO: in json, this value is inserted twice, add @JsonIgnore
     public String getType() {
         return type;
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ConversationDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ConversationDTO.java
@@ -2,11 +2,13 @@ package de.tum.in.www1.artemis.web.rest.metis.conversation.dtos;
 
 import java.time.ZonedDateTime;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import de.tum.in.www1.artemis.domain.metis.conversation.Conversation;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({ @JsonSubTypes.Type(value = OneToOneChatDTO.class, name = "oneToOneChat"), @JsonSubTypes.Type(value = GroupChatDTO.class, name = "groupChat"),
         @JsonSubTypes.Type(value = ChannelDTO.class, name = "channel"), })
@@ -65,6 +67,7 @@ public class ConversationDTO {
         // default constructor
     }
 
+    // TODO: in json, this value is inserted twice
     public String getType() {
         return type;
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/GroupChatDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/GroupChatDTO.java
@@ -2,8 +2,11 @@ package de.tum.in.www1.artemis.web.rest.metis.conversation.dtos;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.metis.conversation.GroupChat;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class GroupChatDTO extends ConversationDTO {
 
     private String name;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/OneToOneChatDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/OneToOneChatDTO.java
@@ -2,8 +2,11 @@ package de.tum.in.www1.artemis.web.rest.metis.conversation.dtos;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.metis.conversation.Conversation;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class OneToOneChatDTO extends ConversationDTO {
 
     public Set<ConversationUserDTO> members;

--- a/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/conversation-detail-dialog.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/conversation-detail-dialog.component.ts
@@ -19,12 +19,9 @@ export enum ConversationDetailTabs {
     templateUrl: './conversation-detail-dialog.component.html',
 })
 export class ConversationDetailDialogComponent extends AbstractDialogComponent {
-    @Input()
-    public activeConversation: ConversationDto;
-    @Input()
-    course: Course;
-    @Input()
-    selectedTab: ConversationDetailTabs = ConversationDetailTabs.MEMBERS;
+    @Input() public activeConversation: ConversationDto;
+    @Input() course: Course;
+    @Input() selectedTab: ConversationDetailTabs = ConversationDetailTabs.MEMBERS;
 
     isInitialized = false;
 

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -299,9 +299,9 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         bitbucketRequestMockProvider.mockUpdateUserDetails(student42.getLogin(), student42.getEmail(), student42.getName());
         bitbucketRequestMockProvider.mockAddUserToGroups();
 
-        List<User> studentsInCourseBefore = userRepo.findAllInGroupWithAuthorities(course1.getStudentGroupName());
+        Set<User> studentsInCourseBefore = userRepo.findAllInGroupWithAuthorities(course1.getStudentGroupName());
         request.postWithoutLocation("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/students/" + TEST_PREFIX + "student42", null, HttpStatus.OK, null);
-        List<User> studentsInCourseAfter = userRepo.findAllInGroupWithAuthorities(course1.getStudentGroupName());
+        Set<User> studentsInCourseAfter = userRepo.findAllInGroupWithAuthorities(course1.getStudentGroupName());
         studentsInCourseBefore.add(student42);
         assertThat(studentsInCourseBefore).containsExactlyInAnyOrderElementsOf(studentsInCourseAfter);
     }

--- a/src/test/java/de/tum/in/www1/artemis/notification/GroupNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/GroupNotificationServiceTest.java
@@ -392,7 +392,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
     /**
      * Checks if a push to android and iOS was created and send
      */
-    private void verifyPush(Notification notification, List<User> users, Object notificationSubject) {
+    private void verifyPush(Notification notification, Set<User> users, Object notificationSubject) {
         verify(applePushNotificationService, timeout(1500)).sendNotification(notification, users, notificationSubject);
         verify(firebasePushNotificationService, timeout(1500)).sendNotification(notification, users, notificationSubject);
     }
@@ -426,7 +426,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
         Notification notification = verifyRepositoryCallWithCorrectNotificationAndReturnNotification(1, ATTACHMENT_CHANGE_TITLE);
 
         verifyEmail();
-        verifyPush(notification, List.of(student), attachment);
+        verifyPush(notification, Set.of(student), attachment);
     }
 
     @Test
@@ -436,7 +436,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
         Notification notification = verifyRepositoryCallWithCorrectNotificationAndReturnNotification(1, EXERCISE_PRACTICE_TITLE);
 
         verifyEmail();
-        verifyPush(notification, List.of(student), exercise);
+        verifyPush(notification, Set.of(student), exercise);
     }
 
     @Test
@@ -514,7 +514,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
         Notification notification = verifyRepositoryCallWithCorrectNotificationAndReturnNotificationAtIndex(NUMBER_OF_ALL_GROUPS, NEW_ANNOUNCEMENT_POST_TITLE, 3);
 
         verifyEmail();
-        verifyPush(notification, List.of(student), post);
+        verifyPush(notification, Set.of(student), post);
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/notification/NotificationScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/NotificationScheduleServiceTest.java
@@ -85,7 +85,7 @@ class NotificationScheduleServiceTest extends AbstractSpringIntegrationBambooBit
         instanceMessageReceiveService.processScheduleExerciseReleasedNotification(exercise.getId());
         await().until(() -> notificationRepository.count() > sizeBefore);
         verify(groupNotificationService, timeout(4000)).notifyAllGroupsAboutReleasedExercise(exercise);
-        verify(mailService, timeout(4000).atLeastOnce()).sendNotification(any(), anyList(), any());
+        verify(mailService, timeout(4000).atLeastOnce()).sendNotification(any(), anySet(), any());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/notification/PushNotificationResourceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/PushNotificationResourceTest.java
@@ -2,8 +2,8 @@ package de.tum.in.www1.artemis.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +61,7 @@ class PushNotificationResourceTest extends AbstractSpringIntegrationBambooBitbuc
         PushNotificationRegisterDTO response = request.postWithResponseBody("/api/push_notification/register", body, PushNotificationRegisterDTO.class);
 
         assertThat(response.secretKey()).isNotEmpty();
-        List<PushNotificationDeviceConfiguration> deviceConfigurations = pushNotificationDeviceConfigurationRepository.findByUserIn(Collections.singletonList(user),
+        List<PushNotificationDeviceConfiguration> deviceConfigurations = pushNotificationDeviceConfigurationRepository.findByUserIn(Set.of(user),
                 PushNotificationDeviceType.FIREBASE);
 
         assertThat(deviceConfigurations).hasSize(1);
@@ -78,7 +78,7 @@ class PushNotificationResourceTest extends AbstractSpringIntegrationBambooBitbuc
         PushNotificationUnregisterRequest body = new PushNotificationUnregisterRequest(FAKE_FIREBASE_TOKEN, PushNotificationDeviceType.FIREBASE);
         request.delete("/api/push_notification/unregister", HttpStatus.OK, body);
 
-        List<PushNotificationDeviceConfiguration> deviceConfigurations = pushNotificationDeviceConfigurationRepository.findByUserIn(Collections.singletonList(user),
+        List<PushNotificationDeviceConfiguration> deviceConfigurations = pushNotificationDeviceConfigurationRepository.findByUserIn(Set.of(user),
                 PushNotificationDeviceType.FIREBASE);
 
         assertThat(deviceConfigurations).isEmpty();

--- a/src/test/java/de/tum/in/www1/artemis/notification/SingleUserNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/SingleUserNotificationServiceTest.java
@@ -556,8 +556,8 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationBambooB
      * @param times how often the email should have been sent
      */
     private void verifyPush(int times) {
-        verify(applePushNotificationService, timeout(1500).times(times)).sendNotification(any(Notification.class), anyList(), any(Object.class));
-        verify(firebasePushNotificationService, timeout(1500).times(times)).sendNotification(any(Notification.class), anyList(), any(Object.class));
+        verify(applePushNotificationService, timeout(1500).times(times)).sendNotification(any(Notification.class), anySet(), any(Object.class));
+        verify(firebasePushNotificationService, timeout(1500).times(times)).sendNotification(any(Notification.class), anySet(), any(Object.class));
     }
 
     private static Stream<Arguments> getNotificationTypesAndTitlesParametersForGroupChat() {

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationServiceTest.java
@@ -109,7 +109,7 @@ class ConversationNotificationServiceTest extends AbstractSpringIntegrationBambo
         post.setContent("hi test");
         post = conversationMessageRepository.save(post);
 
-        conversationNotificationService.notifyAboutNewMessage(post, Set.of(user2), course.getTitle());
+        conversationNotificationService.notifyAboutNewMessage(post, Set.of(user2), course);
         verify(websocketMessagingService, timeout(2000)).sendMessage(eq("/topic/user/" + user2.getId() + "/notifications/conversations"), (Object) any());
         verifyRepositoryCallWithCorrectNotification(NEW_MESSAGE_TITLE);
 

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/ConversationNotificationServiceTest.java
@@ -68,10 +68,12 @@ class ConversationNotificationServiceTest extends AbstractSpringIntegrationBambo
 
     private User user2;
 
+    private Course course;
+
     @BeforeEach
     void setUp() {
         userUtilService.addUsers(TEST_PREFIX, 2, 1, 0, 1);
-        Course course = courseUtilService.createCourse();
+        course = courseUtilService.createCourse();
         user1 = userRepository.findOneByLogin(TEST_PREFIX + "student1").orElseThrow();
         user2 = userRepository.findOneByLogin(TEST_PREFIX + "tutor1").orElseThrow();
 
@@ -107,13 +109,13 @@ class ConversationNotificationServiceTest extends AbstractSpringIntegrationBambo
         post.setContent("hi test");
         post = conversationMessageRepository.save(post);
 
-        conversationNotificationService.notifyAboutNewMessage(post);
+        conversationNotificationService.notifyAboutNewMessage(post, Set.of(user2), course.getTitle());
         verify(websocketMessagingService, timeout(2000)).sendMessage(eq("/topic/user/" + user2.getId() + "/notifications/conversations"), (Object) any());
         verifyRepositoryCallWithCorrectNotification(NEW_MESSAGE_TITLE);
 
         Notification sentNotification = notificationRepository.findAll().stream().max(Comparator.comparing(DomainObject::getId)).orElseThrow();
 
-        verify(generalInstantNotificationService).sendNotification(sentNotification, Arrays.asList(user2), null);
+        verify(generalInstantNotificationService).sendNotification(sentNotification, Set.of(user2), null);
 
         var participants = conversationParticipantRepository.findConversationParticipantByConversationId(oneToOneChat.getId());
         // make sure that objects can be deleted after notification is saved

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationServiceTest.java
@@ -2,9 +2,7 @@ package de.tum.in.www1.artemis.service.notifications;
 
 import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -117,7 +115,7 @@ class GeneralInstantNotificationServiceTest {
      */
     @Test
     void testSendAllNotificationsToMultipleUsers() {
-        List<User> studentList = new ArrayList<>();
+        Set<User> studentList = new HashSet<>();
         studentList.add(student1);
         studentList.add(student2);
 
@@ -135,11 +133,11 @@ class GeneralInstantNotificationServiceTest {
 
     @Test
     void testSendEmailOnlyToOneUser() {
-        List<User> studentList = new ArrayList<>();
+        Set<User> studentList = new HashSet<>();
         studentList.add(student1);
         studentList.add(student2);
         when(notificationSettingsService.filterUsersByNotificationIsAllowedInCommunicationChannelBySettings(notification, studentList,
-                NotificationSettingsCommunicationChannel.EMAIL)).thenReturn(Collections.singletonList(student1));
+                NotificationSettingsCommunicationChannel.EMAIL)).thenReturn(Set.of(student1));
         when(notificationSettingsService.filterUsersByNotificationIsAllowedInCommunicationChannelBySettings(notification, studentList,
                 NotificationSettingsCommunicationChannel.PUSH)).thenReturn(studentList);
 
@@ -147,23 +145,23 @@ class GeneralInstantNotificationServiceTest {
 
         verify(applePushNotificationService).sendNotification(notification, studentList, null);
         verify(firebasePushNotificationService).sendNotification(notification, studentList, null);
-        verify(mailService).sendNotification(notification, Collections.singletonList(student1), null);
+        verify(mailService).sendNotification(notification, Set.of(student1), null);
     }
 
     @Test
     void testSendPushOnlyToOneUser() {
-        List<User> studentList = new ArrayList<>();
+        Set<User> studentList = new HashSet<>();
         studentList.add(student1);
         studentList.add(student2);
         when(notificationSettingsService.filterUsersByNotificationIsAllowedInCommunicationChannelBySettings(notification, studentList,
                 NotificationSettingsCommunicationChannel.EMAIL)).thenReturn(studentList);
         when(notificationSettingsService.filterUsersByNotificationIsAllowedInCommunicationChannelBySettings(notification, studentList,
-                NotificationSettingsCommunicationChannel.PUSH)).thenReturn(Collections.singletonList(student1));
+                NotificationSettingsCommunicationChannel.PUSH)).thenReturn(Set.of(student1));
 
         generalInstantNotificationService.sendNotification(notification, studentList, null);
 
-        verify(applePushNotificationService).sendNotification(notification, Collections.singletonList(student1), null);
-        verify(firebasePushNotificationService).sendNotification(notification, Collections.singletonList(student1), null);
+        verify(applePushNotificationService).sendNotification(notification, Set.of(student1), null);
+        verify(firebasePushNotificationService).sendNotification(notification, Set.of(student1), null);
         verify(mailService).sendNotification(notification, studentList, null);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/push_notifications/AppleFirebasePushNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/push_notifications/AppleFirebasePushNotificationServiceTest.java
@@ -66,8 +66,8 @@ class AppleFirebasePushNotificationServiceTest {
         PushNotificationDeviceConfiguration firebasePushNotificationDeviceConfiguration = new PushNotificationDeviceConfiguration(token, PushNotificationDeviceType.FIREBASE,
                 new Date(), payload, student);
 
-        when(repositoryMock.findByUserIn(anyList(), eq(PushNotificationDeviceType.APNS))).thenReturn(Collections.singletonList(applePushNotificationDeviceConfiguration));
-        when(repositoryMock.findByUserIn(anyList(), eq(PushNotificationDeviceType.FIREBASE))).thenReturn(Collections.singletonList(firebasePushNotificationDeviceConfiguration));
+        when(repositoryMock.findByUserIn(anySet(), eq(PushNotificationDeviceType.APNS))).thenReturn(Collections.singletonList(applePushNotificationDeviceConfiguration));
+        when(repositoryMock.findByUserIn(anySet(), eq(PushNotificationDeviceType.FIREBASE))).thenReturn(Collections.singletonList(firebasePushNotificationDeviceConfiguration));
 
         applePushNotificationService = new ApplePushNotificationService(repositoryMock, appleRestTemplateMock);
         firebasePushNotificationService = new FirebasePushNotificationService(repositoryMock, firebaseRestTemplateMock);

--- a/src/test/java/de/tum/in/www1/artemis/service/scheduled/PushNotificationDeviceConfigurationCleanupServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/scheduled/PushNotificationDeviceConfigurationCleanupServiceTest.java
@@ -4,9 +4,7 @@ import static org.springframework.test.util.AssertionErrors.assertEquals;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +49,7 @@ class PushNotificationDeviceConfigurationCleanupServiceTest extends AbstractSpri
 
         cleanupService.performCleanup();
 
-        List<PushNotificationDeviceConfiguration> result = deviceConfigurationRepository.findByUserIn(Collections.singletonList(user), PushNotificationDeviceType.FIREBASE);
+        List<PushNotificationDeviceConfiguration> result = deviceConfigurationRepository.findByUserIn(Set.of(user), PushNotificationDeviceType.FIREBASE);
 
         assertEquals("The result is not correct", Collections.singletonList(valid), result);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I updated multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.
#### Client
no real client changes

### Motivation and Context
The payload for messages is too large and contains information unnecessary for the client.
We should send minimal payloads to prevent overloading the involved subsystems.

### Description
Hide details in the objects send to the client in the REST call response and when sending notifications via web sockets

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 course (messaging enabled) and 2 Students

1. Open a channel side by side with 2 users
2. Open the Chrome console inspecting the REST call for user 1
3. Open the Chrome console inspecting WS message for user 2
4. Send a message with user 1
5. Make sure the REST response for user 1 contains minimal information: no exercise, no lecture, no exam, no course, no conversation participants
6. Make sure the WS messages for user 2 contain minimal information: no exercise, no lecture, no exam, no course, no conversation participants
7. Also test related cases like editing messages, reacting with emojis, deleting messages and other interactions
8. Make sure in all these cases no additional information is sent in WS messages nor REST responses


Due to refactoring, we need to test all other message types: replies/answers, one to one chats, group chats, etc.



### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2