### PR TITLE
`Development`: Reduce transferred data for course (un)enrollment endpoints

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -296,16 +296,16 @@ public class CourseResource {
      * database.
      *
      * @param courseId to find the course
-     * @return response entity for user who has been enrolled in the course
+     * @return response entity for groups of user who has been enrolled in the course
      */
     @PostMapping("courses/{courseId}/enroll")
     @EnforceAtLeastStudent
-    public ResponseEntity<User> enrollInCourse(@PathVariable Long courseId) {
+    public ResponseEntity<Set<String>> enrollInCourse(@PathVariable Long courseId) {
         Course course = courseRepository.findWithEagerOrganizationsElseThrow(courseId);
         User user = userRepository.getUserWithGroupsAndAuthoritiesAndOrganizations();
         log.debug("REST request to enroll {} in Course {}", user.getName(), course.getTitle());
         courseService.enrollUserForCourseOrThrow(user, course);
-        return ResponseEntity.ok(user);
+        return ResponseEntity.ok(user.getGroups());
     }
 
     /**
@@ -315,16 +315,16 @@ public class CourseResource {
      * database.
      *
      * @param courseId to find the course
-     * @return response entity for user who has been unenrolled from the course
+     * @return response entity for groups of user who has been unenrolled from the course
      */
     @PostMapping("courses/{courseId}/unenroll")
     @EnforceAtLeastStudent
-    public ResponseEntity<User> unenrollFromCourse(@PathVariable Long courseId) {
+    public ResponseEntity<Set<String>> unenrollFromCourse(@PathVariable Long courseId) {
         Course course = courseRepository.findWithEagerOrganizationsElseThrow(courseId);
         User user = userRepository.getUserWithGroupsAndAuthoritiesAndOrganizations();
         log.debug("REST request to unenroll {} for Course {}", user.getName(), course.getTitle());
         courseService.unenrollUserForCourseOrThrow(user, course);
-        return ResponseEntity.ok(user);
+        return ResponseEntity.ok(user.getGroups());
     }
 
     /**

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -78,8 +78,8 @@ export class AccountService implements IAccountService {
         this.userIdentity = identity;
     }
 
-    syncGroups(identity: User) {
-        this.userIdentity!.groups = identity.groups;
+    syncGroups(groups: string[]) {
+        this.userIdentity!.groups = groups;
     }
 
     hasAnyAuthority(authorities: string[]): Promise<boolean> {

--- a/src/main/webapp/app/course/manage/course-management.service.ts
+++ b/src/main/webapp/app/course/manage/course-management.service.ts
@@ -263,9 +263,9 @@ export class CourseManagementService {
      * NB: the body is null, because the server can identify the user anyway
      * @param courseId - the id of the course
      */
-    registerForCourse(courseId: number): Observable<HttpResponse<User>> {
-        return this.http.post<User>(`${this.resourceUrl}/${courseId}/enroll`, null, { observe: 'response' }).pipe(
-            map((res: HttpResponse<User>) => {
+    registerForCourse(courseId: number): Observable<HttpResponse<string[]>> {
+        return this.http.post<string[]>(`${this.resourceUrl}/${courseId}/enroll`, null, { observe: 'response' }).pipe(
+            map((res: HttpResponse<string[]>) => {
                 if (res.body != undefined) {
                     this.accountService.syncGroups(res.body);
                 }
@@ -279,9 +279,9 @@ export class CourseManagementService {
      * NB: the body is null, because the server can identify the user anyway
      * @param courseId - the id of the course
      */
-    unenrollFromCourse(courseId: number): Observable<HttpResponse<User>> {
-        return this.http.post<User>(`${this.resourceUrl}/${courseId}/unenroll`, null, { observe: 'response' }).pipe(
-            map((res: HttpResponse<User>) => {
+    unenrollFromCourse(courseId: number): Observable<HttpResponse<string[]>> {
+        return this.http.post<string[]>(`${this.resourceUrl}/${courseId}/unenroll`, null, { observe: 'response' }).pipe(
+            map((res: HttpResponse<string[]>) => {
                 if (res.body != undefined) {
                     this.accountService.syncGroups(res.body);
                 }

--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -192,8 +192,8 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
         course1 = courseRepository.save(course1);
 
         jenkinsRequestMockProvider.mockUpdateUserAndGroups(student.getLogin(), student, student.getGroups(), Set.of(), false);
-        final var updatedStudent = request.postWithResponseBody("/api/courses/" + course1.getId() + "/enroll", null, User.class, HttpStatus.OK);
-        assertThat(updatedStudent.getGroups()).as("User is registered for course").contains(course1.getStudentGroupName());
+        Set<String> updatedGroups = request.postWithResponseBody("/api/courses/" + course1.getId() + "/enroll", null, Set.class, HttpStatus.OK);
+        assertThat(updatedGroups).as("User is registered for course").contains(course1.getStudentGroupName());
     }
 
     @NotNull

--- a/src/test/java/de/tum/in/www1/artemis/course/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/course/CourseTestService.java
@@ -1542,15 +1542,15 @@ public class CourseTestService {
         mockDelegate.mockAddUserToGroupInUserManagement(student, course1.getStudentGroupName(), false);
         mockDelegate.mockAddUserToGroupInUserManagement(student, course2.getStudentGroupName(), false);
 
-        User updatedStudent = request.postWithResponseBody("/api/courses/" + course1.getId() + "/enroll", null, User.class, HttpStatus.OK);
-        assertThat(updatedStudent.getGroups()).as("User is enrolled in course").contains(course1.getStudentGroupName());
+        Set<String> updatedGroups = request.postWithResponseBody("/api/courses/" + course1.getId() + "/enroll", null, Set.class, HttpStatus.OK);
+        assertThat(updatedGroups).as("User is enrolled in course").contains(course1.getStudentGroupName());
 
         List<AuditEvent> auditEvents = auditEventRepo.find("ab12cde", Instant.now().minusSeconds(20), Constants.ENROLL_IN_COURSE);
         assertThat(auditEvents).as("Audit Event for course enrollment added").hasSize(1);
         AuditEvent auditEvent = auditEvents.get(0);
         assertThat(auditEvent.getData()).as("Correct Event Data").containsEntry("course", course1.getTitle());
 
-        request.postWithResponseBody("/api/courses/" + course2.getId() + "/enroll", null, User.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/courses/" + course2.getId() + "/enroll", null, Set.class, HttpStatus.FORBIDDEN);
     }
 
     // Test
@@ -1597,8 +1597,8 @@ public class CourseTestService {
     }
 
     private void testUnenrollFromCourseSuccessfull(Course course) throws Exception {
-        User updatedStudent = request.postWithResponseBody("/api/courses/" + course.getId() + "/unenroll", null, User.class, HttpStatus.OK);
-        assertThat(updatedStudent.getGroups()).as("User is not enrolled in course").doesNotContain(course.getStudentGroupName());
+        Set<String> updatedGroups = request.postWithResponseBody("/api/courses/" + course.getId() + "/unenroll", null, Set.class, HttpStatus.OK);
+        assertThat(updatedGroups).as("User is not enrolled in course").doesNotContain(course.getStudentGroupName());
         List<AuditEvent> auditEvents = auditEventRepo.find(userPrefix + "student1", Instant.now().minusSeconds(20), Constants.UNENROLL_FROM_COURSE);
         assertThat(auditEvents).as("Audit Event for course unenrollment added").hasSize(1);
         AuditEvent auditEvent = auditEvents.get(0);

--- a/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
@@ -140,13 +140,13 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
         bitbucketRequestMockProvider.mockUpdateUserDetails(student.getLogin(), student.getEmail(), student.getName());
         bitbucketRequestMockProvider.mockAddUserToGroups();
 
-        User updatedStudent = request.postWithResponseBody("/api/courses/" + course1.getId() + "/enroll", null, User.class, HttpStatus.OK);
-        assertThat(updatedStudent.getGroups()).as("User is enrolled in course").contains(course1.getStudentGroupName());
+        Set<String> updatedGroups = request.postWithResponseBody("/api/courses/" + course1.getId() + "/enroll", null, Set.class, HttpStatus.OK);
+        assertThat(updatedGroups).as("User is enrolled in course").contains(course1.getStudentGroupName());
 
-        updatedStudent = request.postWithResponseBody("/api/courses/" + course2.getId() + "/enroll", null, User.class, HttpStatus.OK);
-        assertThat(updatedStudent.getGroups()).as("User is enrolled in course").contains(course2.getStudentGroupName());
+        updatedGroups = request.postWithResponseBody("/api/courses/" + course2.getId() + "/enroll", null, Set.class, HttpStatus.OK);
+        assertThat(updatedGroups).as("User is enrolled in course").contains(course2.getStudentGroupName());
 
-        request.postWithResponseBody("/api/courses/" + course3.getId() + "/enroll", null, User.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/courses/" + course3.getId() + "/enroll", null, Set.class, HttpStatus.FORBIDDEN);
     }
 
     /**

--- a/src/test/javascript/spec/component/course-registration/course-registration-button/course-registration-button.component.spec.ts
+++ b/src/test/javascript/spec/component/course-registration/course-registration-button/course-registration-button.component.spec.ts
@@ -38,7 +38,7 @@ describe('CourseRegistrationButtonComponent', () => {
                 profileService = TestBed.inject(ProfileService);
                 onRegistrationSpy = jest.spyOn(component.onRegistration, 'emit');
 
-                registerForCourseStub = jest.spyOn(courseService, 'registerForCourse').mockReturnValue(of(new HttpResponse({ body: new User() })));
+                registerForCourseStub = jest.spyOn(courseService, 'registerForCourse').mockReturnValue(of(new HttpResponse({ body: ['student-group-name'] })));
                 identityStub = jest.spyOn(accountService, 'identity').mockReturnValue(Promise.resolve({ login: 'ga12tes' } as User));
                 getProfileInfoStub = jest
                     .spyOn(profileService, 'getProfileInfo')

--- a/src/test/javascript/spec/component/course/course-management.service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management.service.spec.ts
@@ -311,26 +311,26 @@ describe('Course Management Service', () => {
     }));
 
     it('should register for the course', fakeAsync(() => {
-        const user = new User(1, 'name');
+        const groups = ['student-group-name'];
         courseManagementService
             .registerForCourse(course.id!)
             .pipe(take(1))
-            .subscribe((res) => expect(res.body).toEqual(user));
+            .subscribe((res) => expect(res.body).toEqual(groups));
         const req = httpMock.expectOne({ method: 'POST', url: `${resourceUrl}/${course.id}/enroll` });
-        req.flush(user);
-        expect(syncGroupsSpy).toHaveBeenCalledWith(user);
+        req.flush(groups);
+        expect(syncGroupsSpy).toHaveBeenCalledWith(groups);
         tick();
     }));
 
     it('should unenroll from the course', fakeAsync(() => {
-        const user = new User(1, 'name');
+        const groups = ['student-group-name'];
         courseManagementService
             .unenrollFromCourse(course.id!)
             .pipe(take(1))
-            .subscribe((res) => expect(res.body).toEqual(user));
+            .subscribe((res) => expect(res.body).toEqual(groups));
         const req = httpMock.expectOne({ method: 'POST', url: `${resourceUrl}/${course.id}/unenroll` });
-        req.flush(user);
-        expect(syncGroupsSpy).toHaveBeenCalledWith(user);
+        req.flush(groups);
+        expect(syncGroupsSpy).toHaveBeenCalledWith(groups);
         tick();
     }));
 

--- a/src/test/javascript/spec/component/course/course-unenrollment/course-unenrollment-modal.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-unenrollment/course-unenrollment-modal.component.spec.ts
@@ -4,7 +4,6 @@ import { CourseManagementService } from 'app/course/manage/course-management.ser
 import { of, throwError } from 'rxjs';
 import dayjs from 'dayjs/esm';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
-import { User } from 'app/core/user/user.model';
 import { MockPipe, MockProvider } from 'ng-mocks';
 import { AlertService } from 'app/core/util/alert.service';
 import { CourseUnenrollmentModalComponent } from 'app/overview/course-unenrollment-modal.component';
@@ -42,7 +41,7 @@ describe('CourseRegistrationButtonComponent', () => {
                 component.course.id = 1;
                 component.course.title = 'Unenrollment Test Course Title';
                 courseService = TestBed.inject(CourseManagementService);
-                unenrollFromCourseStub = jest.spyOn(courseService, 'unenrollFromCourse').mockReturnValue(of(new HttpResponse({ body: new User() })));
+                unenrollFromCourseStub = jest.spyOn(courseService, 'unenrollFromCourse').mockReturnValue(of(new HttpResponse({ body: ['student-group-name'] })));
                 alertService = TestBed.inject(AlertService);
                 successAlertStub = jest.spyOn(alertService, 'success');
                 errorAlertStub = jest.spyOn(alertService, 'error');

--- a/src/test/javascript/spec/service/account.service.spec.ts
+++ b/src/test/javascript/spec/service/account.service.spec.ts
@@ -108,7 +108,7 @@ describe('AccountService', () => {
     it('should sync user groups', () => {
         accountService.userIdentity = user;
 
-        accountService.syncGroups(user3.groups);
+        accountService.syncGroups(user3.groups!);
 
         expect(accountService.userIdentity.groups).toEqual(['USER', 'TA']);
     });

--- a/src/test/javascript/spec/service/account.service.spec.ts
+++ b/src/test/javascript/spec/service/account.service.spec.ts
@@ -108,7 +108,7 @@ describe('AccountService', () => {
     it('should sync user groups', () => {
         accountService.userIdentity = user;
 
-        accountService.syncGroups(user3);
+        accountService.syncGroups(user3.groups);
 
         expect(accountService.userIdentity.groups).toEqual(['USER', 'TA']);
     });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the endpoints for enrollment and unenrollment return the complete User although only the updated Groups are required.

### Description
<!-- Describe your changes in detail -->
This PR changes the return type of the (un)enrollment endpoints to return only the set of groups.
The client services are updated accordingly.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Course with enrollment & unenrollment enabled

1. Log in to Artemis
2. Navigate to course enrollment
3. Make sure you can enroll in the course and access the content
4. In the course overview click unenroll from the course
5. Make sure you can unenroll from the course and you don't see it on the dashboard anymore

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [account.service.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5285/latest/artifact/shared/Coverage-Report-Client-Tests/app/core/auth/account.service.ts.html) | 87.62% | ✅ |
| [course-management.service.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5285/latest/artifact/shared/Coverage-Report-Client-Tests/app/course/manage/course-management.service.ts.html) | 87.66% | ✅ |

#### Server

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [CourseResource.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5285/latest/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.web.rest/CourseResource.html) | 94% | ✅ |


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
