### PR TITLE
`Development`: Start bamboo-build-agent after bamboo container is healthy in development setup

### DIFF
--- a/docker/atlassian.yml
+++ b/docker/atlassian.yml
@@ -11,7 +11,7 @@ services:
         image: ghcr.io/ls1intum/artemis-jira:9.4.3
         pull_policy: always
         volumes:
-          - artemis-jira-data:/var/atlassian/application-data/jira
+            - artemis-jira-data:/var/atlassian/application-data/jira
         ports:
             - "8081:8080"
         # expose the port to make it reachable docker internally even if the external port mapping changes
@@ -57,6 +57,12 @@ services:
             - "8085"
         networks:
             - artemis
+        healthcheck:
+            test: curl -f http://localhost:8085/rest/api/latest/server | grep "<state>RUNNING</state>"
+            interval: 10s
+            timeout: 5s
+            start_period: 40s
+            retries: 120 # = 20 minutes startup time during setup
 
     bamboo-build-agent:
         container_name: artemis-bamboo-build-agent
@@ -74,6 +80,9 @@ services:
             BAMBOO_SERVER: "http://bamboo:8085"
         networks:
             - artemis
+        depends_on:
+            bamboo:
+                condition: service_healthy
 
 networks:
     artemis:


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language (https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
- [x] This change does not affect Artemis itself, only the development setup

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
I am working locally with the Atlassian suite and noticed on starting all the containers that the build agent is always existing and thus, programming exercises can't be worked on unless calling `docker compose -f docker/atlassian.yml up -d` again after bamboo is available.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
Right now, `docker compose -f docker/atlassian.yml up -d` will start all containers, but the bamboo agent is faster on the startup, tries to contact bamboo, and gets connection refused. With the health check and `depends` in the docker-compose.yml we now wait for some time until the status page of bamboo is available and then start the build agent. This makes the whole Atlassian suite a bit nicer to work with locally, and the build agent does not silently fail right after the start.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- docker

1. call `docker compose -f docker/atlassian.yml up -d`
2. wait until all containers are started and are healthy/running
3. make sure with `docker compose -f docker/atlassian.yml ps -a` that no container is Exited

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2