### PR TITLE
`Development`: Skip migration for installations not supported by it

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20230808_203400.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20230808_203400.java
@@ -66,7 +66,7 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
 
     private final CopyOnWriteArrayList<ProgrammingExerciseParticipation> errorList = new CopyOnWriteArrayList<>();
 
-    private static final List<String> PROGRAMMING_EXERCISE_RELATED_PROFILES = List.of("bamboo", "bitbucket", "gitlab", "jenkins", "gitlabci", "localvc", "localci");
+    private static final List<String> MIGRATABLE_PROFILES = List.of("bamboo", "gitlab", "jenkins");
 
     public MigrationEntry20230808_203400(ProgrammingExerciseRepository programmingExerciseRepository,
             SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository,
@@ -86,8 +86,8 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
     @Override
     public void execute() {
         List<String> activeProfiles = List.of(environment.getActiveProfiles());
-        if (activeProfiles.stream().noneMatch(PROGRAMMING_EXERCISE_RELATED_PROFILES::contains)) {
-            log.info("Migration will be skipped and marked run because the system does not support programming exercises according to the selected profiles: {}", activeProfiles);
+        if (activeProfiles.stream().noneMatch(MIGRATABLE_PROFILES::contains)) {
+            log.info("Migration will be skipped and marked run because the system does not support a tech-stack that requires this migration: {}", activeProfiles);
             return;
         }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#6682 failed to account for non-PE systems properly in its migration. It was also caused because the migration checks were not executed apparently and thus not considered before merging.
In the fix #7218 I introduced to many profiles assuming that we run the migration for all programming related profiles. However, the migration is only implemented for bitbucket, gitlab and jenkins. Thus for any other setups related to programming exercises the migration would fail.

### Description
<!-- Describe your changes in detail -->
I replaced the profiles with only migration related ones.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
