### PR TITLE
`Development`: Remove `--legacy-peer-deps` and fix postgres file link

### DIFF
--- a/docker/artemis-migration-check-postgres.yml
+++ b/docker/artemis-migration-check-postgres.yml
@@ -17,8 +17,8 @@ services:
                 condition: service_healthy
     postgresql:
         extends:
-            file: ./postgresql.yml
-            service: postgresql
+            file: ./postgres.yml
+            service: postgres
     migration-check:
         image: alpine
         container_name: migration-check

--- a/docker/cypress-E2E-tests-mysql.yml
+++ b/docker/cypress-E2E-tests-mysql.yml
@@ -45,7 +45,7 @@ services:
         environment:
             CYPRESS_DB_TYPE: "MySQL"
             SORRY_CYPRESS_PROJECT_ID: "artemis-mysql"
-        command: sh -c "cd /app/artemis/src/test/cypress && chmod 777 /root && npm ci --legacy-peer-deps && npm run cypress:setup && (npm run cypress:record:mysql & sleep 60 && npm run cypress:record:mysql & wait)"
+        command: sh -c "cd /app/artemis/src/test/cypress && chmod 777 /root && npm ci && npm run cypress:setup && (npm run cypress:record:mysql & sleep 60 && npm run cypress:record:mysql & wait)"
 
 networks:
     artemis:

--- a/docker/cypress-E2E-tests-postgres.yml
+++ b/docker/cypress-E2E-tests-postgres.yml
@@ -46,7 +46,7 @@ services:
         environment:
             CYPRESS_DB_TYPE: "Postgres"
             SORRY_CYPRESS_PROJECT_ID: "artemis-postgres"
-        command: sh -c "cd /app/artemis/src/test/cypress && chmod 777 /root && npm ci --legacy-peer-deps && npm run cypress:setup && (npm run cypress:record:postgres & sleep 60 && npm run cypress:record:postgres & wait)"
+        command: sh -c "cd /app/artemis/src/test/cypress && chmod 777 /root && npm ci && npm run cypress:setup && (npm run cypress:record:postgres & sleep 60 && npm run cypress:record:postgres & wait)"
 
 networks:
     artemis:


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Since the cypress drag and drop library now supports cypress 13, we can remove the `--legacy-peer-deps` parameter again. 

### Description
<!-- Describe your changes in detail -->
This PR removes the `--legacy-peer-deps` parameter and also renames postgresql to postgres

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
