### PR TITLE
`Development`: Disable secure cookies for local testing with dev profile

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/security/jwt/JWTCookieService.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/jwt/JWTCookieService.java
@@ -17,6 +17,8 @@ public class JWTCookieService {
 
     private static final String CYPRESS_PROFILE = "cypress";
 
+    private static final String DEVELOPMENT_PROFILE = "dev";
+
     private final TokenProvider tokenProvider;
 
     private final Environment environment;
@@ -56,12 +58,13 @@ public class JWTCookieService {
      */
     private ResponseCookie buildJWTCookie(String jwt, Duration duration) {
 
+        // TODO - Remove cypress workaround once cypress uses https and find a better solution for testing locally in Safari
         Collection<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
-        boolean isCypress = activeProfiles.contains(CYPRESS_PROFILE);
+        boolean isSecure = !activeProfiles.contains(CYPRESS_PROFILE) && !activeProfiles.contains(DEVELOPMENT_PROFILE);
 
         return ResponseCookie.from(JWT_COOKIE_NAME, jwt).httpOnly(true) // Must be httpOnly
                 .sameSite("Lax") // Must be Lax to allow navigation links to Artemis to work
-                .secure(!isCypress) // Must be secure - TODO - Remove cypress workaround once cypress uses https
+                .secure(isSecure) // Must be secure
                 .path("/") // Must be "/" to be sent in ALL request
                 .maxAge(duration) // Duration should match the duration of the jwt
                 .build(); // Build cookie


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Logging in on localhost through Safari was not possible, because Safari does not allow secure cookies over http.

### Description
<!-- Describe your changes in detail -->
Added a check for the dev profile. If the dev profile is active, the cookie returned by the JWTCookieService is not secure.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
Safari Browser (Please comment if it also did not work for other browsers)
Local development setup

Locally:
- If you already successfully logged in through safari, please delete the cookies for localhost first ([Delete Cookies in Safari](https://support.apple.com/en-gb/guide/safari/sfri11471/mac))
- Try to log in with an existing user (on develop, this step fails, but on this branch, you should be able to log in)

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2