### PR TITLE
`Assessment`: Fix grading scale inclusivity not displayed correctly

### DIFF
--- a/src/main/webapp/app/grading-system/base-grading-system/base-grading-system.component.ts
+++ b/src/main/webapp/app/grading-system/base-grading-system/base-grading-system.component.ts
@@ -469,7 +469,7 @@ export abstract class BaseGradingSystemComponent implements OnInit {
      */
     setBoundInclusivity(): void {
         this.lowerBoundInclusivity = this.gradingScale.gradeSteps.every((gradeStep) => {
-            return gradeStep.lowerBoundInclusive || gradeStep.lowerBoundPercentage === 0;
+            return gradeStep.lowerBoundInclusive || gradeStep.lowerBoundPercentage === 0 || gradeStep.lowerBoundPercentage === 100;
         });
     }
 


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
Closes #7012

### Description
This was only a client sided displaying issue. The inclusivity property is never saved, but calculated based on the bound values of the grade steps. Here the "1.0+" special case was not correclty considered, leading to the method always returning false (upper bound) even if lower bound is set. 

### Steps for Testing
- 1 Instructor
- 1 Coure with a grading scale

1. Change the scales inclusivity
2. Reload the page, see that it's correctly shown


### Review Progress

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
