### PR TITLE
`Programming exercises`: Fix repository export anonymization

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -1000,7 +1000,7 @@ public class GitService {
 
     /**
      * Removes all author information from the commits on the currently active branch.
-     * Also removes all remotes since they contain data about the student.
+     * Also removes all remotes and FETCH_HEAD since they contain data about the student.
      * Also deletes the .git/logs folder to prevent restoring commits from reflogs
      *
      * @param repository          Local Repository Object.
@@ -1062,6 +1062,10 @@ public class GitService {
             // Delete .git/logs/ folder to delete git reflogs
             Path logsPath = Path.of(repository.getDirectory().getPath(), "logs");
             FileUtils.deleteDirectory(logsPath.toFile());
+
+            // Delete FETCH_HEAD containing the url of the last fetch
+            Path fetchHeadPath = Path.of(repository.getDirectory().getPath(), "FETCH_HEAD");
+            Files.deleteIfExists(fetchHeadPath);
         }
         catch (EntityNotFoundException | GitAPIException | JGitInternalException | IOException ex) {
             log.warn("Cannot anonymize the repo {} due to the following exception: {}", repository.getLocalPath(), ex.getMessage());


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

After exporting an anonymized repository from Artemis I found a file called `FETCH_HEAD` containing the TUM identifier:
```
f6f04166d2beaa36d1e6cd819b72b92edb07855d	not-for-merge	branch 'main' of https://<REDACTED_TUM_ID>@bitbucket.ase.in.tum.de/scm/IOSOSINTRO2223S1DH/iososintro2223s1dh-<REDACTED_TUM_ID>.git
```

Consulting with @maximiliansoelch and @krusche this seems to be an oversight and should be removed for anonymization reasons.

### Description
<!-- Describe your changes in detail -->

Remove `.git/FETCH_HEAD` when anonymizing the `.git` directory.
> FETCH_HEAD is a short-lived reference in Git that records the branch which has been fetched from a remote repository. It keeps track of the last fetched HEAD from all branches in the remote repository, including the specific commit hash that was last fetched. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with Submissions

> **⚠️ Info**
> Ideally pick an exercise on a test server beforehand and check if it contains `.git/FETCH_HEAD` then deploy and check if it successfully removes this. On test server 3 I checked this with [exercise 2717](https://artemistest3.ase.in.tum.de/course-management/180/programming-exercises/2717/scores), those repos contain a `FETCH_HEAD`

1. Log in to Artemis
2. Navigate to Course Management
3. Navigate to any programming exercise
4. Press `Scores` (should have at least one score with a repository)
5. Press `Export` -> `Download Repos`
6. Check `Anonymize repository` and check `Or download the repositories of all students`
7. `Export`
8. Check if `.git/FETCH_HEAD` has been removed from the submissions
9. Check if you can find any other Personal Identifying Information (PII) in the `.git` directory -> You should not find any

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
<img width="485" alt="image" src="https://github.com/ls1intum/Artemis/assets/5898705/89b840b9-ad25-44bd-abed-118b2bd7166a">
After: 
<img width="484" alt="image" src="https://github.com/ls1intum/Artemis/assets/5898705/a9a4b403-d01b-4ebe-887a-82acf1a4c5ce">

