### PR TITLE
`Exam mode`: Prevent content of Exam Checklist from leaving viewport

### DIFF
--- a/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.html
@@ -17,228 +17,230 @@
     <h3>
         {{ 'artemisApp.examStatus.preparation.' + (isTestExam ? 'testExam.' : '') + 'examPreparation' | artemisTranslate }}
     </h3>
-    <table class="table table-striped">
-        <thead>
-            <tr>
-                <th>
-                    <span>#</span>
-                </th>
-                <th>
-                    <span>{{ 'artemisApp.examManagement.checklist.checklistItem' | artemisTranslate }}</span>
-                </th>
-                <th>
-                    <span>{{ 'artemisApp.examManagement.checklist.description' | artemisTranslate }}</span>
-                </th>
-                <th>
-                    <span>{{ 'artemisApp.examManagement.checklist.goTo' | artemisTranslate }}</span>
-                </th>
-            </tr>
-        </thead>
-
-        <tbody>
-            <tr>
-                <td>1</td>
-                <td>
-                    <span>{{ 'artemisApp.examManagement.checklist.tableItem.exerciseGroups' | artemisTranslate }}</span>
-                </td>
-                <td>
-                    <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.exerciseGroups' | artemisTranslate }}</span>
-                    <hr />
-                    <ul class="list-unstyled">
-                        <li class="list-group-item border-1">
-                            <span>
-                                <jhi-checklist-check [checkAttribute]="exam.exerciseGroups && exam.exerciseGroups.length > 0"></jhi-checklist-check>
-                                <span>{{ 'artemisApp.examManagement.checklist.textitems.leastoneexercisegroup' | artemisTranslate }}</span>
-                            </span>
-                        </li>
-                        <li class="list-group-item border-1">
-                            <span>
-                                <!-- assert amount mandatory exercises <= number in settings <= amount total exercises -->
-                                <jhi-checklist-check
-                                    [checkAttribute]="
-                                        exam.exerciseGroups &&
-                                        countMandatoryExercises <= (exam.numberOfExercisesInExam ?? 0) &&
-                                        (exam.numberOfExercisesInExam ?? 0) <= exam.exerciseGroups.length
-                                    "
-                                ></jhi-checklist-check>
-                                <span>{{
-                                    (!hasOptionalExercises
-                                        ? 'artemisApp.examManagement.checklist.textitems.numberofexercisegroupsequal'
-                                        : 'artemisApp.examManagement.checklist.textitems.numberofexercisegroupsinbetween'
-                                    ) | artemisTranslate
-                                }}</span>
-                            </span>
-                        </li>
-                        <li class="list-group-item border-1">
-                            <span>
-                                <jhi-checklist-check [checkAttribute]="allGroupsContainExercise"></jhi-checklist-check>
-                                <span>{{ 'artemisApp.examManagement.checklist.textitems.eachexercisegroup' | artemisTranslate }}</span>
-                            </span>
-                        </li>
-                        <li class="list-group-item border-1">
-                            <span>
-                                <jhi-checklist-check [checkAttribute]="pointsExercisesEqual"></jhi-checklist-check>
-                                <span>{{ 'artemisApp.examManagement.checklist.textitems.pointsexercisegroupequal' | artemisTranslate }}</span>
-                            </span>
-                        </li>
-                        <li class="list-group-item border-1">
-                            <span>
-                                <jhi-checklist-check [checkAttribute]="totalPoints"></jhi-checklist-check>
-                                <span>{{ 'artemisApp.examManagement.checklist.textitems.totalpointspossible' | artemisTranslate }}</span>
-                            </span>
-                        </li>
-                    </ul>
-
-                    <hr />
-                    <!-- Exercise Group table -->
-                    <jhi-exam-checklist-exercisegroup-table [exerciseGroups]="exam.exerciseGroups || []"></jhi-exam-checklist-exercisegroup-table>
-                </td>
-                <td>
-                    <a type="submit" [routerLink]="getExamRoutesByIdentifier('exercise-groups')" class="btn btn-primary" id="exercises-button-groups-table">
-                        <fa-icon [icon]="faListAlt"></fa-icon>
-                        <span>{{ 'artemisApp.examManagement.exerciseGroups' | artemisTranslate }}</span>
-                    </a>
-                </td>
-            </tr>
-            <tr>
-                <td>2</td>
-                <td>
-                    <span>{{ 'artemisApp.examManagement.checklist.tableItem.testRun' | artemisTranslate }}</span>
-                </td>
-                <td>
-                    <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.testRun' | artemisTranslate }}</span>
-                    <hr />
-                    <ul class="list-unstyled">
-                        <li *ngIf="examChecklist" class="list-group-item border-1">
-                            <span>{{ 'artemisApp.examManagement.checklist.textitems.testruns' | artemisTranslate }}</span>
-                            {{ examChecklist.numberOfTestRuns }}
-                        </li>
-                    </ul>
-                </td>
-                <td>
-                    <a [routerLink]="getExamRoutesByIdentifier('test-runs')" class="btn btn-info">
-                        <fa-icon [icon]="faUser"></fa-icon>
-                        <span>{{ 'artemisApp.examManagement.testRun.testRun' | artemisTranslate }}</span>
-                    </a>
-                </td>
-            </tr>
-            <ng-container *ngIf="!isTestExam">
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
                 <tr>
-                    <td>3</td>
+                    <th>
+                        <span>#</span>
+                    </th>
+                    <th>
+                        <span>{{ 'artemisApp.examManagement.checklist.checklistItem' | artemisTranslate }}</span>
+                    </th>
+                    <th>
+                        <span>{{ 'artemisApp.examManagement.checklist.description' | artemisTranslate }}</span>
+                    </th>
+                    <th>
+                        <span>{{ 'artemisApp.examManagement.checklist.goTo' | artemisTranslate }}</span>
+                    </th>
+                </tr>
+            </thead>
+
+            <tbody>
+                <tr>
+                    <td>1</td>
                     <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.register' | artemisTranslate }}</span>
+                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.exerciseGroups' | artemisTranslate }}</span>
                     </td>
                     <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.register' | artemisTranslate }}</span>
+                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.exerciseGroups' | artemisTranslate }}</span>
                         <hr />
                         <ul class="list-unstyled">
                             <li class="list-group-item border-1">
                                 <span>
-                                    <jhi-checklist-check [checkAttribute]="!!exam.numberOfExamUsers && exam.numberOfExamUsers! > 0"></jhi-checklist-check>
-                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.leastonestudent' | artemisTranslate }}</span>
+                                    <jhi-checklist-check [checkAttribute]="exam.exerciseGroups && exam.exerciseGroups.length > 0"></jhi-checklist-check>
+                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.leastoneexercisegroup' | artemisTranslate }}</span>
                                 </span>
                             </li>
                             <li class="list-group-item border-1">
-                                <span>{{ 'artemisApp.examManagement.checklist.textitems.studentsregistered' | artemisTranslate }}</span>
-                                <span> {{ exam.numberOfExamUsers }} </span>
+                                <span>
+                                    <!-- assert amount mandatory exercises <= number in settings <= amount total exercises -->
+                                    <jhi-checklist-check
+                                        [checkAttribute]="
+                                            exam.exerciseGroups &&
+                                            countMandatoryExercises <= (exam.numberOfExercisesInExam ?? 0) &&
+                                            (exam.numberOfExercisesInExam ?? 0) <= exam.exerciseGroups.length
+                                        "
+                                    ></jhi-checklist-check>
+                                    <span>{{
+                                        (!hasOptionalExercises
+                                            ? 'artemisApp.examManagement.checklist.textitems.numberofexercisegroupsequal'
+                                            : 'artemisApp.examManagement.checklist.textitems.numberofexercisegroupsinbetween'
+                                        ) | artemisTranslate
+                                    }}</span>
+                                </span>
+                            </li>
+                            <li class="list-group-item border-1">
+                                <span>
+                                    <jhi-checklist-check [checkAttribute]="allGroupsContainExercise"></jhi-checklist-check>
+                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.eachexercisegroup' | artemisTranslate }}</span>
+                                </span>
+                            </li>
+                            <li class="list-group-item border-1">
+                                <span>
+                                    <jhi-checklist-check [checkAttribute]="pointsExercisesEqual"></jhi-checklist-check>
+                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.pointsexercisegroupequal' | artemisTranslate }}</span>
+                                </span>
+                            </li>
+                            <li class="list-group-item border-1">
+                                <span>
+                                    <jhi-checklist-check [checkAttribute]="totalPoints"></jhi-checklist-check>
+                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.totalpointspossible' | artemisTranslate }}</span>
+                                </span>
+                            </li>
+                        </ul>
+
+                        <hr />
+                        <!-- Exercise Group table -->
+                        <jhi-exam-checklist-exercisegroup-table [exerciseGroups]="exam.exerciseGroups || []"></jhi-exam-checklist-exercisegroup-table>
+                    </td>
+                    <td>
+                        <a type="submit" [routerLink]="getExamRoutesByIdentifier('exercise-groups')" class="btn btn-primary" id="exercises-button-groups-table">
+                            <fa-icon [icon]="faListAlt"></fa-icon>
+                            <span>{{ 'artemisApp.examManagement.exerciseGroups' | artemisTranslate }}</span>
+                        </a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>2</td>
+                    <td>
+                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.testRun' | artemisTranslate }}</span>
+                    </td>
+                    <td>
+                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.testRun' | artemisTranslate }}</span>
+                        <hr />
+                        <ul class="list-unstyled">
+                            <li *ngIf="examChecklist" class="list-group-item border-1">
+                                <span>{{ 'artemisApp.examManagement.checklist.textitems.testruns' | artemisTranslate }}</span>
+                                {{ examChecklist.numberOfTestRuns }}
                             </li>
                         </ul>
                     </td>
                     <td>
-                        <a [routerLink]="getExamRoutesByIdentifier('students')" class="btn btn-info">
+                        <a [routerLink]="getExamRoutesByIdentifier('test-runs')" class="btn btn-info">
                             <fa-icon [icon]="faUser"></fa-icon>
-                            <span>{{ 'artemisApp.examManagement.students' | artemisTranslate }}</span>
+                            <span>{{ 'artemisApp.examManagement.testRun.testRun' | artemisTranslate }}</span>
                         </a>
                     </td>
                 </tr>
-                <tr>
-                    <td>4</td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.generateStudentExams' | artemisTranslate }}</span>
-                    </td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.generateStudentExams' | artemisTranslate }}</span>
-                        <hr />
-                        <ul class="list-unstyled">
-                            <li class="list-group-item border-1">
-                                <span>
-                                    <jhi-checklist-check [checkAttribute]="allExamsGenerated"></jhi-checklist-check>
-                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.allexamsgenerated' | artemisTranslate }}</span>
-                                </span>
-                            </li>
-                        </ul>
-                    </td>
-                    <td>
-                        <a [routerLink]="getExamRoutesByIdentifier('student-exams')" class="btn btn-primary">
-                            <fa-icon [icon]="faEye"></fa-icon>
-                            <span class="d-none d-md-inline">{{ 'artemisApp.examManagement.studentExams' | artemisTranslate }}</span>
-                        </a>
-                    </td>
-                </tr>
-                <tr>
-                    <td>5</td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.prepareExerciseStart' | artemisTranslate }}</span>
-                    </td>
-                    <td>
-                        <span
-                            >{{ 'artemisApp.examManagement.checklist.descriptionItem.prepareExerciseStart' | artemisTranslate }}
+                <ng-container *ngIf="!isTestExam">
+                    <tr>
+                        <td>3</td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.tableItem.register' | artemisTranslate }}</span>
+                        </td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.register' | artemisTranslate }}</span>
                             <hr />
                             <ul class="list-unstyled">
-                                <li *ngIf="examChecklist" class="list-group-item border-1">
-                                    <jhi-checklist-check [checkAttribute]="!!examChecklist.allExamExercisesAllStudentsPrepared && this.allExamsGenerated"></jhi-checklist-check>
-                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.allExercisesPrepared' | artemisTranslate }}</span>
+                                <li class="list-group-item border-1">
+                                    <span>
+                                        <jhi-checklist-check [checkAttribute]="!!exam.numberOfExamUsers && exam.numberOfExamUsers! > 0"></jhi-checklist-check>
+                                        <span>{{ 'artemisApp.examManagement.checklist.textitems.leastonestudent' | artemisTranslate }}</span>
+                                    </span>
+                                </li>
+                                <li class="list-group-item border-1">
+                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.studentsregistered' | artemisTranslate }}</span>
+                                    <span> {{ exam.numberOfExamUsers }} </span>
                                 </li>
                             </ul>
-                        </span>
+                        </td>
+                        <td>
+                            <a [routerLink]="getExamRoutesByIdentifier('students')" class="btn btn-info">
+                                <fa-icon [icon]="faUser"></fa-icon>
+                                <span>{{ 'artemisApp.examManagement.students' | artemisTranslate }}</span>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>4</td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.tableItem.generateStudentExams' | artemisTranslate }}</span>
+                        </td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.generateStudentExams' | artemisTranslate }}</span>
+                            <hr />
+                            <ul class="list-unstyled">
+                                <li class="list-group-item border-1">
+                                    <span>
+                                        <jhi-checklist-check [checkAttribute]="allExamsGenerated"></jhi-checklist-check>
+                                        <span>{{ 'artemisApp.examManagement.checklist.textitems.allexamsgenerated' | artemisTranslate }}</span>
+                                    </span>
+                                </li>
+                            </ul>
+                        </td>
+                        <td>
+                            <a [routerLink]="getExamRoutesByIdentifier('student-exams')" class="btn btn-primary">
+                                <fa-icon [icon]="faEye"></fa-icon>
+                                <span class="d-none d-md-inline">{{ 'artemisApp.examManagement.studentExams' | artemisTranslate }}</span>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>5</td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.tableItem.prepareExerciseStart' | artemisTranslate }}</span>
+                        </td>
+                        <td>
+                            <span
+                                >{{ 'artemisApp.examManagement.checklist.descriptionItem.prepareExerciseStart' | artemisTranslate }}
+                                <hr />
+                                <ul class="list-unstyled">
+                                    <li *ngIf="examChecklist" class="list-group-item border-1">
+                                        <jhi-checklist-check [checkAttribute]="!!examChecklist.allExamExercisesAllStudentsPrepared && this.allExamsGenerated"></jhi-checklist-check>
+                                        <span>{{ 'artemisApp.examManagement.checklist.textitems.allExercisesPrepared' | artemisTranslate }}</span>
+                                    </li>
+                                </ul>
+                            </span>
+                        </td>
+                        <td>
+                            <a [routerLink]="getExamRoutesByIdentifier('student-exams')" class="btn btn-primary">
+                                <fa-icon [icon]="faEye"></fa-icon>
+                                <span class="d-none d-md-inline">{{ 'artemisApp.examManagement.studentExams' | artemisTranslate }}</span>
+                            </a>
+                        </td>
+                    </tr>
+                </ng-container>
+                <tr>
+                    <td>{{ isTestExam ? 3 : 6 }}</td>
+                    <td>
+                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.examDetails' | artemisTranslate }}</span>
                     </td>
                     <td>
-                        <a [routerLink]="getExamRoutesByIdentifier('student-exams')" class="btn btn-primary">
-                            <fa-icon [icon]="faEye"></fa-icon>
-                            <span class="d-none d-md-inline">{{ 'artemisApp.examManagement.studentExams' | artemisTranslate }}</span>
+                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.examDetails' | artemisTranslate }}</span>
+                        <!-- Additional hints for test exams, as several steps are automated compared to the normal exam and therefore do not need to be performed by the user -->
+                        <ul class="list-unstyled" *ngIf="isTestExam">
+                            <hr />
+                            <span>{{ 'artemisApp.examManagement.checklist.testExam.detailsHintForTestExams' | artemisTranslate }}:</span>
+                            <li class="list-group-item border-1">
+                                <span>
+                                    <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
+                                    <span>{{ 'artemisApp.examManagement.checklist.testExam.studentRegistration' | artemisTranslate }}</span>
+                                </span>
+                            </li>
+                            <li class="list-group-item border-1">
+                                <span>
+                                    <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
+                                    <span>{{ 'artemisApp.studentExams.studentExamStatusTestExam' | artemisTranslate }}</span>
+                                </span>
+                            </li>
+                            <li class="list-group-item border-1">
+                                <span>
+                                    <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
+                                    <span>{{ 'artemisApp.examManagement.checklist.testExam.instantResults' | artemisTranslate }}</span>
+                                </span>
+                            </li>
+                        </ul>
+                    </td>
+                    <td>
+                        <a id="editButton_table" [routerLink]="getExamRoutesByIdentifier('edit')" class="btn btn-warning">
+                            <fa-icon [icon]="faWrench"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
                         </a>
                     </td>
                 </tr>
-            </ng-container>
-            <tr>
-                <td>{{ isTestExam ? 3 : 6 }}</td>
-                <td>
-                    <span>{{ 'artemisApp.examManagement.checklist.tableItem.examDetails' | artemisTranslate }}</span>
-                </td>
-                <td>
-                    <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.examDetails' | artemisTranslate }}</span>
-                    <!-- Additional hints for test exams, as several steps are automated compared to the normal exam and therefore do not need to be performed by the user -->
-                    <ul class="list-unstyled" *ngIf="isTestExam">
-                        <hr />
-                        <span>{{ 'artemisApp.examManagement.checklist.testExam.detailsHintForTestExams' | artemisTranslate }}:</span>
-                        <li class="list-group-item border-1">
-                            <span>
-                                <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
-                                <span>{{ 'artemisApp.examManagement.checklist.testExam.studentRegistration' | artemisTranslate }}</span>
-                            </span>
-                        </li>
-                        <li class="list-group-item border-1">
-                            <span>
-                                <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
-                                <span>{{ 'artemisApp.studentExams.studentExamStatusTestExam' | artemisTranslate }}</span>
-                            </span>
-                        </li>
-                        <li class="list-group-item border-1">
-                            <span>
-                                <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
-                                <span>{{ 'artemisApp.examManagement.checklist.testExam.instantResults' | artemisTranslate }}</span>
-                            </span>
-                        </li>
-                    </ul>
-                </td>
-                <td>
-                    <a id="editButton_table" [routerLink]="getExamRoutesByIdentifier('edit')" class="btn btn-warning">
-                        <fa-icon [icon]="faWrench"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
-                    </a>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    </div>
     <hr />
     <h3>{{ 'artemisApp.examStatus.conduction.' + (isTestExam ? 'testExam.' : '') + 'examConduction' | artemisTranslate }}</h3>
     <b>{{
@@ -249,78 +251,8 @@
                       to: exam.endDate! | artemisDate
                   }
     }}</b>
-    <table class="table table-striped">
-        <thead>
-            <tr>
-                <th>
-                    <span>#</span>
-                </th>
-                <th>
-                    <span>{{ 'artemisApp.examManagement.checklist.checklistItem' | artemisTranslate }}</span>
-                </th>
-                <th>
-                    <span>{{ 'artemisApp.examManagement.checklist.description' | artemisTranslate }}</span>
-                </th>
-                <th>
-                    <span>{{ 'artemisApp.examManagement.checklist.goTo' | artemisTranslate }}</span>
-                </th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>1</td>
-                <td>
-                    <span>{{ 'artemisApp.examManagement.checklist.tableItem.conductExam' | artemisTranslate }}</span>
-                </td>
-                <td>
-                    <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.conductExam' | artemisTranslate }}</span>
-                    <hr />
-                    <!-- Display number of registered students -->
-                    <div *ngIf="exam.numberOfExamUsers">
-                        <span>{{ 'artemisApp.examManagement.checklist.textitems.studentsregistered' | artemisTranslate }} {{ exam.numberOfExamUsers! }}</span>
-                        <hr />
-                    </div>
-                    <!-- Display started exams-->
-                    <div *ngIf="examChecklist && examChecklist.numberOfGeneratedStudentExams !== null && examChecklist.numberOfGeneratedStudentExams !== 0 && numberOfStarted > 0">
-                        <!-- -->
-                        <span>{{ 'artemisApp.examManagement.checklist.textitems.startedExam' | artemisTranslate }}:</span>
-                        <div class="pt-2">
-                            <jhi-progress-bar
-                                [denominator]="examChecklist.numberOfGeneratedStudentExams!"
-                                [numerator]="numberOfStarted"
-                                [percentage]="(100 * numberOfStarted) / examChecklist.numberOfGeneratedStudentExams!"
-                            >
-                            </jhi-progress-bar>
-                        </div>
-                        <hr />
-                    </div>
-                    <!-- Display submitted exams-->
-                    <div
-                        *ngIf="examChecklist && examChecklist.numberOfGeneratedStudentExams !== null && examChecklist.numberOfGeneratedStudentExams !== 0 && numberOfSubmitted > 0"
-                    >
-                        <span>{{ 'artemisApp.examManagement.checklist.textitems.submittedExam' | artemisTranslate }}:</span>
-                        <div class="pt-2">
-                            <jhi-progress-bar [denominator]="numberOfStarted" [numerator]="numberOfSubmitted!" [percentage]="(100 * numberOfSubmitted!) / numberOfStarted">
-                            </jhi-progress-bar>
-                        </div>
-                        <br />
-                    </div>
-                    <div *ngIf="examChecklist && numberOfSubmitted! === 0">
-                        <span>{{ 'artemisApp.examManagement.checklist.textitems.noSubmissions' | artemisTranslate }}</span>
-                    </div>
-                </td>
-                <td>
-                    <a [routerLink]="getExamRoutesByIdentifier('student-exams')" class="btn btn-primary">
-                        <fa-icon [icon]="faEye"></fa-icon>
-                        <span class="d-none d-md-inline">{{ 'artemisApp.examManagement.studentExams' | artemisTranslate }}</span>
-                    </a>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    <hr />
-    <ng-container *ngIf="!isTestExam">
-        <h3>{{ 'artemisApp.examStatus.correction.examCorrection' | artemisTranslate }}</h3>
+
+    <div class="table-responsive">
         <table class="table table-striped">
             <thead>
                 <tr>
@@ -342,140 +274,221 @@
                 <tr>
                     <td>1</td>
                     <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.assessAllSubmissions' | artemisTranslate }}</span>
+                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.conductExam' | artemisTranslate }}</span>
                     </td>
                     <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.assessAllSubmissions' | artemisTranslate }}</span>
-
+                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.conductExam' | artemisTranslate }}</span>
                         <hr />
-                        <!-- Display assessment progress summed up over all exercises, by correction round -->
-
-                        <div *ngIf="examChecklist && examChecklist.numberOfTotalExamAssessmentsFinishedByCorrectionRound !== null && numberOfSubmitted !== 0">
-                            <div *ngFor="let finishedByCorrectionRound of examChecklist.numberOfTotalExamAssessmentsFinishedByCorrectionRound; let index = index">
-                                <hr *ngIf="index > 0" />
-                                <span> {{ 'artemisApp.examManagement.checklist.textitems.correctionRound' | artemisTranslate }} {{ index + 1 }} : </span>
-                                <div class="pt-2">
-                                    <jhi-progress-bar
-                                        [denominator]="examChecklist.numberOfTotalParticipationsForAssessment"
-                                        [numerator]="finishedByCorrectionRound!"
-                                        [percentage]="(finishedByCorrectionRound! / examChecklist.numberOfTotalParticipationsForAssessment) * 100"
-                                    >
-                                    </jhi-progress-bar>
-                                </div>
-                            </div>
+                        <!-- Display number of registered students -->
+                        <div *ngIf="exam.numberOfExamUsers">
+                            <span>{{ 'artemisApp.examManagement.checklist.textitems.studentsregistered' | artemisTranslate }} {{ exam.numberOfExamUsers! }}</span>
+                            <hr />
                         </div>
-                        <div *ngIf="examChecklist && numberOfSubmitted === 0">
-                            <span>{{ 'artemisApp.examManagement.checklist.textitems.noSubmissions' | artemisTranslate }}</span>
-                        </div>
-                        <br />
-                    </td>
-                    <td>
-                        <a [routerLink]="getExamRoutesByIdentifier('assessment-dashboard')" class="btn btn-primary">
-                            <fa-icon [icon]="faThList"></fa-icon>
-                            <span>{{ 'artemisApp.examManagement.assessmentDashboard' | artemisTranslate }}</span>
-                        </a>
-                    </td>
-                </tr>
-                <tr>
-                    <td>2</td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.publishResults' | artemisTranslate }}</span>
-                    </td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.publishResults' | artemisTranslate }}</span>
-
-                        <hr />
-                        <ul class="list-unstyled">
-                            <li class="list-group-item border-1">
-                                <span>
-                                    <jhi-checklist-check [checkAttribute]="!!exam.publishResultsDate"></jhi-checklist-check>
-                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.pulishingdateset' | artemisTranslate }}</span>
-                                </span>
-                            </li>
-                        </ul>
-                    </td>
-                    <td>
-                        <a id="editButton_publish" [routerLink]="getExamRoutesByIdentifier('edit')" class="btn btn-warning">
-                            <fa-icon [icon]="faWrench"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
-                        </a>
-                    </td>
-                </tr>
-                <tr>
-                    <td>3</td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.examReview' | artemisTranslate }}</span>
-                    </td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.examReview' | artemisTranslate }}</span>
-
-                        <hr />
-                        <ul class="list-unstyled">
-                            <li class="list-group-item border-1">
-                                <span>
-                                    <jhi-checklist-check [checkAttribute]="!!exam.examStudentReviewStart"></jhi-checklist-check>
-                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.startdatereviewset' | artemisTranslate }}</span>
-                                </span>
-                            </li>
-                            <li class="list-group-item border-1">
-                                <span>
-                                    <jhi-checklist-check [checkAttribute]="!!exam.examStudentReviewEnd"></jhi-checklist-check>
-                                    <span>{{ 'artemisApp.examManagement.checklist.textitems.enddatereviewset' | artemisTranslate }}</span>
-                                </span>
-                            </li>
-                        </ul>
-                    </td>
-                    <td>
-                        <a id="editButton_review" [routerLink]="getExamRoutesByIdentifier('edit')" class="btn btn-warning">
-                            <fa-icon [icon]="faWrench"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit">Edit</span>
-                        </a>
-                    </td>
-                </tr>
-                <tr>
-                    <td>4</td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.resolveComplaints' | artemisTranslate }}</span>
-                    </td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.resolveComplaints' | artemisTranslate }}</span>
-                        <hr />
-                        <div *ngIf="examChecklist && examChecklist.numberOfAllComplaintsDone !== null && examChecklist.numberOfAllComplaints !== 0">
+                        <!-- Display started exams-->
+                        <div
+                            *ngIf="
+                                examChecklist && examChecklist.numberOfGeneratedStudentExams !== null && examChecklist.numberOfGeneratedStudentExams !== 0 && numberOfStarted > 0
+                            "
+                        >
+                            <!-- -->
+                            <span>{{ 'artemisApp.examManagement.checklist.textitems.startedExam' | artemisTranslate }}:</span>
                             <div class="pt-2">
                                 <jhi-progress-bar
-                                    [denominator]="examChecklist.numberOfAllComplaints!"
-                                    [numerator]="examChecklist.numberOfAllComplaintsDone!"
-                                    [percentage]="(examChecklist.numberOfAllComplaintsDone! / examChecklist.numberOfAllComplaints!) * 100"
+                                    [denominator]="examChecklist.numberOfGeneratedStudentExams!"
+                                    [numerator]="numberOfStarted"
+                                    [percentage]="(100 * numberOfStarted) / examChecklist.numberOfGeneratedStudentExams!"
                                 >
                                 </jhi-progress-bar>
                             </div>
+                            <hr />
                         </div>
-                        <div *ngIf="examChecklist && examChecklist.numberOfAllComplaints === 0">
-                            <span>{{ 'artemisApp.examManagement.checklist.textitems.noComplaints' | artemisTranslate }}</span>
+                        <!-- Display submitted exams-->
+                        <div
+                            *ngIf="
+                                examChecklist && examChecklist.numberOfGeneratedStudentExams !== null && examChecklist.numberOfGeneratedStudentExams !== 0 && numberOfSubmitted > 0
+                            "
+                        >
+                            <span>{{ 'artemisApp.examManagement.checklist.textitems.submittedExam' | artemisTranslate }}:</span>
+                            <div class="pt-2">
+                                <jhi-progress-bar [denominator]="numberOfStarted" [numerator]="numberOfSubmitted!" [percentage]="(100 * numberOfSubmitted!) / numberOfStarted">
+                                </jhi-progress-bar>
+                            </div>
+                            <br />
                         </div>
-                        <br />
+                        <div *ngIf="examChecklist && numberOfSubmitted! === 0">
+                            <span>{{ 'artemisApp.examManagement.checklist.textitems.noSubmissions' | artemisTranslate }}</span>
+                        </div>
                     </td>
                     <td>
-                        <a [routerLink]="getExamRoutesByIdentifier('assessment-dashboard')" class="btn btn-primary" id="tutor-exam-dashboard-button_table_complaints">
-                            <fa-icon [icon]="faThList"></fa-icon>
-                            <span>{{ 'artemisApp.examManagement.assessmentDashboard' | artemisTranslate }}</span>
-                        </a>
-                    </td>
-                </tr>
-                <tr>
-                    <td>5</td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.tableItem.exportResults' | artemisTranslate }}</span>
-                    </td>
-                    <td>
-                        <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.exportResults' | artemisTranslate }}</span>
-                    </td>
-                    <td>
-                        <a [routerLink]="getExamRoutesByIdentifier('scores')" class="btn btn-info" id="scores-button_publish_result">
+                        <a [routerLink]="getExamRoutesByIdentifier('student-exams')" class="btn btn-primary">
                             <fa-icon [icon]="faEye"></fa-icon>
-                            <span>{{ 'entity.action.scores' | artemisTranslate }}</span>
+                            <span class="d-none d-md-inline">{{ 'artemisApp.examManagement.studentExams' | artemisTranslate }}</span>
                         </a>
                     </td>
                 </tr>
             </tbody>
         </table>
+    </div>
+    <hr />
+    <ng-container *ngIf="!isTestExam">
+        <h3>{{ 'artemisApp.examStatus.correction.examCorrection' | artemisTranslate }}</h3>
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>
+                            <span>#</span>
+                        </th>
+                        <th>
+                            <span>{{ 'artemisApp.examManagement.checklist.checklistItem' | artemisTranslate }}</span>
+                        </th>
+                        <th>
+                            <span>{{ 'artemisApp.examManagement.checklist.description' | artemisTranslate }}</span>
+                        </th>
+                        <th>
+                            <span>{{ 'artemisApp.examManagement.checklist.goTo' | artemisTranslate }}</span>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>1</td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.tableItem.assessAllSubmissions' | artemisTranslate }}</span>
+                        </td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.assessAllSubmissions' | artemisTranslate }}</span>
+
+                            <hr />
+                            <!-- Display assessment progress summed up over all exercises, by correction round -->
+
+                            <div *ngIf="examChecklist && examChecklist.numberOfTotalExamAssessmentsFinishedByCorrectionRound !== null && numberOfSubmitted !== 0">
+                                <div *ngFor="let finishedByCorrectionRound of examChecklist.numberOfTotalExamAssessmentsFinishedByCorrectionRound; let index = index">
+                                    <hr *ngIf="index > 0" />
+                                    <span> {{ 'artemisApp.examManagement.checklist.textitems.correctionRound' | artemisTranslate }} {{ index + 1 }} : </span>
+                                    <div class="pt-2">
+                                        <jhi-progress-bar
+                                            [denominator]="examChecklist.numberOfTotalParticipationsForAssessment"
+                                            [numerator]="finishedByCorrectionRound!"
+                                            [percentage]="(finishedByCorrectionRound! / examChecklist.numberOfTotalParticipationsForAssessment) * 100"
+                                        >
+                                        </jhi-progress-bar>
+                                    </div>
+                                </div>
+                            </div>
+                            <div *ngIf="examChecklist && numberOfSubmitted === 0">
+                                <span>{{ 'artemisApp.examManagement.checklist.textitems.noSubmissions' | artemisTranslate }}</span>
+                            </div>
+                            <br />
+                        </td>
+                        <td>
+                            <a [routerLink]="getExamRoutesByIdentifier('assessment-dashboard')" class="btn btn-primary">
+                                <fa-icon [icon]="faThList"></fa-icon>
+                                <span>{{ 'artemisApp.examManagement.assessmentDashboard' | artemisTranslate }}</span>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>2</td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.tableItem.publishResults' | artemisTranslate }}</span>
+                        </td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.publishResults' | artemisTranslate }}</span>
+
+                            <hr />
+                            <ul class="list-unstyled">
+                                <li class="list-group-item border-1">
+                                    <span>
+                                        <jhi-checklist-check [checkAttribute]="!!exam.publishResultsDate"></jhi-checklist-check>
+                                        <span>{{ 'artemisApp.examManagement.checklist.textitems.pulishingdateset' | artemisTranslate }}</span>
+                                    </span>
+                                </li>
+                            </ul>
+                        </td>
+                        <td>
+                            <a id="editButton_publish" [routerLink]="getExamRoutesByIdentifier('edit')" class="btn btn-warning">
+                                <fa-icon [icon]="faWrench"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>3</td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.tableItem.examReview' | artemisTranslate }}</span>
+                        </td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.examReview' | artemisTranslate }}</span>
+
+                            <hr />
+                            <ul class="list-unstyled">
+                                <li class="list-group-item border-1">
+                                    <span>
+                                        <jhi-checklist-check [checkAttribute]="!!exam.examStudentReviewStart"></jhi-checklist-check>
+                                        <span>{{ 'artemisApp.examManagement.checklist.textitems.startdatereviewset' | artemisTranslate }}</span>
+                                    </span>
+                                </li>
+                                <li class="list-group-item border-1">
+                                    <span>
+                                        <jhi-checklist-check [checkAttribute]="!!exam.examStudentReviewEnd"></jhi-checklist-check>
+                                        <span>{{ 'artemisApp.examManagement.checklist.textitems.enddatereviewset' | artemisTranslate }}</span>
+                                    </span>
+                                </li>
+                            </ul>
+                        </td>
+                        <td>
+                            <a id="editButton_review" [routerLink]="getExamRoutesByIdentifier('edit')" class="btn btn-warning">
+                                <fa-icon [icon]="faWrench"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit">Edit</span>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>4</td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.tableItem.resolveComplaints' | artemisTranslate }}</span>
+                        </td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.resolveComplaints' | artemisTranslate }}</span>
+                            <hr />
+                            <div *ngIf="examChecklist && examChecklist.numberOfAllComplaintsDone !== null && examChecklist.numberOfAllComplaints !== 0">
+                                <div class="pt-2">
+                                    <jhi-progress-bar
+                                        [denominator]="examChecklist.numberOfAllComplaints!"
+                                        [numerator]="examChecklist.numberOfAllComplaintsDone!"
+                                        [percentage]="(examChecklist.numberOfAllComplaintsDone! / examChecklist.numberOfAllComplaints!) * 100"
+                                    >
+                                    </jhi-progress-bar>
+                                </div>
+                            </div>
+                            <div *ngIf="examChecklist && examChecklist.numberOfAllComplaints === 0">
+                                <span>{{ 'artemisApp.examManagement.checklist.textitems.noComplaints' | artemisTranslate }}</span>
+                            </div>
+                            <br />
+                        </td>
+                        <td>
+                            <a [routerLink]="getExamRoutesByIdentifier('assessment-dashboard')" class="btn btn-primary" id="tutor-exam-dashboard-button_table_complaints">
+                                <fa-icon [icon]="faThList"></fa-icon>
+                                <span>{{ 'artemisApp.examManagement.assessmentDashboard' | artemisTranslate }}</span>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>5</td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.tableItem.exportResults' | artemisTranslate }}</span>
+                        </td>
+                        <td>
+                            <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.exportResults' | artemisTranslate }}</span>
+                        </td>
+                        <td>
+                            <a [routerLink]="getExamRoutesByIdentifier('scores')" class="btn btn-info" id="scores-button_publish_result">
+                                <fa-icon [icon]="faEye"></fa-icon>
+                                <span>{{ 'entity.action.scores' | artemisTranslate }}</span>
+                            </a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </ng-container>
 </div>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
It's an old issue that was labeled `good first issue` so I figured I have a go at it. Hope it's alright and if it's not needed anymore, just close the PR unmerged.
<!-- If it fixes an open issue, please link to the issue here. -->
closes #5525 

### Description
I added the css class `table-responsive` to a new `div` that wraps the original tables. This prevents the buttons from leaving the view. As a result the table is now more responsive and horizontally scrollable if the content does not fit.
| before | now |
|--------|--------|
| <img alt="before" src="https://github.com/ls1intum/Artemis/assets/16179620/5bc96f0f-e7af-4d10-a1ab-0cfa97bf20be"> | ![after](https://github.com/ls1intum/Artemis/assets/16179620/66251c90-128f-47d0-94fd-374a587885ff) |
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Exam

1. Go to the Exam Management
2. Click on Exam Checklist
3. Resize the view
4. Check if the button leaves the view

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Exam

1. Go to the Exam Management
2. Click on Exam Checklist
3. Resize the view
4. Check if the button leaves the view

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
