### PR TITLE
`Modeling exercises`: Fix inconsistent capitalization of 'Problem Statement'

### DIFF
--- a/src/main/webapp/i18n/en/modelingSubmission.json
+++ b/src/main/webapp/i18n/en/modelingSubmission.json
@@ -18,7 +18,7 @@
             "model": "Model",
             "explanationText": "Explanation",
             "modelingEditor": "Modeling Editor",
-            "problemStatement": "Problem statement",
+            "problemStatement": "Problem Statement",
             "maxScore": "<strong>Max. Points: {{maxScore}}</strong>",
             "assessment": {
                 "title": "Assessment",


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
#### Client
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
In today's testing session, we noticed that modeling exercises inconsistently write "Problem statement" instead of "Problem Statement" like everywhere else

### Description
replace s with S

### Steps for Testing
code

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


### Screenshots
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/ccb99b56-a4ed-4c98-a54e-f261affdef14)

