### PR TITLE
`Programming exercises`: Don't create new submissions for test case changes

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
@@ -108,10 +108,6 @@ public class ProgrammingSubmission extends Submission {
         this.buildLogEntries = buildLogEntries;
     }
 
-    public boolean belongsToTestRepository() {
-        return SubmissionType.TEST.equals(getType());
-    }
-
     @Override
     public boolean isEmpty() {
         return false; // programming submissions cannot be empty, they are only created for actual commits in the git repository

--- a/src/main/java/de/tum/in/www1/artemis/repository/TemplateProgrammingExerciseParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/TemplateProgrammingExerciseParticipationRepository.java
@@ -38,6 +38,11 @@ public interface TemplateProgrammingExerciseParticipationRepository extends JpaR
 
     Optional<TemplateProgrammingExerciseParticipation> findByProgrammingExerciseId(Long programmingExerciseId);
 
+    default TemplateProgrammingExerciseParticipation findWithEagerSubmissionsByProgrammingExerciseIdElseThrow(Long exerciseId) {
+        var optional = findWithEagerSubmissionsByProgrammingExerciseId(exerciseId);
+        return optional.orElseThrow(() -> new EntityNotFoundException("Template Programming Exercise Participation", exerciseId));
+    }
+
     default TemplateProgrammingExerciseParticipation findByProgrammingExerciseIdElseThrow(Long programmingExerciseId) {
         var optional = findByProgrammingExerciseId(programmingExerciseId);
         return optional.orElseThrow(() -> new EntityNotFoundException("Template Programming Exercise Participation", programmingExerciseId));

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIConnectorService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIConnectorService.java
@@ -22,7 +22,6 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.enumeration.RepositoryType;
-import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.exception.LocalCIException;
@@ -179,7 +178,8 @@ public class LocalCIConnectorService {
         // Create a new submission for the solution repository.
         ProgrammingSubmission submission;
         try {
-            submission = programmingSubmissionService.createSolutionParticipationSubmissionWithTypeTest(exercise.getId(), commitHash);
+            submission = (ProgrammingSubmission) solutionParticipation.findLatestSubmission()
+                    .orElse(programmingSubmissionService.createSolutionParticipationSubmissionWithTypeTest(exercise.getId(), commitHash));
         }
         catch (EntityNotFoundException | IllegalStateException e) {
             throw new LocalCIException("Could not create submission for solution participation", e);
@@ -207,7 +207,7 @@ public class LocalCIConnectorService {
 
             // The solution participation received a new result, also trigger a build of the template repository.
             try {
-                programmingTriggerService.triggerTemplateBuildAndNotifyUser(exercise.getId(), submission.getCommitHash(), SubmissionType.TEST);
+                programmingTriggerService.triggerTemplateBuildAndNotifyUser(exercise.getId());
             }
             catch (EntityNotFoundException e) {
                 // Something went wrong while retrieving the template participation.

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/AbstractBuildResultNotificationDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/AbstractBuildResultNotificationDTO.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.in.www1.artemis.domain.BuildLogEntry;
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
-import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.service.connectors.bamboo.dto.TestwiseCoverageReportDTO;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -28,25 +27,6 @@ public abstract class AbstractBuildResultNotificationDTO {
     public abstract boolean isBuildSuccessful();
 
     public abstract Double getBuildScore();
-
-    /**
-     * Get the commit hash from the build result, the commit hash will be different for submission types or null.
-     *
-     * @param submissionType describes why the build was started.
-     * @return if the commit hash for the given submission type was found, otherwise empty.
-     */
-    public Optional<String> getCommitHash(SubmissionType submissionType) {
-        final var isAssignmentSubmission = List.of(SubmissionType.MANUAL, SubmissionType.INSTRUCTOR, SubmissionType.ILLEGAL).contains(submissionType);
-        if (isAssignmentSubmission) {
-            return getCommitHashFromAssignmentRepo();
-        }
-        else if (submissionType.equals(SubmissionType.TEST)) {
-            return getCommitHashFromTestsRepo();
-        }
-        else {
-            return Optional.empty();
-        }
-    }
 
     public abstract boolean hasArtifact();
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -23,7 +23,6 @@ import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.CategoryState;
 import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
-import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.participation.*;
 import de.tum.in.www1.artemis.domain.submissionpolicy.LockRepositoryPolicy;
 import de.tum.in.www1.artemis.domain.submissionpolicy.SubmissionPenaltyPolicy;
@@ -204,14 +203,14 @@ public class ProgrammingExerciseGradingService {
         }
 
         return submissions.stream().filter(theSubmission -> {
-            var commitHash = buildResult.getCommitHash(theSubmission.getType());
+            var commitHash = buildResult.getCommitHashFromAssignmentRepo();
             return commitHash.isPresent() && commitHash.get().equals(theSubmission.getCommitHash());
         }).max(Comparator.naturalOrder());
     }
 
     @NotNull
     protected ProgrammingSubmission createAndSaveFallbackSubmission(ProgrammingExerciseParticipation participation, AbstractBuildResultNotificationDTO buildResult) {
-        final var commitHash = buildResult.getCommitHash(SubmissionType.MANUAL);
+        final var commitHash = buildResult.getCommitHashFromAssignmentRepo();
         if (commitHash.isEmpty()) {
             log.error("Could not find commit hash for participation {}, build plan {}", participation.getId(), participation.getBuildPlanId());
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
@@ -65,40 +65,6 @@ public class ProgrammingExerciseParticipationService {
     }
 
     /**
-     * Retrieve the solution participation of the given programming exercise.
-     *
-     * @param programmingExerciseId ProgrammingExercise id
-     * @return the SolutionProgrammingExerciseParticipation of programming exercise.
-     * @throws EntityNotFoundException if the SolutionParticipation can't be found (could be that the programming exercise does not exist or it does not have a
-     *                                     SolutionParticipation).
-     */
-    // TODO: move into solutionParticipationRepository
-    public SolutionProgrammingExerciseParticipation findSolutionParticipationByProgrammingExerciseId(Long programmingExerciseId) throws EntityNotFoundException {
-        Optional<SolutionProgrammingExerciseParticipation> solutionParticipation = solutionParticipationRepository.findByProgrammingExerciseId(programmingExerciseId);
-        if (solutionParticipation.isEmpty()) {
-            throw new EntityNotFoundException("Could not find solution participation for programming exercise with id " + programmingExerciseId);
-        }
-        return solutionParticipation.get();
-    }
-
-    /**
-     * Retrieve the template participation of the given programming exercise.
-     *
-     * @param programmingExerciseId ProgrammingExercise id
-     * @return the TemplateProgrammingExerciseParticipation of programming exercise.
-     * @throws EntityNotFoundException if the TemplateParticipation can't be found (could be that the programming exercise does not exist or it does not have a
-     *                                     TemplateParticipation).
-     */
-    // TODO: move into templateParticipationRepository
-    public TemplateProgrammingExerciseParticipation findTemplateParticipationByProgrammingExerciseId(Long programmingExerciseId) throws EntityNotFoundException {
-        Optional<TemplateProgrammingExerciseParticipation> templateParticipation = templateParticipationRepository.findByProgrammingExerciseId(programmingExerciseId);
-        if (templateParticipation.isEmpty()) {
-            throw new EntityNotFoundException("Could not find solution participation for programming exercise with id " + programmingExerciseId);
-        }
-        return templateParticipation.get();
-    }
-
-    /**
      * Tries to retrieve a team participation for the given exercise and team short name.
      *
      * @param exercise        the exercise for which to find a participation.

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
@@ -50,7 +50,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
 
     private final ProgrammingMessagingService programmingMessagingService;
 
-    private final ProgrammingExerciseParticipationService programmingExerciseParticipationService;
+    private final SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository;
 
     private final ExamSubmissionService examSubmissionService;
 
@@ -70,8 +70,8 @@ public class ProgrammingSubmissionService extends SubmissionService {
             SubmissionRepository submissionRepository, UserRepository userRepository, AuthorizationCheckService authCheckService,
             ProgrammingMessagingService programmingMessagingService, Optional<VersionControlService> versionControlService, ResultRepository resultRepository,
             Optional<ContinuousIntegrationTriggerService> continuousIntegrationTriggerService, ParticipationService participationService,
-            ProgrammingExerciseParticipationService programmingExerciseParticipationService, ExamSubmissionService examSubmissionService, GitService gitService,
-            StudentParticipationRepository studentParticipationRepository, FeedbackRepository feedbackRepository, ExamDateService examDateService,
+            SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository, ExamSubmissionService examSubmissionService,
+            GitService gitService, StudentParticipationRepository studentParticipationRepository, FeedbackRepository feedbackRepository, ExamDateService examDateService,
             ExerciseDateService exerciseDateService, CourseRepository courseRepository, ParticipationRepository participationRepository,
             ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository, ComplaintRepository complaintRepository,
             ProgrammingExerciseGitDiffReportService programmingExerciseGitDiffReportService, ParticipationAuthorizationCheckService participationAuthCheckService,
@@ -83,7 +83,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
         this.programmingMessagingService = programmingMessagingService;
         this.versionControlService = versionControlService;
         this.continuousIntegrationTriggerService = continuousIntegrationTriggerService;
-        this.programmingExerciseParticipationService = programmingExerciseParticipationService;
+        this.solutionProgrammingExerciseParticipationRepository = solutionProgrammingExerciseParticipationRepository;
         this.examSubmissionService = examSubmissionService;
         this.gitService = gitService;
         this.programmingExerciseStudentParticipationRepository = programmingExerciseStudentParticipationRepository;
@@ -316,7 +316,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
      */
     public ProgrammingSubmission createSolutionParticipationSubmissionWithTypeTest(Long programmingExerciseId, @Nullable String commitHash)
             throws EntityNotFoundException, IllegalStateException {
-        var solutionParticipation = programmingExerciseParticipationService.findSolutionParticipationByProgrammingExerciseId(programmingExerciseId);
+        var solutionParticipation = solutionProgrammingExerciseParticipationRepository.findByProgrammingExerciseIdElseThrow(programmingExerciseId);
         // If no commitHash is provided, use the last commitHash for the test repository.
         if (commitHash == null) {
             ProgrammingExercise programmingExercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(programmingExerciseId);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/open/PublicResultResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/open/PublicResultResource.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
 import de.tum.in.www1.artemis.domain.Result;
-import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.exception.ContinuousIntegrationException;
 import de.tum.in.www1.artemis.security.SecurityUtils;
@@ -118,11 +117,7 @@ public class PublicResultResource {
             Result result = optResult.get();
 
             if (participation instanceof SolutionProgrammingExerciseParticipation) {
-                // If the solution participation was updated, also trigger the template participation build.
-                // This method will return without triggering the build if the submission is not of type TEST.
                 var programmingSubmission = (ProgrammingSubmission) result.getSubmission();
-                triggerTemplateBuildIfTestCasesChanged(participation.getProgrammingExercise().getId(), programmingSubmission);
-
                 // the test cases and the submission have been saved to the database previously, therefore we can add the reference to the coverage reports
                 if (Boolean.TRUE.equals(participation.getProgrammingExercise().isTestwiseCoverageEnabled()) && Boolean.TRUE.equals(result.isSuccessful())) {
                     testwiseCoverageService.createTestwiseCoverageReport(result.getCoverageFileReportsByTestCaseName(), participation.getProgrammingExercise(),
@@ -135,32 +130,5 @@ public class PublicResultResource {
             log.info("The new result for {} was saved successfully", planKey);
         }
         return ResponseEntity.ok().build();
-    }
-
-    // TODO: Move to ResultService. Need to break circular dependencies for that
-    /**
-     * Trigger the build of the template repository, if the submission of the provided result is of type TEST.
-     * Will use the commitHash of the submission for triggering the template build.
-     * <p>
-     * If the submission of the provided result is not of type TEST, the method will return without triggering the build.
-     *
-     * @param programmingExerciseId ProgrammingExercise id that belongs to the result.
-     * @param submission            ProgrammingSubmission
-     */
-    private void triggerTemplateBuildIfTestCasesChanged(long programmingExerciseId, ProgrammingSubmission submission) {
-        // We only trigger the template build when the test repository was changed.
-        // If the submission is from type TEST but already has a result, this build was not triggered by a test repository change
-        if (!submission.belongsToTestRepository() || (submission.belongsToTestRepository() && submission.getResults() != null && !submission.getResults().isEmpty())) {
-            return;
-        }
-        try {
-            programmingTriggerService.triggerTemplateBuildAndNotifyUser(programmingExerciseId, submission.getCommitHash(), SubmissionType.TEST);
-        }
-        catch (EntityNotFoundException ex) {
-            // If for some reason the programming exercise does not have a template participation, we can only log and abort.
-            log.error(
-                    "Could not trigger the build of the template repository for the programming exercise id {} because no template participation could be found for the given exercise",
-                    programmingExerciseId);
-        }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We noticed a bug where the template was not rebuilt after the tests were changed. This lead to some debugging and the decision that in the case of a test case change, there should not be a new submission. Instead the results of the template and solution will be added to the latest submission. Only if no corresponding submission exists, a new one is created.

### Description
<!-- Describe your changes in detail -->
No longer create new submissions if the test case changed. Additionally the build for the template is now triggered immediately when the REST endpoint for a test case change is called and not after receiving the result for the solution.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Log in to Artemis
2. Create the exercise
3. Submit to the Template repository
4. Check that Artemis correctly displays the building animation, e.g. at the bottom of the programming exercise details view
5. Check that a new submission was created for the Template
6. Submit to the Solution repository
7. Check that Artemis correctly displays the building animation, e.g. at the bottom of the programming exercise details view
8. Check that a new submission was created for the Solution
9. Submit to the Test repository
10. Check that Artemis correctly displays the building animation for both repositories, e.g. at the bottom of the programming exercise details view
11. Check that no new submission was created but the results are associated with the submission before

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->