### PR TITLE
`Grading`: Improve default grading key

### DIFF
--- a/src/main/webapp/app/grading-system/base-grading-system/base-grading-system.component.ts
+++ b/src/main/webapp/app/grading-system/base-grading-system/base-grading-system.component.ts
@@ -542,7 +542,7 @@ export abstract class BaseGradingSystemComponent implements OnInit {
             upperBoundPercentage: 100,
             isPassingGrade: true,
             lowerBoundInclusive: this.lowerBoundInclusivity,
-            upperBoundInclusive: true,
+            upperBoundInclusive: !this.lowerBoundInclusivity,
         };
         this.setPoints(gradeStep, true);
         this.setPoints(gradeStep, false);

--- a/src/main/webapp/app/grading-system/interval-grading-system/interval-grading-system.component.ts
+++ b/src/main/webapp/app/grading-system/interval-grading-system/interval-grading-system.component.ts
@@ -30,9 +30,6 @@ export class IntervalGradingSystemComponent extends BaseGradingSystemComponent {
         if (this.gradingScale?.gradeSteps?.length === 0) {
             // Add sticky grade step at the end.
             super.createGradeStep();
-
-            // This is to ensure 100 percent is not a part of the sticky grade step.
-            this.gradingScale.gradeSteps.first()!.lowerBoundInclusive = false;
         }
 
         // Remove sticky grade step, add the new step and re-add the sticky grade step.
@@ -43,24 +40,6 @@ export class IntervalGradingSystemComponent extends BaseGradingSystemComponent {
 
         const selectedIndex = this.gradingScale.gradeSteps.length - 2;
         this.setPercentageInterval(selectedIndex);
-    }
-
-    getDefaultGradingScale() {
-        const defaultGradingScale = super.getDefaultGradingScale();
-        const stickyGradeStep = {
-            gradeName: '1.0',
-            lowerBoundPercentage: 100,
-            upperBoundPercentage: 200,
-            lowerBoundInclusive: false,
-            upperBoundInclusive: true,
-            isPassingGrade: true,
-        };
-        defaultGradingScale.gradeSteps.push(stickyGradeStep);
-
-        this.setPoints(stickyGradeStep, true);
-        this.setPoints(stickyGradeStep, false);
-
-        return defaultGradingScale;
     }
 
     /**
@@ -82,14 +61,7 @@ export class IntervalGradingSystemComponent extends BaseGradingSystemComponent {
 
         // Always true
         gradeSteps.first()!.lowerBoundInclusive = true;
-
-        if (gradeSteps.length > 1) {
-            // Ensure 100 percent is not a part of the sticky grade step.
-            gradeSteps[gradeSteps.length - 2].upperBoundInclusive = true;
-            const stickyGradeStep = gradeSteps.last()!;
-            stickyGradeStep.lowerBoundInclusive = false;
-            stickyGradeStep.upperBoundInclusive = true;
-        }
+        gradeSteps.last()!.upperBoundInclusive = true;
     }
 
     /**
@@ -159,9 +131,18 @@ export class IntervalGradingSystemComponent extends BaseGradingSystemComponent {
         this.setPercentageInterval(index, 0);
         super.deleteGradeStep(index);
         const gradeSteps = this.gradingScale.gradeSteps;
-        if (gradeSteps.length === 1) {
-            // Only sticky grade step remains, prevent total percentage is less than 100.
-            this.setPercentageInterval(0, 100);
+
+        if (gradeSteps.length > 0) {
+            // Prevent the total percentage from becoming less than 100.
+            if (gradeSteps.last()!.upperBoundPercentage < 100) {
+                gradeSteps.last()!.upperBoundPercentage = 100;
+            }
+
+            // If the first grade step is deleted, make sure the new first grade step's lower bound inclusivity is true.
+            gradeSteps.first()!.lowerBoundInclusive = true;
+
+            // If the last grade step is deleted, make sure the new last grade step's upper bound inclusivity is true.
+            gradeSteps.last()!.upperBoundInclusive = true;
         }
     }
 

--- a/src/test/javascript/spec/component/grading-system/detailed-grading-system.component.spec.ts
+++ b/src/test/javascript/spec/component/grading-system/detailed-grading-system.component.spec.ts
@@ -182,7 +182,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.gradingScale.gradeSteps[3].upperBoundPercentage).toBe(100);
         expect(comp.gradingScale.gradeSteps[3].isPassingGrade).toBeTrue();
         expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBeTrue();
-        expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBeTrue();
+        expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBeFalse();
     });
 
     it('should delete grade names correctly', () => {

--- a/src/test/javascript/spec/component/grading-system/interval-grading-system.component.spec.ts
+++ b/src/test/javascript/spec/component/grading-system/interval-grading-system.component.spec.ts
@@ -124,7 +124,7 @@ describe('Interval Grading System Component', () => {
         expect(comp.gradingScale.gradeType).toStrictEqual(GradeType.GRADE);
         expect(comp.firstPassingGrade).toBe('4.0');
         expect(comp.lowerBoundInclusivity).toBeTrue();
-        expect(comp.gradingScale.gradeSteps).toHaveLength(14);
+        expect(comp.gradingScale.gradeSteps).toHaveLength(13);
         comp.gradingScale.gradeSteps.forEach((gradeStep) => {
             expect(gradeStep.id).toBeUndefined();
             expect(gradeStep.gradeName).toBeDefined();
@@ -176,7 +176,7 @@ describe('Interval Grading System Component', () => {
         expect(newGradeStep.upperBoundPercentage).toBe(100);
         expect(newGradeStep.isPassingGrade).toBeTrue();
         expect(newGradeStep.lowerBoundInclusive).toBeTrue();
-        expect(newGradeStep.upperBoundInclusive).toBeTrue();
+        expect(newGradeStep.upperBoundInclusive).toBeFalse();
 
         // Previous gradeStep.upperBoundPercentage is already 100.
         expect(comp.getPercentageInterval(newGradeStep)).toBe(0);
@@ -334,13 +334,23 @@ describe('Interval Grading System Component', () => {
         expect(comp.getPercentageInterval(comp.gradingScale.gradeSteps[0])).toBe(100);
     });
 
-    it('should create the initial step and the sticky step when grading scale is empty', () => {
+    it('should create the initial step when grading scale is empty', () => {
         comp.gradingScale = new GradingScale();
         comp.lowerBoundInclusivity = true;
 
         comp.createGradeStep();
 
-        expect(comp.gradingScale.gradeSteps[1].lowerBoundInclusive).toBeFalse();
+        expect(comp.gradingScale.gradeSteps[0].lowerBoundInclusive).toBeTrue();
+        expect(comp.gradingScale.gradeSteps[0].upperBoundInclusive).toBeFalse();
+
+        expect(comp.gradingScale.gradeSteps[0].lowerBoundPercentage).toBe(0);
+        expect(comp.gradingScale.gradeSteps[0].upperBoundPercentage).toBe(100);
+
+        expect(comp.gradingScale.gradeSteps[1].lowerBoundInclusive).toBeTrue();
+        expect(comp.gradingScale.gradeSteps[1].upperBoundInclusive).toBeFalse();
+
+        expect(comp.gradingScale.gradeSteps[1].lowerBoundPercentage).toBe(100);
+
         expect(comp.gradingScale.gradeSteps).toHaveLength(2);
     });
 
@@ -363,9 +373,9 @@ describe('Interval Grading System Component', () => {
         expect(comp.gradingScale.gradeSteps[1].upperBoundInclusive).toBeFalse();
 
         expect(comp.gradingScale.gradeSteps[2].lowerBoundInclusive).toBeTrue();
-        expect(comp.gradingScale.gradeSteps[2].upperBoundInclusive).toBeTrue();
+        expect(comp.gradingScale.gradeSteps[2].upperBoundInclusive).toBeFalse();
 
-        expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBeFalse();
+        expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBeTrue();
         expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBeTrue();
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #7023
Issue #7012 gets fixed, but only for new Grading Scales. Existing Grading Scales are not affected by this PR.
For existing Grading Scales, issue #7012 gets closed by #7018 

### Description
The additional sticky grade step (prev. named "1.0+") got removed. Therefor, the grade steps from the default grading key now have unique names.
Furthermore, the bounds of all grade steps are now dependent on the "Inclusivity" setting. This also means that the second to the last grade step now follows the "Inclusivity" setting for its upper bound, which was always set to true before.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course

For #7023 
- Navigate to course-management > _your course_ > assessment > grading key
- Generate Default Grading Key
- Verify that all Grade Steps have unique names

- Also verify that adding and removing Grade Steps works as expected (edge cases like removing the first grade step or last grade step. Make sure that the boundaries of the grade steps are updated accordingly)

For #7012 (new grading keys only, does not fix 7012 for existing grading keys. A fix for existing grading keys can be found here: #7018)
- Navigate to course-management > _your course_ > assessment > grading key
- Generate Default Grading Key and save it
- Change the "Inclusivity" setting and save the grading key
- Verify that the "Inclusivity" setting is still the same after reloading the page

- Also try adding and removing grade steps (edge cases like grade steps starting above 100%) before saving changes to the inclusivity setting.

### Review Progress

#### Performance Review
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
Changes are covered by existing tests. Existing tests have been adapted to the new default grading key and bounding behaviour.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Default Grading Key before changes:
![Bildschirmfoto 2023-08-03 um 11 54 49](https://github.com/ls1intum/Artemis/assets/47261058/182e6f83-b1d6-46ed-af29-8b5369797672)

Default Grading Key after changes
![Bildschirmfoto 2023-08-03 um 11 54 03](https://github.com/ls1intum/Artemis/assets/47261058/529e9942-db5e-4c0d-b819-033a5c822f55)

