### PR TITLE
`Development`: Fix running Git tests on Windows

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitServiceTest.java
@@ -20,8 +20,6 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -65,14 +63,12 @@ class GitServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
     }
 
     @Test
-    void testCheckoutRepositoryAlreadyOnServer() throws GitAPIException {
+    void testCheckoutRepositoryAlreadyOnServer() {
         gitUtilService.initRepo(defaultBranch);
         var repoUrl = gitUtilService.getRepoUrlByType(GitUtilService.REPOS.REMOTE);
         String newFileContent = "const a = arr.reduce(sum)";
         gitUtilService.updateFile(GitUtilService.REPOS.REMOTE, GitUtilService.FILES.FILE1, newFileContent);
         // Note: the test updates the file, but does not commit the update to the remote repository...
-        gitService.getOrCheckoutRepository(repoUrl, true);
-
         assertThat(gitUtilService.getFileContent(GitUtilService.REPOS.REMOTE, GitUtilService.FILES.FILE1)).isEqualTo(newFileContent);
         // ... therefore it is NOT available in the local repository
         assertThat(gitUtilService.getFileContent(GitUtilService.REPOS.LOCAL, GitUtilService.FILES.FILE1)).isNotEqualTo(newFileContent);
@@ -83,8 +79,9 @@ class GitServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         var repoUrl = gitUtilService.getRepoUrlByType(GitUtilService.REPOS.REMOTE);
         gitUtilService.deleteRepo(GitUtilService.REPOS.LOCAL);
         gitUtilService.reinitializeLocalRepository();
-        gitService.getOrCheckoutRepository(repoUrl, true);
-        assertThat(gitUtilService.isLocalEqualToRemote()).isTrue();
+        try (var repo = gitService.getOrCheckoutRepository(repoUrl, true)) {
+            assertThat(gitUtilService.isLocalEqualToRemote()).isTrue();
+        }
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
@@ -94,9 +91,11 @@ class GitServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         gitUtilService.updateFile(GitUtilService.REPOS.LOCAL, GitUtilService.FILES.FILE1, "Some Change");
         assertThat(gitUtilService.isLocalEqualToRemote()).isFalse();
 
-        gitService.resetToOriginHead(gitUtilService.getRepoByType(GitUtilService.REPOS.LOCAL));
+        try (var repo = gitUtilService.getRepoByType(GitUtilService.REPOS.LOCAL)) {
+            gitService.resetToOriginHead(repo);
 
-        assertThat(gitUtilService.isLocalEqualToRemote()).isTrue();
+            assertThat(gitUtilService.isLocalEqualToRemote()).isTrue();
+        }
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
@@ -106,8 +105,9 @@ class GitServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         // Checkout a different branch in local repo
         gitUtilService.checkoutBranch(GitUtilService.REPOS.LOCAL, "other-branch");
 
-        var repo = gitUtilService.getRepoByType(GitUtilService.REPOS.LOCAL);
-        assertThat(gitService.getOriginHead(repo)).isEqualTo(defaultBranch);
+        try (var repo = gitUtilService.getRepoByType(GitUtilService.REPOS.LOCAL)) {
+            assertThat(gitService.getOriginHead(repo)).isEqualTo(defaultBranch);
+        }
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
@@ -155,7 +155,6 @@ class GitServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // git file locking issues
     void testGetExistingCheckedOutRepositoryByLocalPathRemovesEmptyRepo() throws IOException {
         Repository localRepo = gitUtilService.getRepoByType(GitUtilService.REPOS.LOCAL);
 
@@ -176,7 +175,6 @@ class GitServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
-    @DisabledOnOs(OS.WINDOWS) // git file locking issues
     @MethodSource("getBranchCombinationsToTest")
     void testGetExistingCheckedOutRepositoryByLocalPathSetsBranchCorrectly(String defaultBranchVCS, String defaultBranchArtemis) throws IOException {
         gitUtilService.initRepo(defaultBranchVCS);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitServiceTest.java
@@ -65,7 +65,6 @@ class GitServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
     @Test
     void testCheckoutRepositoryAlreadyOnServer() {
         gitUtilService.initRepo(defaultBranch);
-        var repoUrl = gitUtilService.getRepoUrlByType(GitUtilService.REPOS.REMOTE);
         String newFileContent = "const a = arr.reduce(sum)";
         gitUtilService.updateFile(GitUtilService.REPOS.REMOTE, GitUtilService.FILES.FILE1, newFileContent);
         // Note: the test updates the file, but does not commit the update to the remote repository...

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -48,10 +48,6 @@ public class GitUtilService {
 
     private Repository localRepo;
 
-    private Git localGit;
-
-    private Git remoteGit;
-
     /**
      * Initializes the repository with three dummy files
      */
@@ -69,7 +65,7 @@ public class GitUtilService {
             deleteRepos();
 
             Files.createDirectories(remotePath);
-            remoteGit = LocalRepository.initialize(remotePath.toFile(), defaultBranch);
+            Git remoteGit = LocalRepository.initialize(remotePath.toFile(), defaultBranch);
             // create some files in the remote repository
             remotePath.resolve(FILES.FILE1.toString()).toFile().createNewFile();
             remotePath.resolve(FILES.FILE2.toString()).toFile().createNewFile();
@@ -78,10 +74,13 @@ public class GitUtilService {
             GitService.commit(remoteGit).setMessage("initial commit").call();
 
             // clone remote repository
-            localGit = Git.cloneRepository().setURI(remotePath.toString()).setDirectory(localPath.toFile()).call();
+            Git localGit = Git.cloneRepository().setURI(remotePath.toString()).setDirectory(localPath.toFile()).call();
 
             reinitializeLocalRepository();
             reinitializeRemoteRepository();
+
+            localGit.close();
+            remoteGit.close();
         }
         catch (IOException | GitAPIException ex) {
             ex.printStackTrace();
@@ -104,16 +103,10 @@ public class GitUtilService {
 
     public void deleteRepos() {
         if (remoteRepo != null) {
-            remoteRepo.close();
+            remoteRepo.closeBeforeDelete();
         }
         if (localRepo != null) {
-            localRepo.close();
-        }
-        if (localGit != null) {
-            localGit.close();
-        }
-        if (remoteGit != null) {
-            remoteGit.close();
+            localRepo.closeBeforeDelete();
         }
 
         try {
@@ -173,11 +166,9 @@ public class GitUtilService {
     }
 
     public void updateFile(REPOS repo, FILES fileToUpdate, String content) {
-        try {
-            var fileName = Path.of(getCompleteRepoPathStringByType(repo), fileToUpdate.toString()).toString();
-            PrintWriter writer = new PrintWriter(fileName, StandardCharsets.UTF_8);
+        var fileName = Path.of(getCompleteRepoPathStringByType(repo), fileToUpdate.toString()).toString();
+        try (PrintWriter writer = new PrintWriter(fileName, StandardCharsets.UTF_8)) {
             writer.print(content);
-            writer.close();
         }
         catch (IOException ignored) {
         }


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
Due to file locking issues, some Git Tests were disabled on Windows.

### Description
I noticed that the Git-Process used to initialize the repository was the one causing issues. Since it's only used for setting up the test, we now close the process directly. Additionally, we also close the Repositories once they are no longer needed.

### Steps for Testing
code review. If you are on Windows, you can run the GitServiceTests locally and see if it works now.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2