### PR TITLE
`General`: Fix slow exercise deletion in courses with many participants

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseDeletionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseDeletionService.java
@@ -23,6 +23,7 @@ import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismResultRepository;
 import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseService;
+import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 
 /**
  * Service Implementation for managing Exercise.
@@ -123,8 +124,10 @@ public class ExerciseDeletionService {
         var exercise = exerciseRepository.findByIdWithCompetenciesElseThrow(exerciseId);
         log.info("Request to delete {} with id {}", exercise.getClass().getSimpleName(), exerciseId);
 
+        long start = System.nanoTime();
         Channel exreciseChannel = channelRepository.findChannelByExerciseId(exerciseId);
         channelService.deleteChannel(exreciseChannel);
+        log.info("Deleting the channel took {}", TimeLogUtil.formatDurationFrom(start));
 
         if (exercise instanceof ModelingExercise modelingExercise) {
             log.info("Deleting clusters, elements and cancel scheduled operations of exercise {}", exercise.getId());

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
@@ -189,22 +189,6 @@ public class ChannelService {
     }
 
     /**
-     * Adds users to the channel of the given exam asynchronously
-     *
-     * @param users list of user logins to register for the exam channel
-     * @param exam  exam to which channel the users should be added
-     */
-    @Async
-    public void registerUsersToExamChannel(List<String> users, Exam exam) {
-        Channel channel = channelRepository.findChannelByExamId(exam.getId());
-        if (channel == null) {
-            return;
-        }
-        SecurityUtils.setAuthorizationObject();
-        registerUsersToChannel(false, false, false, users, exam.getCourse(), channel);
-    }
-
-    /**
      * Register users to the newly created channel
      *
      * @param addAllStudents        if true, all students of the course will be added to the channel
@@ -389,21 +373,6 @@ public class ChannelService {
         }
         Channel channel = channelRepository.findChannelByExamId(originalExam.getId());
         return updateChannelName(channel, updatedExam.getChannelName());
-    }
-
-    /**
-     * Removes users from an exam channel
-     *
-     * @param users  users to remove from the channel
-     * @param examId id of the exam the channel belongs to
-     */
-    public void deregisterUsersFromExamChannel(Set<User> users, Long examId) {
-        Channel channel = channelRepository.findChannelByExamId(examId);
-        if (channel == null) {
-            return;
-        }
-
-        conversationService.deregisterUsersFromAConversation(channel.getCourse(), users, channel);
     }
 
     private Channel updateChannelName(Channel channel, String newChannelName) {

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -267,36 +267,6 @@ public class ConversationService {
         recipients.forEach(user -> sendToConversationMembershipChannel(metisCrudAction, conversation, user, conversationParticipantTopicName));
     }
 
-    /**
-     * Deregister all clients from the exercise channel of the given exercise
-     *
-     * @param exercise the exercise that is being deleted
-     */
-    public void deregisterAllClientsFromChannel(Exercise exercise) {
-        // deregister all clients from the channel
-        Channel originalChannel = channelRepository.findChannelByExerciseId(exercise.getId());
-        if (exercise.isCourseExercise() && originalChannel != null) {
-            Set<ConversationParticipant> channelParticipants = conversationParticipantRepository.findConversationParticipantByConversationId(originalChannel.getId());
-            Set<User> usersToBeDeregistered = channelParticipants.stream().map(ConversationParticipant::getUser).collect(Collectors.toSet());
-            broadcastOnConversationMembershipChannel(originalChannel.getCourse(), MetisCrudAction.DELETE, originalChannel, usersToBeDeregistered);
-        }
-    }
-
-    /**
-     * Deregister all clients from the lecture channel of the given exercise
-     *
-     * @param lecture the lecture that is being deleted
-     */
-    public void deregisterAllClientsFromChannel(Lecture lecture) {
-        // deregister all clients from the channel
-        Channel originalChannel = channelRepository.findChannelByLectureId(lecture.getId());
-        if (originalChannel != null) {
-            Set<ConversationParticipant> channelParticipants = conversationParticipantRepository.findConversationParticipantByConversationId(originalChannel.getId());
-            Set<User> usersToBeDeregistered = channelParticipants.stream().map(ConversationParticipant::getUser).collect(Collectors.toSet());
-            broadcastOnConversationMembershipChannel(lecture.getCourse(), MetisCrudAction.DELETE, originalChannel, usersToBeDeregistered);
-        }
-    }
-
     @NotNull
     public static String getConversationParticipantTopicName(Long courseId) {
         return METIS_WEBSOCKET_CHANNEL_PREFIX + "courses/" + courseId + "/conversations/user/";

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -10,7 +10,6 @@ import javax.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import de.tum.in.www1.artemis.domain.*;
@@ -249,11 +248,7 @@ public class ConversationService {
      *
      * @param conversation the conversation to be deleted
      */
-    @Transactional // ok because of delete
     public void deleteConversation(Conversation conversation) {
-        var usersToMessage = conversationParticipantRepository.findConversationParticipantByConversationId(conversation.getId()).stream().map(ConversationParticipant::getUser)
-                .collect(Collectors.toSet());
-        broadcastOnConversationMembershipChannel(conversation.getCourse(), MetisCrudAction.DELETE, conversation, usersToMessage);
         this.postRepository.deleteAllByConversationId(conversation.getId());
         this.conversationParticipantRepository.deleteAllByConversationId(conversation.getId());
         this.conversationRepository.deleteById(conversation.getId());

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/GroupNotificationScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/GroupNotificationScheduleService.java
@@ -6,6 +6,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.Exercise;
+import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.ExerciseDateService;
 import de.tum.in.www1.artemis.service.messaging.InstanceMessageSendService;
 
@@ -140,7 +141,8 @@ public class GroupNotificationScheduleService {
      * @param exercise that is created
      */
     @Async
-    public void checkNotificationsForNewExercise(Exercise exercise) {
+    public void checkNotificationsForNewExerciseAsync(Exercise exercise) {
+        SecurityUtils.setAuthorizationObject(); // required for async
         // TODO: in a course with 2000 participants, this can take really long, we should optimize this
         checkNotificationForExerciseRelease(exercise);
         checkNotificationForAssessmentDueDate(exercise);

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -222,7 +222,7 @@ public class ProgrammingExerciseService {
         // not yet saved in the database, so we cannot save the submission accordingly (see ProgrammingSubmissionService.processNewProgrammingSubmission)
         versionControl.addWebHooksForExercise(savedProgrammingExercise);
         scheduleOperations(savedProgrammingExercise.getId());
-        groupNotificationScheduleService.checkNotificationsForNewExercise(savedProgrammingExercise);
+        groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(savedProgrammingExercise);
         return savedProgrammingExercise;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.feature.Feature;
 import de.tum.in.www1.artemis.service.feature.FeatureToggle;
 import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
-import de.tum.in.www1.artemis.service.metis.conversation.ConversationService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationScheduleService;
 import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
@@ -81,14 +80,12 @@ public class FileUploadExerciseResource {
 
     private final ChannelRepository channelRepository;
 
-    private final ConversationService conversationService;
-
     public FileUploadExerciseResource(FileUploadExerciseRepository fileUploadExerciseRepository, UserRepository userRepository, AuthorizationCheckService authCheckService,
             CourseService courseService, ExerciseService exerciseService, ExerciseDeletionService exerciseDeletionService,
             FileUploadSubmissionExportService fileUploadSubmissionExportService, GradingCriterionRepository gradingCriterionRepository, CourseRepository courseRepository,
             ParticipationRepository participationRepository, GroupNotificationScheduleService groupNotificationScheduleService,
             FileUploadExerciseImportService fileUploadExerciseImportService, FileUploadExerciseService fileUploadExerciseService, ChannelService channelService,
-            ChannelRepository channelRepository, ConversationService conversationService) {
+            ChannelRepository channelRepository) {
         this.fileUploadExerciseRepository = fileUploadExerciseRepository;
         this.userRepository = userRepository;
         this.courseService = courseService;
@@ -104,7 +101,6 @@ public class FileUploadExerciseResource {
         this.fileUploadExerciseService = fileUploadExerciseService;
         this.channelService = channelService;
         this.channelRepository = channelRepository;
-        this.conversationService = conversationService;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -129,7 +129,7 @@ public class FileUploadExerciseResource {
         FileUploadExercise result = fileUploadExerciseRepository.save(fileUploadExercise);
 
         channelService.createExerciseChannel(result, Optional.ofNullable(fileUploadExercise.getChannelName()));
-        groupNotificationScheduleService.checkNotificationsForNewExercise(fileUploadExercise);
+        groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(fileUploadExercise);
 
         return ResponseEntity.created(new URI("/api/file-upload-exercises/" + result.getId())).body(result);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -333,7 +333,6 @@ public class FileUploadExerciseResource {
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, exercise, user);
         // note: we use the exercise service here, because this one makes sure to clean up all lazy references correctly.
         exerciseService.logDeletion(exercise, exercise.getCourseViaExerciseGroupOrCourseMember(), user);
-        conversationService.deregisterAllClientsFromChannel(exercise);
         exerciseDeletionService.delete(exerciseId, false, false);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, exercise.getTitle())).build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
@@ -32,7 +32,6 @@ import de.tum.in.www1.artemis.service.ExerciseService;
 import de.tum.in.www1.artemis.service.LectureImportService;
 import de.tum.in.www1.artemis.service.LectureService;
 import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
-import de.tum.in.www1.artemis.service.metis.conversation.ConversationService;
 import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
@@ -66,15 +65,13 @@ public class LectureResource {
 
     private final ExerciseService exerciseService;
 
-    private final ConversationService conversationService;
-
     private final ChannelService channelService;
 
     private final ChannelRepository channelRepository;
 
     public LectureResource(LectureRepository lectureRepository, LectureService lectureService, LectureImportService lectureImportService, CourseRepository courseRepository,
             UserRepository userRepository, AuthorizationCheckService authCheckService, ExerciseService exerciseService, ChannelService channelService,
-            ConversationService conversationService, ChannelRepository channelRepository) {
+            ChannelRepository channelRepository) {
         this.lectureRepository = lectureRepository;
         this.lectureService = lectureService;
         this.lectureImportService = lectureImportService;
@@ -83,7 +80,6 @@ public class LectureResource {
         this.authCheckService = authCheckService;
         this.exerciseService = exerciseService;
         this.channelService = channelService;
-        this.conversationService = conversationService;
         this.channelRepository = channelRepository;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
@@ -367,7 +367,6 @@ public class LectureResource {
         }
 
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
-        conversationService.deregisterAllClientsFromChannel(lecture);
         log.debug("REST request to delete Lecture : {}", lectureId);
         lectureService.delete(lecture);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, lectureId.toString())).build();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -293,7 +293,6 @@ public class ModelingExerciseResource {
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, modelingExercise, user);
         // note: we use the exercise service here, because this one makes sure to clean up all lazy references correctly.
         exerciseService.logDeletion(modelingExercise, modelingExercise.getCourseViaExerciseGroupOrCourseMember(), user);
-        conversationService.deregisterAllClientsFromChannel(modelingExercise);
         exerciseDeletionService.delete(exerciseId, false, false);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, modelingExercise.getTitle())).build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -150,7 +150,7 @@ public class ModelingExerciseResource {
 
         channelService.createExerciseChannel(result, Optional.ofNullable(modelingExercise.getChannelName()));
         modelingExerciseService.scheduleOperations(result.getId());
-        groupNotificationScheduleService.checkNotificationsForNewExercise(modelingExercise);
+        groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(modelingExercise);
 
         return ResponseEntity.created(new URI("/api/modeling-exercises/" + result.getId())).body(result);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -32,7 +32,6 @@ import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.feature.Feature;
 import de.tum.in.www1.artemis.service.feature.FeatureToggle;
 import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
-import de.tum.in.www1.artemis.service.metis.conversation.ConversationService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationScheduleService;
 import de.tum.in.www1.artemis.service.plagiarism.ModelingPlagiarismDetectionService;
 import de.tum.in.www1.artemis.service.util.TimeLogUtil;
@@ -90,8 +89,6 @@ public class ModelingExerciseResource {
 
     private final ChannelService channelService;
 
-    private final ConversationService conversationService;
-
     private final ChannelRepository channelRepository;
 
     public ModelingExerciseResource(ModelingExerciseRepository modelingExerciseRepository, UserRepository userRepository, CourseService courseService,
@@ -99,8 +96,7 @@ public class ModelingExerciseResource {
             ModelingExerciseService modelingExerciseService, ExerciseDeletionService exerciseDeletionService, PlagiarismResultRepository plagiarismResultRepository,
             ModelingExerciseImportService modelingExerciseImportService, SubmissionExportService modelingSubmissionExportService, ExerciseService exerciseService,
             GroupNotificationScheduleService groupNotificationScheduleService, GradingCriterionRepository gradingCriterionRepository,
-            ModelingPlagiarismDetectionService modelingPlagiarismDetectionService, ChannelService channelService, ConversationService conversationService,
-            ChannelRepository channelRepository) {
+            ModelingPlagiarismDetectionService modelingPlagiarismDetectionService, ChannelService channelService, ChannelRepository channelRepository) {
         this.modelingExerciseRepository = modelingExerciseRepository;
         this.courseService = courseService;
         this.modelingExerciseService = modelingExerciseService;
@@ -117,7 +113,6 @@ public class ModelingExerciseResource {
         this.gradingCriterionRepository = gradingCriterionRepository;
         this.modelingPlagiarismDetectionService = modelingPlagiarismDetectionService;
         this.channelService = channelService;
-        this.conversationService = conversationService;
         this.channelRepository = channelRepository;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -456,7 +456,6 @@ public class ProgrammingExerciseResource {
         User user = userRepository.getUserWithGroupsAndAuthorities();
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, programmingExercise, user);
         exerciseService.logDeletion(programmingExercise, programmingExercise.getCourseViaExerciseGroupOrCourseMember(), user);
-        conversationService.deregisterAllClientsFromChannel(programmingExercise);
         exerciseDeletionService.delete(exerciseId, deleteStudentReposBuildPlans, deleteBaseReposBuildPlans);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, programmingExercise.getTitle())).build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -38,7 +38,6 @@ import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlService;
 import de.tum.in.www1.artemis.service.feature.Feature;
 import de.tum.in.www1.artemis.service.feature.FeatureToggle;
 import de.tum.in.www1.artemis.service.messaging.InstanceMessageSendService;
-import de.tum.in.www1.artemis.service.metis.conversation.ConversationService;
 import de.tum.in.www1.artemis.service.programming.*;
 import de.tum.in.www1.artemis.web.rest.dto.BuildLogStatisticsDTO;
 import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
@@ -108,8 +107,6 @@ public class ProgrammingExerciseResource {
 
     private final BuildLogStatisticsEntryRepository buildLogStatisticsEntryRepository;
 
-    private final ConversationService conversationService;
-
     private final InstanceMessageSendService instanceMessageSendService;
 
     public ProgrammingExerciseResource(ProgrammingExerciseRepository programmingExerciseRepository, ProgrammingExerciseTestCaseRepository programmingExerciseTestCaseRepository,
@@ -120,8 +117,7 @@ public class ProgrammingExerciseResource {
             StaticCodeAnalysisService staticCodeAnalysisService, GradingCriterionRepository gradingCriterionRepository, CourseRepository courseRepository, GitService gitService,
             AuxiliaryRepositoryService auxiliaryRepositoryService, SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository,
             TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository, ProfileService profileService,
-            BuildLogStatisticsEntryRepository buildLogStatisticsEntryRepository, ConversationService conversationService, ChannelRepository channelRepository,
-            InstanceMessageSendService instanceMessageSendService) {
+            BuildLogStatisticsEntryRepository buildLogStatisticsEntryRepository, ChannelRepository channelRepository, InstanceMessageSendService instanceMessageSendService) {
         this.profileService = profileService;
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.programmingExerciseTestCaseRepository = programmingExerciseTestCaseRepository;
@@ -143,7 +139,6 @@ public class ProgrammingExerciseResource {
         this.solutionProgrammingExerciseParticipationRepository = solutionProgrammingExerciseParticipationRepository;
         this.templateProgrammingExerciseParticipationRepository = templateProgrammingExerciseParticipationRepository;
         this.buildLogStatisticsEntryRepository = buildLogStatisticsEntryRepository;
-        this.conversationService = conversationService;
         this.channelRepository = channelRepository;
         this.instanceMessageSendService = instanceMessageSendService;
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -553,7 +553,6 @@ public class QuizExerciseResource {
 
         // note: we use the exercise service here, because this one makes sure to clean up all lazy references correctly.
         exerciseService.logDeletion(quizExercise, quizExercise.getCourseViaExerciseGroupOrCourseMember(), user);
-        conversationService.deregisterAllClientsFromChannel(quizExercise);
         exerciseDeletionService.delete(quizExerciseId, false, false);
         quizExerciseService.cancelScheduledQuiz(quizExerciseId);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, quizExercise.getTitle())).build();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -31,7 +31,6 @@ import de.tum.in.www1.artemis.security.annotations.*;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.exam.ExamDateService;
 import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
-import de.tum.in.www1.artemis.service.metis.conversation.ConversationService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationScheduleService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationService;
 import de.tum.in.www1.artemis.service.scheduled.cache.quiz.QuizScheduleService;
@@ -98,15 +97,12 @@ public class QuizExerciseResource {
 
     private final ChannelRepository channelRepository;
 
-    private final ConversationService conversationService;
-
     public QuizExerciseResource(QuizExerciseService quizExerciseService, QuizExerciseRepository quizExerciseRepository, CourseService courseService, UserRepository userRepository,
             ExerciseDeletionService exerciseDeletionServiceService, QuizScheduleService quizScheduleService, QuizStatisticService quizStatisticService,
             QuizExerciseImportService quizExerciseImportService, AuthorizationCheckService authCheckService, CourseRepository courseRepository,
             GroupNotificationService groupNotificationService, ExerciseService exerciseService, ExamDateService examDateService, QuizMessagingService quizMessagingService,
             GroupNotificationScheduleService groupNotificationScheduleService, StudentParticipationRepository studentParticipationRepository, QuizBatchService quizBatchService,
-            QuizBatchRepository quizBatchRepository, SubmissionRepository submissionRepository, ChannelService channelService, ChannelRepository channelRepository,
-            ConversationService conversationService) {
+            QuizBatchRepository quizBatchRepository, SubmissionRepository submissionRepository, ChannelService channelService, ChannelRepository channelRepository) {
         this.quizExerciseService = quizExerciseService;
         this.quizExerciseRepository = quizExerciseRepository;
         this.exerciseDeletionService = exerciseDeletionServiceService;
@@ -128,7 +124,6 @@ public class QuizExerciseResource {
         this.submissionRepository = submissionRepository;
         this.channelService = channelService;
         this.channelRepository = channelRepository;
-        this.conversationService = conversationService;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -166,7 +166,7 @@ public class TextExerciseResource {
 
         channelService.createExerciseChannel(result, Optional.ofNullable(textExercise.getChannelName()));
         instanceMessageSendService.sendTextExerciseSchedule(result.getId());
-        groupNotificationScheduleService.checkNotificationsForNewExercise(textExercise);
+        groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(textExercise);
         return ResponseEntity.created(new URI("/api/text-exercises/" + result.getId())).body(result);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.service.feature.Feature;
 import de.tum.in.www1.artemis.service.feature.FeatureToggle;
 import de.tum.in.www1.artemis.service.messaging.InstanceMessageSendService;
 import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
-import de.tum.in.www1.artemis.service.metis.conversation.ConversationService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationScheduleService;
 import de.tum.in.www1.artemis.service.plagiarism.TextPlagiarismDetectionService;
 import de.tum.in.www1.artemis.service.util.TimeLogUtil;
@@ -99,8 +98,6 @@ public class TextExerciseResource {
 
     private final ChannelService channelService;
 
-    private final ConversationService conversationService;
-
     private final ChannelRepository channelRepository;
 
     public TextExerciseResource(TextExerciseRepository textExerciseRepository, TextExerciseService textExerciseService, FeedbackRepository feedbackRepository,
@@ -110,7 +107,7 @@ public class TextExerciseResource {
             TextSubmissionExportService textSubmissionExportService, ExampleSubmissionRepository exampleSubmissionRepository, ExerciseService exerciseService,
             GradingCriterionRepository gradingCriterionRepository, TextBlockRepository textBlockRepository, GroupNotificationScheduleService groupNotificationScheduleService,
             InstanceMessageSendService instanceMessageSendService, TextPlagiarismDetectionService textPlagiarismDetectionService, CourseRepository courseRepository,
-            ChannelService channelService, ChannelRepository channelRepository, ConversationService conversationService) {
+            ChannelService channelService, ChannelRepository channelRepository) {
         this.feedbackRepository = feedbackRepository;
         this.exerciseDeletionService = exerciseDeletionService;
         this.plagiarismResultRepository = plagiarismResultRepository;
@@ -133,7 +130,6 @@ public class TextExerciseResource {
         this.textPlagiarismDetectionService = textPlagiarismDetectionService;
         this.courseRepository = courseRepository;
         this.channelService = channelService;
-        this.conversationService = conversationService;
         this.channelRepository = channelRepository;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -300,7 +300,6 @@ public class TextExerciseResource {
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, textExercise, user);
         // NOTE: we use the exerciseDeletionService here, because this one makes sure to clean up all lazy references correctly.
         exerciseService.logDeletion(textExercise, textExercise.getCourseViaExerciseGroupOrCourseMember(), user);
-        conversationService.deregisterAllClientsFromChannel(textExercise);
         exerciseDeletionService.delete(exerciseId, false, false);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, textExercise.getTitle())).build();
     }

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
@@ -20,7 +20,6 @@ import { AlertService } from 'app/core/util/alert.service';
 import { roundValueSpecifiedByCourseSettings } from 'app/shared/util/utils';
 import { LocaleConversionService } from 'app/shared/service/locale-conversion.service';
 import { JhiLanguageHelper } from 'app/core/language/language.helper';
-import { TranslateService } from '@ngx-translate/core';
 import { ParticipantScoresService, ScoresDTO } from 'app/shared/participant-scores/participant-scores.service';
 import { captureException } from '@sentry/angular-ivy';
 import { GradingSystemService } from 'app/grading-system/grading-system.service';
@@ -138,7 +137,6 @@ export class ExamScoresComponent implements OnInit, OnDestroy {
         private changeDetector: ChangeDetectorRef,
         private languageHelper: JhiLanguageHelper,
         private localeConversionService: LocaleConversionService,
-        private translateService: TranslateService,
         private participantScoresService: ParticipantScoresService,
         private gradingSystemService: GradingSystemService,
         private courseManagementService: CourseManagementService,

--- a/src/main/webapp/app/shared/metis/metis-conversation.service.ts
+++ b/src/main/webapp/app/shared/metis/metis-conversation.service.ts
@@ -13,7 +13,6 @@ import { OneToOneChatService } from 'app/shared/metis/conversations/one-to-one-c
 import { ChannelService } from 'app/shared/metis/conversations/channel.service';
 import { onError } from 'app/shared/util/global.utils';
 import { Course } from 'app/entities/course.model';
-import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ChannelDTO } from 'app/entities/metis/conversation/channel.model';
 import { OneToOneChatDTO } from 'app/entities/metis/conversation/one-to-one-chat.model';
 import { GroupChatService } from 'app/shared/metis/conversations/group-chat.service';
@@ -46,7 +45,6 @@ export class MetisConversationService implements OnDestroy {
     private _isServiceSetup$: ReplaySubject<boolean> = new ReplaySubject<boolean>(1);
 
     constructor(
-        private courseManagementService: CourseManagementService,
         private groupChatService: GroupChatService,
         private oneToOneChatService: OneToOneChatService,
         private channelService: ChannelService,

--- a/src/test/java/de/tum/in/www1/artemis/metis/ChannelIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ChannelIntegrationTest.java
@@ -34,6 +34,8 @@ import de.tum.in.www1.artemis.web.websocket.dto.metis.MetisCrudAction;
 
 class ChannelIntegrationTest extends AbstractConversationTest {
 
+    private static final String TEST_PREFIX = "chtest";
+
     @Autowired
     TutorialGroupRepository tutorialGroupRepository;
 
@@ -45,8 +47,6 @@ class ChannelIntegrationTest extends AbstractConversationTest {
 
     @Autowired
     private LectureRepository lectureRepository;
-
-    private static final String TEST_PREFIX = "chtest";
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
@@ -244,8 +244,6 @@ class ChannelIntegrationTest extends AbstractConversationTest {
         request.delete("/api/courses/" + exampleCourseId + "/channels/" + channel.getId(), HttpStatus.OK);
         // then
         assertThat(channelRepository.findById(channel.getId())).isEmpty();
-        verifyMultipleParticipantTopicWebsocketSent(MetisCrudAction.DELETE, channel.getId(), "instructor1");
-        verifyNoParticipantTopicWebsocketSentExceptAction(MetisCrudAction.DELETE);
     }
 
     @ParameterizedTest
@@ -283,8 +281,6 @@ class ChannelIntegrationTest extends AbstractConversationTest {
         request.delete("/api/courses/" + exampleCourseId + "/channels/" + channel.getId(), HttpStatus.OK);
         // then
         assertThat(channelRepository.findById(channel.getId())).isEmpty();
-        verifyMultipleParticipantTopicWebsocketSent(MetisCrudAction.DELETE, channel.getId(), "tutor1");
-        verifyNoParticipantTopicWebsocketSentExceptAction(MetisCrudAction.DELETE);
     }
 
     @ParameterizedTest

--- a/src/test/java/de/tum/in/www1/artemis/notification/GroupNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/GroupNotificationServiceTest.java
@@ -289,7 +289,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
      */
     @Test
     void testCheckNotificationForExerciseRelease_undefinedReleaseDate() {
-        groupNotificationScheduleService.checkNotificationsForNewExercise(exercise);
+        groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(exercise);
         verify(groupNotificationService, timeout(1500)).notifyAllGroupsAboutReleasedExercise(any());
     }
 
@@ -299,7 +299,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
     @Test
     void testCheckNotificationForExerciseRelease_currentOrPastReleaseDate() {
         exercise.setReleaseDate(CURRENT_TIME);
-        groupNotificationScheduleService.checkNotificationsForNewExercise(exercise);
+        groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(exercise);
         verify(groupNotificationService, timeout(1500)).notifyAllGroupsAboutReleasedExercise(any());
     }
 
@@ -309,7 +309,7 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
     @Test
     void testCheckNotificationForExerciseRelease_futureReleaseDate() {
         exercise.setReleaseDate(FUTURE_TIME);
-        groupNotificationScheduleService.checkNotificationsForNewExercise(exercise);
+        groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(exercise);
         verify(instanceMessageSendService, timeout(1500)).sendExerciseReleaseNotificationSchedule(any());
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).
- [x] I adapted multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
A couple of operation were slow due to `@Transactional` use and excessive (and sometimes even duplicated) web socket messages for edge cases, which are not really necessary. On production, I had to wait around 5min until a test exercise in a course with 2.000 participants could be deleted, when I tried to cleanup. This is completely unacceptable and another instance of really bad implementation :-(

### Description
I removed `@Transactional`, unnecessary websocket messages for edge cases and now unnecessary registration and deregistation in channels for exam users. While there might be the edge cases that a user is currently in a channel that is deleted, this is highly unlikely, because active exercises, lectures and exams are typically not deleted. In addition, we recently switched to course_wide channels for which we can implement some kind of broadcast message in such a case, which should be much faster.

In any case, this PR significantly speeds up deletion by up to 99% - it now takes a few seconds as before - and reduced the pressure on the web socket / broker subsystems by getting rid of unnecessary and sometimes even duplicated messages.

### Steps for Testing
The scenario cannot easily be tested, because newly created exercises do not add conversation_participants any more.

#### Preparation
1. Deploy an old version before #7021, e.g. release 6.4.2
2. Make sure you have a course with at least 500 participants
3. Create multiple exercises (e.g. modeling, text)
4. Delete one exercise and notice, it takes quite some time

#### Testing
1. Deploy the version of this PR
2. Delete some of the exercises created in Preparation and make sure this is done without error message and in a few seconds
3. Create an exam
4. Add user to the exam
5. Let the exam become visible
6. Make sure users can now (potentially after reloading the messages tab) see the exam channel and send messages


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
