### PR TITLE
`Development`: Fix start of Artemis in GitLab/Jenkins setups

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
@@ -61,8 +61,8 @@ public class GitLabService extends AbstractVersionControlService {
     @Value("${artemis.version-control.ci-token}")
     private String ciToken;
 
-    @Value("${artemis.version-control.health-api-token}")
-    private Optional<String> ciHealthToken;
+    @Value("${artemis.version-control.health-api-token:#{null}}")
+    private Optional<String> healthToken;
 
     private final UserRepository userRepository;
 
@@ -510,7 +510,7 @@ public class GitLabService extends AbstractVersionControlService {
     public ConnectorHealth health() {
         try {
             UriComponentsBuilder builder = Endpoints.HEALTH.buildEndpoint(gitlabServerUrl.toString());
-            ciHealthToken.ifPresent(token -> builder.queryParam("token", token));
+            healthToken.ifPresent(token -> builder.queryParam("token", token));
             URI uri = builder.build().toUri();
 
             final var healthResponse = shortTimeoutRestTemplate.getForObject(uri, JsonNode.class);

--- a/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
@@ -60,7 +60,7 @@ public class GitlabRequestMockProvider {
     private URL gitlabServerUrl;
 
     @Value("${artemis.version-control.health-api-token}")
-    private String ciHealthToken;
+    private String healthToken;
 
     private final RestTemplate restTemplate;
 
@@ -342,7 +342,7 @@ public class GitlabRequestMockProvider {
     }
 
     public void mockHealth(String healthStatus, HttpStatus httpStatus) throws URISyntaxException, JsonProcessingException {
-        final var uri = UriComponentsBuilder.fromUri(gitlabServerUrl.toURI()).path("/-/liveness").queryParam("token", ciHealthToken).build().toUri();
+        final var uri = UriComponentsBuilder.fromUri(gitlabServerUrl.toURI()).path("/-/liveness").queryParam("token", healthToken).build().toUri();
         final var response = new ObjectMapper().writeValueAsString(Map.of("status", healthStatus));
         mockServerShortTimeout.expect(requestTo(uri)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(httpStatus).contentType(MediaType.APPLICATION_JSON).body(response));
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
Artemis 6.3.8 does not start in GitLab setups since the optional new configuration value introduced in #6948 is not truly optional, but required since no default is set.

### Description
Makes the configuration value properly optional.
Gives the attribute a better name, since the token is used to authenticate against GitLab, not Jenkins.

### Steps for Testing
1. Start Artemis in a GitLab/Jenkins setup.
2. Artemis starts.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2