### PR TITLE
`Programming exercises`: Prevent tree compression for single files within the online code editor

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser-folder.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser-folder.component.html
@@ -21,11 +21,11 @@
         <button [disabled]="disableActions" (click)="setCreatingNodeInFolder($event, FileType.FOLDER)" class="btn btn-small">
             <fa-icon [icon]="faFolder" title="{{ 'artemisApp.editor.fileBrowser.createFolder' | artemisTranslate }}"></fa-icon>
         </button>
-        <button [disabled]="disableActions || (isCompressed && item.children && item.children.length)" (click)="setRenamingNode($event)" class="btn btn-small">
+        <button [disabled]="disableActions || (isCompressed && item.value.includes('/'))" (click)="setRenamingNode($event)" class="btn btn-small">
             <fa-icon
                 [icon]="faEdit"
                 title="{{
-                    (!disableActions && isCompressed && item.children && item.children.length
+                    (!disableActions && isCompressed && item.value.includes('/')
                         ? 'artemisApp.editor.fileBrowser.renameFolderDisabledTooltip'
                         : 'artemisApp.editor.fileBrowser.renameFolder'
                     ) | artemisTranslate

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
@@ -379,7 +379,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
      * @param node Tree node
      */
     compressTree(node: FileTreeItem): FileTreeItem {
-        if (node.children && node.children.length === 1 && node.children[0].children) {
+        if (node.children && node.children.length === 1 && this.repositoryFiles[node.children[0].value] === FileType.FOLDER) {
             return this.compressTree({ ...node.children[0], text: node.text + '/' + node.children[0].text, folder: node.folder, file: node.file });
         } else if (node.children) {
             return { ...node, children: node.children.map(this.compressTree.bind(this)) };

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
@@ -379,11 +379,16 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
      * @param node Tree node
      */
     compressTree(node: FileTreeItem): FileTreeItem {
+        // If the node has only one child and that child is a folder, we can compress the tree.
         if (node.children && node.children.length === 1 && this.repositoryFiles[node.children[0].value] === FileType.FOLDER) {
             return this.compressTree({ ...node.children[0], text: node.text + '/' + node.children[0].text, folder: node.folder, file: node.file });
-        } else if (node.children) {
+        }
+        // If the node has children, we cannot compress it. However, we can try to compress its children.
+        else if (node.children) {
             return { ...node, children: node.children.map(this.compressTree.bind(this)) };
-        } else {
+        }
+        // If the node has no children, there is nothing to compress.
+        else {
             return node;
         }
     }

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.scss
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.scss
@@ -77,6 +77,8 @@ File browser tree
             }
             button {
                 padding: 0;
+                border: none;
+                pointer-events: auto;
                 fa-icon {
                     cursor: pointer;
                 }

--- a/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
@@ -157,19 +157,24 @@ describe('CodeEditorFileBrowserComponent', () => {
             'folder2/file2': FileType.FILE,
             'folder2/folder3': FileType.FOLDER,
             'folder2/folder3/file3': FileType.FILE,
+            'folder2/folder3/folder4': FileType.FOLDER,
+            'folder2/folder3/folder4/folder5': FileType.FOLDER,
         };
         comp.compressFolders = true;
         comp.setupTreeview();
         fixture.detectChanges();
         // after compression
         expect(comp.filesTreeViewItem).toHaveLength(2);
-        expect(comp.filesTreeViewItem[0].children).toHaveLength(0);
+        expect(comp.filesTreeViewItem[0].children).toHaveLength(1);
+        expect(comp.filesTreeViewItem[0].children[0].children).toHaveLength(0);
         expect(comp.filesTreeViewItem[1].children).toHaveLength(2);
         expect(comp.filesTreeViewItem[1].children[0].children).toHaveLength(0);
-        expect(comp.filesTreeViewItem[1].children[1].children).toHaveLength(0);
+        expect(comp.filesTreeViewItem[1].children[1].children).toHaveLength(2);
+        expect(comp.filesTreeViewItem[1].children[1].children[0].children).toHaveLength(0);
+        expect(comp.filesTreeViewItem[1].children[1].children[1].children).toHaveLength(0);
         const folder = comp.filesTreeViewItem.find(({ value }) => value === 'folder')!;
-        expect(folder).toBeUndefined();
-        const file1 = comp.filesTreeViewItem.find(({ value }) => value === 'folder/file1')!;
+        expect(folder).toBeObject();
+        const file1 = folder.children.find(({ value }) => value === 'folder/file1')!;
         expect(file1).toBeObject();
         expect(file1.children).toEqual([]);
         const folder2 = comp.filesTreeViewItem.find(({ value }) => value === 'folder2')!;
@@ -179,13 +184,18 @@ describe('CodeEditorFileBrowserComponent', () => {
         expect(file2).toBeDefined();
         expect(file2.children).toEqual([]);
         const folder3 = folder2.children.find(({ value }) => value === 'folder2/folder3')!;
-        expect(folder3).toBeUndefined();
-        const file3 = folder2.children.find(({ value }) => value === 'folder2/folder3/file3')!;
+        expect(folder3).toBeObject();
+        const file3 = folder3.children.find(({ value }) => value === 'folder2/folder3/file3')!;
         expect(file3).toBeDefined();
         expect(file3.children).toEqual([]);
+        const folder4 = folder3.children.find(({ value }) => value === 'folder2/folder3/folder4')!;
+        expect(folder4).toBeUndefined();
+        const folder5 = folder3.children.find(({ value }) => value === 'folder2/folder3/folder4/folder5')!;
+        expect(folder5).toBeObject();
+        expect(folder5.children).toEqual([]);
         const renderedFolders = debugElement.queryAll(By.css('jhi-code-editor-file-browser-folder'));
         const renderedFiles = debugElement.queryAll(By.css('jhi-code-editor-file-browser-file'));
-        expect(renderedFolders).toHaveLength(1);
+        expect(renderedFolders).toHaveLength(4);
         expect(renderedFiles).toHaveLength(3);
     });
 


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Fixes #6988 
Exam mode SS 23 - Issues Students#14
"When you create a single file in a new folder, it becomes a single file with a strange path" ~ @pal03377 
"One small problem I still have is that you still cannot rename a single non-empty folder in the "normal" compressed view"  ~ @pal03377 

### Description
- Changes to the compressTree method now prevent files from being compressed. Compression is, from now on, only enabled for folders.
- When compression is enabled, but a folder is not part of a compressed path, the folder can still be renamed. This is done by checking if a tree view item value contains '/' which indicates that the path of the folder has been compressed.
- When a folder is compressed, the rename button is disabled. However, from now on, the tooltip is still being presented to the user.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Programming Exercise with online code editor enabled

1. Participate in programming exercise with online code editor
2. Create a new folder
3. Create a new file within this folder (step 2) -> The file should not be compressed 
4. Create a new folder
5. Create a new folder within this folder (step 4) -> empty folders should be compressed by default
_Note: You can still click the icon marked in the picture below for accessing individual nested folders_
<img width="421" alt="Bildschirmfoto 2023-07-24 um 10 31 33" src="https://github.com/ls1intum/Artemis/assets/47261058/4312c4e4-9de4-4366-9b1b-9505a590235e">

Also check:
- It's possible to rename uncompressed folders
- A tooltip is displayed for the rename button on hover, even if it is disabled
- Try various different paths that might break the introduced changes

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before: By default, it was not possible to create new files in a folder when there was only a single file in that folder.
<img width="323" alt="Bildschirmfoto 2023-07-24 um 09 15 13" src="https://github.com/ls1intum/Artemis/assets/47261058/cf87ba67-d074-4de6-8426-16d4f4ffb1a2">

After: By default, files get not compressed and new files can be created within a new folder. Folders do still get compressed.
<img width="323" alt="Bildschirmfoto 2023-07-24 um 10 20 50" src="https://github.com/ls1intum/Artemis/assets/47261058/479d8bc7-23e5-4c41-9ec1-5f07b623bf4d">


After: Displays tooltip for disabled button on hover (explaining how to enable the button).
<img width="323" alt="Bildschirmfoto 2023-07-24 um 15 20 36" src="https://github.com/ls1intum/Artemis/assets/47261058/cffc7042-f6c6-40fa-866e-fd4c58a5c4ba">


After: Nested but uncompressed folders can be renamed.
<img width="323" alt="Bildschirmfoto 2023-07-24 um 15 20 41" src="https://github.com/ls1intum/Artemis/assets/47261058/cf991c53-63b0-4d42-a6b5-b2f45f0cdef8">