### PR TITLE
`Communication`: Display hint if no conversation settings are available

### DIFF
--- a/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-settings/conversation-settings.component.html
+++ b/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-settings/conversation-settings.component.html
@@ -1,22 +1,22 @@
 <div *ngIf="activeConversation && course" class="container-fluid conversation-settings">
-    <div class="row settings-container">
+    <div *ngIf="canLeaveConversation || canChangeChannelArchivalState || canDeleteChannel; else noSettings" class="row settings-container">
         <div class="col-12 settings-section text-center">
-            <button *ngIf="canLeaveConversation(activeConversation)" type="button" class="btn btn-danger leave-conversation" (click)="leaveConversation($event)">
+            <button *ngIf="canLeaveConversation" type="button" class="btn btn-danger leave-conversation" (click)="leaveConversation($event)">
                 {{ 'artemisApp.dialogs.conversationSettings.actions.leave' | artemisTranslate }}
             </button>
         </div>
-        <ng-container *ngIf="getAsChannel(activeConversation) as channel">
-            <div class="col-12 settings-section text-center" *ngIf="!channel.isArchived && canChangeArchivalState(channel)">
+        <ng-container *ngIf="conversationAsChannel as channel">
+            <div class="col-12 settings-section text-center" *ngIf="!channel.isArchived && canChangeChannelArchivalState">
                 <button type="button" class="btn btn-danger archive" (click)="openArchivalModal($event)">
                     {{ 'artemisApp.dialogs.conversationSettings.actions.archiveChannel' | artemisTranslate }}
                 </button>
             </div>
-            <div class="col-12 settings-section text-center" *ngIf="channel.isArchived && canChangeArchivalState(channel)">
+            <div class="col-12 settings-section text-center" *ngIf="channel.isArchived && canChangeChannelArchivalState">
                 <button type="button" class="btn btn-danger unarchive" (click)="openUnArchivalModal($event)">
                     {{ 'artemisApp.dialogs.conversationSettings.actions.unarchiveChannel' | artemisTranslate }}
                 </button>
             </div>
-            <div class="col-12 settings-section text-center" *ngIf="canDeleteChannel(course, channel)">
+            <div class="col-12 settings-section text-center" *ngIf="canDeleteChannel">
                 <button
                     class="btn btn-danger delete"
                     [id]="'delete-' + channel.id"
@@ -33,4 +33,7 @@
             </div>
         </ng-container>
     </div>
+    <ng-template #noSettings>
+        <div class="col-12 settings-section text-center" jhiTranslate="artemisApp.dialogs.conversationSettings.settingsUnavailable">No settings possible</div>
+    </ng-template>
 </div>

--- a/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-settings/conversation-settings.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-settings/conversation-settings.component.ts
@@ -1,5 +1,5 @@
-import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
-import { getAsChannelDto, isChannelDto } from 'app/entities/metis/conversation/channel.model';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { ChannelDTO, getAsChannelDto, isChannelDto } from 'app/entities/metis/conversation/channel.model';
 import { ConversationDto } from 'app/entities/metis/conversation/conversation.model';
 import { Course } from 'app/entities/course.model';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
@@ -21,7 +21,7 @@ import { catchError } from 'rxjs/operators';
     templateUrl: './conversation-settings.component.html',
     styleUrls: ['./conversation-settings.component.scss'],
 })
-export class ConversationSettingsComponent implements OnDestroy {
+export class ConversationSettingsComponent implements OnInit, OnDestroy {
     private ngUnsubscribe = new Subject<void>();
 
     @Input()
@@ -39,15 +39,15 @@ export class ConversationSettingsComponent implements OnDestroy {
     @Output()
     conversationLeave: EventEmitter<void> = new EventEmitter<void>();
 
-    canChangeArchivalState = canChangeChannelArchivalState;
-    canDeleteChannel = canDeleteChannel;
-    canLeaveConversation = canLeaveConversation;
-    getAsChannel = getAsChannelDto;
-
     private dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
 
     faTimes = faTimes;
+
+    conversationAsChannel: ChannelDTO | undefined;
+    canLeaveConversation: boolean;
+    canChangeChannelArchivalState: boolean;
+    canDeleteChannel: boolean;
 
     constructor(
         private modalService: NgbModal,
@@ -55,6 +55,13 @@ export class ConversationSettingsComponent implements OnDestroy {
         private groupChatService: GroupChatService,
         private alertService: AlertService,
     ) {}
+
+    ngOnInit(): void {
+        this.canLeaveConversation = canLeaveConversation(this.activeConversation);
+        this.conversationAsChannel = getAsChannelDto(this.activeConversation);
+        this.canChangeChannelArchivalState = this.conversationAsChannel ? canChangeChannelArchivalState(this.conversationAsChannel) : false;
+        this.canDeleteChannel = this.conversationAsChannel ? canDeleteChannel(this.course, this.conversationAsChannel) : false;
+    }
 
     leaveConversation($event: MouseEvent) {
         $event.stopPropagation();

--- a/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-settings/conversation-settings.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-settings/conversation-settings.component.ts
@@ -58,6 +58,7 @@ export class ConversationSettingsComponent implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         this.canLeaveConversation = canLeaveConversation(this.activeConversation);
+
         this.conversationAsChannel = getAsChannelDto(this.activeConversation);
         this.canChangeChannelArchivalState = this.conversationAsChannel ? canChangeChannelArchivalState(this.conversationAsChannel) : false;
         this.canDeleteChannel = this.conversationAsChannel ? canDeleteChannel(this.course, this.conversationAsChannel) : false;

--- a/src/main/webapp/i18n/de/conversation.json
+++ b/src/main/webapp/i18n/de/conversation.json
@@ -106,6 +106,7 @@
                 "remove": "Nutzer:in entfernen"
             },
             "conversationSettings": {
+                "settingsUnavailable": "Keine Einstellungen möglich",
                 "actions": {
                     "leave": "Konversation verlassen",
                     "archiveChannel": "Kanal archivieren",

--- a/src/main/webapp/i18n/en/conversation.json
+++ b/src/main/webapp/i18n/en/conversation.json
@@ -106,6 +106,7 @@
                 "remove": "Remove user"
             },
             "conversationSettings": {
+                "settingsUnavailable": "No settings possible",
                 "actions": {
                     "leave": "Leave Conversation",
                     "archiveChannel": "Archive Channel",

--- a/src/test/javascript/spec/component/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-settings/conversation-settings.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-conversations/dialogs/conversation-detail-dialog/tabs/conversation-settings/conversation-settings.component.spec.ts
@@ -49,10 +49,6 @@ examples.forEach((activeConversation) => {
             fixture.detectChanges();
         });
 
-        afterEach(() => {
-            jest.resetAllMocks();
-        });
-
         it('should create', () => {
             expect(component).toBeTruthy();
         });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With the introduction of course-wide channels in #7021, there are channels that do not provide any settings for students (because they cannot be left). Therefore, the settings menu was empty, which looked unintended.

### Description
<!-- Describe your changes in detail -->
If the settings menu is empty, i.e. there are no buttons shown, a short hint is displayed, indicating that no settings are possible (see screenshots).

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Course with course-wide channels (if none available, just create a new lecture and use the lecture channel)

1. Login as the student
2. Navigate to the messages tab
3. Click on the settings for the course-wide channel
4. Confirm that a message indicating that no settings are possible is displayed
5. Click on the settings of any other conversation that is not course-wide
6. Confirm that no hint is visible if there are buttons available

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
before:
<img width="794" alt="before" src="https://github.com/ls1intum/Artemis/assets/44754405/802acc13-88cd-4193-91a7-c19f6e91fe5e">

after:
<img width="794" alt="after" src="https://github.com/ls1intum/Artemis/assets/44754405/f5b546a7-0ce6-4b9a-be1b-76eb6866b1f9">

