### PR TITLE
`Development`: Fix sorry cypress for cypress version 13

### DIFF
--- a/src/test/cypress/cypress.config.ts
+++ b/src/test/cypress/cypress.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress';
 import { cloudPlugin } from 'cypress-cloud/plugin';
+import fs from 'fs';
 
 export default defineConfig({
     clientCertificates: [
@@ -38,7 +39,6 @@ export default defineConfig({
     screenshotsFolder: 'screenshots',
     videosFolder: 'videos',
     video: true,
-    videoUploadOnPasses: false,
     screenshotOnRunFailure: true,
     viewportWidth: 1920,
     viewportHeight: 1080,
@@ -64,6 +64,14 @@ export default defineConfig({
                     console.log('\x1b[37m', 'LOG: ', message, '\x1b[0m');
                     return null;
                 },
+            });
+            on('after:spec', (spec: Cypress.Spec, results: CypressCommandLine.RunResult) => {
+                if (results && results.video) {
+                    const failures = results.tests.some((test) => test.attempts.some((attempt) => attempt.state === 'failed'));
+                    if (!failures) {
+                        fs.unlinkSync(results.video);
+                    }
+                }
             });
             on('before:browser:launch', (browser, launchOptions) => {
                 launchOptions.args.push('--lang=en');

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -8,13 +8,13 @@
             "license": "MIT",
             "devDependencies": {
                 "@4tw/cypress-drag-drop": "2.2.4",
-                "@types/node": "20.5.9",
+                "@types/node": "20.6.0",
                 "cypress": "13.1.0",
-                "cypress-cloud": "1.9.4",
+                "cypress-cloud": "1.10.0-beta.4",
                 "cypress-file-upload": "5.0.8",
                 "cypress-wait-until": "2.0.1",
                 "typescript": "5.2.2",
-                "uuid": "9.0.0",
+                "uuid": "9.0.1",
                 "wait-on": "7.0.1"
             }
         },
@@ -301,9 +301,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.5.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-            "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
+            "version": "20.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+            "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
             "dev": true
         },
         "node_modules/@types/sinonjs__fake-timers": {
@@ -962,9 +962,9 @@
             }
         },
         "node_modules/cypress-cloud": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/cypress-cloud/-/cypress-cloud-1.9.4.tgz",
-            "integrity": "sha512-zItu3zTtSOFMfKExlqOrWXA8A3aI2fhKLGuVDDVYFtW+uthrSlImVfIl+Yj+KB8lnJmLR/+z94Q3GvCPHKQzxg==",
+            "version": "1.10.0-beta.4",
+            "resolved": "https://registry.npmjs.org/cypress-cloud/-/cypress-cloud-1.10.0-beta.4.tgz",
+            "integrity": "sha512-8pe+ifmf8Uotx9lVL4Crq9LQokAa8U6/09p+wj9XEZoEiY/FJhbbvOygduqZmF6BaQaDAf5q1DagKKHmLXGErA==",
             "dev": true,
             "dependencies": {
                 "@cypress/commit-info": "^2.2.0",
@@ -975,8 +975,10 @@
                 "commander": "^10.0.0",
                 "common-path-prefix": "^3.0.0",
                 "cy2": "^3.4.2",
+                "date-fns": "^2.30.0",
                 "debug": "^4.3.4",
                 "execa": "^5.1.1",
+                "fast-safe-stringify": "^2.1.1",
                 "getos": "^3.2.1",
                 "globby": "^11.1.0",
                 "is-absolute": "^1.0.0",
@@ -995,9 +997,6 @@
             },
             "engines": {
                 "node": ">=14.7.0"
-            },
-            "peerDependencies": {
-                "cypress": ">=10.0.0"
             }
         },
         "node_modules/cypress-cloud/node_modules/commander": {
@@ -1087,6 +1086,22 @@
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+            "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.21.0"
+            },
+            "engines": {
+                "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
             }
         },
         "node_modules/dayjs": {
@@ -1329,6 +1344,12 @@
             "engines": {
                 "node": ">=8.6.0"
             }
+        },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
         },
         "node_modules/fastq": {
             "version": "1.15.0",
@@ -3036,10 +3057,14 @@
             }
         },
         "node_modules/uuid": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "bin": {
                 "uuid": "dist/bin/uuid"
             }

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -9,7 +9,7 @@
             "devDependencies": {
                 "@4tw/cypress-drag-drop": "2.2.4",
                 "@types/node": "20.6.0",
-                "cypress": "13.1.0",
+                "cypress": "13.2.0",
                 "cypress-cloud": "1.10.0-beta.4",
                 "cypress-file-upload": "5.0.8",
                 "cypress-wait-until": "2.0.1",
@@ -904,15 +904,15 @@
             }
         },
         "node_modules/cypress": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
-            "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+            "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
                 "@cypress/request": "^3.0.0",
                 "@cypress/xvfb": "^1.2.4",
-                "@types/node": "^16.18.39",
+                "@types/node": "^18.17.5",
                 "@types/sinonjs__fake-timers": "8.1.1",
                 "@types/sizzle": "^2.3.2",
                 "arch": "^2.2.0",
@@ -1071,9 +1071,9 @@
             "dev": true
         },
         "node_modules/cypress/node_modules/@types/node": {
-            "version": "16.18.48",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
-            "integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==",
+            "version": "18.17.15",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+            "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA==",
             "dev": true
         },
         "node_modules/dashdash": {

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -9,7 +9,7 @@
     "devDependencies": {
         "@4tw/cypress-drag-drop": "2.2.4",
         "@types/node": "20.6.0",
-        "cypress": "13.1.0",
+        "cypress": "13.2.0",
         "cypress-cloud": "1.10.0-beta.4",
         "cypress-file-upload": "5.0.8",
         "cypress-wait-until": "2.0.1",
@@ -30,7 +30,7 @@
         "cypress:open": "cypress open",
         "cypress:run": "cypress run --browser=chrome",
         "cypress:setup": "cypress install && cypress run --quiet --spec init/ImportUsers.cy.ts",
-        "cypress:record:mysql": "npx cypress-cloud run --parallel --record --ci-build-id \"${SORRY_CYPRESS_BRANCH_NAME} #${SORRY_CYPRESS_BUILD_ID} ${SORRY_CYPRESS_RERUN_COUNT} (MySQL)\"",
+        "cypress:record:mysql": "npx cypress-cloud run --cloud-debug --parallel --record --ci-build-id \"${SORRY_CYPRESS_BRANCH_NAME} #${SORRY_CYPRESS_BUILD_ID} ${SORRY_CYPRESS_RERUN_COUNT} (MySQL)\"",
         "cypress:record:postgres": "npx cypress-cloud run --parallel --record --ci-build-id \"${SORRY_CYPRESS_BRANCH_NAME} #${SORRY_CYPRESS_BUILD_ID} ${SORRY_CYPRESS_RERUN_COUNT} (Postgres)\"",
         "update": "npm-upgrade"
     }

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -8,13 +8,13 @@
     ],
     "devDependencies": {
         "@4tw/cypress-drag-drop": "2.2.4",
-        "@types/node": "20.5.9",
+        "@types/node": "20.6.0",
         "cypress": "13.1.0",
-        "cypress-cloud": "1.9.4",
+        "cypress-cloud": "1.10.0-beta.4",
         "cypress-file-upload": "5.0.8",
         "cypress-wait-until": "2.0.1",
         "typescript": "5.2.2",
-        "uuid": "9.0.0",
+        "uuid": "9.0.1",
         "wait-on": "7.0.1"
     },
     "overrides": {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Since the update to cypress 13, the `sorry-cypress` dashboard did not work anymore:
![image](https://github.com/ls1intum/Artemis/assets/1368405/bd7a5989-70b3-4d26-a159-c98778d724dc)


### Description
<!-- Describe your changes in detail -->
This PR updates the `cypress-cloud` package to a beta version, which makes sorry cypress compatible with cypress 13 again. 
It also updates other dependencies within the e2e folder. 
Additionally, it removes the `videoUploadOnPasses` cypress option, which is not available anymore in cypress 13. The option was replaced by a custom `after:spec` hook, as suggested here:
https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
