### PR TITLE
`Development`: Reduce `for-dashboard` payload significantly when participation results exist

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/CourseScoreCalculationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseScoreCalculationService.java
@@ -230,12 +230,16 @@ public class CourseScoreCalculationService {
         Map<ExerciseType, CourseScoresDTO> scoresPerExerciseType = calculateCourseScoresPerExerciseType(course, gradedStudentParticipations, userId, plagiarismCases);
 
         // Get participation results (used in course-statistics.component).
-        List<Result> participationResults = new ArrayList<>();
+        List<ParticipationResultDTO> participationResults = new ArrayList<>();
         for (StudentParticipation studentParticipation : gradedStudentParticipations) {
             if (studentParticipation.getResults() != null && !studentParticipation.getResults().isEmpty()) {
-                Result participationResult = getResultForParticipation(studentParticipation, studentParticipation.getIndividualDueDate());
-                participationResult.setParticipation(studentParticipation);
+                Result result = getResultForParticipation(studentParticipation, studentParticipation.getIndividualDueDate());
+                var participationResult = new ParticipationResultDTO(result.getScore(), result.isRated(), studentParticipation.getId());
                 participationResults.add(participationResult);
+                // this line is an important workaround. It prevents that the whole tree
+                // "result -> participation -> exercise -> course -> exercises -> studentParticipations -> submissions -> results" is sent again to the client which is useless
+                // TODO: in the future, we need a better solution to prevent this
+                studentParticipation.setExercise(null);
             }
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/CourseForDashboardDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/CourseForDashboardDTO.java
@@ -5,7 +5,6 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.in.www1.artemis.domain.Course;
-import de.tum.in.www1.artemis.domain.Result;
 
 /**
  * Returned by the for-dashboard resources.
@@ -23,5 +22,5 @@ import de.tum.in.www1.artemis.domain.Result;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record CourseForDashboardDTO(Course course, CourseScoresDTO totalScores, CourseScoresDTO textScores, CourseScoresDTO programmingScores, CourseScoresDTO modelingScores,
-        CourseScoresDTO fileUploadScores, CourseScoresDTO quizScores, List<Result> participationResults) {
+        CourseScoresDTO fileUploadScores, CourseScoresDTO quizScores, List<ParticipationResultDTO> participationResults) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ParticipationResultDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ParticipationResultDTO.java
@@ -1,0 +1,7 @@
+package de.tum.in.www1.artemis.web.rest.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ParticipationResultDTO(Double score, Boolean rated, Long participationId) {
+}

--- a/src/main/webapp/app/course/course-scores/scores-storage.service.ts
+++ b/src/main/webapp/app/course/course-scores/scores-storage.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
+import { ParticipationResultDTO } from 'app/course/manage/course-for-dashboard-dto';
 import { ScoresPerExerciseType } from 'app/entities/exercise.model';
-import { Result } from 'app/entities/result.model';
 import { CourseScores } from 'app/course/course-scores/course-scores';
 
 /**
@@ -24,7 +24,7 @@ export class ScoresStorageService {
     /**
      * This map stores the {@link Result} object for each {@link Participation} of the currently logged-in user. The number is the id of the participation.
      */
-    private storedParticipationResults: Map<number, Result> = new Map();
+    private storedParticipationResults: Map<number, ParticipationResultDTO> = new Map();
 
     getStoredTotalScores(courseId: number): CourseScores | undefined {
         return this.storedTotalScores.get(courseId);
@@ -42,13 +42,13 @@ export class ScoresStorageService {
         this.storedScoresPerExerciseType.set(courseId, scoresPerExerciseType);
     }
 
-    getStoredParticipationResult(participationId: number): Result | undefined {
+    getStoredParticipationResult(participationId: number): ParticipationResultDTO | undefined {
         return this.storedParticipationResults.get(participationId);
     }
 
-    setStoredParticipationResults(participationResults?: Result[]): void {
-        for (const result of participationResults ?? []) {
-            this.storedParticipationResults.set(result.participation!.id!, result);
+    setStoredParticipationResults(participationResults?: ParticipationResultDTO[]): void {
+        for (const participationResult of participationResults ?? []) {
+            this.storedParticipationResults.set(participationResult.participationId, participationResult);
         }
     }
 }

--- a/src/main/webapp/app/course/manage/course-for-dashboard-dto.ts
+++ b/src/main/webapp/app/course/manage/course-for-dashboard-dto.ts
@@ -1,6 +1,5 @@
 import { Course } from 'app/entities/course.model';
 import { CourseScores } from 'app/course/course-scores/course-scores';
-import { Result } from 'app/entities/result.model';
 
 export class CourseForDashboardDTO {
     course: Course;
@@ -13,7 +12,14 @@ export class CourseForDashboardDTO {
     fileUploadScores: CourseScores;
     quizScores: CourseScores;
 
-    participationResults: Result[];
+    participationResults: ParticipationResultDTO[];
 
+    constructor() {}
+}
+
+export class ParticipationResultDTO {
+    score?: number;
+    rated?: boolean;
+    participationId: number;
     constructor() {}
 }

--- a/src/main/webapp/app/overview/course-statistics/course-statistics.component.ts
+++ b/src/main/webapp/app/overview/course-statistics/course-statistics.component.ts
@@ -5,6 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Color, ScaleType } from '@swimlane/ngx-charts';
 import { CourseScores } from 'app/course/course-scores/course-scores';
 import { ScoresStorageService } from 'app/course/course-scores/scores-storage.service';
+import { ParticipationResultDTO } from 'app/course/manage/course-for-dashboard-dto';
 import { CourseStorageService } from 'app/course/manage/course-storage.service';
 import { Course } from 'app/entities/course.model';
 import { Exercise, ExerciseType, IncludedInOverallScore, ScoresPerExerciseType } from 'app/entities/exercise.model';
@@ -12,7 +13,6 @@ import { GradeDTO } from 'app/entities/grade-step.model';
 import { GradeType } from 'app/entities/grading-scale.model';
 import { InitializationState } from 'app/entities/participation/participation.model';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
-import { Result } from 'app/entities/result.model';
 import { GraphColors } from 'app/entities/statistics.model';
 import { GradingSystemService } from 'app/grading-system/grading-system.service';
 import { BarControlConfiguration, BarControlConfigurationProvider } from 'app/shared/tab-bar/tab-bar';
@@ -326,7 +326,7 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy, AfterViewIn
                 } else {
                     exercise.studentParticipations.forEach((participation: StudentParticipation) => {
                         if (participation.id && participation.results?.length) {
-                            const participationResult: Result | undefined = this.scoresStorageService.getStoredParticipationResult(participation.id);
+                            const participationResult: ParticipationResultDTO | undefined = this.scoresStorageService.getStoredParticipationResult(participation.id);
                             if (participationResult?.rated) {
                                 const roundedParticipationScore = roundValueSpecifiedByCourseSettings(participationResult.score!, this.course);
                                 const cappedParticipationScore = Math.min(roundedParticipationScore, 100);

--- a/src/test/javascript/spec/component/course/course-management.service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management.service.spec.ts
@@ -21,11 +21,10 @@ import { MockRouter } from '../../helpers/mocks/mock-router';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { OnlineCourseConfiguration } from 'app/entities/online-course-configuration.model';
-import { CourseForDashboardDTO } from 'app/course/manage/course-for-dashboard-dto';
+import { CourseForDashboardDTO, ParticipationResultDTO } from 'app/course/manage/course-for-dashboard-dto';
 import { CourseScores } from 'app/course/course-scores/course-scores';
 import { ScoresStorageService } from 'app/course/course-scores/scores-storage.service';
 import { CourseStorageService } from 'app/course/manage/course-storage.service';
-import { Result } from 'app/entities/result.model';
 
 describe('Course Management Service', () => {
     let courseManagementService: CourseManagementService;
@@ -48,7 +47,7 @@ describe('Course Management Service', () => {
     let courseForDashboard: CourseForDashboardDTO;
     let courseScores: CourseScores;
     let scoresPerExerciseType: ScoresPerExerciseType;
-    let participationResult: Result;
+    let participationResult: ParticipationResultDTO;
     let onlineCourseConfiguration: OnlineCourseConfiguration;
     let exercises: Exercise[];
     let returnedFromService: any;
@@ -96,10 +95,8 @@ describe('Course Management Service', () => {
         courseForDashboard.quizScores = courseScores;
         courseForDashboard.textScores = courseScores;
         courseForDashboard.fileUploadScores = courseScores;
-        participationResult = new Result();
-        const participation = new StudentParticipation();
-        participation.id = 432;
-        participationResult.participation = participation;
+        participationResult = new ParticipationResultDTO();
+        participationResult.participationId = 432;
         courseForDashboard.participationResults = [participationResult];
 
         scoresPerExerciseType = new Map<ExerciseType, CourseScores>();

--- a/src/test/javascript/spec/component/overview/course-statistics/course-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-statistics/course-statistics.component.spec.ts
@@ -7,6 +7,7 @@ import { BarChartModule, PieChartModule } from '@swimlane/ngx-charts';
 import { CourseScores } from 'app/course/course-scores/course-scores';
 import { ScoresStorageService } from 'app/course/course-scores/scores-storage.service';
 import { DueDateStat } from 'app/course/dashboards/due-date-stat.model';
+import { ParticipationResultDTO } from 'app/course/manage/course-for-dashboard-dto';
 import { CourseStorageService } from 'app/course/manage/course-storage.service';
 import { Course } from 'app/entities/course.model';
 import { ExerciseCategory } from 'app/entities/exercise-category.model';
@@ -15,7 +16,6 @@ import { FileUploadExercise } from 'app/entities/file-upload-exercise.model';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
-import { Result } from 'app/entities/result.model';
 import { TreeviewModule } from 'app/exercises/programming/shared/code-editor/treeview/treeview.module';
 import { CourseCompetenciesComponent } from 'app/overview/course-competencies/course-competencies.component';
 import { CourseStatisticsComponent, NgxExercise } from 'app/overview/course-statistics/course-statistics.component';
@@ -360,7 +360,7 @@ describe('CourseStatisticsComponent', () => {
         const courseToAdd = { ...course };
         courseToAdd.exercises = [programmingExercise, quizExercise, ...modelingExercises, fileUploadExercise];
         jest.spyOn(courseStorageService, 'getCourse').mockReturnValue(courseToAdd);
-        const mockParticipationResult: Result = { rated: true, score: 100 };
+        const mockParticipationResult: ParticipationResultDTO = { rated: true, score: 100, participationId: 1 };
         jest.spyOn(scoresStorageService, 'getStoredParticipationResult').mockReturnValue(mockParticipationResult);
         fixture.detectChanges();
         comp.ngOnInit();
@@ -384,7 +384,7 @@ describe('CourseStatisticsComponent', () => {
         const courseToAdd = { ...course };
         courseToAdd.exercises = [...modelingExercises];
         jest.spyOn(courseStorageService, 'getCourse').mockReturnValue(courseToAdd);
-        const mockParticipationResult: Result = { rated: true, score: 100 };
+        const mockParticipationResult: ParticipationResultDTO = { rated: true, score: 100, participationId: 1 };
         jest.spyOn(scoresStorageService, 'getStoredParticipationResult').mockReturnValue(mockParticipationResult);
         fixture.detectChanges();
         comp.ngOnInit();
@@ -480,7 +480,7 @@ describe('CourseStatisticsComponent', () => {
         });
 
         it('should filter optional exercises correctly', () => {
-            const mockParticipationResult: Result = { rated: true, score: 100 };
+            const mockParticipationResult: ParticipationResultDTO = { rated: true, score: 100, participationId: 1 };
             jest.spyOn(scoresStorageService, 'getStoredParticipationResult').mockReturnValue(mockParticipationResult);
             comp.toggleNotIncludedInScoreExercises();
 

--- a/src/test/javascript/spec/service/scores-storage.service.spec.ts
+++ b/src/test/javascript/spec/service/scores-storage.service.spec.ts
@@ -12,10 +12,10 @@ describe('ScoresStorageService', () => {
         participation2.id = 2;
 
         scoresStorageService.setStoredParticipationResults([
-            { successful: true, participation: participation1 },
-            { successful: false, participation: participation2 },
+            { score: 100, participationId: participation1.id },
+            { score: 0, participationId: participation2.id },
         ]);
-        expect(scoresStorageService.getStoredParticipationResult(1)).toEqual({ successful: true, participation: participation1 });
+        expect(scoresStorageService.getStoredParticipationResult(1)).toEqual({ score: 100, participationId: participation1.id });
         // Should return undefined for an unknown participation id.
         expect(scoresStorageService.getStoredParticipationResult(3)).toBeUndefined();
     });
@@ -24,7 +24,7 @@ describe('ScoresStorageService', () => {
         const scoresStorageService = new ScoresStorageService();
         const participation = new StudentParticipation();
         participation.id = 234;
-        scoresStorageService.setStoredParticipationResults([{ successful: true, participation }]);
+        scoresStorageService.setStoredParticipationResults([{ score: 100, participationId: participation.id }]);
         expect(scoresStorageService.getStoredParticipationResult(1)).toBeUndefined();
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
For each participation result, the `for-dashboard` REST call includes the whole data again, because of the chain "result -> participation -> exercise -> course -> exercises -> studentParticipations -> submissions -> results". In the worst case, this could result in a 80x larger payload in case a student participated in 80 course exercises. 

### Description
I created a new DTO because basically just 3 values are needed in the client: score, rated, participationId

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Open Artemis and navigate into the course statistics
2. Double check there are not Typescript errors in the console related to the changes in this PR
3. Make sure the statistics are still the same as before (when e.g. deploying `develop`) 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2