### PR TITLE
`Development`: Execute architecture tests during java style action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
       run: ./gradlew checkstyleMain -x webapp
       if: success() || failure()
     - name: Java Architecture Tests
-      run: ./gradlew test -DincludeTags='ArchitectureTest' -x webapp
+      run: ./gradlew architectureTest -x webapp
       if: success() || failure()
     - name: Test Report
       uses: dorny/test-reporter@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,6 +209,15 @@ jobs:
     - name: Java Documentation
       run: ./gradlew checkstyleMain -x webapp
       if: success() || failure()
+    - name: Java Architecture Tests
+      run: ./gradlew test --tests "de.tum.in.www1.artemis.ArchitectureTest" -x webapp
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()    # run this step even if previous step failed
+      with:
+        name: Java Architecture Tests
+        path: build/test-results/test/*.xml
+        reporter: java-junit
 
   client-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,14 +210,14 @@ jobs:
       run: ./gradlew checkstyleMain -x webapp
       if: success() || failure()
     - name: Java Architecture Tests
-      run: ./gradlew architectureTest -x webapp
+      run: ./gradlew test -DincludeTags='ArchitectureTest' -x webapp
       if: success() || failure()
     - name: Test Report
       uses: dorny/test-reporter@v1
       if: success() || failure()    # run this step even if previous step failed
       with:
         name: Java Architecture Tests
-        path: build/test-results/architectureTest/*.xml
+        path: build/test-results/test/*.xml
         reporter: java-junit
 
   client-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,6 +211,7 @@ jobs:
       if: success() || failure()
     - name: Java Architecture Tests
       run: ./gradlew test --tests "de.tum.in.www1.artemis.ArchitectureTest" -x webapp
+      if: success() || failure()
     - name: Test Report
       uses: dorny/test-reporter@v1
       if: success() || failure()    # run this step even if previous step failed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
       run: ./gradlew checkstyleMain -x webapp
       if: success() || failure()
     - name: Java Architecture Tests
-      run: ./gradlew test --tests "de.tum.in.www1.artemis.ArchitectureTest" -x webapp
+      run: ./gradlew test -DincludeTags='ArchitectureTest' -x webapp
       if: success() || failure()
     - name: Test Report
       uses: dorny/test-reporter@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,7 @@ jobs:
       if: success() || failure()    # run this step even if previous step failed
       with:
         name: Java Architecture Tests
-        path: build/test-results/test/*.xml
+        path: build/test-results/architectureTest/*.xml
         reporter: java-junit
 
   client-tests:

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ tasks.register("architectureTest", Test) {
         events "FAILED", "SKIPPED"
     }
     testLogging.showStandardStreams = true
-    reports.html.required = false
+    reports.junitXml.required = true
     minHeapSize = "1024m" // initial heap size
     maxHeapSize = "3072m" // maximum heap size
 }

--- a/build.gradle
+++ b/build.gradle
@@ -96,10 +96,17 @@ modernizer {
 }
 
 // Execute the test cases: ./gradlew test
-
+// Execute only architecture tests: ./gradlew test -DincludeTags='ArchitectureTest'
 test {
-    useJUnitPlatform()
-    exclude "**/*IT*", "**/*IntTest*"
+    if (System.getProperty("includeTags")) {
+        useJUnitPlatform {
+            includeTags System.getProperty("includeTags")
+        }
+    } else {
+        useJUnitPlatform()
+        exclude "**/*IT*", "**/*IntTest*"
+    }
+
     testLogging {
         events "FAILED", "SKIPPED"
     }
@@ -112,20 +119,6 @@ test {
 tasks.register("testReport", TestReport) {
     destinationDirectory = file("$buildDir/reports/tests")
     testResults.from(test)
-}
-
-// Custom task to only execute ArchUnit tests
-tasks.register("architectureTest", Test) {
-    useJUnitPlatform {
-        includeTags "ArchitectureTest"
-    }
-    testLogging {
-        events "FAILED", "SKIPPED"
-    }
-    testLogging.showStandardStreams = true
-    reports.junitXml.required = true
-    minHeapSize = "1024m" // initial heap size
-    maxHeapSize = "3072m" // maximum heap size
 }
 
 jacoco {

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,13 @@ tasks.register("testReport", TestReport) {
     testResults.from(test)
 }
 
+// Custom task to only execute ArchUnit tests
+tasks.register("architectureTest", Test) {
+    useJUnitPlatform {
+        includeTags "ArchitectureTest"
+    }
+}
+
 jacoco {
     toolVersion = "0.8.8"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,13 @@ tasks.register("architectureTest", Test) {
     useJUnitPlatform {
         includeTags "ArchitectureTest"
     }
+    testLogging {
+        events "FAILED", "SKIPPED"
+    }
+    testLogging.showStandardStreams = true
+    reports.html.required = false
+    minHeapSize = "1024m" // initial heap size
+    maxHeapSize = "3072m" // maximum heap size
 }
 
 jacoco {

--- a/src/test/java/de/tum/in/www1/artemis/AbstractArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractArchitectureTest.java
@@ -3,12 +3,14 @@ package de.tum.in.www1.artemis;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 
-public abstract class AbstractArchitectureTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
+@Tag("ArchitectureTest")
+public abstract class AbstractArchitectureTest {
 
     protected static final String ARTEMIS_PACKAGE = "de.tum.in.www1.artemis";
 

--- a/src/test/java/de/tum/in/www1/artemis/AbstractArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractArchitectureTest.java
@@ -22,10 +22,11 @@ public abstract class AbstractArchitectureTest {
 
     @BeforeAll
     static void loadClasses() {
-        testClasses = new ClassFileImporter().withImportOption(new ImportOption.OnlyIncludeTests()).importPackages(ARTEMIS_PACKAGE);
-        productionClasses = new ClassFileImporter().withImportOption(new ImportOption.DoNotIncludeTests()).importPackages(ARTEMIS_PACKAGE);
-        allClasses = new ClassFileImporter().importPackages(ARTEMIS_PACKAGE);
-
+        if (allClasses == null) {
+            testClasses = new ClassFileImporter().withImportOption(new ImportOption.OnlyIncludeTests()).importPackages(ARTEMIS_PACKAGE);
+            productionClasses = new ClassFileImporter().withImportOption(new ImportOption.DoNotIncludeTests()).importPackages(ARTEMIS_PACKAGE);
+            allClasses = new ClassFileImporter().importPackages(ARTEMIS_PACKAGE);
+        }
         ensureClassSetsNonEmpty();
         ensureAllClassesFound();
     }

--- a/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationArchitectureTest.java
@@ -2,18 +2,9 @@ package de.tum.in.www1.artemis.authorization;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import com.tngtech.archunit.lang.ArchRule;
 
@@ -23,13 +14,7 @@ import de.tum.in.www1.artemis.security.annotations.*;
 /**
  * Contains the one automatic test covering all rest endpoints for authorization tests.
  */
-class AuthorizationTest extends AbstractArchitectureTest {
-
-    @Autowired
-    private ApplicationContext applicationContext;
-
-    @Autowired
-    private AuthorizationTestService authorizationTestService;
+class AuthorizationArchitectureTest extends AbstractArchitectureTest {
 
     private static final String ARTEMIS_PACKAGE = "de.tum.in.www1.artemis";
 
@@ -40,21 +25,10 @@ class AuthorizationTest extends AbstractArchitectureTest {
     private static final String REST_OPEN_PACKAGE = REST_BASE_PACKAGE + ".open";
 
     @Test
-    void testEndpoints() throws InvocationTargetException, IllegalAccessException {
-        var requestMappingHandlerMapping = applicationContext.getBean("requestMappingHandlerMapping", RequestMappingHandlerMapping.class);
-        Map<RequestMappingInfo, HandlerMethod> endpointMap = requestMappingHandlerMapping.getHandlerMethods();
-        // Filter out endpoints that should not be tested.
-        endpointMap = endpointMap.entrySet().stream().filter(entry -> authorizationTestService.validEndpointToTest(entry.getValue(), false))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-        authorizationTestService.testEndpoints(endpointMap);
-    }
-
-    @Test
     void testNoPreAuthorizeOnRestControllers() {
         ArchRule rule = noClasses().that().areAnnotatedWith(RestController.class).should().beAnnotatedWith(PreAuthorize.class).because(
                 "All endpoints should be secured directly using the Artemis enforcement annotations on the method definition. Refer to the server guidelines in our documentation.");
-        rule.check(productionClasses);
+        rule.check(allClasses);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationArchitectureTest.java
@@ -11,9 +11,6 @@ import com.tngtech.archunit.lang.ArchRule;
 import de.tum.in.www1.artemis.AbstractArchitectureTest;
 import de.tum.in.www1.artemis.security.annotations.*;
 
-/**
- * Contains the one automatic test covering all rest endpoints for authorization tests.
- */
 class AuthorizationArchitectureTest extends AbstractArchitectureTest {
 
     private static final String ARTEMIS_PACKAGE = "de.tum.in.www1.artemis";

--- a/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationArchitectureTest.java
@@ -28,7 +28,7 @@ class AuthorizationArchitectureTest extends AbstractArchitectureTest {
     void testNoPreAuthorizeOnRestControllers() {
         ArchRule rule = noClasses().that().areAnnotatedWith(RestController.class).should().beAnnotatedWith(PreAuthorize.class).because(
                 "All endpoints should be secured directly using the Artemis enforcement annotations on the method definition. Refer to the server guidelines in our documentation.");
-        rule.check(allClasses);
+        rule.check(productionClasses);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationEndpointTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationEndpointTest.java
@@ -12,6 +12,9 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 
+/**
+ * Contains the one automatic test covering all rest endpoints for authorization tests.
+ */
 class AuthorizationEndpointTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     @Autowired

--- a/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationEndpointTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authorization/AuthorizationEndpointTest.java
@@ -1,0 +1,33 @@
+package de.tum.in.www1.artemis.authorization;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
+
+class AuthorizationEndpointTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private AuthorizationTestService authorizationTestService;
+
+    @Test
+    void testEndpoints() {
+        var requestMappingHandlerMapping = applicationContext.getBean("requestMappingHandlerMapping", RequestMappingHandlerMapping.class);
+        Map<RequestMappingInfo, HandlerMethod> endpointMap = requestMappingHandlerMapping.getHandlerMethods();
+        // Filter out endpoints that should not be tested.
+        endpointMap = endpointMap.entrySet().stream().filter(entry -> authorizationTestService.validEndpointToTest(entry.getValue(), false))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        authorizationTestService.testEndpoints(endpointMap);
+    }
+}


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
We use architecture tests with ArchUnit to ensure that the code follows some general rules.
@jakubriegel pointed out that these tests are currently only run during a full server test run, which can take a while. Instead of letting developers wait until all server tests are finished, these special tests should be executed separately to quickly review issues.

### Description
We now execute the ArchitecureTests directly in the server-style action.

### Steps for Testing
code review

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Screenshots
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/0eea303d-e202-40de-86a3-54000f41ee5b)
