### PR TITLE
`Exam mode`: Speedup unlock operation for programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionPolicyService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionPolicyService.java
@@ -246,7 +246,7 @@ public class SubmissionPolicyService {
     private void unlockParticipationsWhenSubmissionsGreaterLimit(ProgrammingExercise exercise, int submissionLimit) {
         for (StudentParticipation studentParticipation : exercise.getStudentParticipations()) {
             if (getParticipationSubmissionCount(studentParticipation) >= submissionLimit) {
-                programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(exercise, (ProgrammingExerciseStudentParticipation) studentParticipation);
+                programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation((ProgrammingExerciseStudentParticipation) studentParticipation);
             }
         }
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/TeamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TeamService.java
@@ -12,6 +12,7 @@ import de.tum.in.www1.artemis.domain.enumeration.TeamImportStrategyType;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
+import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
 import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlService;
 import de.tum.in.www1.artemis.service.dto.TeamSearchUserDTO;
 import de.tum.in.www1.artemis.service.team.TeamImportStrategy;
@@ -90,8 +91,8 @@ public class TeamService {
             // Users in the updated team that were not yet part of the existing team need to be added
             Set<User> usersToAdd = new HashSet<>(updatedTeam.getStudents());
             usersToAdd.removeAll(existingTeam.getStudents());
-            usersToAdd.forEach(user -> versionControlService.orElseThrow().addMemberToRepository(participation.getVcsRepositoryUrl(), user,
-                    VersionControlService.RepositoryPermissions.READ_WRITE));
+            usersToAdd.forEach(
+                    user -> versionControlService.orElseThrow().addMemberToRepository(participation.getVcsRepositoryUrl(), user, VersionControlRepositoryPermission.REPO_WRITE));
         });
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
@@ -91,7 +91,7 @@ public class BitbucketService extends AbstractVersionControlService {
             }
 
             if (allowAccess) {
-                final RepositoryPermissions permissions = determineRepositoryPermissions(exercise);
+                final VersionControlRepositoryPermission permissions = determineRepositoryPermissions(exercise);
                 addMemberToRepository(participation.getVcsRepositoryUrl(), user, permissions);
             }
         }
@@ -102,19 +102,11 @@ public class BitbucketService extends AbstractVersionControlService {
     }
 
     @Override
-    public void addMemberToRepository(VcsRepositoryUrl repositoryUrl, User user, RepositoryPermissions permissions) {
+    public void addMemberToRepository(VcsRepositoryUrl repositoryUrl, User user, VersionControlRepositoryPermission permissions) {
         final String projectKey = urlService.getProjectKeyFromRepositoryUrl(repositoryUrl);
         final String urlSlug = urlService.getRepositorySlugFromRepositoryUrl(repositoryUrl);
-        final VersionControlRepositoryPermission repositoryPermission = getVersionControlPermissions(permissions);
 
-        giveRepoPermission(projectKey, urlSlug, user.getLogin(), repositoryPermission);
-    }
-
-    private static VersionControlRepositoryPermission getVersionControlPermissions(final RepositoryPermissions permissions) {
-        return switch (permissions) {
-            case READ_ONLY -> VersionControlRepositoryPermission.REPO_READ;
-            case READ_WRITE -> VersionControlRepositoryPermission.REPO_WRITE;
-        };
+        giveRepoPermission(projectKey, urlSlug, user.getLogin(), permissions);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
@@ -45,6 +45,7 @@ import de.tum.in.www1.artemis.service.connectors.ConnectorHealth;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.gitlab.dto.GitLabPushNotificationDTO;
 import de.tum.in.www1.artemis.service.connectors.vcs.AbstractVersionControlService;
+import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
 import de.tum.in.www1.artemis.service.util.UrlUtils;
 
 @Profile("gitlab")
@@ -92,7 +93,7 @@ public class GitLabService extends AbstractVersionControlService {
             }
 
             if (allowAccess) {
-                final RepositoryPermissions permissions = determineRepositoryPermissions(exercise);
+                final VersionControlRepositoryPermission permissions = determineRepositoryPermissions(exercise);
                 addMemberToRepository(participation.getVcsRepositoryUrl(), user, permissions);
             }
 
@@ -106,7 +107,7 @@ public class GitLabService extends AbstractVersionControlService {
     }
 
     @Override
-    public void addMemberToRepository(VcsRepositoryUrl repositoryUrl, User user, RepositoryPermissions permissions) {
+    public void addMemberToRepository(VcsRepositoryUrl repositoryUrl, User user, VersionControlRepositoryPermission permissions) {
         final String repositoryPath = urlService.getRepositoryPathFromRepositoryUrl(repositoryUrl);
         final Long userId = gitLabUserManagementService.getUserId(user.getLogin());
         final AccessLevel repositoryPermissions = permissionsToAccessLevel(permissions);
@@ -131,10 +132,10 @@ public class GitLabService extends AbstractVersionControlService {
         }
     }
 
-    private static AccessLevel permissionsToAccessLevel(final RepositoryPermissions permissions) {
+    private static AccessLevel permissionsToAccessLevel(final VersionControlRepositoryPermission permissions) {
         return switch (permissions) {
-            case READ_ONLY -> REPORTER;
-            case READ_WRITE -> DEVELOPER;
+            case REPO_READ -> REPORTER;
+            case REPO_WRITE -> DEVELOPER;
         };
     }
 
@@ -473,7 +474,7 @@ public class GitLabService extends AbstractVersionControlService {
 
     @Override
     public void setRepositoryPermissionsToReadOnly(VcsRepositoryUrl repositoryUrl, String projectKey, Set<User> users) {
-        users.forEach(user -> updateMemberPermissionInRepository(repositoryUrl, user, RepositoryPermissions.READ_ONLY));
+        users.forEach(user -> updateMemberPermissionInRepository(repositoryUrl, user, VersionControlRepositoryPermission.REPO_READ));
     }
 
     /**
@@ -483,7 +484,7 @@ public class GitLabService extends AbstractVersionControlService {
      * @param user          The GitLab user
      * @param permissions   The new access level for the user
      */
-    private void updateMemberPermissionInRepository(VcsRepositoryUrl repositoryUrl, User user, RepositoryPermissions permissions) {
+    private void updateMemberPermissionInRepository(VcsRepositoryUrl repositoryUrl, User user, VersionControlRepositoryPermission permissions) {
         final var userId = gitLabUserManagementService.getUserId(user.getLogin());
         final var repositoryPath = urlService.getRepositoryPathFromRepositoryUrl(repositoryUrl);
         try {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCService.java
@@ -43,6 +43,7 @@ import de.tum.in.www1.artemis.service.UrlService;
 import de.tum.in.www1.artemis.service.connectors.ConnectorHealth;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.vcs.AbstractVersionControlService;
+import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
 
 /**
  * Implementation of VersionControlService for the local VC server.
@@ -74,7 +75,7 @@ public class LocalVCService extends AbstractVersionControlService {
     }
 
     @Override
-    public void addMemberToRepository(VcsRepositoryUrl repositoryUrl, User user, RepositoryPermissions permissions) {
+    public void addMemberToRepository(VcsRepositoryUrl repositoryUrl, User user, VersionControlRepositoryPermission permissions) {
         // Members cannot be added to a local repository. Authenticated users have access by default and are authorized in the LocalVCFetchFilter and LocalVCPushFilter.
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/vcs/AbstractVersionControlService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/vcs/AbstractVersionControlService.java
@@ -191,13 +191,13 @@ public abstract class AbstractVersionControlService implements VersionControlSer
      * @param programmingExercise The programming exercise the repository belongs to.
      * @return The permissions the user should receive for a repository.
      */
-    protected RepositoryPermissions determineRepositoryPermissions(final ProgrammingExercise programmingExercise) {
+    protected VersionControlRepositoryPermission determineRepositoryPermissions(final ProgrammingExercise programmingExercise) {
         // NOTE: null values are interpreted as offline IDE is allowed
         if (Boolean.FALSE.equals(programmingExercise.isAllowOfflineIde())) {
-            return RepositoryPermissions.READ_ONLY;
+            return VersionControlRepositoryPermission.REPO_READ;
         }
         else {
-            return RepositoryPermissions.READ_WRITE;
+            return VersionControlRepositoryPermission.REPO_WRITE;
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/vcs/VersionControlService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/vcs/VersionControlService.java
@@ -135,11 +135,7 @@ public interface VersionControlService {
      * @param user          User which to add to the repository
      * @param permissions   The permissions the user should get for the repository.
      */
-    void addMemberToRepository(VcsRepositoryUrl repositoryUrl, User user, RepositoryPermissions permissions);
-
-    enum RepositoryPermissions {
-        READ_ONLY, READ_WRITE
-    }
+    void addMemberToRepository(VcsRepositoryUrl repositoryUrl, User user, VersionControlRepositoryPermission permissions);
 
     /**
      * Remove the user from the repository

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
@@ -678,7 +678,7 @@ public class StudentExamService {
                             programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(programmingExercise, programmingParticipation);
                         }
                         else {
-                            programmingExerciseParticipationService.lockStudentParticipation(programmingExercise, programmingParticipation);
+                            programmingExerciseParticipationService.lockStudentParticipation(programmingParticipation);
                         }
                     }
                     log.info("SUCCESS: Start exercise for student exam {} and exercise {} and student {}", studentExam.getId(), exercise.getId(),

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
@@ -675,7 +675,7 @@ public class StudentExamService {
                         if (studentExam.isTestRun() || studentExam.isTestExam()
                                 || ProgrammingExerciseScheduleService.getExamProgrammingExerciseUnlockDate(programmingExercise).isBefore(ZonedDateTime.now())) {
                             // Note: only unlock the programming exercise student repository for the affected user (Important: Do NOT invoke unlockAll)
-                            programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(programmingExercise, programmingParticipation);
+                            programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(programmingParticipation);
                         }
                         else {
                             programmingExerciseParticipationService.lockStudentParticipation(programmingParticipation);

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
@@ -276,10 +276,9 @@ public class ProgrammingExerciseParticipationService {
      * Unlock a student repository. This is necessary if the student is now allowed to submit either from the online editor or from their local Git client.
      * This is the case, if the start date of the exercise is in the past, if the due date is in the future, and if the student has not reached the submission limit yet.
      *
-     * @param programmingExercise the programming exercise this repository belongs to
-     * @param participation       the participation whose repository should be unlocked
+     * @param participation the participation whose repository should be unlocked
      */
-    public void unlockStudentRepository(ProgrammingExercise programmingExercise, ProgrammingExerciseStudentParticipation participation) {
+    public void unlockStudentRepository(ProgrammingExerciseStudentParticipation participation) {
         if (participation.getInitializationState().hasCompletedState(InitializationState.REPO_CONFIGURED)) {
             for (User user : participation.getStudents()) {
                 versionControlService.orElseThrow().addMemberToRepository(participation.getVcsRepositoryUrl(), user, VersionControlRepositoryPermission.REPO_WRITE);
@@ -294,12 +293,9 @@ public class ProgrammingExerciseParticipationService {
      * Unlock a student participation. This is necessary if the student is now allowed to submit either from the online editor or from their local Git client.
      * This is the case, if the start date of the exercise is in the past, if the due date is in the future, and if the student has not reached the submission limit yet.
      *
-     * @param programmingExercise the programming exercise this participation belongs to
-     *                                Note: This parameter is not required to unlock the student participation but needs to be present here to be able to use this method with
-     *                                ProgrammingExerciseScheduleService#runUnlockOperation(), which requires a BiConsumer.
-     * @param participation       the participation to be unlocked
+     * @param participation the participation to be unlocked
      */
-    public void unlockStudentParticipation(ProgrammingExercise programmingExercise, ProgrammingExerciseStudentParticipation participation) {
+    public void unlockStudentParticipation(ProgrammingExerciseStudentParticipation participation) {
         // Update the locked field for the given participation in the database.
         studentParticipationRepository.updateLockedById(participation.getId(), false);
         // Also set the correct value on the participation object in case the caller uses this participation for further processing.
@@ -309,13 +305,12 @@ public class ProgrammingExerciseParticipationService {
     /**
      * Unlock the repository associated with a programming participation and the participation itself.
      *
-     * @param programmingExercise the programming exercise
-     * @param participation       the programming exercise student participation whose repository should be unlocked
+     * @param participation the programming exercise student participation whose repository should be unlocked
      * @throws VersionControlException if unlocking was not successful, e.g. if the repository was already unlocked
      */
-    public void unlockStudentRepositoryAndParticipation(ProgrammingExercise programmingExercise, ProgrammingExerciseStudentParticipation participation) {
-        unlockStudentRepository(programmingExercise, participation);
-        unlockStudentParticipation(programmingExercise, participation);
+    public void unlockStudentRepositoryAndParticipation(ProgrammingExerciseStudentParticipation participation) {
+        unlockStudentRepository(participation);
+        unlockStudentParticipation(participation);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
@@ -22,6 +22,7 @@ import de.tum.in.www1.artemis.exception.VersionControlException;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
+import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
 import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlService;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
@@ -250,12 +251,9 @@ public class ProgrammingExerciseParticipationService {
      * Lock a student participation. This is necessary if the student is not allowed to submit either from the online editor or from their local Git client.
      * This is the case, if the start date of the exercise is in the future, if the due date is in the past, or if the student has reached the submission limit.
      *
-     * @param programmingExercise the programming exercise this participation belongs to
-     *                                Note: This parameter is not required to lock the student participation but needs to be present here to be able to use this method with
-     *                                ProgrammingExerciseScheduleService#invokeOperationOnAllParticipationsThatSatisfy(), which requires a BiConsumer.
-     * @param participation       the participation to be locked
+     * @param participation the participation to be locked
      */
-    public void lockStudentParticipation(ProgrammingExercise programmingExercise, ProgrammingExerciseStudentParticipation participation) {
+    public void lockStudentParticipation(ProgrammingExerciseStudentParticipation participation) {
         // Update the locked field for the given participation in the database.
         studentParticipationRepository.updateLockedById(participation.getId(), true);
         // Also set the correct value on the participation object in case the caller uses this participation for further processing.
@@ -271,7 +269,7 @@ public class ProgrammingExerciseParticipationService {
      */
     public void lockStudentRepositoryAndParticipation(ProgrammingExercise programmingExercise, ProgrammingExerciseStudentParticipation participation) {
         lockStudentRepository(programmingExercise, participation);
-        lockStudentParticipation(programmingExercise, participation);
+        lockStudentParticipation(participation);
     }
 
     /**
@@ -283,8 +281,9 @@ public class ProgrammingExerciseParticipationService {
      */
     public void unlockStudentRepository(ProgrammingExercise programmingExercise, ProgrammingExerciseStudentParticipation participation) {
         if (participation.getInitializationState().hasCompletedState(InitializationState.REPO_CONFIGURED)) {
-            // TODO: this calls protect branches which might not be necessary if the branches have already been protected during "start exercise" which is typically the case
-            versionControlService.orElseThrow().configureRepository(programmingExercise, participation, true);
+            for (User user : participation.getStudents()) {
+                versionControlService.orElseThrow().addMemberToRepository(participation.getVcsRepositoryUrl(), user, VersionControlRepositoryPermission.REPO_WRITE);
+            }
         }
         else {
             log.warn("Cannot unlock student repository for participation {} because the repository was not copied yet!", participation.getId());

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -840,7 +840,8 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
     private List<ProgrammingExerciseStudentParticipation> updateParticipationsLockedInDatabase(Long programmingExerciseId,
             Predicate<ProgrammingExerciseStudentParticipation> condition) throws EntityNotFoundException {
-        return invokeOperationOnAllParticipationsThatSatisfy(programmingExerciseId, programmingExerciseParticipationService::lockStudentParticipation, condition,
+        return invokeOperationOnAllParticipationsThatSatisfy(programmingExerciseId,
+                (programmingExercise, participation) -> programmingExerciseParticipationService.lockStudentParticipation(participation), condition,
                 "lock all student participations");
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -692,7 +692,6 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
                     if (dueDate != null) {
                         individualDueDates.add(new Tuple<>(dueDate, participation));
                     }
-                    programmingExercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(programmingExercise.getId());
                     unlockOperation.accept(programmingExercise, participation);
                 };
                 List<ProgrammingExerciseStudentParticipation> failedUnlockOperations = invokeOperationOnAllParticipationsThatSatisfy(programmingExerciseId,
@@ -887,6 +886,8 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
                 failedOperations.add(programmingExerciseStudentParticipation);
             }
         }
+
+        log.info("Finished executing (scheduled) task '{}' for programming exercise with id {}.", operationName, programmingExercise.getId());
 
         return failedOperations;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -5,6 +5,7 @@ import static de.tum.in.www1.artemis.config.Constants.EXAM_START_WAIT_TIME_MINUT
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -679,7 +680,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @return a Runnable that will unlock the repositories once it is executed
      */
     @NotNull
-    public Runnable runUnlockOperation(ProgrammingExercise exercise, BiConsumer<ProgrammingExercise, ProgrammingExerciseStudentParticipation> unlockOperation,
+    public Runnable runUnlockOperation(ProgrammingExercise exercise, Consumer<ProgrammingExerciseStudentParticipation> unlockOperation,
             Predicate<ProgrammingExerciseStudentParticipation> condition) {
         Long programmingExerciseId = exercise.getId();
         return () -> {
@@ -692,7 +693,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
                     if (dueDate != null) {
                         individualDueDates.add(new Tuple<>(dueDate, participation));
                     }
-                    unlockOperation.accept(programmingExercise, participation);
+                    unlockOperation.accept(participation);
                 };
                 List<ProgrammingExerciseStudentParticipation> failedUnlockOperations = invokeOperationOnAllParticipationsThatSatisfy(programmingExerciseId,
                         unlockAndCollectOperation, condition, "add write permissions to all student repositories");

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -508,8 +508,8 @@ public class ParticipationResource {
             instanceMessageSendService.sendProgrammingExerciseSchedule(programmingExercise.getId());
 
             // when changing the individual due date after the regular due date, the repository might already have been locked
-            updatedParticipations.stream().filter(exerciseDateService::isBeforeDueDate).forEach(participation -> programmingExerciseParticipationService
-                    .unlockStudentRepositoryAndParticipation(programmingExercise, (ProgrammingExerciseStudentParticipation) participation));
+            updatedParticipations.stream().filter(exerciseDateService::isBeforeDueDate).forEach(
+                    participation -> programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation((ProgrammingExerciseStudentParticipation) participation));
             // the new due date may be in the past, students should no longer be able to make any changes
             updatedParticipations.stream().filter(exerciseDateService::isAfterDueDate).forEach(participation -> programmingExerciseParticipationService
                     .lockStudentRepositoryAndParticipation(programmingExercise, (ProgrammingExerciseStudentParticipation) participation));

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingAssessmentResource.java
@@ -214,7 +214,7 @@ public class ProgrammingAssessmentResource extends AssessmentResource {
             participation.setIndividualDueDate(null);
             studentParticipationRepository.save(participation);
 
-            programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(programmingExercise, (ProgrammingExerciseStudentParticipation) participation);
+            programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation((ProgrammingExerciseStudentParticipation) participation);
         }
 
         return ResponseEntity.ok(newManualResult);

--- a/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
@@ -43,7 +43,6 @@ import de.tum.in.www1.artemis.service.UrlService;
 import de.tum.in.www1.artemis.service.connectors.bitbucket.BitbucketPermission;
 import de.tum.in.www1.artemis.service.connectors.bitbucket.dto.*;
 import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
-import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlService;
 
 @Component
 @Profile("bitbucket")
@@ -358,22 +357,18 @@ public class BitbucketRequestMockProvider {
     }
 
     public void mockGiveWritePermission(ProgrammingExercise exercise, String repositoryName, String username, HttpStatus status) throws URISyntaxException {
-        mockGiveRepoPermission(exercise, repositoryName, username, status, VersionControlService.RepositoryPermissions.READ_WRITE);
+        mockGiveRepoPermission(exercise, repositoryName, username, status, VersionControlRepositoryPermission.REPO_WRITE);
     }
 
     public void mockGiveReadPermission(ProgrammingExercise exercise, String repositoryName, String username, HttpStatus status) throws URISyntaxException {
-        mockGiveRepoPermission(exercise, repositoryName, username, status, VersionControlService.RepositoryPermissions.READ_ONLY);
+        mockGiveRepoPermission(exercise, repositoryName, username, status, VersionControlRepositoryPermission.REPO_READ);
     }
 
-    private void mockGiveRepoPermission(ProgrammingExercise exercise, String repositoryName, String username, HttpStatus status,
-            VersionControlService.RepositoryPermissions permissions) throws URISyntaxException {
-        final String repoPermissions = switch (permissions) {
-            case READ_ONLY -> "REPO_READ";
-            case READ_WRITE -> "REPO_WRITE";
-        };
+    private void mockGiveRepoPermission(ProgrammingExercise exercise, String repositoryName, String username, HttpStatus status, VersionControlRepositoryPermission permissions)
+            throws URISyntaxException {
         final var projectKey = exercise.getProjectKey();
         final var permissionPath = UriComponentsBuilder.fromUri(bitbucketServerUrl.toURI()).path("/rest/api/latest/projects/").pathSegment(projectKey).path("/repos/")
-                .pathSegment(repositoryName).path("/permissions/users").queryParam("name", username).queryParam("permission", repoPermissions).build().toUri();
+                .pathSegment(repositoryName).path("/permissions/users").queryParam("name", username).queryParam("permission", permissions.toString()).build().toUri();
 
         mockServer.expect(requestTo(permissionPath)).andExpect(method(HttpMethod.PUT)).andRespond(withStatus(status));
     }

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -65,6 +65,7 @@ import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.QuizSubmissionService;
+import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
 import de.tum.in.www1.artemis.service.dto.StudentDTO;
 import de.tum.in.www1.artemis.service.exam.*;
 import de.tum.in.www1.artemis.service.ldap.LdapUserDto;
@@ -662,9 +663,11 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
                 assertThat(participation.getExercise().getExerciseGroup()).isEqualTo(exam2.getExerciseGroups().get(0));
                 // No initial submissions should be created for programming exercises
                 assertThat(participation.getSubmissions()).isEmpty();
+                ProgrammingExerciseStudentParticipation studentParticipation = (ProgrammingExerciseStudentParticipation) participation;
                 // The participation should not get locked if it gets created after the exam already started
-                assertThat(((ProgrammingExerciseParticipation) participation).isLocked()).isFalse();
-                verify(versionControlService, atLeastOnce()).configureRepository(eq(programmingExercise), (ProgrammingExerciseStudentParticipation) eq(participation), eq(true));
+                assertThat(studentParticipation.isLocked()).isFalse();
+                verify(versionControlService).addMemberToRepository(studentParticipation.getVcsRepositoryUrl(), studentParticipation.getStudent().orElseThrow(),
+                        VersionControlRepositoryPermission.REPO_WRITE);
             }
         }
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingAssessmentIntegrationTest.java
@@ -897,14 +897,14 @@ class ProgrammingAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         result.setScore(100D);
         resultRepository.save(result);
 
-        doNothing().when(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(programmingExercise, participation);
+        doNothing().when(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(participation);
 
         var response = request.putWithResponseBody("/api/participations/" + participation.getId() + "/manual-results", result, Result.class, HttpStatus.OK);
 
         var responseParticipation = response.getParticipation();
         assertThat(responseParticipation.getIndividualDueDate()).isNull();
 
-        verify(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(programmingExercise, participation);
+        verify(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(participation);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -64,6 +64,7 @@ import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.FileService;
 import de.tum.in.www1.artemis.service.UrlService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
+import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
 import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlService;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.*;
@@ -1658,8 +1659,10 @@ class ProgrammingExerciseIntegrationTestService {
         final var endpoint = ProgrammingExerciseResourceEndpoints.UNLOCK_ALL_REPOSITORIES.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));
         request.put(ROOT + endpoint, null, HttpStatus.OK);
 
-        verify(versionControlService).configureRepository(programmingExercise, participation1, true);
-        verify(versionControlService).configureRepository(programmingExercise, participation2, true);
+        verify(versionControlService).addMemberToRepository(participation1.getVcsRepositoryUrl(), participation1.getStudent().orElseThrow(),
+                VersionControlRepositoryPermission.REPO_WRITE);
+        verify(versionControlService).addMemberToRepository(participation2.getVcsRepositoryUrl(), participation2.getStudent().orElseThrow(),
+                VersionControlRepositoryPermission.REPO_WRITE);
 
         userUtilService.changeUser(userPrefix + "instructor1");
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseScheduleServiceTest.java
@@ -137,8 +137,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
             ProgrammingExerciseStudentParticipation programmingExerciseStudentParticipation = (ProgrammingExerciseStudentParticipation) studentParticipation;
             verify(versionControlService, timeout(timeoutInMs).times(callCount)).setRepositoryPermissionsToReadOnly(programmingExerciseStudentParticipation.getVcsRepositoryUrl(),
                     programmingExercise.getProjectKey(), programmingExerciseStudentParticipation.getStudents());
-            verify(programmingExerciseParticipationService, timeout(timeoutInMs).times(callCount)).lockStudentParticipation(programmingExercise,
-                    programmingExerciseStudentParticipation);
+            verify(programmingExerciseParticipationService, timeout(timeoutInMs).times(callCount)).lockStudentParticipation(programmingExerciseStudentParticipation);
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
@@ -74,6 +74,7 @@ import de.tum.in.www1.artemis.service.UrlService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.ci.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.connectors.gitlab.GitLabException;
+import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
 import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlService;
 import de.tum.in.www1.artemis.service.programming.JavaTemplateUpgradeService;
 import de.tum.in.www1.artemis.service.programming.ProgrammingLanguageFeature;
@@ -1071,12 +1072,12 @@ public class ProgrammingExerciseTestService {
 
         startProgrammingExercise_correctInitializationState(INDIVIDUAL);
 
-        final VersionControlService.RepositoryPermissions permissions;
+        final VersionControlRepositoryPermission permissions;
         if (offlineIde == null || Boolean.TRUE.equals(offlineIde)) {
-            permissions = VersionControlService.RepositoryPermissions.READ_WRITE;
+            permissions = VersionControlRepositoryPermission.REPO_WRITE;
         }
         else {
-            permissions = VersionControlService.RepositoryPermissions.READ_ONLY;
+            permissions = VersionControlRepositoryPermission.REPO_READ;
         }
 
         final User participant = userRepo.getUserByLoginElseThrow(userPrefix + studentLogin);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
@@ -61,6 +61,7 @@ import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismComparisonRepository;
 import de.tum.in.www1.artemis.service.BuildLogEntryService;
+import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseParticipationService;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.GitUtilService;
@@ -1027,7 +1028,8 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
         doAnswer((Answer<Void>) invocation -> {
             ((ProgrammingExercise) participation.getExercise()).setBuildAndTestStudentSubmissionsAfterDueDate(null);
             return null;
-        }).when(versionControlService).configureRepository(programmingExercise, participation, true);
+        }).when(versionControlService).addMemberToRepository(participation.getVcsRepositoryUrl(), participation.getStudent().orElseThrow(),
+                VersionControlRepositoryPermission.REPO_WRITE);
 
         programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(participation);
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
@@ -1029,7 +1029,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
             return null;
         }).when(versionControlService).configureRepository(programmingExercise, participation, true);
 
-        programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(programmingExercise, participation);
+        programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(participation);
 
         assertThat(((ProgrammingExercise) participation.getExercise()).getBuildAndTestStudentSubmissionsAfterDueDate()).isNull();
         assertThat(participation.isLocked()).isFalse();
@@ -1039,7 +1039,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testUnlockStudentRepository_beforeStateRepoConfigured() {
         participation.setInitializationState(InitializationState.REPO_COPIED);
-        programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(programmingExercise, participation);
+        programmingExerciseParticipationService.unlockStudentRepositoryAndParticipation(participation);
 
         // Check the logs
         List<ILoggingEvent> logsList = listAppender.list;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/SubmissionPolicyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/SubmissionPolicyIntegrationTest.java
@@ -250,9 +250,7 @@ class SubmissionPolicyIntegrationTest extends AbstractSpringIntegrationBambooBit
         programmingExerciseUtilService.addProgrammingSubmissionToResultAndParticipation(new Result().score(30.0), participation2, "commit3");
         String repositoryName = programmingExercise.getProjectKey().toLowerCase() + "-" + TEST_PREFIX + "student2";
         bitbucketRequestMockProvider.enableMockingOfRequests();
-        bitbucketRequestMockProvider.mockUserExists(TEST_PREFIX + "student2");
         bitbucketRequestMockProvider.mockGiveWritePermission(programmingExercise, repositoryName, TEST_PREFIX + "student2", HttpStatus.OK);
-        bitbucketRequestMockProvider.mockProtectBranches(programmingExercise, repositoryName);
         request.patch(requestUrl(), SubmissionPolicyBuilder.lockRepo().active(true).limit(3).policy(), HttpStatus.OK);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
@@ -908,7 +908,7 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         final var participation2 = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student2");
         participation2.setIndividualDueDate(ZonedDateTime.now().plusHours(1));
 
-        doNothing().when(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(exercise, participation);
+        doNothing().when(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(participation);
 
         final var participationsToUpdate = new StudentParticipationList(participation, participation2);
         final var response = request.putWithResponseBodyList(String.format("/api/exercises/%d/participations/update-individual-due-date", exercise.getId()), participationsToUpdate,
@@ -918,8 +918,8 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         assertThat(response.get(0).getIndividualDueDate()).isEqualToIgnoringNanos(participation.getIndividualDueDate());
 
         verify(programmingExerciseScheduleService).updateScheduling(exercise);
-        verify(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(exercise, participation);
-        verify(programmingExerciseParticipationService, never()).unlockStudentRepositoryAndParticipation(exercise, participation2);
+        verify(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(participation);
+        verify(programmingExerciseParticipationService, never()).unlockStudentRepositoryAndParticipation(participation2);
     }
 
     @Test
@@ -937,7 +937,7 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
 
         assertThat(response).isEmpty();
         verify(programmingExerciseScheduleService, never()).updateScheduling(exercise);
-        verify(programmingExerciseParticipationService, never()).unlockStudentRepositoryAndParticipation(exercise, participation);
+        verify(programmingExerciseParticipationService, never()).unlockStudentRepositoryAndParticipation(participation);
     }
 
     @Test
@@ -957,7 +957,7 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
 
         assertThat(response).isEmpty(); // individual due date should remain null
         verify(programmingExerciseScheduleService, never()).updateScheduling(exercise);
-        verify(programmingExerciseParticipationService, never()).unlockStudentRepositoryAndParticipation(exercise, participation);
+        verify(programmingExerciseParticipationService, never()).unlockStudentRepositoryAndParticipation(participation);
     }
 
     @Test
@@ -974,7 +974,7 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
 
         participation.setIndividualDueDate(ZonedDateTime.now().plusHours(2));
 
-        doNothing().when(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(exercise, participation);
+        doNothing().when(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(participation);
 
         final var participationsToUpdate = new StudentParticipationList(participation);
         final var response = request.putWithResponseBodyList(String.format("/api/exercises/%d/participations/update-individual-due-date", exercise.getId()), participationsToUpdate,
@@ -983,7 +983,7 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         assertThat(response).hasSize(1);
         verify(programmingExerciseScheduleService).updateScheduling(exercise);
         // make sure the student repo is unlocked as the due date is in the future
-        verify(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(exercise, participation);
+        verify(programmingExerciseParticipationService).unlockStudentRepositoryAndParticipation(participation);
     }
 
     @Test


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
Unlocking many repositories could take some time. This PR aims to speedup the process.

### Description
The performance increments come from:
- Reducing the needed calls to the external system from 2 to 1 (we only configure the branch settings once, that's not needed every time).
- Removing an unnecessary database call that was executed for every participation.

This cuts the time needed for the unlock operation in half!

The other changes in this PR are refactorings:
- Since the unlock operations don't need the programming exercise, we removed the parameter. This should avoid unnecessary database operations in the future.
- There were two duplicated enums containing repository permissions. We now removed one of them.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Exam with many participations

1. Use prepare exercises to create the repositories
2. Verify that branch protection rules are in place. Verify that the students cannot push to the repository.
3. Use the "unlock repositories" button or wait until the planed start of the exercise
4. Verify that all participations got successfully unlocked.

### Review Progress
#### Performance Review
- [x] I confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2