### PR TITLE
`Development`: Update checkout GitHub action from v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     name: Build .war artifact
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
@@ -103,17 +103,17 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       # Checkout pull request HEAD commit instead of merge commit
       # this is done to include the correct branch and git information inside the build
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
     - name: Git Checkout for push actions
       if: ${{ github.event_name == 'push' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.ref_name }}
     - name: Git Checkout for push actions
       if: ${{ github.event_name == 'release' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Install Java 17
     - name: Setup Node.js

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -17,7 +17,7 @@ jobs:
         name: "Gradle Wrapper Validation"
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: gradle/wrapper-validation-action@v1
               with:
                   min-wrapper-count: 6 # 5 in the different gradle templates and 1 for the Artemis project itself

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -93,7 +93,7 @@ jobs:
       concurrency:
           group: server-tests-mysql
       steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
           - name: Setup Java
             uses: actions/setup-java@v3
             with:
@@ -147,7 +147,7 @@ jobs:
       concurrency:
           group: server-tests-postgres
       steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
           - name: Setup Java
             uses: actions/setup-java@v3
             with:
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         # It seems like there is some memory issue with these tests with the project-wide default node option
         # `--max-old-space-size` set in the .npmrc, therefore we delete it for this test as a workaround
         - name: remove project-wide node options set in .npmrc just for this test
@@ -235,7 +235,7 @@ jobs:
       runs-on: ubuntu-latest
       timeout-minutes: 30
       steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
             with:
                 fetch-depth: 0
           - name: Setup Node.js
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
@@ -272,7 +272,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
Checkout v4 just released and it somehow broke v3:
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/13a17e05-25ee-4168-8611-170977d6d435)


### Description
Updating to v4 fixes the issue, so let's just update. The changes don't seem breaking: https://github.com/actions/checkout/releases/tag/v4.0.0