### PR TITLE
`Development`: Explicitly disable git gpg signing to fix tests in environments with global gpg signing enabled

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -640,7 +640,7 @@ public class GitService {
      */
     public void commit(Repository repo, String message) throws GitAPIException {
         try (Git git = new Git(repo)) {
-            commit(git).setMessage(message).setAllowEmpty(true).setCommitter(artemisGitName, artemisGitEmail).call();
+            GitService.commit(git).setMessage(message).setAllowEmpty(true).setCommitter(artemisGitName, artemisGitEmail).call();
         }
     }
 
@@ -652,7 +652,7 @@ public class GitService {
      * @param git Git Repository Object.
      * @return CommitCommand with signing set to false.
      */
-    public CommitCommand commit(Git git) {
+    public static CommitCommand commit(Git git) {
         return git.commit().setSign(false);
     }
 
@@ -669,7 +669,7 @@ public class GitService {
         String name = user != null ? user.getName() : artemisGitName;
         String email = user != null ? user.getEmail() : artemisGitEmail;
         try (Git git = new Git(repo)) {
-            commit(git).setMessage(message).setAllowEmpty(emptyCommit).setCommitter(name, email).call();
+            GitService.commit(git).setMessage(message).setAllowEmpty(emptyCommit).setCommitter(name, email).call();
             log.debug("commitAndPush -> Push {}", repo.getLocalPath());
             setRemoteUrl(repo);
             pushCommand(git).call();
@@ -986,7 +986,7 @@ public class GitService {
             var optionalStudent = ((StudentParticipation) repository.getParticipation()).getStudents().stream().findFirst();
             var name = optionalStudent.map(User::getName).orElse(artemisGitName);
             var email = optionalStudent.map(User::getEmail).orElse(artemisGitEmail);
-            commit(studentGit).setMessage("All student changes in one commit").setCommitter(name, email).call();
+            GitService.commit(studentGit).setMessage("All student changes in one commit").setCommitter(name, email).call();
         }
         catch (EntityNotFoundException | GitAPIException | JGitInternalException ex) {
             log.warn("Cannot reset the repo {} due to the following exception: {}", repository.getLocalPath(), ex.getMessage());
@@ -1040,7 +1040,7 @@ public class GitService {
                 if (!head.equals(studentGit.getRepository().resolve(headName))) {
                     PersonIdent authorIdent = commit.getAuthorIdent();
                     PersonIdent fakeIdent = new PersonIdent(ANONYMIZED_STUDENT_NAME, ANONYMIZED_STUDENT_EMAIL, authorIdent.getWhen(), authorIdent.getTimeZone());
-                    commit(studentGit).setAmend(true).setAuthor(fakeIdent).setCommitter(fakeIdent).setMessage(commit.getFullMessage()).call();
+                    GitService.commit(studentGit).setAmend(true).setAuthor(fakeIdent).setCommitter(fakeIdent).setMessage(commit.getFullMessage()).call();
                 }
             }
             // Delete copy branch
@@ -1189,7 +1189,7 @@ public class GitService {
             if (firstCommit != null) {
                 git.reset().setMode(ResetCommand.ResetType.SOFT).setRef(firstCommit.getId().getName()).call();
                 git.add().addFilepattern(".").call();
-                commit(git).setAmend(true).setMessage(firstCommit.getFullMessage()).call();
+                GitService.commit(git).setAmend(true).setMessage(firstCommit.getFullMessage()).call();
                 log.debug("combineAllCommitsIntoInitialCommit -> Push {}", repo.getLocalPath());
                 pushCommand(git).setForce(true).call();
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -610,6 +610,7 @@ public class GitService {
             StoredConfig gitRepoConfig = repository.getConfig();
             gitRepoConfig.setInt(ConfigConstants.CONFIG_GC_SECTION, null, ConfigConstants.CONFIG_KEY_AUTO, 0);
             gitRepoConfig.setBoolean(ConfigConstants.CONFIG_CORE_SECTION, null, ConfigConstants.CONFIG_KEY_SYMLINKS, false);
+            gitRepoConfig.setBoolean(ConfigConstants.CONFIG_COMMIT_SECTION, null, ConfigConstants.CONFIG_KEY_GPGSIGN, false);
             gitRepoConfig.setString(ConfigConstants.CONFIG_BRANCH_SECTION, defaultBranch, ConfigConstants.CONFIG_REMOTE_SECTION, REMOTE_NAME);
             gitRepoConfig.setString(ConfigConstants.CONFIG_BRANCH_SECTION, defaultBranch, ConfigConstants.CONFIG_MERGE_SECTION, "refs/heads/" + defaultBranch);
 
@@ -639,8 +640,20 @@ public class GitService {
      */
     public void commit(Repository repo, String message) throws GitAPIException {
         try (Git git = new Git(repo)) {
-            git.commit().setMessage(message).setAllowEmpty(true).setCommitter(artemisGitName, artemisGitEmail).call();
+            commit(git).setMessage(message).setAllowEmpty(true).setCommitter(artemisGitName, artemisGitEmail).call();
         }
+    }
+
+    /**
+     * Creates a CommitCommand and sets signing to false. Egit uses the local git configuration and if signing of
+     * commits is enabled, tests will fail because it will not be able to actually sign the commit.
+     * This method makes sure that signing is disabled and commits work on systems regardless of the local git configuration.
+     *
+     * @param git Git Repository Object.
+     * @return CommitCommand with signing set to false.
+     */
+    public CommitCommand commit(Git git) {
+        return git.commit().setSign(false);
     }
 
     /**
@@ -656,7 +669,7 @@ public class GitService {
         String name = user != null ? user.getName() : artemisGitName;
         String email = user != null ? user.getEmail() : artemisGitEmail;
         try (Git git = new Git(repo)) {
-            git.commit().setMessage(message).setAllowEmpty(emptyCommit).setCommitter(name, email).call();
+            commit(git).setMessage(message).setAllowEmpty(emptyCommit).setCommitter(name, email).call();
             log.debug("commitAndPush -> Push {}", repo.getLocalPath());
             setRemoteUrl(repo);
             pushCommand(git).call();
@@ -973,7 +986,7 @@ public class GitService {
             var optionalStudent = ((StudentParticipation) repository.getParticipation()).getStudents().stream().findFirst();
             var name = optionalStudent.map(User::getName).orElse(artemisGitName);
             var email = optionalStudent.map(User::getEmail).orElse(artemisGitEmail);
-            studentGit.commit().setMessage("All student changes in one commit").setCommitter(name, email).call();
+            commit(studentGit).setMessage("All student changes in one commit").setCommitter(name, email).call();
         }
         catch (EntityNotFoundException | GitAPIException | JGitInternalException ex) {
             log.warn("Cannot reset the repo {} due to the following exception: {}", repository.getLocalPath(), ex.getMessage());
@@ -1027,7 +1040,7 @@ public class GitService {
                 if (!head.equals(studentGit.getRepository().resolve(headName))) {
                     PersonIdent authorIdent = commit.getAuthorIdent();
                     PersonIdent fakeIdent = new PersonIdent(ANONYMIZED_STUDENT_NAME, ANONYMIZED_STUDENT_EMAIL, authorIdent.getWhen(), authorIdent.getTimeZone());
-                    studentGit.commit().setAmend(true).setAuthor(fakeIdent).setCommitter(fakeIdent).setMessage(commit.getFullMessage()).call();
+                    commit(studentGit).setAmend(true).setAuthor(fakeIdent).setCommitter(fakeIdent).setMessage(commit.getFullMessage()).call();
                 }
             }
             // Delete copy branch
@@ -1176,7 +1189,7 @@ public class GitService {
             if (firstCommit != null) {
                 git.reset().setMode(ResetCommand.ResetType.SOFT).setRef(firstCommit.getId().getName()).call();
                 git.add().addFilepattern(".").call();
-                git.commit().setAmend(true).setMessage(firstCommit.getFullMessage()).call();
+                commit(git).setAmend(true).setMessage(firstCommit.getFullMessage()).call();
                 log.debug("combineAllCommitsIntoInitialCommit -> Push {}", repo.getLocalPath());
                 pushCommand(git).setForce(true).call();
             }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseGitIntegrationTest.java
@@ -28,6 +28,7 @@ import de.tum.in.www1.artemis.domain.VcsRepositoryUrl;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.GitUtilService;
 import de.tum.in.www1.artemis.util.LocalRepository;
@@ -81,13 +82,13 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractSpringIntegrationBam
         // the following 2 lines prepare the generation of the structural test oracle
         var testJsonFilePath = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test.json");
         gitUtilService.writeEmptyJsonFileToPath(testJsonFilePath);
-        gitService.commit(localGit).setMessage("add test.json").setAuthor("test", "test@test.com").call();
+        GitService.commit(localGit).setMessage("add test.json").setAuthor("test", "test@test.com").call();
         var testJsonFilePath2 = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test2.json");
         gitUtilService.writeEmptyJsonFileToPath(testJsonFilePath2);
-        gitService.commit(localGit).setMessage("add test2.json").setAuthor("test", "test@test.com").call();
+        GitService.commit(localGit).setMessage("add test2.json").setAuthor("test", "test@test.com").call();
         var testJsonFilePath3 = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test3.json");
         gitUtilService.writeEmptyJsonFileToPath(testJsonFilePath3);
-        gitService.commit(localGit).setMessage("add test3.json").setAuthor("test", "test@test.com").call();
+        GitService.commit(localGit).setMessage("add test3.json").setAuthor("test", "test@test.com").call();
 
         var repository = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), null);
         doReturn(repository).when(gitService).getOrCheckoutRepository(any(VcsRepositoryUrl.class), anyString(), anyBoolean());

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseGitIntegrationTest.java
@@ -81,13 +81,13 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractSpringIntegrationBam
         // the following 2 lines prepare the generation of the structural test oracle
         var testJsonFilePath = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test.json");
         gitUtilService.writeEmptyJsonFileToPath(testJsonFilePath);
-        localGit.commit().setMessage("add test.json").setAuthor("test", "test@test.com").call();
+        gitService.commit(localGit).setMessage("add test.json").setAuthor("test", "test@test.com").call();
         var testJsonFilePath2 = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test2.json");
         gitUtilService.writeEmptyJsonFileToPath(testJsonFilePath2);
-        localGit.commit().setMessage("add test2.json").setAuthor("test", "test@test.com").call();
+        gitService.commit(localGit).setMessage("add test2.json").setAuthor("test", "test@test.com").call();
         var testJsonFilePath3 = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test3.json");
         gitUtilService.writeEmptyJsonFileToPath(testJsonFilePath3);
-        localGit.commit().setMessage("add test3.json").setAuthor("test", "test@test.com").call();
+        gitService.commit(localGit).setMessage("add test3.json").setAuthor("test", "test@test.com").call();
 
         var repository = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), null);
         doReturn(repository).when(gitService).getOrCheckoutRepository(any(VcsRepositoryUrl.class), anyString(), anyBoolean());

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -221,7 +221,7 @@ class ProgrammingExerciseIntegrationTestService {
         var testjsonFilePath = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test.json");
         gitUtilService.writeEmptyJsonFileToPath(testjsonFilePath);
         // create two empty commits
-        gitService.commit(localGit).setMessage("empty").setAllowEmpty(true).setAuthor("test", "test@test.com").call();
+        GitService.commit(localGit).setMessage("empty").setAllowEmpty(true).setAuthor("test", "test@test.com").call();
         localGit.push().call();
 
         // we use the temp repository as remote origin for all repositories that are created during the
@@ -458,7 +458,7 @@ class ProgrammingExerciseIntegrationTestService {
         // Add commit to anonymize
         assertThat(localRepoFile.toPath().resolve("Test.java").toFile().createNewFile()).isTrue();
         localGit.add().addFilepattern(".").call();
-        gitService.commit(localGit).setMessage("commit").setAuthor("user1", "email1").call();
+        GitService.commit(localGit).setMessage("commit").setAuthor("user1", "email1").call();
 
         // Rest call
         final var path = ROOT + EXPORT_SUBMISSIONS_BY_PARTICIPATIONS.replace("{exerciseId}", String.valueOf(programmingExercise.getId())).replace("{participationIds}",

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -221,7 +221,7 @@ class ProgrammingExerciseIntegrationTestService {
         var testjsonFilePath = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test.json");
         gitUtilService.writeEmptyJsonFileToPath(testjsonFilePath);
         // create two empty commits
-        localGit.commit().setMessage("empty").setAllowEmpty(true).setSign(false).setAuthor("test", "test@test.com").call();
+        gitService.commit(localGit).setMessage("empty").setAllowEmpty(true).setAuthor("test", "test@test.com").call();
         localGit.push().call();
 
         // we use the temp repository as remote origin for all repositories that are created during the
@@ -458,7 +458,7 @@ class ProgrammingExerciseIntegrationTestService {
         // Add commit to anonymize
         assertThat(localRepoFile.toPath().resolve("Test.java").toFile().createNewFile()).isTrue();
         localGit.add().addFilepattern(".").call();
-        localGit.commit().setMessage("commit").setAuthor("user1", "email1").call();
+        gitService.commit(localGit).setMessage("commit").setAuthor("user1", "email1").call();
 
         // Rest call
         final var path = ROOT + EXPORT_SUBMISSIONS_BY_PARTICIPATIONS.replace("{exerciseId}", String.valueOf(programmingExercise.getId())).replace("{participationIds}",

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
@@ -1679,7 +1679,7 @@ public class ProgrammingExerciseTestService {
             Files.createFile(file);
         }
         localRepository.localGit.add().addFilepattern(file.getFileName().toString()).call();
-        gitService.commit(localRepository.localGit).setMessage("Added testfile").call();
+        GitService.commit(localRepository.localGit).setMessage("Added testfile").call();
     }
 
     // Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
@@ -1654,7 +1654,7 @@ public class ProgrammingExerciseTestService {
             Files.createFile(file);
         }
         localRepository.localGit.add().addFilepattern(file.getFileName().toString()).call();
-        localRepository.localGit.commit().setMessage("Added testfile").call();
+        gitService.commit(localRepository.localGit).setMessage("Added testfile").call();
     }
 
     // Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
@@ -61,6 +61,7 @@ import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismComparisonRepository;
 import de.tum.in.www1.artemis.service.BuildLogEntryService;
+import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseParticipationService;
 import de.tum.in.www1.artemis.user.UserUtilService;
@@ -659,7 +660,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
 
         // Stage all changes and make a second commit in the remote repository
         gitService.stageAllChanges(remoteRepository);
-        gitService.commit(studentRepository.originGit).setMessage("TestCommit").setAllowEmpty(true).setCommitter("testname", "test@email").call();
+        GitService.commit(studentRepository.originGit).setMessage("TestCommit").setAllowEmpty(true).setCommitter("testname", "test@email").call();
 
         // Checks if the current commit is not equal on the local and the remote repository
         assertThat(studentRepository.getAllLocalCommits().get(0)).isNotEqualTo(studentRepository.getAllOriginCommits().get(0));
@@ -698,7 +699,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
         // write content to the created file
         FileUtils.write(localFile, "local", Charset.defaultCharset());
         gitService.stageAllChanges(localRepo);
-        gitService.commit(studentRepository.localGit).setMessage("local").call();
+        GitService.commit(studentRepository.localGit).setMessage("local").call();
 
         // Create file in the remote repository and commit it
         Path remoteFilePath = Path.of(studentRepository.originRepoFile + "/" + fileName);
@@ -706,7 +707,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
         // write content to the created file
         FileUtils.write(remoteFile, "remote", Charset.defaultCharset());
         gitService.stageAllChanges(remoteRepo);
-        gitService.commit(studentRepository.originGit).setMessage("remote").call();
+        GitService.commit(studentRepository.originGit).setMessage("remote").call();
 
         // Merge the two and a conflict will occur
         studentRepository.localGit.fetch().setRemote("origin").call();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
@@ -659,7 +659,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
 
         // Stage all changes and make a second commit in the remote repository
         gitService.stageAllChanges(remoteRepository);
-        studentRepository.originGit.commit().setMessage("TestCommit").setAllowEmpty(true).setCommitter("testname", "test@email").call();
+        gitService.commit(studentRepository.originGit).setMessage("TestCommit").setAllowEmpty(true).setCommitter("testname", "test@email").call();
 
         // Checks if the current commit is not equal on the local and the remote repository
         assertThat(studentRepository.getAllLocalCommits().get(0)).isNotEqualTo(studentRepository.getAllOriginCommits().get(0));
@@ -698,7 +698,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
         // write content to the created file
         FileUtils.write(localFile, "local", Charset.defaultCharset());
         gitService.stageAllChanges(localRepo);
-        studentRepository.localGit.commit().setMessage("local").call();
+        gitService.commit(studentRepository.localGit).setMessage("local").call();
 
         // Create file in the remote repository and commit it
         Path remoteFilePath = Path.of(studentRepository.originRepoFile + "/" + fileName);
@@ -706,7 +706,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
         // write content to the created file
         FileUtils.write(remoteFile, "remote", Charset.defaultCharset());
         gitService.stageAllChanges(remoteRepo);
-        studentRepository.originGit.commit().setMessage("remote").call();
+        gitService.commit(studentRepository.originGit).setMessage("remote").call();
 
         // Merge the two and a conflict will occur
         studentRepository.localGit.fetch().setRemote("origin").call();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/TestRepositoryResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/TestRepositoryResourceIntegrationTest.java
@@ -391,7 +391,7 @@ class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegrationBam
 
         // Stage all changes and make a second commit in the remote repository
         gitService.stageAllChanges(remoteRepository);
-        testRepo.originGit.commit().setMessage("TestCommit").setAllowEmpty(true).setCommitter("testname", "test@email").call();
+        gitService.commit(testRepo.originGit).setMessage("TestCommit").setAllowEmpty(true).setCommitter("testname", "test@email").call();
 
         // Checks if the current commit is not equal on the local and the remote repository
         assertThat(testRepo.getAllLocalCommits().get(0)).isNotEqualTo(testRepo.getAllOriginCommits().get(0));
@@ -430,7 +430,7 @@ class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegrationBam
         // write content to the created file
         FileUtils.write(localFile, "local", Charset.defaultCharset());
         gitService.stageAllChanges(localRepo);
-        testRepo.localGit.commit().setMessage("local").call();
+        gitService.commit(testRepo.localGit).setMessage("local").call();
 
         // Create file in the remote repository and commit it
         Path remoteFilePath = Path.of(testRepo.originRepoFile + "/" + fileName);
@@ -438,7 +438,7 @@ class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegrationBam
         // write content to the created file
         FileUtils.write(remoteFile, "remote", Charset.defaultCharset());
         gitService.stageAllChanges(remoteRepo);
-        testRepo.originGit.commit().setMessage("remote").call();
+        gitService.commit(testRepo.originGit).setMessage("remote").call();
 
         // Merge the two and a conflict will occur
         testRepo.localGit.fetch().setRemote("origin").call();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/TestRepositoryResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/TestRepositoryResourceIntegrationTest.java
@@ -29,6 +29,7 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.GitUtilService;
 import de.tum.in.www1.artemis.util.LocalRepository;
@@ -391,7 +392,7 @@ class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegrationBam
 
         // Stage all changes and make a second commit in the remote repository
         gitService.stageAllChanges(remoteRepository);
-        gitService.commit(testRepo.originGit).setMessage("TestCommit").setAllowEmpty(true).setCommitter("testname", "test@email").call();
+        GitService.commit(testRepo.originGit).setMessage("TestCommit").setAllowEmpty(true).setCommitter("testname", "test@email").call();
 
         // Checks if the current commit is not equal on the local and the remote repository
         assertThat(testRepo.getAllLocalCommits().get(0)).isNotEqualTo(testRepo.getAllOriginCommits().get(0));
@@ -430,7 +431,7 @@ class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegrationBam
         // write content to the created file
         FileUtils.write(localFile, "local", Charset.defaultCharset());
         gitService.stageAllChanges(localRepo);
-        gitService.commit(testRepo.localGit).setMessage("local").call();
+        GitService.commit(testRepo.localGit).setMessage("local").call();
 
         // Create file in the remote repository and commit it
         Path remoteFilePath = Path.of(testRepo.originRepoFile + "/" + fileName);
@@ -438,7 +439,7 @@ class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegrationBam
         // write content to the created file
         FileUtils.write(remoteFile, "remote", Charset.defaultCharset());
         gitService.stageAllChanges(remoteRepo);
-        gitService.commit(testRepo.originGit).setMessage("remote").call();
+        GitService.commit(testRepo.originGit).setMessage("remote").call();
 
         // Merge the two and a conflict will occur
         testRepo.localGit.fetch().setRemote("origin").call();

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCIntegrationTest.java
@@ -36,9 +36,6 @@ class LocalVCIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
     @Autowired
     ProgrammingSubmissionRepository programmingSubmissionRepository;
 
-    @Autowired
-    private GitService gitService;
-
     private LocalRepository assignmentRepository;
 
     private LocalRepository templateRepository;
@@ -227,7 +224,7 @@ class LocalVCIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
         Path testFilePath = assignmentRepository.localRepoFile.toPath().resolve("new-file.txt");
         Files.createFile(testFilePath);
         assignmentRepository.localGit.add().addFilepattern(".").call();
-        gitService.commit(assignmentRepository.localGit).setMessage("Add new file").call();
+        GitService.commit(assignmentRepository.localGit).setMessage("Add new file").call();
         pushResult = assignmentRepository.localGit.push().setRemote(repositoryUrl).call().iterator().next();
         assertThat(pushResult.getMessages()).contains("Only pushes to the default branch will be graded.");
         submission = programmingSubmissionRepository.findFirstByParticipationIdOrderBySubmissionDateDesc(studentParticipation.getId());

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCIntegrationTest.java
@@ -25,6 +25,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionRepository;
+import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.util.LocalRepository;
 
 /**
@@ -34,6 +35,9 @@ class LocalVCIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
 
     @Autowired
     ProgrammingSubmissionRepository programmingSubmissionRepository;
+
+    @Autowired
+    private GitService gitService;
 
     private LocalRepository assignmentRepository;
 
@@ -223,7 +227,7 @@ class LocalVCIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
         Path testFilePath = assignmentRepository.localRepoFile.toPath().resolve("new-file.txt");
         Files.createFile(testFilePath);
         assignmentRepository.localGit.add().addFilepattern(".").call();
-        assignmentRepository.localGit.commit().setMessage("Add new file").call();
+        gitService.commit(assignmentRepository.localGit).setMessage("Add new file").call();
         pushResult = assignmentRepository.localGit.push().setRemote(repositoryUrl).call().iterator().next();
         assertThat(pushResult.getMessages()).contains("Only pushes to the default branch will be graded.");
         submission = programmingSubmissionRepository.findFirstByParticipationIdOrderBySubmissionDateDesc(studentParticipation.getId());

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCITestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCITestService.java
@@ -54,6 +54,7 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionRepository;
+import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCRepositoryUrl;
 import de.tum.in.www1.artemis.util.LocalRepository;
 
@@ -71,6 +72,9 @@ public class LocalVCLocalCITestService {
 
     @Autowired
     private ProgrammingSubmissionRepository programmingSubmissionRepository;
+
+    @Autowired
+    private GitService gitService;
 
     @Autowired
     private ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository;
@@ -364,7 +368,7 @@ public class LocalVCLocalCITestService {
         Path testFilePath = localRepositoryFolder.resolve(fileName);
         Files.createFile(testFilePath);
         localGit.add().addFilepattern(".").call();
-        RevCommit commit = localGit.commit().setMessage("Add " + fileName).call();
+        RevCommit commit = gitService.commit(localGit).setMessage("Add " + fileName).call();
         return commit.getId().getName();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCITestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCITestService.java
@@ -74,9 +74,6 @@ public class LocalVCLocalCITestService {
     private ProgrammingSubmissionRepository programmingSubmissionRepository;
 
     @Autowired
-    private GitService gitService;
-
-    @Autowired
     private ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository;
 
     @Value("${artemis.version-control.url}")
@@ -368,7 +365,7 @@ public class LocalVCLocalCITestService {
         Path testFilePath = localRepositoryFolder.resolve(fileName);
         Files.createFile(testFilePath);
         localGit.add().addFilepattern(".").call();
-        RevCommit commit = gitService.commit(localGit).setMessage("Add " + fileName).call();
+        RevCommit commit = GitService.commit(localGit).setMessage("Add " + fileName).call();
         return commit.getId().getName();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -15,7 +15,6 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ReflogEntry;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -53,9 +52,6 @@ public class GitUtilService {
 
     private Git remoteGit;
 
-    @Autowired
-    private GitService gitService;
-
     /**
      * Initializes the repository with three dummy files
      */
@@ -78,7 +74,7 @@ public class GitUtilService {
             remotePath.resolve(FILES.FILE2.toString()).toFile().createNewFile();
             remotePath.resolve(FILES.FILE3.toString()).toFile().createNewFile();
             remoteGit.add().addFilepattern(".").call();
-            gitService.commit(remoteGit).setMessage("initial commit").call();
+            GitService.commit(remoteGit).setMessage("initial commit").call();
 
             // clone remote repository
             localGit = Git.cloneRepository().setURI(remotePath.toString()).setDirectory(localPath.toFile()).call();
@@ -206,7 +202,7 @@ public class GitUtilService {
         try {
             Git git = new Git(getRepoByType(repo));
             git.add().addFilepattern(".").call();
-            gitService.commit(git).setMessage("new commit").call();
+            GitService.commit(git).setMessage("new commit").call();
         }
         catch (GitAPIException ignored) {
         }

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -15,11 +15,13 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ReflogEntry;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.Repository;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUrl;
+import de.tum.in.www1.artemis.service.connectors.GitService;
 
 @Service
 public class GitUtilService {
@@ -51,6 +53,9 @@ public class GitUtilService {
 
     private Git remoteGit;
 
+    @Autowired
+    private GitService gitService;
+
     /**
      * Initializes the repository with three dummy files
      */
@@ -73,7 +78,7 @@ public class GitUtilService {
             remotePath.resolve(FILES.FILE2.toString()).toFile().createNewFile();
             remotePath.resolve(FILES.FILE3.toString()).toFile().createNewFile();
             remoteGit.add().addFilepattern(".").call();
-            remoteGit.commit().setMessage("initial commit").call();
+            gitService.commit(remoteGit).setMessage("initial commit").call();
 
             // clone remote repository
             localGit = Git.cloneRepository().setURI(remotePath.toString()).setDirectory(localPath.toFile()).call();
@@ -201,7 +206,7 @@ public class GitUtilService {
         try {
             Git git = new Git(getRepoByType(repo));
             git.add().addFilepattern(".").call();
-            git.commit().setMessage("new commit").call();
+            gitService.commit(git).setMessage("new commit").call();
         }
         catch (GitAPIException ignored) {
         }

--- a/src/test/java/de/tum/in/www1/artemis/util/LocalRepository.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/LocalRepository.java
@@ -17,6 +17,8 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.URIish;
 
+import de.tum.in.www1.artemis.service.connectors.GitService;
+
 /**
  * This class describes a local repository cloned from an origin repository.
  * In the case of using the local VCS with the local CIS instead of, e.g. Bitbucket and Bamboo, the local VCS contains the origin repositories,
@@ -85,7 +87,7 @@ public class LocalRepository {
         Path filePath = localRepoPath.resolve("test.txt");
         Files.createFile(filePath);
         localGit.add().addFilepattern("test.txt").call();
-        localGit.commit().setSign(false).setMessage("Initial commit").call();
+        GitService.commit(localGit).setMessage("Initial commit").call();
         localGit.push().setRemote("origin").call();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/LocalRepository.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/LocalRepository.java
@@ -85,7 +85,7 @@ public class LocalRepository {
         Path filePath = localRepoPath.resolve("test.txt");
         Files.createFile(filePath);
         localGit.add().addFilepattern("test.txt").call();
-        localGit.commit().setMessage("Initial commit").call();
+        localGit.commit().setSign(false).setMessage("Initial commit").call();
         localGit.push().setRemote("origin").call();
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
I could not run all the tests (around 184 failed) because on my system I have gpg signing of commits enabled globally. In my opinion, this should not affect the tests, so I added `setSign(false)` to all the commits in the broken tests. This results, again in my opinion and please correct me if I'm wrong, in more stable tests because it is less dependent on the git config of the developer. 
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- git installation

1. set signing to true, execute tests on `develop`
2. observe around 184 tests failing
3. set signing to false, test again
4. all tests should pass
5. now pull my changes and test again with the flag true and false
6. both times, all tests should pass


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
