### PR TITLE
`Communication`: Create channels for test-exams

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
@@ -283,9 +283,6 @@ public class ChannelService {
      * @return the created channel
      */
     public Channel createExamChannel(Exam exam, Optional<String> channelName) {
-        if (exam.isTestExam()) {
-            return null;
-        }
         Channel channelToCreate = createDefaultChannel(channelName, "exam-", exam.getTitle());
         channelToCreate.setIsPublic(false);
         channelToCreate.setExam(exam);

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.ts
@@ -74,7 +74,7 @@ export class ExamUpdateComponent implements OnInit {
                 next: (response: HttpResponse<Course>) => {
                     this.exam.course = response.body!;
                     this.course = response.body!;
-                    this.hideChannelNameInput = exam.testExam || (exam.id !== undefined && exam.channelName === undefined) || !isMessagingEnabled(this.course);
+                    this.hideChannelNameInput = (exam.id !== undefined && exam.channelName === undefined) || !isMessagingEnabled(this.course);
                 },
                 error: (err: HttpErrorResponse) => onError(this.alertService, err),
             });

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -1028,9 +1028,12 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
     void testCreateTestExam_asInstructor() throws Exception {
         // Test the creation of a test exam
         Exam examA = ExamFactory.generateTestExam(course1);
-        request.post("/api/courses/" + course1.getId() + "/exams", examA, HttpStatus.CREATED);
+        URI examUri = request.post("/api/courses/" + course1.getId() + "/exams", examA, HttpStatus.CREATED);
+        Exam savedExam = request.get(String.valueOf(examUri), HttpStatus.OK, Exam.class);
 
         verify(examAccessService).checkCourseAccessForInstructorElseThrow(course1.getId());
+        Channel channelFromDB = channelRepository.findChannelByExamId(savedExam.getId());
+        assertThat(channelFromDB).isNotNull();
     }
 
     @Test

--- a/src/test/javascript/spec/component/exam/exam-update.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/exam-update.component.spec.ts
@@ -12,7 +12,7 @@ import { of, throwError } from 'rxjs';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule } from '@angular/forms';
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
-import { Course } from 'app/entities/course.model';
+import { Course, CourseInformationSharingConfiguration } from 'app/entities/course.model';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { FormDateTimePickerComponent } from 'app/shared/date-time-picker/date-time-picker.component';
 import { MarkdownEditorComponent } from 'app/shared/markdown-editor/markdown-editor.component';
@@ -57,6 +57,7 @@ describe('Exam Update Component', () => {
 
     const course = new Course();
     course.id = 1;
+    course.courseInformationSharingConfiguration = CourseInformationSharingConfiguration.COMMUNICATION_AND_MESSAGING;
     const routes = [
         { path: 'course-management/:courseId/exams/:examId', component: DummyComponent },
         { path: 'course-management/:courseId/exams', component: DummyComponent },
@@ -210,6 +211,14 @@ describe('Exam Update Component', () => {
             fixture.detectChanges();
             expect(component.isValidConfiguration).toBeFalse();
         });
+
+        it('should show channel name input for test exams', fakeAsync(() => {
+            examWithoutExercises.testExam = true;
+            examWithoutExercises.channelName = 'test-exam';
+            component.ngOnInit();
+            tick();
+            expect(component.hideChannelNameInput).toBeFalse();
+        }));
 
         it('should validate the example solution publication date correctly', () => {
             const newExamWithoutExercises = new Exam();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).(https://ls1intum.github.io/Artemis/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Before, exam channels were only created for real exams. However, channels for test exams are also useful to students.

### Description
<!-- Describe your changes in detail -->
The channel-name input field is no longer hidden for test exams. The server also no longer checks, whether the created exam is a test exam but creates a channel in both cases.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Create a test exam
2. Navigate to the messages tab and confirm that there is a channel for the created test-exam
3. Import a test exam
4. Navigate to the messages tab and confirm that there is a channel for the imported test-exam

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [exam-update.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5405/latest/artifact/shared/Coverage-Report-Client-Tests/app/exam/manage/exams/exam-update.component.ts.html) | 95.86% | ✅ |

#### Server

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [ChannelService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5405/latest/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.metis.conversation/ChannelService.html) | 95% | ✅ |


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
No UI changes