### PR TITLE
`Programming exercises`: Speedup archival

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/PublicResourcesConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/PublicResourcesConfiguration.java
@@ -82,7 +82,7 @@ public class PublicResourcesConfiguration implements WebMvcConfigurer {
      */
     private static String getFileSystemPublicSubPathResourceLocation(String... subPaths) {
         var userDir = System.getProperty("user.dir");
-        var morePaths = Stream.concat(Stream.of("public"), Arrays.stream(subPaths)).toList().toArray(new String[1 + subPaths.length]);
+        var morePaths = Stream.concat(Stream.of("public"), Arrays.stream(subPaths)).toArray(String[]::new);
         return "file:" + Path.of(userDir, morePaths) + "/";
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
@@ -115,7 +115,7 @@ public class CourseExamExportService {
 
         Optional<Path> exportedCourse = zipExportedExercises(outputDir, exportErrors, notificationTopic, tmpCourseDir, exportedFiles);
 
-        log.info("Successfully exported course {}. The zip file is located at: {}", course.getId(), exportedCourse);
+        log.info("Successfully exported course {}. The zip file is located at: {}", course.getId(), exportedCourse.orElse(null));
         return exportedCourse;
     }
 
@@ -178,7 +178,7 @@ public class CourseExamExportService {
 
         Optional<Path> exportedExamPath = zipExportedExercises(outputDir, exportErrors, notificationTopic, tempExamsDir, exportedExercises);
 
-        log.info("Successfully exported exam {}. The zip file is located at: {}", exam.getId(), exportedExamPath);
+        log.info("Successfully exported exam {}. The zip file is located at: {}", exam.getId(), exportedExamPath.orElse(null));
         return exportedExamPath;
     }
 
@@ -356,7 +356,7 @@ public class CourseExamExportService {
 
         // Export exercises
         for (var exercise : sortedExercises) {
-            log.info("Exporting exercise {} with id {} ", exercise.getTitle(), exercise.getId());
+            log.info("Exporting {} exercise {} with id {} ", exercise.getType(), exercise.getTitle(), exercise.getId());
 
             // Notify the user after the progress
             currentProgress++;

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -746,7 +746,7 @@ public class CourseService {
         }
 
         // This contains possible errors encountered during the archive process
-        ArrayList<String> exportErrors = new ArrayList<>();
+        List<String> exportErrors = Collections.synchronizedList(new ArrayList<>());
 
         groupNotificationService.notifyInstructorGroupAboutCourseArchiveState(course, NotificationType.COURSE_ARCHIVE_STARTED, exportErrors);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -776,7 +776,7 @@ public class CourseService {
         }
 
         groupNotificationService.notifyInstructorGroupAboutCourseArchiveState(course, NotificationType.COURSE_ARCHIVE_FINISHED, exportErrors);
-        log.info("archiveCourse took {}", TimeLogUtil.formatDurationFrom(start));
+        log.info("archive course took {}", TimeLogUtil.formatDurationFrom(start));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -738,6 +738,7 @@ public class CourseService {
      */
     @Async
     public void archiveCourse(Course course) {
+        long start = System.nanoTime();
         SecurityUtils.setAuthorizationObject();
 
         // Archiving a course is only possible after the course is over
@@ -775,6 +776,7 @@ public class CourseService {
         }
 
         groupNotificationService.notifyInstructorGroupAboutCourseArchiveState(course, NotificationType.COURSE_ARCHIVE_FINISHED, exportErrors);
+        log.info("archiveCourse took {}", TimeLogUtil.formatDurationFrom(start));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/dataexport/DataExportExerciseCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dataexport/DataExportExerciseCreationService.java
@@ -7,9 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -136,12 +134,12 @@ public class DataExportExerciseCreationService {
         var listOfProgrammingExerciseParticipations = programmingExercise.getStudentParticipations().stream()
                 .filter(studentParticipation -> studentParticipation instanceof ProgrammingExerciseStudentParticipation)
                 .map(studentParticipation -> (ProgrammingExerciseStudentParticipation) studentParticipation).toList();
-        List<String> exportRepoErrors = new ArrayList<>();
+
         // we use this directory only to clone the repository and don't do this in our current directory because the current directory is part of the final data export
         // --> we can delete it after use
         var tempRepoWorkingDir = fileService.getTemporaryUniquePath(repoClonePath, 10);
         programmingExerciseExportService.exportStudentRepositories(programmingExercise, listOfProgrammingExerciseParticipations, repositoryExportOptions, tempRepoWorkingDir,
-                exerciseDir, exportRepoErrors);
+                exerciseDir, Collections.synchronizedList(new ArrayList<>()));
 
         createPlagiarismCaseInfoExport(programmingExercise, exerciseDir, userId);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/dataexport/DataExportExerciseCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dataexport/DataExportExerciseCreationService.java
@@ -130,7 +130,7 @@ public class DataExportExerciseCreationService {
         repositoryExportOptions.setCombineStudentCommits(false);
         repositoryExportOptions.setFilterLateSubmissionsIndividualDueDate(false);
         repositoryExportOptions.setExcludePracticeSubmissions(false);
-        repositoryExportOptions.setNormalizeCodeStyle(true);
+        repositoryExportOptions.setNormalizeCodeStyle(false);
         var listOfProgrammingExerciseParticipations = programmingExercise.getStudentParticipations().stream()
                 .filter(studentParticipation -> studentParticipation instanceof ProgrammingExerciseStudentParticipation)
                 .map(studentParticipation -> (ProgrammingExerciseStudentParticipation) studentParticipation).toList();

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -1187,9 +1187,10 @@ public class ExamService {
      */
     @Async
     public void archiveExam(Exam exam) {
+        long start = System.nanoTime();
         SecurityUtils.setAuthorizationObject();
 
-        // Archiving a course is only possible after the exam is over
+        // Archiving an exam is only possible after the exam is over
         if (ZonedDateTime.now().isBefore(exam.getEndDate())) {
             return;
         }
@@ -1224,6 +1225,7 @@ public class ExamService {
         }
 
         groupNotificationService.notifyInstructorGroupAboutExamArchiveState(exam, NotificationType.EXAM_ARCHIVE_FINISHED, exportErrors);
+        log.info("archive exam took {}", TimeLogUtil.formatDurationFrom(start));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -1195,7 +1195,7 @@ public class ExamService {
         }
 
         // This contains possible errors encountered during the archive process
-        ArrayList<String> exportErrors = new ArrayList<>();
+        List<String> exportErrors = Collections.synchronizedList(new ArrayList<>());
 
         groupNotificationService.notifyInstructorGroupAboutExamArchiveState(exam, NotificationType.EXAM_ARCHIVE_STARTED, exportErrors);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
@@ -695,7 +695,7 @@ public class StudentExamService {
                                     generatedParticipations.size(), startedAt, lock);
                             return null;
                         }))
-                .toList().toArray(new CompletableFuture<?>[studentExams.size()]);
+                .toArray(CompletableFuture[]::new);
         return CompletableFuture.allOf(futures).thenApply((emtpy) -> {
             threadPool.shutdown();
             sendAndCacheExercisePreparationStatus(examId, finishedExamsCounter.get(), failedExamsCounter.get(), studentExams.size(), generatedParticipations.size(), startedAt,

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -556,7 +556,7 @@ public class ProgrammingExerciseExportService {
             }
         }, threadPool).toCompletableFuture()).toList().toArray(new CompletableFuture<?>[participations.size()]);
         // wait until all operations finish
-        CompletableFuture.allOf(futures).join();
+        CompletableFuture.allOf(futures).thenRun(threadPool::shutdown).join();
         return exportedStudentRepositories;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -554,10 +554,9 @@ public class ProgrammingExerciseExportService {
                         + "' (id: " + programmingExercise.getId() + ") because the repository couldn't be downloaded. ";
                 exportErrors.add(error);
             }
-        }).toCompletableFuture()).toList().toArray(new CompletableFuture<?>[participations.size()]);
-        CompletableFuture.allOf(futures).thenAccept((emtpy) -> {
-            threadPool.shutdown();
-        });
+        }, threadPool).toCompletableFuture()).toList().toArray(new CompletableFuture<?>[participations.size()]);
+        // wait until all operations finish
+        CompletableFuture.allOf(futures).join();
         return exportedStudentRepositories;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -554,7 +554,7 @@ public class ProgrammingExerciseExportService {
                         + "' (id: " + programmingExercise.getId() + ") because the repository couldn't be downloaded. ";
                 exportErrors.add(error);
             }
-        }, threadPool).toCompletableFuture()).toList().toArray(new CompletableFuture<?>[participations.size()]);
+        }, threadPool).toCompletableFuture()).toArray(CompletableFuture[]::new);
         // wait until all operations finish
         CompletableFuture.allOf(futures).thenRun(threadPool::shutdown).join();
         return exportedStudentRepositories;

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -238,6 +238,7 @@ public class ProgrammingExerciseExportService {
                     .map(studentParticipation -> (ProgrammingExerciseStudentParticipation) studentParticipation).sorted(Comparator.comparing(DomainObject::getId)).toList();
             var exportOptions = new RepositoryExportOptionsDTO();
             exportOptions.setAnonymizeRepository(false);
+            exportOptions.setExportAllParticipants(true);
 
             // Export student repositories and add them to list
             var exportedStudentRepositoryFiles = exportStudentRepositories(exercise, studentParticipations, exportOptions, outputDir, outputDir, exportErrors).stream()
@@ -530,11 +531,14 @@ public class ProgrammingExerciseExportService {
             RepositoryExportOptionsDTO repositoryExportOptions, Path workingDir, Path outputDir, List<String> exportErrors) {
         var programmingExerciseId = programmingExercise.getId();
         if (repositoryExportOptions.isExportAllParticipants()) {
-            log.info("Request to export all student or team repositories of programming exercise {} with title '{}'", programmingExerciseId, programmingExercise.getTitle());
+            log.info("Request to export all {} student or team repositories of programming exercise {} with title '{}'", participations.size(), programmingExerciseId,
+                    programmingExercise.getTitle());
         }
         else {
-            log.info("Request to export the repositories of programming exercise {} with title '{}' of the following students or teams: {}", programmingExerciseId,
-                    programmingExercise.getTitle(), participations.stream().map(StudentParticipation::getParticipantIdentifier).collect(Collectors.joining(", ")));
+            log.info("Request to export the repositories of programming exercise {} with title '{}' of {} students or teams", programmingExerciseId, programmingExercise.getTitle(),
+                    participations.size());
+            log.debug("Export repositories for students or teams: {}",
+                    participations.stream().map(StudentParticipation::getParticipantIdentifier).collect(Collectors.joining(", ")));
         }
 
         List<Path> exportedStudentRepositories = Collections.synchronizedList(new ArrayList<>());

--- a/src/main/java/de/tum/in/www1/artemis/service/util/TimeLogUtil.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/util/TimeLogUtil.java
@@ -10,23 +10,23 @@ public class TimeLogUtil {
      */
     public static String formatDurationFrom(long timeNanoStart) {
         long durationInMicroSeconds = (System.nanoTime() - timeNanoStart) / 1000;
-        if (durationInMicroSeconds > 1000) {
-            double durationInMilliSeconds = durationInMicroSeconds / 1000.0;
-            if (durationInMilliSeconds > 1000) {
-                double durationInSeconds = durationInMilliSeconds / 1000.0;
-                if (durationInSeconds > 60) {
-                    double durationInMinutes = durationInSeconds / 60.0;
-                    if (durationInMinutes > 60) {
-                        double durationInHours = durationInMinutes / 60.0;
-                        return roundOffTo2DecPlaces(durationInHours) + "hours";
-                    }
-                    return roundOffTo2DecPlaces(durationInSeconds) + "minutes";
-                }
-                return roundOffTo2DecPlaces(durationInSeconds) + "s";
-            }
+        if (durationInMicroSeconds < 1000) {
+            return durationInMicroSeconds + "µs";
+        }
+        double durationInMilliSeconds = durationInMicroSeconds / 1000.0;
+        if (durationInMilliSeconds < 1000) {
             return roundOffTo2DecPlaces(durationInMilliSeconds) + "ms";
         }
-        return durationInMicroSeconds + "µs";
+        double durationInSeconds = durationInMilliSeconds / 1000.0;
+        if (durationInSeconds < 60) {
+            return roundOffTo2DecPlaces(durationInSeconds) + "sec";
+        }
+        double durationInMinutes = durationInSeconds / 60.0;
+        if (durationInMinutes < 60) {
+            return roundOffTo2DecPlaces(durationInMinutes) + "min";
+        }
+        double durationInHours = durationInMinutes / 60.0;
+        return roundOffTo2DecPlaces(durationInHours) + "hours";
     }
 
     private static String roundOffTo2DecPlaces(double val) {

--- a/src/main/java/de/tum/in/www1/artemis/service/util/TimeLogUtil.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/util/TimeLogUtil.java
@@ -14,6 +14,14 @@ public class TimeLogUtil {
             double durationInMilliSeconds = durationInMicroSeconds / 1000.0;
             if (durationInMilliSeconds > 1000) {
                 double durationInSeconds = durationInMilliSeconds / 1000.0;
+                if (durationInSeconds > 60) {
+                    double durationInMinutes = durationInSeconds / 60.0;
+                    if (durationInMinutes > 60) {
+                        double durationInHours = durationInMinutes / 60.0;
+                        return roundOffTo2DecPlaces(durationInHours) + "hours";
+                    }
+                    return roundOffTo2DecPlaces(durationInSeconds) + "minutes";
+                }
                 return roundOffTo2DecPlaces(durationInSeconds) + "s";
             }
             return roundOffTo2DecPlaces(durationInMilliSeconds) + "ms";

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseExportImportResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseExportImportResource.java
@@ -8,10 +8,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
@@ -270,7 +267,7 @@ public class ProgrammingExerciseExportImportResource {
         long start = System.nanoTime();
         Path path;
         try {
-            path = programmingExerciseExportService.exportProgrammingExerciseInstructorMaterial(programmingExercise, new ArrayList<>());
+            path = programmingExerciseExportService.exportProgrammingExerciseInstructorMaterial(programmingExercise, Collections.synchronizedList(new ArrayList<>()));
         }
         catch (Exception e) {
             log.error("Error while exporting programming exercise with id " + exerciseId + " for instructor", e);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/RepositoryExportOptionsDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/RepositoryExportOptionsDTO.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * This is a dto for the repository export options.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+// TODO: we should convert this into a Record
 public class RepositoryExportOptionsDTO {
 
     private boolean exportAllParticipants;

--- a/src/test/java/de/tum/in/www1/artemis/course/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/course/CourseTestService.java
@@ -2102,7 +2102,7 @@ public class CourseTestService {
     }
 
     private List<Path> archiveCourseAndExtractFiles(Course course) throws IOException {
-        List<String> exportErrors = new ArrayList<>();
+        List<String> exportErrors = Collections.synchronizedList(new ArrayList<>());
         Optional<Path> exportedCourse = courseExamExportService.exportCourse(course, courseArchivesDirPath, exportErrors);
         assertThat(exportedCourse).isNotEmpty();
 
@@ -2118,7 +2118,7 @@ public class CourseTestService {
 
     public void testExportCourse_cannotCreateTmpDir() throws Exception {
         Course course = courseUtilService.createCourseWithTestModelingAndFileUploadExercisesAndSubmissions(userPrefix);
-        List<String> exportErrors = new ArrayList<>();
+        List<String> exportErrors = Collections.synchronizedList(new ArrayList<>());
 
         MockedStatic<Files> mockedFiles = mockStatic(Files.class);
         mockedFiles.when(() -> Files.createDirectories(argThat(path -> path.toString().contains("exports")))).thenThrow(IOException.class);
@@ -2130,7 +2130,7 @@ public class CourseTestService {
 
     public void testExportCourse_cannotCreateCourseExercisesDir() throws Exception {
         Course course = courseUtilService.createCourseWithTestModelingAndFileUploadExercisesAndSubmissions(userPrefix);
-        List<String> exportErrors = new ArrayList<>();
+        List<String> exportErrors = Collections.synchronizedList(new ArrayList<>());
 
         MockedStatic<Files> mockedFiles = mockStatic(Files.class);
         mockedFiles.when(() -> Files.createDirectory(argThat(path -> path.toString().contains("course-exercises")))).thenThrow(IOException.class);
@@ -2142,7 +2142,7 @@ public class CourseTestService {
 
     public void testExportCourseExam_cannotCreateTmpDir() throws Exception {
         Course course = courseUtilService.createCourseWithExamAndExercises(userPrefix);
-        List<String> exportErrors = new ArrayList<>();
+        List<String> exportErrors = Collections.synchronizedList(new ArrayList<>());
 
         Optional<Exam> exam = examRepo.findByCourseId(course.getId()).stream().findFirst();
         assertThat(exam).isPresent();
@@ -2157,7 +2157,7 @@ public class CourseTestService {
 
     public void testExportCourseExam_cannotCreateExamsDir() throws Exception {
         Course course = courseUtilService.createCourseWithExamAndExercises(userPrefix);
-        List<String> exportErrors = new ArrayList<>();
+        List<String> exportErrors = Collections.synchronizedList(new ArrayList<>());
 
         course = courseRepo.findWithEagerExercisesById(course.getId());
 


### PR DESCRIPTION
Archiving programming exercises as part of a course or exam was done sequentially which can take quite some time, especially in courses with between 10.000 and 80.000 repositories (such as on the TUM production system).

This PR speeds up the process by running the clone and zip operation in 10 parallel threads. In a local test, the archival time of one course was around 5-7x faster with this approach.

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- Archive a course (and an exam) with passed end date on the course management detail page
- Download the archive and verify all student repositories are included

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2