### PR TITLE
`Development`: Fix JaCoCo coverage verification

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/iris/IrisConstants.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/iris/IrisConstants.java
@@ -5,6 +5,10 @@ package de.tum.in.www1.artemis.service.iris;
  */
 public final class IrisConstants {
 
+    private IrisConstants() {
+        // Utility class for constants
+    }
+
     // The default guidance template for the chat feature
     public static final String DEFAULT_CHAT_TEMPLATE = """
             {{#system~}}


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] The changed server tests succeed **locally** and on **Bamboo**.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
On the develop branch, the server tests' coverage verification currently fails with 20 uncovered classes because only 19 uncovered classes are allowed.

### Description
The implicitly public default constructor from _IrisConstants.java_ was not covered by any tests. Consequently, the JaCoCo coverage verification failed on the develop branch since the entire _IrisConstants_ class is not covered. Making the constructor private mitigates this issue by allowing JaCoCo to detect that there is nothing to cover in this class.

### Steps for Testing
**Test changes only**

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2


##### Before (develop branch)
![Before (develop branch)](https://github.com/ls1intum/Artemis/assets/47261058/196053c4-f368-4d71-af68-07d5aa9c48d9)



##### After (this pr's branch)
![After (this pr's branch)](https://github.com/ls1intum/Artemis/assets/47261058/118ff95e-0319-4d62-b47a-d5e6263be15a)
