### PR TITLE
`Programming exercises`: Fix task detail view in online code editor

### DIFF
--- a/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { Observable, Subscription, of } from 'rxjs';
-import { catchError, map, mergeMap, tap } from 'rxjs/operators';
+import { Observable, Subscription } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
 import { ProgrammingExerciseParticipationService } from 'app/exercises/programming/manage/services/programming-exercise-participation.service';
 import { GuidedTourService } from 'app/guided-tour/guided-tour.service';
 import { codeEditorTour } from 'app/guided-tour/tours/code-editor-tour';
@@ -17,7 +17,6 @@ import { CodeEditorContainerComponent } from 'app/exercises/programming/shared/c
 import { ProgrammingExerciseStudentParticipation } from 'app/entities/participation/programming-exercise-student-participation.model';
 import { getUnreferencedFeedback } from 'app/exercises/shared/result/result.utils';
 import { SubmissionType } from 'app/entities/submission.model';
-import { Participation } from 'app/entities/participation/participation.model';
 import { SubmissionPolicyType } from 'app/entities/submission-policy.model';
 import { Course } from 'app/entities/course.model';
 import { SubmissionPolicyService } from 'app/exercises/programming/manage/services/submission-policy.service';
@@ -134,32 +133,15 @@ export class CodeEditorStudentContainerComponent implements OnInit, OnDestroy {
      */
     loadParticipationWithLatestResult(participationId: number): Observable<ProgrammingExerciseStudentParticipation> {
         return this.programmingExerciseParticipationService.getStudentParticipationWithLatestResult(participationId).pipe(
-            mergeMap((participation: ProgrammingExerciseStudentParticipation) =>
-                participation.results?.length
-                    ? this.loadResultDetails(participation, participation.results[0]).pipe(
-                          map((feedbacks) => {
-                              participation.results![0].feedbacks = feedbacks;
-                              return participation;
-                          }),
-                          catchError(() => of(participation)),
-                      )
-                    : of(participation),
-            ),
-        );
-    }
-
-    /**
-     * Fetches details for the result (if we received one) and attach them to the result.
-     * Mutates the input parameter result.
-     */
-    loadResultDetails(participation: Participation, result: Result): Observable<Feedback[]> {
-        return this.resultService.getFeedbackDetailsForResult(participation.id!, result).pipe(
-            map((res) => {
-                return res.body || [];
+            map((participation: ProgrammingExerciseStudentParticipation) => {
+                if (participation.results?.length) {
+                    // connect result and participation
+                    participation.results[0].participation = participation;
+                }
+                return participation;
             }),
         );
     }
-
     checkForTutorAssessment(dueDateHasPassed: boolean) {
         let isManualResult = false;
         let hasTutorFeedback = false;

--- a/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
@@ -142,6 +142,7 @@ export class CodeEditorStudentContainerComponent implements OnInit, OnDestroy {
             }),
         );
     }
+
     checkForTutorAssessment(dueDateHasPassed: boolean) {
         let isManualResult = false;
         let hasTutorFeedback = false;

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/build-output/code-editor-build-output.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/build-output/code-editor-build-output.component.ts
@@ -172,13 +172,13 @@ export class CodeEditorBuildOutputComponent implements AfterViewInit, OnInit, On
     }
 
     /**
-     * @function loadResultDetails
+     * @function loadAndAttachResultDetails
      * @desc Fetches details for the result (if we received one) and attach them to the result.
      * Mutates the input parameter result.
      */
     loadAndAttachResultDetails(participation: Participation, result: Result): Observable<Result> {
         return this.resultService.getFeedbackDetailsForResult(participation.id!, result).pipe(
-            map((res) => res && res.body),
+            map((res) => res?.body),
             map((feedbacks: Feedback[]) => {
                 result.feedbacks = feedbacks;
                 return result;

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, HostListener, Input, Output, ViewChild } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { isEmpty as _isEmpty, fromPairs, toPairs, uniq } from 'lodash-es';
-import { ActivatedRoute } from '@angular/router';
 import { CodeEditorFileService } from 'app/exercises/programming/shared/code-editor/service/code-editor-file.service';
 import { ComponentCanDeactivate } from 'app/shared/guard/can-deactivate.model';
 import { CodeEditorGridComponent } from 'app/exercises/programming/shared/code-editor/layout/code-editor-grid.component';
@@ -15,7 +14,6 @@ import {
     RenameFileChange,
     ResizeType,
 } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
-import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
 import { AlertService } from 'app/core/util/alert.service';
 import { CodeEditorFileBrowserComponent, InteractableEvent } from 'app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component';
 import { CodeEditorActionsComponent } from 'app/exercises/programming/shared/code-editor/actions/code-editor-actions.component';
@@ -98,9 +96,7 @@ export class CodeEditorContainerComponent implements ComponentCanDeactivate {
     annotations: Array<Annotation> = [];
 
     constructor(
-        private participationService: ParticipationService,
         private translateService: TranslateService,
-        private route: ActivatedRoute,
         private alertService: AlertService,
         private fileService: CodeEditorFileService,
     ) {

--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/programming-exercise-instruction.component.ts
@@ -221,6 +221,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
             if (!latestResult) {
                 return of(undefined);
             }
+            latestResult.participation = this.participation;
             return latestResult.feedbacks ? of(latestResult) : this.loadAndAttachResultDetails(latestResult);
         } else if (this.participation && this.participation.id) {
             // Only load results if the exercise already is in our database, otherwise there can be no build result anyway

--- a/src/main/webapp/app/exercises/shared/feedback/feedback.component.ts
+++ b/src/main/webapp/app/exercises/shared/feedback/feedback.component.ts
@@ -179,7 +179,7 @@ export class FeedbackComponent implements OnInit {
                     }
                 }),
                 switchMap((feedbacks: Feedback[] | undefined | null) => {
-                    if (feedbacks && feedbacks.length) {
+                    if (feedbacks?.length) {
                         this.result.feedbacks = feedbacks!;
 
                         const filteredFeedback = this.feedbackService.filterFeedback(feedbacks, this.feedbackFilter);

--- a/src/test/javascript/spec/integration/code-editor/code-editor-student.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-student.integration.spec.ts
@@ -80,7 +80,7 @@ describe('CodeEditorStudentIntegration', () => {
     let subscribeForLatestResultOfParticipationSubject: BehaviorSubject<Result | undefined>;
     let routeSubject: Subject<Params>;
 
-    const result = { id: 3, successful: false, completionDate: dayjs().subtract(2, 'days') };
+    const result: Result = { id: 3, successful: false, completionDate: dayjs().subtract(2, 'days') };
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
@@ -166,22 +166,19 @@ describe('CodeEditorStudentIntegration', () => {
 
     it('should initialize correctly on route change if participation can be retrieved', () => {
         container.ngOnInit();
-        const participation = { id: 1, results: [result], exercise: { id: 99 } } as Participation;
         const feedbacks = [{ id: 2 }] as Feedback[];
+        result.feedbacks = feedbacks;
+        const participation = { id: 1, results: [result], exercise: { id: 99 } } as Participation;
         const findWithLatestResultSubject = new Subject<Participation>();
-        const getFeedbackDetailsForResultSubject = new Subject<{ body: Feedback[] }>();
         getStudentParticipationWithLatestResultStub.mockReturnValue(findWithLatestResultSubject);
-        getFeedbackDetailsForResultStub.mockReturnValue(getFeedbackDetailsForResultSubject);
 
         routeSubject.next({ participationId: 1 });
 
         expect(container.loadingParticipation).toBeTrue();
 
         findWithLatestResultSubject.next(participation);
-        getFeedbackDetailsForResultSubject.next({ body: feedbacks });
 
         expect(getStudentParticipationWithLatestResultStub).toHaveBeenNthCalledWith(1, participation.id);
-        expect(getFeedbackDetailsForResultStub).toHaveBeenNthCalledWith(1, participation.id, result);
         expect(container.loadingParticipation).toBeFalse();
         expect(container.participationCouldNotBeFetched).toBeFalse();
         expect(container.participation).toEqual({ ...participation, results: [{ ...result, feedbacks }] });


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
This fixes another issue I encountered while working on #7015.

When viewing a result in the code editor, the task details were not shown correctly. Instead, it always showed "no result availiable".

### Description
The `result.participation` object was undefined, however the feedback component assumed it to be always set. We now reconnect the result with its participation.

While I'm at it, I removed an unnecessary REST call (the first endpoint already returns all feedback, you don't need to load it a second time)

### Steps for Testing
Prerequisites:
- 2 Student
- 1 Programming Exercise with online code editor active

1. Open the code editor and submit something
2. Click on the 'x out of y tests passed' text in the problem statement
3. Verify that the popup contains the correctly filtered content.

#### Exam Mode Testing
same as above but for an exam programming exercise.

### Review Progress

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [x] Test 1
- [x] Test 2

### Screenshots
old:
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/07d893fc-27e7-44d0-8ec6-4cb70f037eed)

new:
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/344493b3-c4b6-4ff5-9d2f-6b47105288f3)


