### PR TITLE
`Development`: Fix warning when running the CodeQL GitHub action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,17 +42,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
-    # Install Java 16
+    # Install Java 17
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
@@ -73,22 +64,10 @@ jobs:
          languages: javascript, java
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
 
     - run: rm -rf build/resources/main/static
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
I noticed the following warning while running the CodeQL GitHub action:
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/7e9dd136-9295-4e97-a0ee-719f4ddb4f82)


### Description
Removed the step according to the documentation: https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/unnecessary-step-found

I also removed some unnecessary comments from the default example setup.

### Steps for Testing
code review

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2