### PR TITLE
`Exam mode`: Fix an issue with locked participations

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -318,14 +318,7 @@ export class ExamParticipationService {
         if (exercise.type !== ExerciseType.PROGRAMMING) {
             return submission.isSynced ? 'synced' : 'notSynced';
         }
-
-        // The exercise is a programming exercise
-
-        const participation = ExamParticipationService.getParticipationForExercise(exercise) as ProgrammingExerciseStudentParticipation;
         if (submission.submitted && submission.isSynced) {
-            if (participation.locked) {
-                return 'submittedSubmissionLimitReached';
-            }
             return 'submitted'; // You have submitted an exercise. You can submit again
         } else if (!submission.submitted && submission.isSynced) {
             return 'notSubmitted'; // starting point

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -14,7 +14,6 @@ import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import { StudentExamWithGradeDTO } from 'app/exam/exam-scores/exam-score-dtos.model';
 import { captureException } from '@sentry/angular-ivy';
-import { ProgrammingExerciseStudentParticipation } from 'app/entities/participation/programming-exercise-student-participation.model';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 
 export type ButtonTooltipType = 'submitted' | 'submittedSubmissionLimitReached' | 'notSubmitted' | 'synced' | 'notSynced' | 'notSavedOrSubmitted';

--- a/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
@@ -9,7 +9,7 @@
     </div>
 
     <jhi-code-editor-container
-        [editable]="!participationIsLocked"
+        [editable]="true"
         [participation]="studentParticipation"
         [showEditorInstructions]="showEditorInstructions"
         [course]="getCourseFromExercise(exercise)"

--- a/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.ts
@@ -42,7 +42,6 @@ export class ProgrammingExamSubmissionComponent extends ExamSubmissionComponent 
     @Input()
     courseId: number;
 
-    participationIsLocked = false;
     showEditorInstructions = true;
     hasSubmittedOnce = false;
 
@@ -72,9 +71,6 @@ export class ProgrammingExamSubmissionComponent extends ExamSubmissionComponent 
      * Will load the participation according to participation Id with the latest result and result details.
      */
     ngOnInit(): void {
-        // We lock the online editor when the participation is locked.
-        // This is the case before the exam start date and after the individual exam end date, or when the submission limit is reached for the participation's exercise.
-        this.participationIsLocked = this.studentParticipation.locked ?? false;
         this.updateDomain();
     }
 

--- a/src/test/javascript/spec/component/exam/participate/exercises/programming-exam-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exercises/programming-exam-submission.component.spec.ts
@@ -73,29 +73,6 @@ describe('ProgrammingExamSubmissionComponent', () => {
         return participation;
     };
 
-    it('should initialize with unlocked repository', () => {
-        const exercise = newExercise();
-        component.exercise = exercise;
-        component.studentParticipation = {};
-
-        fixture.detectChanges();
-
-        expect(domainServiceSetDomainSpy).toHaveBeenCalledOnce();
-        expect(domainServiceSetDomainSpy).toHaveBeenCalledWith([DomainType.PARTICIPATION, { exercise }]);
-
-        expect(component.participationIsLocked).toBeFalse();
-        expect(component.getExercise()).toEqual(newExercise());
-    });
-
-    it('should set the participationIsLocked value to true', () => {
-        component.exercise = newExercise();
-        component.studentParticipation = { locked: true };
-
-        fixture.detectChanges();
-
-        expect(component.participationIsLocked).toBeTrue();
-    });
-
     it('should change state on commit', () => {
         component.studentParticipation = newParticipation();
 

--- a/src/test/javascript/spec/component/exam/participate/exercises/programming-exam-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exercises/programming-exam-submission.component.spec.ts
@@ -9,7 +9,7 @@ import { ProgrammingSubmission } from 'app/entities/programming-submission.model
 import { ProgrammingExamSubmissionComponent } from 'app/exam/participate/exercises/programming/programming-exam-submission.component';
 import { ModelingEditorComponent } from 'app/exercises/modeling/shared/modeling-editor.component';
 import { CodeEditorContainerComponent } from 'app/exercises/programming/shared/code-editor/container/code-editor-container.component';
-import { CommitState, DomainType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
+import { CommitState } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
 import { DomainService } from 'app/exercises/programming/shared/code-editor/service/code-editor-domain.service';
 import { IncludedInScoreBadgeComponent } from 'app/exercises/shared/exercise-headers/included-in-score-badge.component';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
@@ -22,9 +22,6 @@ import { ProgrammingExerciseStudentTriggerBuildButtonComponent } from 'app/exerc
 describe('ProgrammingExamSubmissionComponent', () => {
     let fixture: ComponentFixture<ProgrammingExamSubmissionComponent>;
     let component: ProgrammingExamSubmissionComponent;
-
-    let domainService: DomainService;
-    let domainServiceSetDomainSpy: jest.SpyInstance;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -47,9 +44,6 @@ describe('ProgrammingExamSubmissionComponent', () => {
             .then(() => {
                 fixture = TestBed.createComponent(ProgrammingExamSubmissionComponent);
                 component = fixture.componentInstance;
-                domainService = fixture.debugElement.injector.get(DomainService);
-
-                domainServiceSetDomainSpy = jest.spyOn(domainService, 'setDomain');
             });
     });
 
@@ -90,7 +84,7 @@ describe('ProgrammingExamSubmissionComponent', () => {
         expect(component.studentParticipation.submissions![0].isSynced).toBeTrue();
     });
 
-    it('should desync on file change', () => {
+    it('should not be synced on file change', () => {
         component.studentParticipation = newParticipation();
 
         component.studentParticipation.submissions![0].isSynced = true;


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.

### Motivation and Context
We got reports that students see "Your submission is locked" messages while working on the exam. This is becuase we don't reload the participation from the server. If the students open the exam before the unlock exercises date (exam visibility date is more than 5 minutes before the exam start), a locked participation gets loaded and never refreshed.

### Description
For now, we ignore the locked status in the exam client. Submission policies in exam exercises are barly used and are still supported on the server side.

### Steps for Testing
Prerequisites:
- 2 Student
- 1 Exam with Programming exercises and visibility date more than 5 minutes before the exam start
- Add many students to the exam -> long unlocking time

1. Open the exam more than 5 minutes before the start
2. Press the start button as soon as it becomes available
3. (Optional: Verify using the dev tools that the received participation has locked set to true)
4. Submit changes to the PE using both Git and the online code editor. There should not be any problems

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2