### PR TITLE
`Programming exercises`: Fix unauthorized alert for tutors when opening exercise details page

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -197,7 +197,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
 
                 this.loadGitDiffReport();
 
-                // the build logs endpoint is requires at least editor privileges
+                // the build logs endpoint requires at least editor privileges
                 if (this.programmingExercise.isAtLeastEditor) {
                     this.programmingExerciseService.getBuildLogStatistics(exerciseId!).subscribe((buildLogStatisticsDto) => {
                         this.programmingExercise.buildLogStatistics = buildLogStatisticsDto;

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -197,9 +197,12 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
 
                 this.loadGitDiffReport();
 
-                this.programmingExerciseService.getBuildLogStatistics(exerciseId!).subscribe((buildLogStatisticsDto) => {
-                    this.programmingExercise.buildLogStatistics = buildLogStatisticsDto;
-                });
+                // the build logs endpoint is requires at least editor privileges
+                if (this.programmingExercise.isAtLeastEditor) {
+                    this.programmingExerciseService.getBuildLogStatistics(exerciseId!).subscribe((buildLogStatisticsDto) => {
+                        this.programmingExercise.buildLogStatistics = buildLogStatisticsDto;
+                    });
+                }
 
                 this.setLatestCoveredLineRatio();
 

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-detail.component.spec.ts
@@ -175,7 +175,6 @@ describe('ProgrammingExercise Management Detail Component', () => {
             expect(findWithTemplateAndSolutionParticipationStub).toHaveBeenCalledOnce();
             expect(statisticsServiceStub).toHaveBeenCalledOnce();
             expect(gitDiffReportStub).toHaveBeenCalledOnce();
-            expect(buildLogStatisticsStub).toHaveBeenCalledOnce();
             expect(comp.programmingExercise).toEqual(mockProgrammingExercise);
             expect(comp.isExamExercise).toBeFalse();
             expect(comp.doughnutStats.participationsInPercent).toBe(100);
@@ -186,7 +185,6 @@ describe('ProgrammingExercise Management Detail Component', () => {
         }));
 
         it.each([true, false])('should only call service method to get build log statistics onInit if the user is at least an editor for this exercise', (isEditor: boolean) => {
-            const buildLogsSpy = jest.spyOn(exerciseService, 'getBuildLogStatistics').mockReturnValue(of(buildLogStatistics));
             const programmingExercise = new ProgrammingExercise(new Course(), undefined);
             programmingExercise.id = 123;
             programmingExercise.isAtLeastEditor = isEditor;
@@ -195,9 +193,9 @@ describe('ProgrammingExercise Management Detail Component', () => {
             );
             comp.ngOnInit();
             if (isEditor) {
-                expect(buildLogsSpy).toHaveBeenCalledOnce();
+                expect(buildLogStatisticsStub).toHaveBeenCalledOnce();
             } else {
-                expect(buildLogsSpy).not.toHaveBeenCalled();
+                expect(buildLogStatisticsStub).not.toHaveBeenCalled();
             }
         });
     });
@@ -224,7 +222,6 @@ describe('ProgrammingExercise Management Detail Component', () => {
             expect(findWithTemplateAndSolutionParticipationStub).toHaveBeenCalledOnce();
             expect(statisticsServiceStub).toHaveBeenCalledOnce();
             expect(gitDiffReportStub).toHaveBeenCalledOnce();
-            expect(buildLogStatisticsStub).toHaveBeenCalledOnce();
             expect(comp.programmingExercise).toEqual(mockProgrammingExercise);
             expect(comp.isExamExercise).toBeTrue();
             expect(comp.programmingExercise.gitDiffReport).toBeDefined();

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-detail.component.spec.ts
@@ -184,6 +184,23 @@ describe('ProgrammingExercise Management Detail Component', () => {
             expect(comp.programmingExercise.gitDiffReport).toBeDefined();
             expect(comp.programmingExercise.gitDiffReport?.entries).toHaveLength(1);
         }));
+
+        it.each([true, false])('should only call service method to get build log statistics onInit if the user is at least an editor for this exercise', (isEditor: boolean) => {
+            const buildLogsSpy = jest.spyOn(exerciseService, 'getBuildLogStatistics').mockReturnValue(of(buildLogStatistics));
+            const programmingExercise = new ProgrammingExercise(new Course(), undefined);
+            programmingExercise.id = 123;
+            programmingExercise.isAtLeastEditor = isEditor;
+            jest.spyOn(exerciseService, 'findWithTemplateAndSolutionParticipationAndLatestResults').mockReturnValue(
+                of({ body: programmingExercise } as unknown as HttpResponse<ProgrammingExercise>),
+            );
+            comp.ngOnInit();
+            if (isEditor) {
+                expect(buildLogsSpy).toHaveBeenCalledOnce();
+            }
+            if (!isEditor) {
+                expect(buildLogsSpy).not.toHaveBeenCalled();
+            }
+        });
     });
 
     describe('onInit for exam exercise', () => {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-detail.component.spec.ts
@@ -196,8 +196,7 @@ describe('ProgrammingExercise Management Detail Component', () => {
             comp.ngOnInit();
             if (isEditor) {
                 expect(buildLogsSpy).toHaveBeenCalledOnce();
-            }
-            if (!isEditor) {
+            } else {
                 expect(buildLogsSpy).not.toHaveBeenCalled();
             }
         });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #5819 

### Description
The build log statistics endpoint is only accessible for editors and instructors but the client always sent a request when opening the exercise details page even if the user was just a TA.
We now only try to get the build logs statistics if the user is at least an editor. In the html template, the component was already not rendered if the user was not at least an editor.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Tutor
- 1 Editor or Instructor
- 1 Programming exercise

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to any exercise details page of a programming exercise
4. If you are a tutor, verify that there's no unauthorized alert and the network tab doesn't contain a request with a 403 status code.
5. If you are a editor, verify that the request is sent and the build logs statistics contain some data



### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) | Comment|
|------------|--------------:|---------------------:|------------------------:|
| [programming-exercise-detail.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5370/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/programming/manage/programming-exercise-detail.component.ts.html) | 70.69% | ✅ | my change is fully covered


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
