### PR TITLE
`Communication`: Increase maximum channel name length to 30

### DIFF
--- a/src/main/webapp/app/overview/course-conversations/dialogs/channels-create-dialog/channel-form/channel-form.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/dialogs/channels-create-dialog/channel-form/channel-form.component.ts
@@ -11,7 +11,7 @@ export interface ChannelFormData {
 
 export type ChannelType = 'PUBLIC' | 'PRIVATE';
 
-export const channelRegex = new RegExp('^[a-z0-9-]{1}[a-z0-9-]{0,20}$');
+export const channelRegex = new RegExp('^[a-z0-9-]{1}[a-z0-9-]{0,30}$');
 
 @Component({
     selector: 'jhi-channel-form',

--- a/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts
@@ -89,7 +89,7 @@ export class ConversationInfoComponent implements OnInit, OnDestroy {
         };
 
         event.stopPropagation();
-        this.openEditPropertyDialog(channelOrGroupChat, 'name', 20, true, channelRegex, keys);
+        this.openEditPropertyDialog(channelOrGroupChat, 'name', 30, true, channelRegex, keys);
     }
 
     openEditTopicModal(event: MouseEvent) {

--- a/src/test/javascript/spec/component/overview/course-conversations/dialogs/channels-create-dialog/channel-form/channel-form.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-conversations/dialogs/channels-create-dialog/channel-form/channel-form.component.spec.ts
@@ -60,7 +60,7 @@ describe('ChannelFormComponent', () => {
         checkFormIsInvalid();
 
         setFormValid();
-        setName('too-long-channel-name-should-be-rejected');
+        setName('long-channel-with-31-characters');
         checkFormIsInvalid();
     }));
 

--- a/src/test/javascript/spec/component/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.spec.ts
@@ -18,6 +18,7 @@ import { HttpResponse } from '@angular/common/http';
 import { of } from 'rxjs';
 import { GenericUpdateTextPropertyDialogComponent } from 'app/overview/course-conversations/dialogs/generic-update-text-property-dialog/generic-update-text-property-dialog.component';
 import { defaultSecondLayerDialogOptions } from 'app/overview/course-conversations/other/conversation.util';
+
 const examples: ConversationDto[] = [generateOneToOneChatDTO({}), generateExampleGroupChatDTO({}), generateExampleChannelDTO({})];
 
 examples.forEach((activeConversation) => {
@@ -117,7 +118,7 @@ examples.forEach((activeConversation) => {
             if (isChannelDto(activeConversation) || isGroupChatDto(activeConversation)) {
                 genericEditPropertyDialogTest('name', {
                     propertyName: 'name',
-                    maxPropertyLength: 20,
+                    maxPropertyLength: 30,
                     isRequired: true,
                     regexPattern: channelRegex,
                 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With the introduction of automatically generated channels, the maximum channel name length got increased to 30. However, the input field for editing a channel name on the messages tab still had a client-side validation with a maximum length of 20.

### Description
<!-- Describe your changes in detail -->
The client-side validation for the input field for the channel name on the messages tab got increased to 30.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 channel

1. Navigate to the messages tab
2. Open the settings for the channel and navigate to the Info tab
3. Edit the channel name
4. Verify, that you can enter a name up to 30 characters

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| channel-form.component.ts | not found (modified) | ❌ |
| conversation-info.component.ts | not found (modified) | ❌ |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
before:
<img width="784" alt="before" src="https://github.com/ls1intum/Artemis/assets/44754405/0033b587-a5ac-4a6d-a646-fcfe15fbec2b">

after:
<img width="784" alt="after" src="https://github.com/ls1intum/Artemis/assets/44754405/d305b902-e850-4b89-ba0b-8b4c125ee2f4">
