### PR TITLE
`Development`: Remove all temporary files when using the ProgrammingExerciseTestService

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import javax.validation.constraints.NotNull;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -117,6 +118,11 @@ class ExamUserIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJi
         programmingExerciseTestService.setup(this, versionControlService, continuousIntegrationService);
         bitbucketRequestMockProvider.enableMockingOfRequests(true);
         bambooRequestMockProvider.enableMockingOfRequests(true);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        programmingExerciseTestService.tearDown();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTemplateIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTemplateIntegrationTest.java
@@ -122,9 +122,10 @@ class ProgrammingExerciseTemplateIntegrationTest extends AbstractSpringIntegrati
     }
 
     @AfterEach
-    void tearDown() throws IOException {
+    void tearDown() throws Exception {
         reset(gitService);
         reset(bambooServer);
+        programmingExerciseTestService.tearDown();
         bitbucketRequestMockProvider.reset();
         bambooRequestMockProvider.reset();
         exerciseRepo.resetLocalRepo();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
@@ -287,6 +287,7 @@ public class ProgrammingExerciseTestService {
         exerciseRepo.resetLocalRepo();
         testRepo.resetLocalRepo();
         solutionRepo.resetLocalRepo();
+        auxRepo.resetLocalRepo();
         sourceExerciseRepo.resetLocalRepo();
         sourceTestRepo.resetLocalRepo();
         sourceSolutionRepo.resetLocalRepo();

--- a/src/test/java/de/tum/in/www1/artemis/service/DataExportCreationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/DataExportCreationServiceTest.java
@@ -148,6 +148,7 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
 
     @AfterEach
     void tearDown() throws Exception {
+        programmingExerciseTestService.tearDown();
         apollonRequestMockProvider.reset();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -127,16 +127,11 @@ public class GitUtilService {
     }
 
     private void tryToDeleteDirectory(Path path) throws Exception {
-        if (!Files.exists(path)) {
-            return;
-        }
-
         for (int i = 0; i < 10 && FileUtils.isDirectory(path.toFile()); i++) {
             try {
                 FileUtils.deleteDirectory(path.toFile());
             }
             catch (IOException e) {
-                e.printStackTrace();
                 Thread.sleep(10);
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -30,7 +30,7 @@ public class GitUtilService {
     // Note: the first string has to be same as artemis.repo-clone-path (see src/test/resources/config/application-artemis.yml) because here local git repos will be cloned
     private final Path localPath = Path.of(".", "repos", "server-integration-test").resolve("test-repository").normalize();
 
-    private final Path remotePath = Path.of(System.getProperty("java.io.tmpdir")).resolve("scm/test-repository");
+    private final Path remotePath = Path.of(System.getProperty("java.io.tmpdir")).resolve("remotegittest/scm/test-repository");
 
     public GitUtilService() throws IOException {
     }
@@ -127,11 +127,16 @@ public class GitUtilService {
     }
 
     private void tryToDeleteDirectory(Path path) throws Exception {
+        if (!Files.exists(path)) {
+            return;
+        }
+
         for (int i = 0; i < 10 && FileUtils.isDirectory(path.toFile()); i++) {
             try {
                 FileUtils.deleteDirectory(path.toFile());
             }
             catch (IOException e) {
+                e.printStackTrace();
                 Thread.sleep(10);
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -30,7 +30,7 @@ public class GitUtilService {
     // Note: the first string has to be same as artemis.repo-clone-path (see src/test/resources/config/application-artemis.yml) because here local git repos will be cloned
     private final Path localPath = Path.of(".", "repos", "server-integration-test").resolve("test-repository").normalize();
 
-    private final Path remotePath = Files.createTempDirectory("remotegittest").resolve("scm/test-repository");
+    private final Path remotePath = Path.of(System.getProperty("java.io.tmpdir")).resolve("scm/test-repository");
 
     public GitUtilService() throws IOException {
     }
@@ -67,6 +67,7 @@ public class GitUtilService {
         try {
             deleteRepos();
 
+            Files.createDirectories(remotePath);
             remoteGit = LocalRepository.initialize(remotePath.toFile(), defaultBranch);
             // create some files in the remote repository
             remotePath.resolve(FILES.FILE1.toString()).toFile().createNewFile();


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
I noticed that running the server tests create a lot of temporary files which never got cleaned up. These files got created by the `ProgrammingExerciseTestService` and are supposed to get deleted when calling `tearDown()`. However, some tests only called `setup()` (which creates these files) and missed calling `tearDown()`. 

### Description
I added the missing method calls.

### Steps for Testing
code review

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2