### PR TITLE
`Plagiarism detection`: Change log level of de.jplag.Submission to ERROR

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -21,6 +21,7 @@ logging:
         tech.jhipster: INFO
         org.springframework.web.socket.config: INFO
         liquibase: INFO
+        de.jplag.Submission: ERROR
     logback:
         rollingpolicy:
             max-history: 90


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
Jplag is not able to process programming submission which do not compile. It ignores them during comparison and logs a long information about that to the console. This information is not necessary as it does not break the plagiarism check and at this point Artemis does not check correctness of the solution. Fixes #7013.

### Description
Changed log level for `de.jplag.Submission` to `ERROR`. The log that we want to get rid of is `WARN` and all the others in this class are `ERROR`, so changing this will not hide any useful information.

`de.jplag.Submission`: https://github.com/jplag/JPlag/blob/main/core/src/main/java/de/jplag/Submission.java#L251


### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


