### PR TITLE
`Development`: Check for correct profile before trying to fetch IRIS settings in exercises

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-update.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-update.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
 import { ActivatedRoute } from '@angular/router';
-import { Observable, Subscription } from 'rxjs';
+import { Observable, Subscription, filter, switchMap } from 'rxjs';
 import { AlertService } from 'app/core/util/alert.service';
 import { ExerciseHintService } from '../shared/exercise-hint.service';
 import { EditorMode, MarkdownEditorHeight } from 'app/shared/markdown-editor/markdown-editor.component';
@@ -20,6 +20,7 @@ import { CodeHintService } from 'app/exercises/shared/exercise-hint/services/cod
 import { onError } from 'app/shared/util/global.utils';
 import { IrisSettingsService } from 'app/iris/settings/shared/iris-settings.service';
 import { IrisSettings } from 'app/entities/iris/settings/iris-settings.model';
+import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 
 const DEFAULT_DISPLAY_THRESHOLD = 3;
 
@@ -62,6 +63,7 @@ export class ExerciseHintUpdateComponent implements OnInit, OnDestroy {
         private programmingExerciseService: ProgrammingExerciseService,
         private navigationUtilService: ArtemisNavigationUtilService,
         protected irisSettingsService: IrisSettingsService,
+        private profileService: ProfileService,
     ) {}
 
     /**
@@ -90,9 +92,15 @@ export class ExerciseHintUpdateComponent implements OnInit, OnDestroy {
                 }
             });
 
-            this.irisSettingsService.getCombinedProgrammingExerciseSettings(this.exercise.id!).subscribe((settings) => {
-                this.irisSettings = settings;
-            });
+            this.profileService
+                .getProfileInfo()
+                .pipe(
+                    filter((profileInfo) => profileInfo?.activeProfiles?.includes('iris')),
+                    switchMap(() => this.irisSettingsService.getCombinedProgrammingExerciseSettings(this.exercise.id!)),
+                )
+                .subscribe((settings) => {
+                    this.irisSettings = settings;
+                });
         });
     }
 

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, switchMap } from 'rxjs/operators';
 import { Result } from 'app/entities/result.model';
 import dayjs from 'dayjs/esm';
 import { User } from 'app/core/user/user.model';
@@ -217,9 +217,15 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
                 this.submissionPolicy = submissionPolicy;
             });
 
-            this.irisSettingsService.getCombinedProgrammingExerciseSettings(this.exercise!.id!).subscribe((settings) => {
-                this.irisSettings = settings;
-            });
+            this.profileService
+                .getProfileInfo()
+                .pipe(
+                    filter((profileInfo) => profileInfo?.activeProfiles?.includes('iris')),
+                    switchMap(() => this.irisSettingsService.getCombinedProgrammingExerciseSettings(this.exercise!.id!)),
+                )
+                .subscribe((settings) => {
+                    this.irisSettings = settings;
+                });
         }
 
         this.showIfExampleSolutionPresent(newExercise);

--- a/src/test/javascript/spec/component/exercise-hint/manage/exercise-hint-update.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/manage/exercise-hint-update.component.spec.ts
@@ -147,7 +147,7 @@ describe('ExerciseHint Management Update Component', () => {
         'should load iris settings only if profile iris is active',
         fakeAsync((activeProfiles: string[]) => {
             // Mock getProfileInfo to return activeProfiles
-            const profileService = TestBed.inject(ProfileService); // Make sure to import ProfileService
+            const profileService = TestBed.inject(ProfileService);
             jest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of({ activeProfiles }));
 
             // Mock getTasksAndTestsExtractedFromProblemStatement
@@ -156,7 +156,7 @@ describe('ExerciseHint Management Update Component', () => {
             const fakeSettings = {};
 
             // Mock getCombinedProgrammingExerciseSettings
-            const irisSettingsService = TestBed.inject(IrisSettingsService); // Make sure to import IrisSettingsService
+            const irisSettingsService = TestBed.inject(IrisSettingsService);
             const getCombinedProgrammingExerciseSettingsSpy = jest.spyOn(irisSettingsService, 'getCombinedProgrammingExerciseSettings').mockReturnValue(of(fakeSettings));
 
             // Run ngOnInit

--- a/src/test/javascript/spec/component/exercise-hint/manage/exercise-hint-update.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/manage/exercise-hint-update.component.spec.ts
@@ -18,6 +18,9 @@ import { ProgrammingExerciseTestCase } from 'app/entities/programming-exercise-t
 import { ProgrammingExercise, ProgrammingLanguage } from 'app/entities/programming-exercise.model';
 import { CodeHint } from 'app/entities/hestia/code-hint-model';
 import { CodeHintService } from 'app/exercises/shared/exercise-hint/services/code-hint.service';
+import { ProfileService } from '../../../../../../main/webapp/app/shared/layouts/profiles/profile.service';
+import { MockProfileService } from '../../../helpers/mocks/service/mock-profile.service';
+import { IrisSettingsService } from '../../../../../../main/webapp/app/iris/settings/shared/iris-settings.service';
 
 describe('ExerciseHint Management Update Component', () => {
     let comp: ExerciseHintUpdateComponent;
@@ -51,6 +54,8 @@ describe('ExerciseHint Management Update Component', () => {
                 MockProvider(ProgrammingExerciseService),
                 MockProvider(ExerciseHintService),
                 MockProvider(TranslateService),
+                MockProvider(IrisSettingsService),
+                MockProfileService,
                 { provide: ActivatedRoute, useValue: route },
             ],
         })
@@ -137,6 +142,38 @@ describe('ExerciseHint Management Update Component', () => {
         expect(comp.exerciseHint.content).toBe('Hello Content');
         expect(comp.exerciseHint.description).toBe('Hello Description');
     }));
+
+    it.each<[string[]]>([[[]], [['iris']]])(
+        'should load iris settings only if profile iris is active',
+        fakeAsync((activeProfiles: string[]) => {
+            // Mock getProfileInfo to return activeProfiles
+            const profileService = TestBed.inject(ProfileService); // Make sure to import ProfileService
+            jest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of({ activeProfiles }));
+
+            // Mock getTasksAndTestsExtractedFromProblemStatement
+            jest.spyOn(programmingExerciseService, 'getTasksAndTestsExtractedFromProblemStatement').mockReturnValue(of([]));
+
+            const fakeSettings = {};
+
+            // Mock getCombinedProgrammingExerciseSettings
+            const irisSettingsService = TestBed.inject(IrisSettingsService); // Make sure to import IrisSettingsService
+            const getCombinedProgrammingExerciseSettingsSpy = jest.spyOn(irisSettingsService, 'getCombinedProgrammingExerciseSettings').mockReturnValue(of(fakeSettings));
+
+            // Run ngOnInit
+            comp.ngOnInit();
+            tick();
+
+            if (activeProfiles.includes('iris')) {
+                // Should have called getCombinedProgrammingExerciseSettings if 'iris' is active
+                expect(getCombinedProgrammingExerciseSettingsSpy).toHaveBeenCalledOnce();
+                expect(comp.irisSettings).toBe(fakeSettings);
+            } else {
+                // Should not have called getCombinedProgrammingExerciseSettings if 'iris' is not active
+                expect(getCombinedProgrammingExerciseSettingsSpy).not.toHaveBeenCalled();
+                expect(comp.irisSettings).toBeUndefined();
+            }
+        }),
+    );
 
     it('should generate descriptions', () => {
         const codeHint = new CodeHint();

--- a/src/test/javascript/spec/component/exercise-hint/manage/exercise-hint-update.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/manage/exercise-hint-update.component.spec.ts
@@ -21,6 +21,8 @@ import { CodeHintService } from 'app/exercises/shared/exercise-hint/services/cod
 import { ProfileService } from '../../../../../../main/webapp/app/shared/layouts/profiles/profile.service';
 import { MockProfileService } from '../../../helpers/mocks/service/mock-profile.service';
 import { IrisSettingsService } from '../../../../../../main/webapp/app/iris/settings/shared/iris-settings.service';
+import { IrisSettings } from '../../../../../../main/webapp/app/entities/iris/settings/iris-settings.model';
+import { ProfileInfo } from '../../../../../../main/webapp/app/shared/layouts/profiles/profile-info.model';
 
 describe('ExerciseHint Management Update Component', () => {
     let comp: ExerciseHintUpdateComponent;
@@ -148,12 +150,12 @@ describe('ExerciseHint Management Update Component', () => {
         fakeAsync((activeProfiles: string[]) => {
             // Mock getProfileInfo to return activeProfiles
             const profileService = TestBed.inject(ProfileService);
-            jest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of({ activeProfiles }));
+            jest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of({ activeProfiles } as any as ProfileInfo));
 
             // Mock getTasksAndTestsExtractedFromProblemStatement
             jest.spyOn(programmingExerciseService, 'getTasksAndTestsExtractedFromProblemStatement').mockReturnValue(of([]));
 
-            const fakeSettings = {};
+            const fakeSettings = {} as any as IrisSettings;
 
             // Mock getCombinedProgrammingExerciseSettings
             const irisSettingsService = TestBed.inject(IrisSettingsService);

--- a/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
@@ -67,6 +67,7 @@ import { ResetRepoButtonComponent } from 'app/shared/components/reset-repo-butto
 import { ProblemStatementComponent } from 'app/overview/exercise-details/problem-statement/problem-statement.component';
 import { ExerciseInfoComponent } from 'app/exercises/shared/exercise-info/exercise-info.component';
 import { IrisSettingsService } from '../../../../../../main/webapp/app/iris/settings/shared/iris-settings.service';
+import { IrisSettings } from '../../../../../../main/webapp/app/entities/iris/settings/iris-settings.model';
 
 describe('CourseExerciseDetailsComponent', () => {
     let comp: CourseExerciseDetailsComponent;
@@ -366,7 +367,7 @@ describe('CourseExerciseDetailsComponent', () => {
                 course: {},
             } as unknown as ProgrammingExercise;
 
-            const fakeSettings = {};
+            const fakeSettings = {} as any as IrisSettings;
 
             const irisSettingsService = TestBed.inject(IrisSettingsService);
             const getCombinedProgrammingExerciseSettingsMock = jest.spyOn(irisSettingsService, 'getCombinedProgrammingExerciseSettings');
@@ -379,7 +380,7 @@ describe('CourseExerciseDetailsComponent', () => {
             getExerciseDetailsMock.mockReturnValue(of({ body: programmingExercise }));
 
             const profileService = TestBed.inject(ProfileService);
-            jest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of({ activeProfiles }));
+            jest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of({ activeProfiles } as any as ProfileInfo));
 
             // Act
             comp.ngOnInit();

--- a/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
@@ -66,6 +66,7 @@ import { ProgrammingExerciseExampleSolutionRepoDownloadComponent } from 'app/exe
 import { ResetRepoButtonComponent } from 'app/shared/components/reset-repo-button/reset-repo-button.component';
 import { ProblemStatementComponent } from 'app/overview/exercise-details/problem-statement/problem-statement.component';
 import { ExerciseInfoComponent } from 'app/exercises/shared/exercise-info/exercise-info.component';
+import { IrisSettingsService } from '../../../../../../main/webapp/app/iris/settings/shared/iris-settings.service';
 
 describe('CourseExerciseDetailsComponent', () => {
     let comp: CourseExerciseDetailsComponent;
@@ -145,6 +146,7 @@ describe('CourseExerciseDetailsComponent', () => {
                 MockProvider(SubmissionPolicyService),
                 MockProvider(PlagiarismCasesService),
                 MockProvider(AlertService),
+                MockProvider(IrisSettingsService),
             ],
         })
             .compileComponents()
@@ -352,4 +354,46 @@ describe('CourseExerciseDetailsComponent', () => {
         expect(alertServiceSpy).toHaveBeenCalledOnce();
         expect(alertServiceSpy).toHaveBeenCalledWith(error.message);
     }));
+
+    it.each<[string[]]>([[[]], [['iris']]])(
+        'should load iris settings only if profile iris is active',
+        fakeAsync((activeProfiles: string[]) => {
+            // Setup
+            const programmingExercise = {
+                id: 42,
+                type: ExerciseType.PROGRAMMING,
+                studentParticipations: [],
+                course: {},
+            } as unknown as ProgrammingExercise;
+
+            const fakeSettings = {};
+
+            const irisSettingsService = TestBed.inject(IrisSettingsService);
+            const getCombinedProgrammingExerciseSettingsMock = jest.spyOn(irisSettingsService, 'getCombinedProgrammingExerciseSettings');
+            getCombinedProgrammingExerciseSettingsMock.mockReturnValue(of(fakeSettings));
+
+            const submissionPolicyService = TestBed.inject(SubmissionPolicyService);
+            const submissionPolicy = new LockRepositoryPolicy();
+            jest.spyOn(submissionPolicyService, 'getSubmissionPolicyOfProgrammingExercise').mockReturnValue(of(submissionPolicy));
+
+            getExerciseDetailsMock.mockReturnValue(of({ body: programmingExercise }));
+
+            const profileService = TestBed.inject(ProfileService);
+            jest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of({ activeProfiles }));
+
+            // Act
+            comp.ngOnInit();
+            tick();
+
+            if (activeProfiles.includes('iris')) {
+                // Should have called getCombinedProgrammingExerciseSettings if 'iris' is active
+                expect(getCombinedProgrammingExerciseSettingsMock).toHaveBeenCalled();
+                expect(comp.irisSettings).toBe(fakeSettings);
+            } else {
+                // Should not have called getCombinedProgrammingExerciseSettings if 'iris' is not active
+                expect(getCombinedProgrammingExerciseSettingsMock).not.toHaveBeenCalled();
+                expect(comp.irisSettings).toBeUndefined();
+            }
+        }),
+    );
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Some components attempted to load exercise-level IRIS settings even if IRIS was not enabled globablly (profile based). This caused an internal server error.

### Description
<!-- Describe your changes in detail -->

Check for the profile before fetching.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Programming Exercise on Test Server with IRIS disabled (currently every server **except** TS9 ans staging)

1. Log in to Artemis
2. Open dev tools network tab
3. Navigate to the exercise detail view
4. Verify that no iris related request is sent
5. Verify no "internal server error" alert appears


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
