### PR TITLE
`Development`: Fix package for `NonNull` in data export service

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/DataExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/DataExportService.java
@@ -8,7 +8,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 
-import org.jetbrains.annotations.NotNull;
+import javax.validation.constraints.NotNull;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally ~~and was confirmed by another developer on a test server.~~
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
The `@NonNull` annotation used belonged to `org.jetbrains.annotations.NotNull` in Artemis we use `javax.validation.constraints.NotNull`. This caused `ArchitectureTest.testNullnessAnnotations` to fail.

### Description
The package was replaced. The logic of that service remains the same.

### Steps for Testing
- run `ArchitectureTest`

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

