### PR TITLE
`Programming exercises`: Fix issues with binary files when importing and starting programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/aop/logging/LoggingAspect.java
+++ b/src/main/java/de/tum/in/www1/artemis/aop/logging/LoggingAspect.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
 
+import de.tum.in.www1.artemis.service.connectors.vcs.AbstractVersionControlService;
 import tech.jhipster.config.JHipsterConstants;
 
 /**
@@ -53,10 +54,14 @@ public class LoggingAspect {
      */
     @AfterThrowing(pointcut = "applicationPackagePointcut() && springBeanPointcut()", throwing = "e")
     public void logAfterThrowing(JoinPoint joinPoint, Throwable e) {
+        if (AbstractVersionControlService.isReadFullyShortReadOfBlockException(e)) {
+            // ignore
+            return;
+        }
+
         if (env.acceptsProfiles(Profiles.of(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT))) {
             log.error("Exception in {}.{}() with cause = \'{}\' and exception = \'{}\'", joinPoint.getSignature().getDeclaringTypeName(), joinPoint.getSignature().getName(),
                     e.getCause() != null ? e.getCause() : "NULL", e.getMessage(), e);
-
         }
         else {
             log.error("Exception in {}.{}() with cause = {}", joinPoint.getSignature().getDeclaringTypeName(), joinPoint.getSignature().getName(),
@@ -86,7 +91,6 @@ public class LoggingAspect {
         }
         catch (IllegalArgumentException e) {
             log.error("Illegal argument: {} in {}.{}()", Arrays.toString(joinPoint.getArgs()), joinPoint.getSignature().getDeclaringTypeName(), joinPoint.getSignature().getName());
-
             throw e;
         }
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/UserGroup.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/UserGroup.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.domain;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -18,12 +19,36 @@ public class UserGroup {
     private String group;
 
     @Embeddable
-    public class UserGroupKey implements Serializable {
+    public static class UserGroupKey implements Serializable {
 
         @Column(name = "user_id")
         private Long userId;
 
         @Column(name = "`groups`")
         private String group;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            UserGroupKey that = (UserGroupKey) o;
+
+            if (!Objects.equals(userId, that.userId)) {
+                return false;
+            }
+            return Objects.equals(group, that.group);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = userId != null ? userId.hashCode() : 0;
+            result = 31 * result + (group != null ? group.hashCode() : 0);
+            return result;
+        }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -64,7 +64,7 @@ public class FileService implements DisposableBean {
      * Extensions must be lower-case without leading dots.
      */
     private static final Set<String> binaryFileExtensions = Set.of("png", "jpg", "jpeg", "heic", "gif", "tiff", "psd", "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "pages",
-            "numbers", "key", "odt", "zip", "rar", "7z", "tar", "iso", "mdb", "sqlite", "exe");
+            "numbers", "key", "odt", "zip", "rar", "7z", "tar", "iso", "mdb", "sqlite", "exe", "jar");
 
     /**
      * The list of file extensions that are allowed to be uploaded in a Markdown editor.

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -60,6 +60,13 @@ public class FileService implements DisposableBean {
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
 
     /**
+     * A list of common binary file extensions.
+     * Extensions must be lower-case without leading dots.
+     */
+    private static final Set<String> binaryFileExtensions = Set.of("png", "jpg", "jpeg", "heic", "gif", "tiff", "psd", "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "pages",
+            "numbers", "key", "odt", "zip", "rar", "7z", "tar", "iso", "mdb", "sqlite", "exe");
+
+    /**
      * The list of file extensions that are allowed to be uploaded in a Markdown editor.
      * Extensions must be lower-case without leading dots.
      * NOTE: Has to be kept in sync with the client-side definitions in file-extensions.constants.ts
@@ -942,9 +949,8 @@ public class FileService implements DisposableBean {
      * @return whether the simple check for file endings determines the underlying file to be binary (true) or not (false)
      */
     private static boolean isBinaryFile(Path filePath) {
-        // TODO: extend the list of potential binary files
-        var fileName = filePath.toString().toLowerCase();
-        return fileName.endsWith(".png") || fileName.endsWith(".jpg") || fileName.endsWith(".heic");
+        final String fileExtension = FilenameUtils.getExtension(filePath.getFileName().toString());
+        return binaryFileExtensions.stream().anyMatch(fileExtension::equalsIgnoreCase);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -670,8 +670,8 @@ public class ProgrammingExerciseExportService {
             if (repositoryExportOptions.isNormalizeCodeStyle()) {
                 try {
                     log.debug("Normalizing code style for participation {}", participation);
-                    fileService.normalizeLineEndingsDirectory(repository.getLocalPath().toString());
-                    fileService.convertToUTF8Directory(repository.getLocalPath().toString());
+                    fileService.normalizeLineEndingsDirectory(repository.getLocalPath());
+                    fileService.convertToUTF8Directory(repository.getLocalPath());
                 }
                 catch (IOException ex) {
                     log.warn("Cannot normalize code style in the repository {} due to the following exception: {}", repository.getLocalPath(), ex.getMessage());

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseImportFromFileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseImportFromFileService.java
@@ -78,6 +78,7 @@ public class ProgrammingExerciseImportFromFileService {
             checkRepositoriesExist(importExerciseDir);
             var oldShortName = getProgrammingExerciseFromDetailsFile(importExerciseDir).getShortName();
             programmingExerciseService.validateNewProgrammingExerciseSettings(programmingExerciseForImport, course);
+            // TODO: creating the whole exercise (from template) is a bad solution in this case, we do not want the template content, instead we want the file content of the zip
             importedProgrammingExercise = programmingExerciseService.createProgrammingExercise(programmingExerciseForImport);
             if (Boolean.TRUE.equals(programmingExerciseForImport.isStaticCodeAnalysisEnabled())) {
                 staticCodeAnalysisService.createDefaultCategories(importedProgrammingExercise);
@@ -131,9 +132,9 @@ public class ProgrammingExerciseImportFromFileService {
         gitService.commitAndPush(testRepo, "Import tests from file", true, null);
     }
 
-    private void replaceImportedExerciseShortName(Map<String, String> replacements, Repository... repositories) throws IOException {
+    private void replaceImportedExerciseShortName(Map<String, String> replacements, Repository... repositories) {
         for (Repository repository : repositories) {
-            fileService.replaceVariablesInFileRecursive(repository.getLocalPath().toString(), replacements, SHORT_NAME_REPLACEMENT_EXCLUSIONS);
+            fileService.replaceVariablesInFileRecursive(repository.getLocalPath(), replacements, SHORT_NAME_REPLACEMENT_EXCLUSIONS);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseImportService.java
@@ -95,18 +95,18 @@ public class ProgrammingExerciseImportService {
 
         String sourceBranch = versionControl.getOrRetrieveBranchOfExercise(templateExercise);
 
+        // TODO: in case one of those operations fail, we should do error handling and revert all previous operations
         versionControl.copyRepository(sourceProjectKey, templateRepoName, sourceBranch, targetProjectKey, RepositoryType.TEMPLATE.getName());
         versionControl.copyRepository(sourceProjectKey, solutionRepoName, sourceBranch, targetProjectKey, RepositoryType.SOLUTION.getName());
         versionControl.copyRepository(sourceProjectKey, testRepoName, sourceBranch, targetProjectKey, RepositoryType.TESTS.getName());
 
-        List<AuxiliaryRepository> auxiliaryRepositories = templateExercise.getAuxiliaryRepositories();
-        for (int i = 0; i < auxiliaryRepositories.size(); i++) {
-            AuxiliaryRepository auxiliaryRepository = auxiliaryRepositories.get(i);
-            String repositoryUrl = versionControl
-                    .copyRepository(sourceProjectKey, auxiliaryRepository.getRepositoryName(), sourceBranch, targetProjectKey, auxiliaryRepository.getName()).toString();
-            AuxiliaryRepository newAuxiliaryRepository = newExercise.getAuxiliaryRepositories().get(i);
-            newAuxiliaryRepository.setRepositoryUrl(repositoryUrl);
-            auxiliaryRepositoryRepository.save(newAuxiliaryRepository);
+        List<AuxiliaryRepository> auxRepos = templateExercise.getAuxiliaryRepositories();
+        for (int i = 0; i < auxRepos.size(); i++) {
+            AuxiliaryRepository auxRepo = auxRepos.get(i);
+            var repoUrl = versionControl.copyRepository(sourceProjectKey, auxRepo.getRepositoryName(), sourceBranch, targetProjectKey, auxRepo.getName()).toString();
+            AuxiliaryRepository newAuxRepos = newExercise.getAuxiliaryRepositories().get(i);
+            newAuxRepos.setRepositoryUrl(repoUrl);
+            auxiliaryRepositoryRepository.save(newAuxRepos);
         }
 
         // Unprotect the default branch of the template exercise repo.
@@ -255,12 +255,11 @@ public class ProgrammingExerciseImportService {
      * @param repositoryName the name of the repository that should be adjusted
      * @param user           the user which performed the action (used as Git author)
      * @throws GitAPIException If the checkout/push of one repository fails
-     * @throws IOException     If the values in the files could not be replaced
      */
-    private void adjustProjectName(Map<String, String> replacements, String projectKey, String repositoryName, User user) throws GitAPIException, IOException {
+    private void adjustProjectName(Map<String, String> replacements, String projectKey, String repositoryName, User user) throws GitAPIException {
         final var repositoryUrl = versionControlService.orElseThrow().getCloneRepositoryUrl(projectKey, repositoryName);
         Repository repository = gitService.getOrCheckoutRepository(repositoryUrl, true);
-        fileService.replaceVariablesInFileRecursive(repository.getLocalPath().toAbsolutePath().toString(), replacements, List.of("gradle-wrapper.jar"));
+        fileService.replaceVariablesInFileRecursive(repository.getLocalPath().toAbsolutePath(), replacements, List.of("gradle-wrapper.jar"));
         gitService.stageAllChanges(repository);
         gitService.commitAndPush(repository, "Template adjusted by Artemis", true, user);
         repository.setFiles(null); // Clear cache to avoid multiple commits when Artemis server is not restarted between attempts

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseImportService.java
@@ -104,9 +104,9 @@ public class ProgrammingExerciseImportService {
         for (int i = 0; i < auxRepos.size(); i++) {
             AuxiliaryRepository auxRepo = auxRepos.get(i);
             var repoUrl = versionControl.copyRepository(sourceProjectKey, auxRepo.getRepositoryName(), sourceBranch, targetProjectKey, auxRepo.getName()).toString();
-            AuxiliaryRepository newAuxRepos = newExercise.getAuxiliaryRepositories().get(i);
-            newAuxRepos.setRepositoryUrl(repoUrl);
-            auxiliaryRepositoryRepository.save(newAuxRepos);
+            AuxiliaryRepository newAuxRepo = newExercise.getAuxiliaryRepositories().get(i);
+            newAuxRepo.setRepositoryUrl(repoUrl);
+            auxiliaryRepositoryRepository.save(newAuxRepo);
         }
 
         // Unprotect the default branch of the template exercise repo.

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseRepositoryService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseRepositoryService.java
@@ -580,7 +580,7 @@ public class ProgrammingExerciseRepositoryService {
         replacements.put("${exerciseName}", programmingExercise.getTitle());
         replacements.put("${studentWorkingDirectory}", Constants.STUDENT_WORKING_DIRECTORY);
         replacements.put("${packaging}", programmingExercise.hasSequentialTestRuns() ? "pom" : "jar");
-        fileService.replaceVariablesInFileRecursive(repository.getLocalPath().toAbsolutePath().toString(), replacements, List.of("gradle-wrapper.jar"));
+        fileService.replaceVariablesInFileRecursive(repository.getLocalPath().toAbsolutePath(), replacements, List.of("gradle-wrapper.jar"));
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
@@ -156,7 +156,7 @@ class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         Map<String, String> replacements = new HashMap<>();
         replacements.put("${exerciseName}", "SomeCoolExerciseName");
 
-        fileService.replaceVariablesInFileRecursive(pomXml.getParent(), replacements);
+        fileService.replaceVariablesInFileRecursive(pomXml.getParentFile().toPath(), replacements);
         fileContent = FileUtils.readFileToString(pomXml, Charset.defaultCharset());
 
         assertThat(fileContent).doesNotContain("${exerciseName}").contains("SomeCoolExerciseName");
@@ -173,7 +173,7 @@ class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         Map<String, String> replacements = new HashMap<>();
         replacements.put("${exerciseName}", "SomeCoolExerciseName");
 
-        fileService.replaceVariablesInFileRecursive(pomXml.getParent(), replacements, List.of("pom.xml"));
+        fileService.replaceVariablesInFileRecursive(pomXml.getParentFile().toPath(), replacements, List.of("pom.xml"));
         fileContent = FileUtils.readFileToString(pomXml, Charset.defaultCharset());
 
         assertThat(fileContent).contains("${exerciseName}").doesNotContain("SomeCoolExerciseName");
@@ -288,7 +288,7 @@ class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     @Test
     void testReplaceVariablesInFileRecursive_shouldThrowException() {
-        assertThatRuntimeException().isThrownBy(() -> fileService.replaceVariablesInFileRecursive("some-path", new HashMap<>()))
+        assertThatRuntimeException().isThrownBy(() -> fileService.replaceVariablesInFileRecursive(Path.of("some-path"), new HashMap<>()))
                 .withMessageEndingWith("should be replaced but the directory does not exist.");
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
@@ -104,7 +104,7 @@ class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         int size = Files.readAllBytes(Path.of(".", "exportTest", "LineEndingsUnix.java")).length;
         assertThat(size).isEqualTo(129);
 
-        fileService.normalizeLineEndings(Path.of(".", "exportTest", "LineEndingsUnix.java").toString());
+        fileService.normalizeLineEndings(Path.of(".", "exportTest", "LineEndingsUnix.java"));
         size = Files.readAllBytes(Path.of(".", "exportTest", "LineEndingsUnix.java")).length;
         assertThat(size).isEqualTo(129);
     }
@@ -122,7 +122,7 @@ class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         int size = Files.readAllBytes(Path.of(".", "exportTest", "LineEndingsWindows.java")).length;
         assertThat(size).isEqualTo(136);
 
-        fileService.normalizeLineEndings(Path.of(".", "exportTest", "LineEndingsWindows.java").toString());
+        fileService.normalizeLineEndings(Path.of(".", "exportTest", "LineEndingsWindows.java"));
         size = Files.readAllBytes(Path.of(".", "exportTest", "LineEndingsWindows.java")).length;
         assertThat(size).isEqualTo(129);
     }
@@ -140,7 +140,7 @@ class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         Charset charset = fileService.detectCharset(Files.readAllBytes(Path.of(".", "exportTest", "EncodingISO_8559_1.java")));
         assertThat(charset).isEqualTo(StandardCharsets.ISO_8859_1);
 
-        fileService.convertToUTF8(Path.of(".", "exportTest", "EncodingISO_8559_1.java").toString());
+        fileService.convertToUTF8(Path.of(".", "exportTest", "EncodingISO_8559_1.java"));
         charset = fileService.detectCharset(Files.readAllBytes(Path.of(".", "exportTest", "EncodingISO_8559_1.java")));
         assertThat(charset).isEqualTo(StandardCharsets.UTF_8);
     }
@@ -294,13 +294,13 @@ class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     @Test
     void testNormalizeLineEndingsDirectory_shouldThrowException() {
-        assertThatRuntimeException().isThrownBy(() -> fileService.normalizeLineEndingsDirectory("some-path"))
+        assertThatRuntimeException().isThrownBy(() -> fileService.normalizeLineEndingsDirectory(Path.of("some-path")))
                 .withMessageEndingWith("should be normalized but the directory does not exist.");
     }
 
     @Test
     void testConvertToUTF8Directory_shouldThrowException() {
-        assertThatRuntimeException().isThrownBy(() -> fileService.convertToUTF8Directory("some-path"))
+        assertThatRuntimeException().isThrownBy(() -> fileService.convertToUTF8Directory(Path.of("some-path")))
                 .withMessageEndingWith("should be converted to UTF-8 but the directory does not exist.");
     }
 


### PR DESCRIPTION
Fixes #6440 and fixes #6890

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
There are different issues when dealing with binary files when importing and starting programming exercises.

### Description
* Ignore binary files during replacement
* Ignore a JGit exception when reading the response of a git push operation

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student

1. Create a programming exercise 
2. Add at least one binary file (e.g., add PNGs into the repo) to all three repos (template, solution, tests)
3. Import the exercise within Artemis
4. Also import the exercise from file (after downloading a zip of the exercise from the details page)
5. Start the two new imported exercises and participate from student's perspective
6. Make sure everything is working properly

#### Exam Mode Testing
Same as above

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
no changes

### Screenshots
no changes