### PR TITLE
`Development`: Improved Awaitility's default values for server tests

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -8,7 +8,6 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -366,7 +365,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationBamboo
 
         request.putWithResponseBody("/api/complaint-responses/complaint/" + examExerciseComplaint.getId() + "/resolve", complaintResponse, ComplaintResponse.class, HttpStatus.OK);
         TextSubmission finalTextSubmission = textSubmission;
-        await().timeout(10, TimeUnit.SECONDS).untilAsserted(() -> assertThat(complaintRepo.findByResultId(finalTextSubmission.getId())).isPresent());
+        await().untilAsserted(() -> assertThat(complaintRepo.findByResultId(finalTextSubmission.getId())).isPresent());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.awaitility.Awaitility.await;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -180,7 +179,7 @@ class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationBambooBit
         participations = studentParticipationRepository.findByExerciseIdAndStudentId(idOfIndividualTextExercise, student1.getId());
         assertThat(participations).isNotEmpty();
 
-        await().pollInterval(10, TimeUnit.MILLISECONDS).until(() -> participantScoreScheduleService.isIdle());
+        await().until(() -> participantScoreScheduleService.isIdle());
 
         for (StudentParticipation studentParticipation : participations) {
             request.delete("/api/participations/" + studentParticipation.getId(), HttpStatus.OK);

--- a/src/test/java/de/tum/in/www1/artemis/util/junit_extensions/AwaitilityExtension.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/junit_extensions/AwaitilityExtension.java
@@ -1,0 +1,30 @@
+package de.tum.in.www1.artemis.util.junit_extensions;
+
+import java.time.Duration;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * A JUnit 5 extension that configures {@link Awaitility} to use a different default poll delay and interval.
+ *
+ * By default, {@link Awaitility} would use a poll delay and interval of 100ms, which makes tests run slower.
+ */
+public class AwaitilityExtension implements BeforeAllCallback {
+
+    private static final Duration DEFAULT_POLL_DELAY = Duration.ZERO;
+
+    private static final Duration DEFAULT_POLL_INTERVAL = Duration.ofMillis(10);
+
+    private static boolean configured;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        if (!configured) {
+            configured = true;
+            Awaitility.setDefaultPollDelay(DEFAULT_POLL_DELAY);
+            Awaitility.setDefaultPollInterval(DEFAULT_POLL_INTERVAL);
+        }
+    }
+}

--- a/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+de.tum.in.www1.artemis.util.junit_extensions.AwaitilityExtension

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,3 +1,6 @@
 #junit.jupiter.execution.parallel.enabled = true
 #junit.jupiter.execution.parallel.mode.default = concurrent
 #junit.jupiter.execution.parallel.mode.classes.default = same_thread
+
+# Enables JUnit5 automatic detection of extensions.
+junit.jupiter.extensions.autodetection.enabled = true


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] The changed server tests succeed **locally** and on **Bamboo** and on **GitHub Actions**.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
Makes tests go faster 🏎️
Awaitility's await() method is fundamental to asynchronous testing in Java. It checks a condition for the first time after an initial delay (pollDelay) and continues checking with a regular interval (pollInterval) until the condition is met or a TimeOut Exception is thrown.

### Description
In this PR, the default values for pollDelay and pollInterval have been adapted for our tests. By default, these values are set to 100ms meaning that a lot of time is wasted if a condition is met earlier than the initial poll delay. Since most tests run only for a few ms, the pollInterval has also been adapted.

I locally tested the current develop branch and this PR's branch multiple times and can verify that on my machine™️ the tests are now ~30sec faster

### Steps for Testing
**Test changes only**

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2


I verify that I have cleaned the build for each test run and I have tested both, develop and this branch multiple times in different orders to prevent wrong assumptions due to caching and/or other related issues when testing execution times.

##### Before (develop branch)
![Bildschirmfoto 2023-08-31 um 09 31 34](https://github.com/ls1intum/Artemis/assets/47261058/01fb97b0-869c-49d1-bb43-862f3be52bde)

##### After (this pr's branch)
![Bildschirmfoto 2023-08-31 um 09 52 52](https://github.com/ls1intum/Artemis/assets/47261058/ed8f7c4d-1ca8-40ed-8f84-e331b14b6a23)