### PR TITLE
`Assessment`: Escape special characters in inline feedback

### DIFF
--- a/src/main/webapp/app/entities/feedback.model.ts
+++ b/src/main/webapp/app/entities/feedback.model.ts
@@ -2,7 +2,7 @@ import { BaseEntity } from 'app/shared/model/base-entity';
 import { Result } from 'app/entities/result.model';
 import { TextBlock } from 'app/entities/text-block.model';
 import { GradingInstruction } from 'app/exercises/shared/structured-grading-criterion/grading-instruction.model';
-import { convertToHtmlLinebreaks } from 'app/utils/text.utils';
+import { convertToHtmlLinebreaks, escapeString } from 'app/utils/text.utils';
 
 export enum FeedbackHighlightColor {
     RED = 'rgba(219, 53, 69, 0.6)',
@@ -213,6 +213,8 @@ export const buildFeedbackTextForReview = (feedback: Feedback, addFeedbackText =
         feedbackText = feedback.text;
     }
 
+    // escape special characters like "<", ">", "&" to render them correctly
+    feedbackText = escapeString(feedbackText);
     return convertToHtmlLinebreaks(feedbackText);
 };
 /**

--- a/src/test/javascript/spec/component/programming-assessment/code-editor-tutor-assessment-inline-feedback.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/code-editor-tutor-assessment-inline-feedback.component.spec.ts
@@ -137,4 +137,14 @@ describe('CodeEditorTutorAssessmentInlineFeedbackComponent', () => {
         textToBeDisplayed = comp.buildFeedbackTextForCodeEditor(feedback);
         expect(textToBeDisplayed).toEqual(gradingInstruction.feedback + '<br>' + feedback.detailText);
     });
+
+    it('should escape special characters', () => {
+        const feedbackWithSpecialCharacters = {
+            detailText: 'feedback <with> special characters & "',
+        } as Feedback;
+        const expectedTextToBeDisplayed = 'feedback &lt;with&gt; special characters &amp; &quot;';
+
+        const textToBeDisplayed = comp.buildFeedbackTextForCodeEditor(feedbackWithSpecialCharacters);
+        expect(textToBeDisplayed).toEqual(expectedTextToBeDisplayed);
+    });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
The inline feedback in the programming exercise assessment renderer sanitized the feedback text from HTML alike tags (e.g. "&lt;something >") because it misinterpreted it as HTML tag. It should be possible to use and display comments including special characters. This resolves #6965 

### Description
This PR uses an already existing escaping function to replace special characters with their unicode representation. (This could lead to weird displaying if the string is inserted in HTML as actual string, but this would already be an issue because of the replacement of line separators with "<br>")

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students
- 1 Programming Exercise with manual assessment enabled

1. Log in to Artemis
2. Navigate to Exercise assessment
3. write inline feedback including some special character combinations (especially also HTML tags, e.g. &lt;div>hello&lt;/div>)
4. verify that they are displayed correctly (just like you wrote it) in the assessment and student view


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
![image](https://github.com/ls1intum/Artemis/assets/78978542/6abbbaaa-9395-4de4-9cd5-b412b12c3c12)

![image](https://github.com/ls1intum/Artemis/assets/78978542/208db550-2bf5-422c-b60b-f33ec2e52a85)
