### PR TITLE
`Development`: Enable parallel run for e2e tests

### DIFF
--- a/docker/cypress-E2E-tests-mysql.yml
+++ b/docker/cypress-E2E-tests-mysql.yml
@@ -44,7 +44,9 @@ services:
         environment:
             CYPRESS_DB_TYPE: "MySQL"
             SORRY_CYPRESS_PROJECT_ID: "artemis-mysql"
-        command: sh -c "cd /app/artemis/src/test/cypress && chmod 777 /root && npm ci && npm run cypress:record:mysql"
+        command: >
+            sh -c "cd /app/artemis/src/test/cypress && chmod 777 /root && npm ci && npm run cypress:setup && npm run cypress:record:mysql & 
+            sleep 60 && cd /app/artemis/src/test/cypress && npm run cypress:record:mysql"
 
 networks:
     artemis:

--- a/docker/cypress-E2E-tests-postgres.yml
+++ b/docker/cypress-E2E-tests-postgres.yml
@@ -44,7 +44,9 @@ services:
         environment:
             CYPRESS_DB_TYPE: "Postgres"
             SORRY_CYPRESS_PROJECT_ID: "artemis-postgres"
-        command: sh -c "cd /app/artemis/src/test/cypress && chmod 777 /root && npm ci && npm run cypress:record:postgres"
+        command: >
+            sh -c "cd /app/artemis/src/test/cypress && chmod 777 /root && npm ci && npm run cypress:setup && npm run cypress:record:postgres & 
+            sleep 60 && cd /app/artemis/src/test/cypress && npm run cypress:record:postgres"
 
 networks:
     artemis:

--- a/src/test/cypress/init/ImportUsers.cy.ts
+++ b/src/test/cypress/init/ImportUsers.cy.ts
@@ -7,7 +7,11 @@ describe('Setup users', () => {
             cy.login(admin);
             for (const userKey in USER_ID) {
                 const user = users.getUserWithId(USER_ID[userKey]);
-                userManagementRequest.createUser(user.username, user.password, USER_ROLE[userKey]);
+                userManagementRequest.getUser(user.username).then((response) => {
+                    if (!response.isOkStatusCode) {
+                        userManagementRequest.createUser(user.username, user.password, USER_ROLE[userKey]);
+                    }
+                });
             }
         });
     }

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -26,8 +26,9 @@
     "scripts": {
         "cypress:open": "cypress open",
         "cypress:run": "cypress run --browser=chrome",
-        "cypress:record:mysql": "npx cypress-cloud run --record --ci-build-id \"${SORRY_CYPRESS_BRANCH_NAME} #${SORRY_CYPRESS_BUILD_ID} (MySQL)\"",
-        "cypress:record:postgres": "npx cypress-cloud run --record --ci-build-id \"${SORRY_CYPRESS_BRANCH_NAME} #${SORRY_CYPRESS_BUILD_ID} (Postgres)\"",
+        "cypress:setup": "cypress install && cypress run --quiet --spec init/ImportUsers.cy.ts",
+        "cypress:record:mysql": "npx cypress-cloud run --parallel --record --ci-build-id \"${SORRY_CYPRESS_BRANCH_NAME} #${SORRY_CYPRESS_BUILD_ID} (MySQL)\"",
+        "cypress:record:postgres": "npx cypress-cloud run --parallel --record --ci-build-id \"${SORRY_CYPRESS_BRANCH_NAME} #${SORRY_CYPRESS_BUILD_ID} (Postgres)\"",
         "update": "npm-upgrade"
     }
 }

--- a/src/test/cypress/support/requests/UserManagementRequest.ts
+++ b/src/test/cypress/support/requests/UserManagementRequest.ts
@@ -1,4 +1,4 @@
-import { BASE_API, POST } from '../constants';
+import { BASE_API, GET, POST } from '../constants';
 import { UserRole } from '../users';
 
 /**
@@ -24,6 +24,14 @@ export class UserManagementRequests {
             url: BASE_API + 'admin/users',
             method: POST,
             body: user,
+        });
+    }
+
+    getUser(username: string) {
+        return cy.request({
+            url: BASE_API + `users/${username}`,
+            method: GET,
+            failOnStatusCode: false,
         });
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the e2e tests take about 50-60 minutes. This is a long time for devs to wait for the result of the tests.

### Description
<!-- Describe your changes in detail -->
This PR enables parallel runs for the e2e tests. This reduces the run time to about 25-35 minutes. After waiting for 1 minutes after the first cypress instance starts, a second instance is spawned. Both connect to the sorry cypress dashboard, were they both instances get certain specs assigned. Then each instance runs their assigned specs. Since we also need to make sure, that the ImportUsers.cy.ts spec is run before all the other specs (and not assigned to the second instance), I added a new npm script, that runs only the ImportUser spec file. This file is later still assigned to a instance, so I needed to ensure, that the new users on the postgres setup are only created if they are missing. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
