### PR TITLE
`Development`: Migrate legacy course-wide channels

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20230907114600_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230907114600_changelog.xml
@@ -14,6 +14,7 @@
             SET is_course_wide = true
             WHERE c.lecture_id IS NOT null
                 OR c.exercise_id IS NOT null
+                OR c.exam_id IS NOT null
                 OR (
                     c.creator_id IS null
                     AND NOT EXISTS (

--- a/src/main/resources/config/liquibase/changelog/20230907114600_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230907114600_changelog.xml
@@ -3,6 +3,12 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
     <changeSet author="keller" id="20230907114600">
+        <comment>
+            Set the is_course_wide value to true for course-wide channels that have been created before this flag existed.
+            On the first hand, these are lecture and exercise channels, identified by an existing lecture_id or exercise_id.
+            On the other hand, these are the 4 default channels (announcement, organization, random, tech-support) created on course creation,
+            identified by the absence of a creator and no association with a tutorial group.
+        </comment>
         <sql>
             UPDATE conversation c
             SET is_course_wide = true

--- a/src/main/resources/config/liquibase/changelog/20230907114600_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230907114600_changelog.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="keller" id="20230907114600">
+        <sql>
+            UPDATE conversation c
+            SET is_course_wide = true
+            WHERE c.lecture_id IS NOT null
+                OR c.exercise_id IS NOT null
+                OR (
+                    c.creator_id IS null
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM tutorial_group AS tg
+                        WHERE tg.tutorial_group_channel_id = c.id
+                    )
+                )
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -52,6 +52,7 @@
     <include file="classpath:config/liquibase/changelog/20230812135300_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230622000000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230713113211_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20230907114600_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command 'date '+%Y%m%d%H%M%S'' to get the current date and time in the correct format -->


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Originally, the course-default, lecture, and exercise channels were created with is_course_wide = false (since the column didn't exist in the database). Now, for corresponding existing database entries, this field can be set to true.

### Description
<!-- Describe your changes in detail -->
A migration script handles the update for course-default, lecture and exercise channels. Lecture and exercise channels are recognized by the existence of an id in lecture_id or exercise_id. Course-default channels are recognized by the absence of both a creator and an associated tutorial group.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- One course that has tutorial group channels and also legacy default, lecture and exercise channels (you can recognize these legacy channels by the fact that you can add members to them as an instructor)

1. After deploying, the channels have been migrated, if you cannot add members to them anymore (and all course members are a member automatically)
2. Confirm that only default, lecture, and exercise channels have been migrated

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
Same as develop

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
No UI changes