### PR TITLE
`Development`: Improve notifications performance

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/GroupNotificationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/GroupNotificationRepository.java
@@ -6,13 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import de.tum.in.www1.artemis.domain.notification.GroupNotification;
-import de.tum.in.www1.artemis.domain.notification.Notification;
 
 /**
  * Spring Data repository for the Notification entity.
  */
 @Repository
-public interface GroupNotificationRepository extends JpaRepository<Notification, Long> {
+public interface GroupNotificationRepository extends JpaRepository<GroupNotification, Long> {
 
     List<GroupNotification> findAllByCourseId(Long courseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/NotificationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/NotificationRepository.java
@@ -3,6 +3,8 @@ package de.tum.in.www1.artemis.repository;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
+import javax.validation.constraints.NotNull;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,8 +26,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                 FROM Notification notification
                     LEFT JOIN notification.course
                     LEFT JOIN notification.recipient
-                WHERE notification.notificationDate IS NOT NULL
-                    AND (cast(:hideUntil as timestamp ) IS NULL OR notification.notificationDate > :hideUntil)
+                WHERE notification.notificationDate > :hideUntil
                     AND (
                         (type(notification) = GroupNotification
                             AND ((notification.course.instructorGroupName IN :#{#currentGroups} AND notification.type = 'INSTRUCTOR')
@@ -42,7 +43,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                     )
             """)
     Page<Notification> findAllNotificationsForRecipientWithLogin(@Param("currentGroups") Set<String> currentUserGroups, @Param("login") String login,
-            @Param("hideUntil") ZonedDateTime hideUntil, @Param("tutorialGroupIds") Set<Long> tutorialGroupIds,
+            @NotNull @Param("hideUntil") ZonedDateTime hideUntil, @Param("tutorialGroupIds") Set<Long> tutorialGroupIds,
             @Param("titlesToNotLoadNotification") Set<String> titlesToNotLoadNotification, Pageable pageable);
 
     @Query("""
@@ -50,8 +51,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                 FROM Notification notification
                     LEFT JOIN notification.course
                     LEFT JOIN notification.recipient
-                WHERE notification.notificationDate IS NOT NULL
-                    AND (:#{#hideUntil} IS NULL OR notification.notificationDate > :#{#hideUntil})
+                WHERE notification.notificationDate > :hideUntil
                     AND (
                          (type(notification) = GroupNotification
                             AND (notification.title NOT IN :#{#deactivatedTitles}
@@ -79,6 +79,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                 )
             """)
     Page<Notification> findAllNotificationsFilteredBySettingsForRecipientWithLogin(@Param("currentGroups") Set<String> currentUserGroups, @Param("login") String login,
-            @Param("hideUntil") ZonedDateTime hideUntil, @Param("deactivatedTitles") Set<String> deactivatedTitles, @Param("tutorialGroupIds") Set<Long> tutorialGroupIds,
+            @NotNull @Param("hideUntil") ZonedDateTime hideUntil, @Param("deactivatedTitles") Set<String> deactivatedTitles, @Param("tutorialGroupIds") Set<Long> tutorialGroupIds,
             @Param("titlesToNotLoadNotification") Set<String> titlesToNotLoadNotification, Pageable pageable);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/NotificationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/NotificationRepository.java
@@ -6,11 +6,9 @@ import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.in.www1.artemis.domain.notification.Notification;
 
@@ -83,13 +81,4 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Page<Notification> findAllNotificationsFilteredBySettingsForRecipientWithLogin(@Param("currentGroups") Set<String> currentUserGroups, @Param("login") String login,
             @Param("hideUntil") ZonedDateTime hideUntil, @Param("deactivatedTitles") Set<String> deactivatedTitles, @Param("tutorialGroupIds") Set<Long> tutorialGroupIds,
             @Param("titlesToNotLoadNotification") Set<String> titlesToNotLoadNotification, Pageable pageable);
-
-    @Transactional // ok because of modifying query
-    @Modifying
-    @Query("""
-            UPDATE Notification n
-            SET n.author = null
-            WHERE n.author.id = :userId
-            """)
-    void removeAuthor(@Param("userId") long userId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/SystemNotificationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SystemNotificationRepository.java
@@ -16,6 +16,12 @@ import de.tum.in.www1.artemis.domain.notification.SystemNotification;
 @Repository
 public interface SystemNotificationRepository extends JpaRepository<SystemNotification, Long> {
 
-    @Query("SELECT distinct notification FROM SystemNotification notification WHERE (notification.expireDate >= :now OR notification.expireDate IS NULL) ORDER BY notification.notificationDate ASC")
+    @Query("""
+            SELECT DISTINCT notification
+            FROM SystemNotification notification
+            WHERE notification.expireDate >= :now
+                OR notification.expireDate IS NULL
+            ORDER BY notification.notificationDate ASC
+            """)
     List<SystemNotification> findAllActiveAndFutureSystemNotifications(@Param("now") ZonedDateTime now);
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/NotificationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/NotificationResource.java
@@ -84,7 +84,12 @@ public class NotificationResource {
         Set<NotificationType> deactivatedTypes = notificationSettingsService.findDeactivatedNotificationTypes(NotificationSettingsCommunicationChannel.WEBAPP,
                 notificationSettings);
         Set<String> deactivatedTitles = notificationSettingsService.convertNotificationTypesToTitles(deactivatedTypes);
-        final ZonedDateTime hideNotificationsUntilDate = currentUser.getHideNotificationsUntil();
+        // Note: at the moment, we only support to show notifications from the last month, because without a proper date the query below becomes too slow
+        var hideNotificationsUntilDate = currentUser.getHideNotificationsUntil();
+        var notificationDateLimit = ZonedDateTime.now().minusMonths(3);
+        if (hideNotificationsUntilDate == null || hideNotificationsUntilDate.isBefore(notificationDateLimit)) {
+            hideNotificationsUntilDate = notificationDateLimit;
+        }
         final Page<Notification> page;
         if (deactivatedTitles.isEmpty()) {
             page = notificationRepository.findAllNotificationsForRecipientWithLogin(currentUser.getGroups(), currentUser.getLogin(), hideNotificationsUntilDate, tutorialGroupIds,

--- a/src/main/resources/config/liquibase/changelog/20230812135300_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230812135300_changelog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="krusche" id="20230812135300">
+        <createIndex tableName="notification" indexName="notification_discriminator">
+            <column name="discriminator"/>
+        </createIndex>
+        <createIndex tableName="notification" indexName="notification_expire_date">
+            <column name="expire_date"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -48,6 +48,7 @@
     <include file="classpath:config/liquibase/changelog/20230626220000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230629194400_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230721135400_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20230812135300_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command 'date '+%Y%m%d%H%M%S'' to get the current date and time in the correct format -->


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
The notification DB calls are quite slow in cases when there are more than 100.000 entries in the database. This first small PR attempts to make it faster:
* System notifications can be loaded in ~5-10% of the time due to new indices (~5ms instead of ~100ms in my tests)
* Other notifications can be loaded in ~25% of the time by limiting them to the last 3 months (~100ms instead of ~400ms in my tests when hide until is null)

Note: There will be additional performance improvements in #7048, I only extracted a few in this PR to deploy them faster

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 student

1. Log in to Artemis
2. Check system notifications and normal notifications REST calls in the chrome console. They should work normally, but are faster, in particular when there are many notifications in the database

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2