### PR TITLE
`Development`: Fix quiz creation and websocket handshakes during k6 tests

### DIFF
--- a/src/test/k6/api_tests.sh
+++ b/src/test/k6/api_tests.sh
@@ -122,7 +122,7 @@ result=$(docker run -i --rm --network=host --name api-tests-"$tests"-"$programmi
   -e ADMIN_USERNAME="$adminUsername" -e ADMIN_PASSWORD="$adminPassword" -e CREATE_USERS="$createUsers" -e TIMEOUT_EXERCISE="$timeoutExercise" \
   -e PROGRAMMING_LANGUAGE="$programmingLanguage" -e ENABLE_SCA="$enableStaticCodeAnalysis" -e USER_OFFSET="$userOffset" -e COURSE_ID="$courseId" -e EXERCISE_ID="$exerciseId" \
   -e WAIT_QUIZ_START="$waitQuizStart" -e ONLY_PREPARE="$onlyPrepare" \
-  loadimpact/k6 run --address localhost:0 /src/"$tests".js 2>&1)
+  grafana/k6 run --address localhost:0 /src/"$tests".js 2>&1)
 
 echo "########## FINISHED testing - evaluating result ##########"
 echo "$result"

--- a/src/test/k6/requests/exam.js
+++ b/src/test/k6/requests/exam.js
@@ -20,6 +20,8 @@ export function newExam(artemis, course) {
     const startDate = new Date(currentDate.getTime() + 60000); // Starting in 60 secs
     const endDate = new Date(currentDate.getTime() + 600000); // Ending in 600 secs
 
+    const examName = nextAlphanumeric(5);
+
     const exam = {
         course: course,
         visibleDate: visibleDate,
@@ -29,9 +31,10 @@ export function newExam(artemis, course) {
         numberOfExercisesInExam: 4,
         randomizeExerciseOrder: false,
         started: false,
-        title: 'Exam K6 ' + nextAlphanumeric(5),
+        title: 'Exam K6 ' + examName,
         visible: false,
         gracePeriod: 180,
+        channelName: 'exam-' + examName,
     };
 
     const res = artemis.post(EXAMS(course.id), exam);

--- a/src/test/k6/requests/modeling.js
+++ b/src/test/k6/requests/modeling.js
@@ -27,13 +27,15 @@ export function submitRandomModelingAnswerExam(artemis, exercise, submissionId, 
 }
 
 export function newModelingExercise(artemis, exerciseGroup, courseId) {
+    const exerciseName = nextAlphanumeric(5);
     const exercise = {
         maxPoints: 1,
-        title: 'Modeling K6 ' + nextAlphanumeric(5),
+        title: 'Modeling K6 ' + exerciseName,
         type: 'modeling',
         mode: 'INDIVIDUAL',
         assessmentType: 'SEMI_AUTOMATIC',
         diagramType: 'ClassDiagram',
+        channelName: 'exercise-' + exerciseName,
     };
 
     if (courseId) {

--- a/src/test/k6/requests/programmingExercise.js
+++ b/src/test/k6/requests/programmingExercise.js
@@ -77,9 +77,10 @@ export function createProgrammingExercise(artemis, courseId, exerciseGroup = und
             break;
     }
 
+    const exerciseName = nextAlphanumeric(10);
     // The actual exercise
     const exercise = {
-        title: 'TEST K6' + nextAlphanumeric(10),
+        title: 'TEST K6' + exerciseName,
         shortName: 'TESTK6' + nextAlphanumeric(5).toUpperCase(),
         maxPoints: 42,
         assessmentType: 'AUTOMATIC',
@@ -93,6 +94,7 @@ export function createProgrammingExercise(artemis, courseId, exerciseGroup = und
         sequentialTestRuns: false,
         mode: 'INDIVIDUAL',
         projectType: programmingLanguage === 'JAVA' ? 'PLAIN_MAVEN' : undefined,
+        channelName: 'exercise-' + exerciseName,
     };
 
     if (courseId) {

--- a/src/test/k6/requests/quiz.js
+++ b/src/test/k6/requests/quiz.js
@@ -9,9 +9,10 @@ export function createQuizExercise(artemis, course, exerciseGroup = null, startQ
     const currentDate = new Date();
     const releaseDate = new Date(currentDate.getTime() + 7 * 24 * 60 * 60 * 1000); // Automatic release in one week -> Will be set to 'NOW' once set-visible is called
 
+    const exerciseName = nextAlphanumeric(10);
     // The actual exercise
     const exercise = {
-        title: 'Quiz K6' + nextAlphanumeric(10),
+        title: 'Quiz K6' + exerciseName,
         type: 'quiz',
         teamMode: false,
         releaseDate: setReleaseDate ? releaseDate : null,
@@ -30,6 +31,7 @@ export function createQuizExercise(artemis, course, exerciseGroup = null, startQ
         course: course,
         exerciseGroup: exerciseGroup,
         quizQuestions: generateQuizQuestions(10),
+        channelName: 'exercise-' + exerciseName,
     };
 
     res = artemis.post(QUIZ_EXERCISES, exercise);

--- a/src/test/k6/requests/text.js
+++ b/src/test/k6/requests/text.js
@@ -23,11 +23,13 @@ export function submitRandomTextAnswerExam(artemis, exercise, submissionId) {
 }
 
 export function newTextExercise(artemis, exerciseGroup, courseID) {
+    const exerciseName = nextAlphanumeric(5);
     const textExercise = {
         maxPoints: 1,
-        title: 'Text K6 ' + nextAlphanumeric(5),
+        title: 'Text K6 ' + exerciseName,
         type: 'text',
         mode: 'INDIVIDUAL',
+        channelName: 'exercise-' + exerciseName,
     };
 
     if (courseID) {


### PR DESCRIPTION
### Motivation and Context
K6 tests for quizzes are currently failing for two reasons:
1. A required parameter `channelName` is not set when creating the quiz exercise
2. The `loadimpact/k6`-Docker image seems to have issues with WebSocket handshakes.

### Description
1. Add required parameter
2. Switch Docker image to `grafana/k6` (k6 is now maintained by Grafana since [Grafana purchased LoadImpact](https://k6.io/blog/joining-grafana-labs/))

### Steps for Testing
Execute the K6 quiz tests - they should work again.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2