### PR TITLE
`Development`: Skip PE related migration for non-PE systems

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20230808_203400.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20230808_203400.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -57,17 +58,21 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
 
     private final Optional<CIVCSMigrationService> ciMigrationService;
 
-    private final AbstractVersionControlService versionControlService;
+    private final Optional<AbstractVersionControlService> versionControlService;
+
+    private final Environment environment;
 
     private final UrlService urlService = new UrlService();
 
     private final CopyOnWriteArrayList<ProgrammingExerciseParticipation> errorList = new CopyOnWriteArrayList<>();
 
+    private static final List<String> PROGRAMMING_EXERCISE_RELATED_PROFILES = List.of("bamboo", "bitbucket", "gitlab", "jenkins", "gitlabci", "localvc", "localci");
+
     public MigrationEntry20230808_203400(ProgrammingExerciseRepository programmingExerciseRepository,
             SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository,
             TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository,
             ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository, AuxiliaryRepositoryRepository auxiliaryRepositoryRepository,
-            Optional<CIVCSMigrationService> ciMigrationService, AbstractVersionControlService versionControlService) {
+            Optional<CIVCSMigrationService> ciMigrationService, Optional<AbstractVersionControlService> versionControlService, Environment environment) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.solutionProgrammingExerciseParticipationRepository = solutionProgrammingExerciseParticipationRepository;
         this.templateProgrammingExerciseParticipationRepository = templateProgrammingExerciseParticipationRepository;
@@ -75,10 +80,17 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
         this.auxiliaryRepositoryRepository = auxiliaryRepositoryRepository;
         this.ciMigrationService = ciMigrationService;
         this.versionControlService = versionControlService;
+        this.environment = environment;
     }
 
     @Override
     public void execute() {
+        List<String> activeProfiles = List.of(environment.getActiveProfiles());
+        if (activeProfiles.stream().anyMatch(PROGRAMMING_EXERCISE_RELATED_PROFILES::contains)) {
+            log.info("Migration will be skipped and marked run because the system does not support programming exercises according to the selected profiles: {}", activeProfiles);
+            return;
+        }
+
         try {
             ciMigrationService.orElseThrow().checkPrerequisites();
         }
@@ -195,7 +207,7 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
                 // 2nd step: check if the default branch exists, this cleans up the database a bit and fixes the effects of a bug that
                 // we had in the past
                 // note: this method calls directly saves the participation in the database with the updated branch
-                String branch = versionControlService.getOrRetrieveBranchOfExercise(participation.getProgrammingExercise());
+                String branch = versionControlService.orElseThrow().getOrRetrieveBranchOfExercise(participation.getProgrammingExercise());
                 if (branch == null || branch.isEmpty()) {
                     log.warn("Failed to get default branch for template of exercise {} with buildPlanId {}, will abort migration for this Participation",
                             participation.getProgrammingExercise().getId(), participation.getBuildPlanId());
@@ -248,7 +260,7 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
                 // 2nd step: check if the default branch exists, this cleans up the database a bit and fixes the effects of a bug that
                 // we had in the past
                 // note: this method calls directly saves the participation in the database with the updated branch
-                String branch = versionControlService.getOrRetrieveBranchOfExercise(participation.getProgrammingExercise());
+                String branch = versionControlService.orElseThrow().getOrRetrieveBranchOfExercise(participation.getProgrammingExercise());
                 if (branch == null || branch.isEmpty()) {
                     log.warn("Failed to get default branch for template of exercise {} with buildPlanId {}, will abort migration for this Participation",
                             participation.getProgrammingExercise().getId(), participation.getBuildPlanId());
@@ -291,7 +303,7 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
 
                 // 2nd step: check if the default branch exists, this cleans up the database a bit and fixes the effects of a bug that we had in the past
                 // note: this method calls directly saves the participation in the database with the updated branch in case it was not available
-                String branch = versionControlService.getOrRetrieveBranchOfStudentParticipation(participation);
+                String branch = versionControlService.orElseThrow().getOrRetrieveBranchOfStudentParticipation(participation);
                 if (branch == null || branch.isEmpty()) {
                     log.warn("Failed to get default branch for template of exercise {} with buildPlanId {}, will abort migration for this Participation",
                             participation.getProgrammingExercise().getId(), participation.getBuildPlanId());


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#6682 failed to account for non-PE systems properly in its migration. It was also caused because the migration checks were not executed apparently and thus not considered before merging.

### Description
<!-- Describe your changes in detail -->
I test for all profiles currently related to programming exercises. If none is activated, I skip the migration. I also made the AbstractVersionControlService optional so the start-up won't fail if no profile is activated.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
