### PR TITLE
`General`: Improve archive downloading

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -21,10 +21,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
@@ -761,7 +758,11 @@ public class CourseResource {
 
         File zipFile = archive.toFile();
         InputStreamResource resource = new InputStreamResource(new FileInputStream(zipFile));
-        return ResponseEntity.ok().contentLength(zipFile.length()).contentType(MediaType.APPLICATION_OCTET_STREAM).header("filename", zipFile.getName()).body(resource);
+        ContentDisposition contentDisposition = ContentDisposition.builder("attachment").filename(zipFile.getName()).build();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentDisposition(contentDisposition);
+        return ResponseEntity.ok().headers(headers).contentLength(zipFile.length()).contentType(MediaType.APPLICATION_OCTET_STREAM).header("filename", zipFile.getName())
+                .body(resource);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -24,10 +24,7 @@ import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -1150,8 +1147,12 @@ public class ExamResource {
         Path archive = Path.of(examArchivesDirPath, exam.getExamArchivePath());
 
         File zipFile = archive.toFile();
+        ContentDisposition contentDisposition = ContentDisposition.builder("attachment").filename(zipFile.getName()).build();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentDisposition(contentDisposition);
         InputStreamResource resource = new InputStreamResource(new FileInputStream(zipFile));
-        return ResponseEntity.ok().contentLength(zipFile.length()).contentType(MediaType.APPLICATION_OCTET_STREAM).header("filename", zipFile.getName()).body(resource);
+        return ResponseEntity.ok().headers(headers).contentLength(zipFile.length()).contentType(MediaType.APPLICATION_OCTET_STREAM).header("filename", zipFile.getName())
+                .body(resource);
     }
 
     /**

--- a/src/main/webapp/app/course/manage/course-management.service.ts
+++ b/src/main/webapp/app/course/manage/course-management.service.ts
@@ -417,11 +417,9 @@ export class CourseManagementService {
      * if the archive does not exist.
      * @param courseId The id of the course
      */
-    downloadCourseArchive(courseId: number): Observable<HttpResponse<Blob>> {
-        return this.http.get(`${this.resourceUrl}/${courseId}/download-archive`, {
-            observe: 'response',
-            responseType: 'blob',
-        });
+    downloadCourseArchive(courseId: number): void {
+        const url = `api/courses/${courseId}/download-archive`;
+        window.open(url, '_blank');
     }
 
     /**

--- a/src/main/webapp/app/course/manage/course-management.service.ts
+++ b/src/main/webapp/app/course/manage/course-management.service.ts
@@ -418,7 +418,7 @@ export class CourseManagementService {
      * @param courseId The id of the course
      */
     downloadCourseArchive(courseId: number): void {
-        const url = `api/courses/${courseId}/download-archive`;
+        const url = `${this.resourceUrl}/${courseId}/download-archive`;
         window.open(url, '_blank');
     }
 

--- a/src/main/webapp/app/exam/manage/exam-management.service.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.service.ts
@@ -468,11 +468,9 @@ export class ExamManagementService {
      * @param courseId
      * @param examId The id of the exam
      */
-    downloadExamArchive(courseId: number, examId: number): Observable<HttpResponse<Blob>> {
-        return this.http.get(`${this.resourceUrl}/${courseId}/exams/${examId}/download-archive`, {
-            observe: 'response',
-            responseType: 'blob',
-        });
+    downloadExamArchive(courseId: number, examId: number): void {
+        const url = `${this.resourceUrl}/${courseId}/exams/${examId}/download-archive`;
+        window.open(url, '_blank');
     }
 
     /**

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.ts
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.ts
@@ -9,7 +9,6 @@ import { ExamManagementService } from 'app/exam/manage/exam-management.service';
 import { Course } from 'app/entities/course.model';
 import { Exam } from 'app/entities/exam.model';
 import dayjs from 'dayjs/esm';
-import { downloadZipFileFromResponse } from 'app/shared/util/download.util';
 import { ButtonSize } from '../button.component';
 import { ActionType } from 'app/shared/delete-dialog/delete-dialog.model';
 import { Subject } from 'rxjs';
@@ -176,9 +175,6 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
     openModal(modalRef: TemplateRef<any>) {
         this.modalService.open(modalRef).result.then(
             (result: string) => {
-                if (result === 'archive-confirm' && this.canDownloadArchive()) {
-                    this.openModal(this.archiveConfirmModal);
-                }
                 if (result === 'archive' || !this.canDownloadArchive()) {
                     this.archive();
                 } else {
@@ -211,15 +207,9 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
 
     downloadArchive() {
         if (this.archiveMode === 'Exam' && this.exam) {
-            this.examService.downloadExamArchive(this.course.id!, this.exam.id!).subscribe({
-                next: (response) => downloadZipFileFromResponse(response),
-                error: () => this.alertService.error('artemisApp.courseExamArchive.archiveDownloadError'),
-            });
+            this.examService.downloadExamArchive(this.course.id!, this.exam.id!);
         } else {
-            this.courseService.downloadCourseArchive(this.course.id!).subscribe({
-                next: (response) => downloadZipFileFromResponse(response),
-                error: () => this.alertService.error('artemisApp.courseExamArchive.archiveDownloadError'),
-            });
+            this.courseService.downloadCourseArchive(this.course.id!);
         }
     }
 

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.ts
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.ts
@@ -175,6 +175,9 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
     openModal(modalRef: TemplateRef<any>) {
         this.modalService.open(modalRef).result.then(
             (result: string) => {
+                if (result === 'archive-confirm' && this.canDownloadArchive()) {
+                    this.openModal(this.archiveConfirmModal);
+                }
                 if (result === 'archive' || !this.canDownloadArchive()) {
                     this.archive();
                 } else {

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.ts
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { AlertService } from 'app/core/util/alert.service';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
@@ -69,7 +69,6 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
         private translateService: TranslateService,
         private modalService: NgbModal,
         private accountService: AccountService,
-        private changeDetectionRef: ChangeDetectorRef,
     ) {}
 
     ngOnInit() {
@@ -126,13 +125,11 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
         if (this.archiveMode === 'Exam' && this.exam) {
             this.examService.find(this.course.id!, this.exam.id!).subscribe((res) => {
                 this.exam = res.body!;
-                this.changeDetectionRef.detectChanges();
                 this.displayDownloadArchiveButton = this.canDownloadArchive();
             });
         } else {
             this.courseService.find(this.course.id!).subscribe((res) => {
                 this.course = res.body!;
-                this.changeDetectionRef.detectChanges();
                 this.displayDownloadArchiveButton = this.canDownloadArchive();
             });
         }
@@ -180,8 +177,6 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
                 }
                 if (result === 'archive' || !this.canDownloadArchive()) {
                     this.archive();
-                } else {
-                    this.reloadCourseOrExam();
                 }
             },
             () => {},

--- a/src/test/java/de/tum/in/www1/artemis/course/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/course/CourseTestService.java
@@ -2176,9 +2176,11 @@ public class CourseTestService {
     public void testDownloadCourseArchiveAsInstructor() throws Exception {
         // Archive the course and wait until it's complete
         Course updatedCourse = testArchiveCourseWithTestModelingAndFileUploadExercises();
+        Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("Content-Disposition", "attachment; filename=\"" + updatedCourse.getCourseArchivePath() + "\"");
 
         // Download the archive
-        var archive = request.getFile("/api/courses/" + updatedCourse.getId() + "/download-archive", HttpStatus.OK, new LinkedMultiValueMap<>());
+        var archive = request.getFile("/api/courses/" + updatedCourse.getId() + "/download-archive", HttpStatus.OK, new LinkedMultiValueMap<>(), expectedHeaders);
         assertThat(archive).isNotNull();
         assertThat(archive).exists();
         assertThat(archive.getPath().length()).isGreaterThanOrEqualTo(4);

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -1069,7 +1069,10 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         // Download the archive
         var exam = examRepository.findByCourseId(course.getId()).stream().findFirst().orElseThrow();
-        var archive = request.getFile("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/download-archive", HttpStatus.OK, new LinkedMultiValueMap<>());
+        Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("Content-Disposition", "attachment; filename=\"" + exam.getExamArchivePath() + "\"");
+        var archive = request.getFile("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/download-archive", HttpStatus.OK, new LinkedMultiValueMap<>(),
+                expectedHeaders);
         assertThat(archive).isNotNull();
 
         // Extract the archive

--- a/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
@@ -69,9 +69,9 @@ public class RequestUtilService {
      * @param file           the optional file to be sent
      * @param responseType   the expected response type as class
      * @param expectedStatus the expected status
+     * @param <T>            the type of the main object to send
+     * @param <R>            the type of the response object
      * @return the response as object of the given type or null if the status is not 2xx
-     * @param <T> the type of the main object to send
-     * @param <R> the type of the response object
      * @throws Exception if the request fails
      */
     public <T, R> R postWithMultipartFile(String path, T paramValue, String paramName, MockMultipartFile file, Class<R> responseType, HttpStatus expectedStatus) throws Exception {
@@ -87,9 +87,9 @@ public class RequestUtilService {
      * @param files          the optional files to be sent
      * @param responseType   the expected response type as class
      * @param expectedStatus the expected status
+     * @param <T>            the type of the main object to send
+     * @param <R>            the type of the response object
      * @return the response as object of the given type or null if the status is not 2xx
-     * @param <T> the type of the main object to send
-     * @param <R> the type of the response object
      * @throws Exception if the request fails
      */
     public <T, R> R postWithMultipartFiles(String path, T paramValue, String paramName, List<MockMultipartFile> files, Class<R> responseType, HttpStatus expectedStatus)
@@ -380,9 +380,9 @@ public class RequestUtilService {
      * @param responseType   the expected response type as class
      * @param expectedStatus the expected status
      * @param params         the optional parameters for the request
+     * @param <T>            the type of the main object to send
+     * @param <R>            the type of the response object
      * @return the response as object of the given type or null if the status is not 2xx
-     * @param <T> the type of the main object to send
-     * @param <R> the type of the response object
      * @throws Exception if the request fails
      */
     public <T, R> R putWithMultipartFile(String path, T paramValue, String paramName, MockMultipartFile file, Class<R> responseType, HttpStatus expectedStatus,
@@ -400,9 +400,9 @@ public class RequestUtilService {
      * @param responseType   the expected response type as class
      * @param expectedStatus the expected status
      * @param params         the optional parameters for the request
+     * @param <T>            the type of the main object to send
+     * @param <R>            the type of the response object
      * @return the response as object of the given type or null if the status is not 2xx
-     * @param <T> the type of the main object to send
-     * @param <R> the type of the response object
      * @throws Exception if the request fails
      */
     public <T, R> R putWithMultipartFiles(String path, T paramValue, String paramName, List<MockMultipartFile> files, Class<R> responseType, HttpStatus expectedStatus,
@@ -558,12 +558,17 @@ public class RequestUtilService {
     }
 
     public File getFile(String path, HttpStatus expectedStatus, MultiValueMap<String, String> params) throws Exception {
+        return getFile(path, expectedStatus, params, null);
+    }
+
+    public File getFile(String path, HttpStatus expectedStatus, MultiValueMap<String, String> params, @Nullable Map<String, String> expectedResponseHeaders) throws Exception {
         MvcResult res = mvc.perform(MockMvcRequestBuilders.get(new URI(path)).params(params).headers(new HttpHeaders())).andExpect(status().is(expectedStatus.value())).andReturn();
         restoreSecurityContext();
         if (!expectedStatus.is2xxSuccessful()) {
             assertThat(res.getResponse().containsHeader("location")).as("no location header on failed request").isFalse();
             return null;
         }
+        verifyExpectedResponseHeaders(expectedResponseHeaders, res);
 
         String tmpDirectory = System.getProperty("java.io.tmpdir");
         var filename = res.getResponse().getHeader("filename");

--- a/src/test/javascript/spec/component/course/course-management.service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management.service.spec.ts
@@ -426,15 +426,11 @@ describe('Course Management Service', () => {
         tick();
     }));
 
-    it('should download course archive', fakeAsync(() => {
-        const expectedBlob = new Blob(['abc', 'cfe']);
-        courseManagementService.downloadCourseArchive(course.id!).subscribe((resp) => {
-            expect(resp.body).toEqual(expectedBlob);
-        });
-        const req = httpMock.expectOne({ method: 'GET', url: `${resourceUrl}/${course.id}/download-archive` });
-        req.flush(expectedBlob);
-        tick();
-    }));
+    it('should download course archive', () => {
+        const windowSpy = jest.spyOn(window, 'open').mockImplementation();
+        courseManagementService.downloadCourseArchive(1);
+        expect(windowSpy).toHaveBeenCalledWith('api/courses/1/download-archive', '_blank');
+    });
 
     it('should archive the course', fakeAsync(() => {
         courseManagementService.archiveCourse(course.id!).subscribe((res) => expect(res.body).toEqual(course));

--- a/src/test/javascript/spec/component/exam/manage/exam-management.service.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-management.service.spec.ts
@@ -641,21 +641,11 @@ describe('Exam Management Service Tests', () => {
     }));
 
     it('should download the exam from archive', fakeAsync(() => {
-        // GIVEN
         const mockExam: Exam = { id: 1 };
-        const mockResponse = new Blob();
-        const expected = new Blob();
 
-        // WHEN
-        service.downloadExamArchive(course.id!, mockExam.id!).subscribe((res) => expect(res.body).toEqual(expected));
-
-        // THEN
-        const req = httpMock.expectOne({
-            method: 'GET',
-            url: `${service.resourceUrl}/${course.id}/exams/${mockExam.id}/download-archive`,
-        });
-        req.flush(mockResponse);
-        tick();
+        const windowSpy = jest.spyOn(window, 'open').mockImplementation();
+        service.downloadExamArchive(course.id!, mockExam.id!);
+        expect(windowSpy).toHaveBeenCalledWith('api/courses/456/exams/1/download-archive', '_blank');
     }));
 
     it('should archive the exam', fakeAsync(() => {

--- a/src/test/javascript/spec/component/shared/course-exam-archive-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/course-exam-archive-button.component.spec.ts
@@ -170,8 +170,7 @@ describe('Course Exam Archive Button Component', () => {
         }));
 
         it('should download archive for course', fakeAsync(() => {
-            const response: HttpResponse<Blob> = new HttpResponse({ status: 200 });
-            const downloadStub = jest.spyOn(courseManagementService, 'downloadCourseArchive').mockReturnValue(of(response));
+            const downloadStub = jest.spyOn(courseManagementService, 'downloadCourseArchive').mockImplementation(() => {});
 
             comp.downloadArchive();
 
@@ -253,14 +252,13 @@ describe('Course Exam Archive Button Component', () => {
             expect(comp.canCleanupCourse()).toBeFalse();
         }));
 
-        it('should download archive for exam', fakeAsync(() => {
-            const response: HttpResponse<Blob> = new HttpResponse({ status: 200 });
-            const downloadStub = jest.spyOn(examManagementService, 'downloadExamArchive').mockReturnValue(of(response));
+        it('should download archive for exam', () => {
+            const downloadStub = jest.spyOn(examManagementService, 'downloadExamArchive').mockImplementation(() => {});
 
             comp.downloadArchive();
 
             expect(downloadStub).toHaveBeenCalledOnce();
-        }));
+        });
 
         it('should archive course', fakeAsync(() => {
             const response: HttpResponse<void> = new HttpResponse({ status: 200 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
At the moment, the webapp downloads the course and exam archive from the server and then hands it over to the browser.
This is not ideal and especially problematic in case of large files that are created when archiving courses and exams.
### Description
<!-- Describe your changes in detail -->
The download now directly calls the respective endpoint on the server and then the browser manages the download and not the webapp.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Exam for which the conduction period is over
- 1 Course that has an end date in the past

1. Log in to Artemis
2. Navigate to Course Administration
3. Archive the course and the exam.
4. Download the exam and the course.
5. In both cases the download should be directly visible in the browser and you should see a progress bar for the download in the browser.

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Covered with the testing steps above.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

https://github.com/ls1intum/Artemis/assets/84102468/f1a8c63c-869d-44cb-9d46-ac8eb88695c5


