### PR TITLE
`Programming exercises`: Fix illegal submission for practice submissions after due date

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
@@ -236,8 +236,8 @@ public class ProgrammingSubmissionService extends SubmissionService {
         User student = optionalStudentWithGroups.get();
 
         if (!isAllowedToSubmit(studentParticipation, student, programmingSubmission)) {
-            final String message = "The student %s illegally submitted code after the allowed individual due date (including the grace period) in the participation %d for the programming exercise %d"
-                    .formatted(student.getLogin(), programmingExerciseParticipation.getId(), programmingExercise.getId());
+            final String message = ("The student %s illegally submitted code after the allowed individual due date (including the grace period) in the participation %d for the "
+                    + "programming exercise \"%s\"").formatted(student.getLogin(), programmingExerciseParticipation.getId(), programmingExercise.getTitle());
             programmingSubmission.setType(SubmissionType.ILLEGAL);
             programmingMessagingService.notifyInstructorGroupAboutIllegalSubmissionsForExercise(programmingExercise, message);
             log.warn(message);
@@ -246,8 +246,8 @@ public class ProgrammingSubmissionService extends SubmissionService {
 
         // we include submission policies here: if the student (for whatever reason) has more submission than allowed attempts, the submission would be illegal
         if (exceedsSubmissionPolicy(studentParticipation, submissionPolicy)) {
-            final String message = "The student %s illegally submitted code after the submission policy lock limit %d in the participation %d for the programming exercise %d"
-                    .formatted(student.getLogin(), submissionPolicy.getSubmissionLimit(), programmingExerciseParticipation.getId(), programmingExercise.getId());
+            final String message = "The student %s illegally submitted code after the submission policy lock limit %d in the participation %d for the programming exercise \"%s\""
+                    .formatted(student.getLogin(), submissionPolicy.getSubmissionLimit(), programmingExerciseParticipation.getId(), programmingExercise.getTitle());
             programmingSubmission.setType(SubmissionType.ILLEGAL);
             programmingMessagingService.notifyInstructorGroupAboutIllegalSubmissionsForExercise(programmingExercise, message);
             log.warn(message);
@@ -272,7 +272,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
 
     private boolean isAllowedToSubmitForCourseExercise(ProgrammingExerciseStudentParticipation participation, ProgrammingSubmission programmingSubmission) {
         var dueDate = ExerciseDateService.getDueDate(participation);
-        if (dueDate.isEmpty()) {
+        if (dueDate.isEmpty() || participation.isTestRun()) {
             return true;
         }
         return dueDate.get().plusSeconds(PROGRAMMING_GRACE_PERIOD_SECONDS).isAfter(programmingSubmission.getSubmissionDate());

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest.java
@@ -947,9 +947,9 @@ class ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest extends Abstr
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
-    @MethodSource("testGracePeriodValues")
+    @MethodSource("testSubmissionAfterDueDateValues")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGracePeriod(ZonedDateTime dueDate, SubmissionType expectedType, boolean expectedRated) throws Exception {
+    void testSubmissionAfterDueDate(ZonedDateTime dueDate, SubmissionType expectedType, boolean expectedRated, boolean testRun) throws Exception {
         var user = userRepository.findUserWithGroupsAndAuthoritiesByLogin(TEST_PREFIX + "student1").orElseThrow();
 
         Course course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
@@ -959,6 +959,10 @@ class ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest extends Abstr
 
         // Add a participation for the programming exercise
         var participation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, user.getLogin());
+        if (testRun) {
+            participation.setTestRun(testRun);
+            participation = participationRepository.save(participation);
+        }
 
         // mock request for fetchCommitInfo()
         final String projectKey = "test201904bprogrammingexercise6";
@@ -993,13 +997,15 @@ class ProgrammingSubmissionAndResultBitbucketBambooIntegrationTest extends Abstr
         assertThat(createdResult.getParticipation().getId()).isEqualTo(updatedParticipation.getId());
     }
 
-    private static Stream<Arguments> testGracePeriodValues() {
+    private static Stream<Arguments> testSubmissionAfterDueDateValues() {
         ZonedDateTime now = ZonedDateTime.now();
         return Stream.of(
                 // short after due date -> grace period active, type manual + rated
-                Arguments.of(now.minusSeconds(10), SubmissionType.MANUAL, true),
+                Arguments.of(now.minusSeconds(10), SubmissionType.MANUAL, true, false),
                 // long after due date -> grace period not active, illegal + non rated
-                Arguments.of(now.minusMinutes(2), SubmissionType.ILLEGAL, false));
+                Arguments.of(now.minusMinutes(2), SubmissionType.ILLEGAL, false, false),
+                // After grace period but a practice submission and therefore ok
+                Arguments.of(now.minusMinutes(2), SubmissionType.MANUAL, false, true));
     }
 
     private Result assertBuildError(Long participationId, String userLogin, ProgrammingLanguage programmingLanguage) throws Exception {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix a bug regarding practice submissions introduced in #6867

### Description
<!-- Describe your changes in detail -->
The above mentioned PR did not take practice submissions into account when determining if a submission after the due date is illegal. This PR fixes that bug.
Additionally the title of the programming exercise is now used instead of the id, since instructors usually don't know the ids, but should be able to determine if the submission is relevant based on the exercise title.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise with a due date in the past

1. Log in to Artemis
2. Create a practice participation and submit something
3. Check as an instructor that the practice submission is not marked as illegal and you did not receive a notification about an illegal submission in the notification menu (bell icon)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->