### PR TITLE
`Exam mode`: Allow instructors to cleanup archived exams

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -60,7 +60,7 @@ module.exports = {
             statements: 85.6,
             branches: 72.8,
             functions: 79.4,
-            lines: 85.9,
+            lines: 85.8,
         },
     },
     coverageReporters: ["clover", "json", "lcov", "text-summary"],

--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -176,6 +176,10 @@ public final class Constants {
 
     public static final String UNENROLL_FROM_COURSE = "UNENROLL_FROM_COURSE";
 
+    public static final String CLEANUP_COURSE = "CLEANUP_COURSE";
+
+    public static final String CLEANUP_EXAM = "CLEANUP_EXAM";
+
     public static final String DELETE_EXERCISE = "DELETE_EXERCISE";
 
     public static final String EDIT_EXERCISE = "EDIT_EXERCISE";

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -799,7 +799,7 @@ public class CourseService {
         }
 
         // The Objects::nonNull is needed here because the relationship exam -> exercise groups is ordered and
-        // hibernate sometimes adds nulls to in the list of exercise groups to keep the order
+        // hibernate sometimes adds nulls into the list of exercise groups to keep the order
         Set<Exercise> examExercises = examRepository.findByCourseIdWithExerciseGroupsAndExercises(courseId).stream().flatMap(e -> e.getExerciseGroups().stream())
                 .filter(Objects::nonNull).map(ExerciseGroup::getExercises).flatMap(Collection::stream).collect(Collectors.toSet());
 

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -7,6 +7,7 @@ import static tech.jhipster.config.JHipsterConstants.SPRING_PROFILE_PRODUCTION;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.Principal;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -782,13 +783,16 @@ public class CourseService {
 
     /**
      * Cleans up a course by cleaning up all exercises from that course. This deletes all student
-     * submissions. Note that a course has to be archived first before being cleaned up.
+     * repositories and build plans. Note that a course has to be archived first before being cleaned up.
      *
-     * @param courseId The id of the course to clean up
+     * @param courseId  The id of the course to clean up
+     * @param principal the user that wants to cleanup the course
      */
-    public void cleanupCourse(Long courseId) {
+    public void cleanupCourse(Long courseId, Principal principal) {
+        final var auditEvent = new AuditEvent(principal.getName(), Constants.CLEANUP_COURSE, "course=" + courseId);
+        auditEventRepository.add(auditEvent);
         // Get the course with all exercises
-        var course = courseRepository.findByIdWithExercisesAndLecturesElseThrow(courseId);
+        var course = courseRepository.findByIdWithEagerExercisesElseThrow(courseId);
         if (!course.hasCourseArchive()) {
             log.info("Cannot clean up course {} because it hasn't been archived.", courseId);
             return;
@@ -796,7 +800,7 @@ public class CourseService {
 
         // The Objects::nonNull is needed here because the relationship exam -> exercise groups is ordered and
         // hibernate sometimes adds nulls to in the list of exercise groups to keep the order
-        Set<Exercise> examExercises = examRepository.findByCourseIdWithExerciseGroupsAndExercises(courseId).stream().map(Exam::getExerciseGroups).flatMap(Collection::stream)
+        Set<Exercise> examExercises = examRepository.findByCourseIdWithExerciseGroupsAndExercises(courseId).stream().flatMap(e -> e.getExerciseGroups().stream())
                 .filter(Objects::nonNull).map(ExerciseGroup::getExercises).flatMap(Collection::stream).collect(Collectors.toSet());
 
         var exercisesToCleanup = Stream.concat(course.getExercises().stream(), examExercises.stream()).collect(Collectors.toSet());
@@ -804,8 +808,6 @@ public class CourseService {
             if (exercise instanceof ProgrammingExercise) {
                 exerciseDeletionService.cleanup(exercise.getId(), true);
             }
-
-            // TODO: extend exerciseDeletionService.cleanup to clean up all exercise types
         });
 
         log.info("The course {} has been cleaned up!", courseId);

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseDeletionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseDeletionService.java
@@ -3,6 +3,8 @@ package de.tum.in.www1.artemis.service;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +18,6 @@ import de.tum.in.www1.artemis.domain.lecture.ExerciseUnit;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
-import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
@@ -89,26 +90,29 @@ public class ExerciseDeletionService {
      * @param deleteRepositories if true, the repositories gets deleted
      */
     public void cleanup(Long exerciseId, boolean deleteRepositories) {
+        log.info("Cleanup all participations for exercise {} in parallel", exerciseId);
         Exercise exercise = exerciseRepository.findByIdWithStudentParticipationsElseThrow(exerciseId);
-        log.info("Request to cleanup all participations for Exercise : {}", exercise.getTitle());
+        if (!(exercise instanceof ProgrammingExercise)) {
+            log.warn("Exercise with exerciseId {} is not an instance of ProgrammingExercise. Ignoring the request to cleanup repositories and build plan", exerciseId);
+            return;
+        }
 
-        if (exercise instanceof ProgrammingExercise) {
-            for (StudentParticipation participation : exercise.getStudentParticipations()) {
+        // Cleanup in parallel to speedup the process
+        var threadPool = Executors.newFixedThreadPool(10);
+        var futures = exercise.getStudentParticipations().stream().map(participation -> CompletableFuture.runAsync(() -> {
+            try {
                 participationService.cleanupBuildPlan((ProgrammingExerciseStudentParticipation) participation);
-            }
-
-            if (!deleteRepositories) {
-                return; // in this case, we are done
-            }
-
-            for (StudentParticipation participation : exercise.getStudentParticipations()) {
+                if (!deleteRepositories) {
+                    return; // in this case, we are done with the participation
+                }
                 participationService.cleanupRepository((ProgrammingExerciseStudentParticipation) participation);
             }
-
-        }
-        else {
-            log.warn("Exercise with exerciseId {} is not an instance of ProgrammingExercise. Ignoring the request to cleanup repositories and build plan", exerciseId);
-        }
+            catch (Exception exception) {
+                log.error("Failed to clean the student participation {} for programming exercise {}", participation.getId(), exerciseId);
+            }
+        }, threadPool).toCompletableFuture()).toArray(CompletableFuture[]::new);
+        // wait until all operations finish before returning
+        CompletableFuture.allOf(futures).thenRun(threadPool::shutdown).join();
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -1329,7 +1329,7 @@ public class ExamService {
         auditEventRepository.add(auditEvent);
 
         // The Objects::nonNull is needed here because the relationship exam -> exercise groups is ordered and
-        // hibernate sometimes adds nulls to in the list of exercise groups to keep the order
+        // hibernate sometimes adds nulls into the list of exercise groups to keep the order
         Set<Exercise> examExercises = examRepository.findByIdWithExamUsersExerciseGroupsAndExercisesElseThrow(examId).getExerciseGroups().stream().filter(Objects::nonNull)
                 .map(ExerciseGroup::getExercises).flatMap(Collection::stream).collect(Collectors.toSet());
 

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -5,6 +5,7 @@ import static de.tum.in.www1.artemis.service.util.RoundingUtil.roundScoreSpecifi
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.Principal;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -16,6 +17,8 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Async;
@@ -23,6 +26,7 @@ import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.*;
 import de.tum.in.www1.artemis.domain.exam.Exam;
@@ -107,7 +111,11 @@ public class ExamService {
 
     private final BonusService bonusService;
 
+    private final ExerciseDeletionService exerciseDeletionService;
+
     private final SubmittedAnswerRepository submittedAnswerRepository;
+
+    private final AuditEventRepository auditEventRepository;
 
     private final CourseScoreCalculationService courseScoreCalculationService;
 
@@ -121,8 +129,8 @@ public class ExamService {
             ProgrammingExerciseRepository programmingExerciseRepository, QuizExerciseRepository quizExerciseRepository, ResultRepository resultRepository,
             SubmissionRepository submissionRepository, CourseExamExportService courseExamExportService, GitService gitService, GroupNotificationService groupNotificationService,
             GradingScaleRepository gradingScaleRepository, PlagiarismCaseRepository plagiarismCaseRepository, AuthorizationCheckService authorizationCheckService,
-            BonusService bonusService, SubmittedAnswerRepository submittedAnswerRepository, CourseScoreCalculationService courseScoreCalculationService,
-            CourseRepository courseRepository) {
+            BonusService bonusService, ExerciseDeletionService exerciseDeletionService, SubmittedAnswerRepository submittedAnswerRepository,
+            AuditEventRepository auditEventRepository, CourseScoreCalculationService courseScoreCalculationService, CourseRepository courseRepository) {
         this.examRepository = examRepository;
         this.studentExamRepository = studentExamRepository;
         this.userRepository = userRepository;
@@ -143,7 +151,9 @@ public class ExamService {
         this.plagiarismCaseRepository = plagiarismCaseRepository;
         this.authorizationCheckService = authorizationCheckService;
         this.bonusService = bonusService;
+        this.exerciseDeletionService = exerciseDeletionService;
         this.submittedAnswerRepository = submittedAnswerRepository;
+        this.auditEventRepository = auditEventRepository;
         this.courseScoreCalculationService = courseScoreCalculationService;
         this.courseRepository = courseRepository;
         this.defaultObjectMapper = new ObjectMapper();
@@ -1305,6 +1315,31 @@ public class ExamService {
         // active exam means that exam has visible date in the past 7 days or next 7 days.
         return examRepository.findAllActiveExamsInCoursesWhereInstructor(user.getGroups(), pageable, ZonedDateTime.now().minusDays(EXAM_ACTIVE_DAYS),
                 ZonedDateTime.now().plusDays(EXAM_ACTIVE_DAYS));
+    }
+
+    /**
+     * Cleans up an exam by cleaning up all exercises from that course. This deletes all student
+     * repositories and build plans. Note that an exam has to be archived first before being cleaned up.
+     *
+     * @param examId    The id of the exam to clean up
+     * @param principal the user that wants to cleanup the exam
+     */
+    public void cleanupExam(Long examId, Principal principal) {
+        final var auditEvent = new AuditEvent(principal.getName(), Constants.CLEANUP_EXAM, "exam=" + examId);
+        auditEventRepository.add(auditEvent);
+
+        // The Objects::nonNull is needed here because the relationship exam -> exercise groups is ordered and
+        // hibernate sometimes adds nulls to in the list of exercise groups to keep the order
+        Set<Exercise> examExercises = examRepository.findByIdWithExamUsersExerciseGroupsAndExercisesElseThrow(examId).getExerciseGroups().stream().filter(Objects::nonNull)
+                .map(ExerciseGroup::getExercises).flatMap(Collection::stream).collect(Collectors.toSet());
+
+        examExercises.forEach(exercise -> {
+            if (exercise instanceof ProgrammingExercise) {
+                exerciseDeletionService.cleanup(exercise.getId(), true);
+            }
+        });
+
+        log.info("The exam {} has been cleaned up!", examId);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
@@ -39,9 +39,7 @@ import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseParticipationService;
 import de.tum.in.www1.artemis.service.programming.ProgrammingTriggerService;
-import de.tum.in.www1.artemis.service.scheduled.ProgrammingExerciseScheduleService;
 import de.tum.in.www1.artemis.service.util.ExamExerciseStartPreparationStatus;
-import de.tum.in.www1.artemis.service.util.Tuple;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
@@ -89,8 +87,6 @@ public class StudentExamService {
 
     private final WebsocketMessagingService websocketMessagingService;
 
-    private final ProgrammingExerciseScheduleService programmingExerciseScheduleService;
-
     private final TaskScheduler scheduler;
 
     public StudentExamService(StudentExamRepository studentExamRepository, UserRepository userRepository, ParticipationService participationService,
@@ -99,7 +95,7 @@ public class StudentExamService {
             ProgrammingExerciseParticipationService programmingExerciseParticipationService, SubmissionService submissionService,
             StudentParticipationRepository studentParticipationRepository, ExamQuizService examQuizService, ProgrammingExerciseRepository programmingExerciseRepository,
             ProgrammingTriggerService programmingTriggerService, ExamRepository examRepository, CacheManager cacheManager, WebsocketMessagingService websocketMessagingService,
-            ProgrammingExerciseScheduleService programmingExerciseScheduleService, @Qualifier("taskScheduler") TaskScheduler scheduler) {
+            @Qualifier("taskScheduler") TaskScheduler scheduler) {
         this.participationService = participationService;
         this.studentExamRepository = studentExamRepository;
         this.userRepository = userRepository;
@@ -117,7 +113,6 @@ public class StudentExamService {
         this.examRepository = examRepository;
         this.cacheManager = cacheManager;
         this.websocketMessagingService = websocketMessagingService;
-        this.programmingExerciseScheduleService = programmingExerciseScheduleService;
         this.scheduler = scheduler;
     }
 
@@ -654,8 +649,9 @@ public class StudentExamService {
                             // Normally, the locking operation at the end of the exam gets scheduled during the initial unlocking process
                             // (see ProgrammingExerciseScheduleService#scheduleIndividualRepositoryAndParticipationLockTasks)
                             // Since this gets never executed here, we need to manually schedule the locking.
-                            var tupel = new Tuple<>(studentExam.getIndividualEndDate(), programmingParticipation);
-                            programmingExerciseScheduleService.scheduleIndividualRepositoryAndParticipationLockTasks(programmingExercise, Set.of(tupel));
+                            // TODO: reconsider this edge case and instead send a message to over the instanceMessageSendService
+                            // var tupel = new Tuple<>(studentExam.getIndividualEndDate(), programmingParticipation);
+                            // programmingExerciseScheduleService.scheduleIndividualRepositoryAndParticipationLockTasks(programmingExercise, Set.of(tupel));
                         }
                         else {
                             programmingExerciseParticipationService.lockStudentParticipation(programmingParticipation);

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -803,7 +803,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise                             the programming exercise for which the lock is executed
      * @param individualParticipationsWithDueDates the set of student participations with their individual due dates
      */
-    public void scheduleIndividualRepositoryAndParticipationLockTasks(ProgrammingExercise exercise,
+    private void scheduleIndividualRepositoryAndParticipationLockTasks(ProgrammingExercise exercise,
             Set<Tuple<ZonedDateTime, ProgrammingExerciseStudentParticipation>> individualParticipationsWithDueDates) {
         // 1. Group all participations by due date
         // TODO: use student exams for safety if some participations are not pre-generated

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
@@ -236,7 +236,7 @@ public class ComplaintResource {
      * exercises
      *
      * @param exerciseId the id of the exercise we are interested in
-     * @param principal  that wants to get complaints
+     * @param principal  the user that wants to get complaints
      * @return the ResponseEntity with status 200 (OK) and a list of complaints. The list can be empty
      */
     @GetMapping("exercises/{exerciseId}/complaints-for-test-run-dashboard")

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
+import java.security.Principal;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -769,12 +770,13 @@ public class CourseResource {
     /**
      * DELETE /courses/:course/cleanup : Cleans up a course by deleting all student submissions.
      *
-     * @param courseId id of the course to clean up
+     * @param courseId  id of the course to clean up
+     * @param principal the user that wants to cleanup the course
      * @return ResponseEntity with status
      */
     @DeleteMapping("courses/{courseId}/cleanup")
     @EnforceAtLeastInstructor
-    public ResponseEntity<Resource> cleanup(@PathVariable Long courseId) {
+    public ResponseEntity<Resource> cleanup(@PathVariable Long courseId, Principal principal) {
         log.info("REST request to cleanup the Course : {}", courseId);
         final Course course = courseRepository.findByIdElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
@@ -782,7 +784,7 @@ public class CourseResource {
         if (!course.hasCourseArchive()) {
             throw new BadRequestAlertException("Failed to clean up course " + courseId + " because it needs to be archived first.", Course.ENTITY_NAME, "archivenonexistant");
         }
-        courseService.cleanupCourse(courseId);
+        courseService.cleanupCourse(courseId, principal);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/webapp/app/exam/manage/exam-management.service.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.service.ts
@@ -492,6 +492,10 @@ export class ExamManagementService {
         return this.http.put(`${this.resourceUrl}/${courseId}/exams/${examId}/archive`, {}, { observe: 'response' });
     }
 
+    cleanupExam(courseId: number, examId: number): Observable<HttpResponse<void>> {
+        return this.http.delete<void>(`${this.resourceUrl}/${courseId}/exams/${examId}/cleanup`, { observe: 'response' });
+    }
+
     private sendTitlesToEntityTitleService(exam: Exam | undefined | null) {
         this.entityTitleService.setTitle(EntityType.EXAM, [exam?.id], exam?.title);
     }

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.html
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.html
@@ -96,7 +96,7 @@
         <span jhiTranslate="artemisApp.courseExamArchive.downloadArchive">Download Archive</span>
     </button>
     <button
-        *ngIf="canCleanupCourse()"
+        *ngIf="canCleanup() && archiveMode === 'Course'"
         [disabled]="isBeingArchived"
         [attr.data-mode]="archiveMode"
         jhiDeleteButton
@@ -104,9 +104,25 @@
         [actionType]="ActionType.Cleanup"
         [entityTitle]="course.title!"
         deleteQuestion="artemisApp.course.cleanup.question"
-        (delete)="cleanupCourse()"
+        (delete)="cleanup()"
         [dialogError]="dialogError$"
         deleteConfirmationText="artemisApp.course.delete.typeNameToConfirm"
+        style="margin-right: 0 !important"
+    >
+        <fa-icon [icon]="faEraser"></fa-icon>
+    </button>
+    <button
+        *ngIf="canCleanup() && archiveMode === 'Exam'"
+        [disabled]="isBeingArchived"
+        [attr.data-mode]="archiveMode"
+        jhiDeleteButton
+        [buttonSize]="ButtonSize.MEDIUM"
+        [actionType]="ActionType.Cleanup"
+        [entityTitle]="exam!.title!"
+        deleteQuestion="artemisApp.exam.cleanup.question"
+        (delete)="cleanup()"
+        [dialogError]="dialogError$"
+        deleteConfirmationText="artemisApp.examManagement.delete.typeNameToConfirm"
         style="margin-right: 0 !important"
     >
         <fa-icon [icon]="faEraser"></fa-icon>

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.ts
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.ts
@@ -211,29 +211,38 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
         }
     }
 
-    canCleanupCourse() {
-        if (this.archiveMode !== 'Course') {
-            return false;
+    canCleanup() {
+        let hasBeenArchived: boolean;
+        if (this.archiveMode === 'Exam' && this.exam) {
+            hasBeenArchived = !!this.exam.examArchivePath && this.exam.examArchivePath.length > 0;
+        } else {
+            hasBeenArchived = !!this.course.courseArchivePath && this.course.courseArchivePath.length > 0;
         }
-
-        // A course can only be cleaned up if the course has been archived.
-        const courseHasBeenArchived = !!this.course.courseArchivePath && this.course.courseArchivePath.length > 0;
-        return this.accountService.isAtLeastInstructorInCourse(this.course) && courseHasBeenArchived;
+        // A course / exam can only be cleaned up if the course / exam has been archived.
+        return this.accountService.isAtLeastInstructorInCourse(this.course) && hasBeenArchived;
     }
 
-    cleanupCourse() {
-        if (this.archiveMode !== 'Course') {
-            return;
+    cleanup() {
+        if (this.archiveMode === 'Exam' && this.exam) {
+            this.examService.cleanupExam(this.course.id!, this.exam.id!).subscribe({
+                next: () => {
+                    this.alertService.success('artemisApp.programmingExercise.cleanup.successMessageCleanup');
+                    this.dialogErrorSource.next('');
+                },
+                error: (error) => {
+                    this.dialogErrorSource.next(error.error.title);
+                },
+            });
+        } else {
+            this.courseService.cleanupCourse(this.course.id!).subscribe({
+                next: () => {
+                    this.alertService.success('artemisApp.programmingExercise.cleanup.successMessageCleanup');
+                    this.dialogErrorSource.next('');
+                },
+                error: (error) => {
+                    this.dialogErrorSource.next(error.error.title);
+                },
+            });
         }
-
-        this.courseService.cleanupCourse(this.course.id!).subscribe({
-            next: () => {
-                this.alertService.success('artemisApp.programmingExercise.cleanup.successMessage');
-                this.dialogErrorSource.next('');
-            },
-            error: (error) => {
-                this.dialogErrorSource.next(error.error.title);
-            },
-        });
     }
 }

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -133,6 +133,10 @@
             "falseName": "Der angegebene Name ist nicht korrekt. Bitte versuche es erneut!",
             "notSet": "Nicht gesetzt",
             "startExamToolTip": "Button wird 5 Minuten vor der Klausur aktiviert.",
+            "cleanup": {
+                "title": "Aufräumen",
+                "question": "Möchtest du die Prüfung <strong>{{title}}</strong> wirklich bereinigen? Dadurch werden alle Studierenden-Repositories in der Prüfung gelöscht. Diese Aktion kann <strong class='text-danger'>NICHT</strong> rückgängig gemacht werden!"
+            },
             "validation": {
                 "startAndEndMustBeSet": "Start- und Enddatum der Klausur müssen festgelegt werden.",
                 "atLeastOneExercisePerExerciseGroup": "Alle Aufgabengruppen müssen mindestens eine Aufgabe haben.",

--- a/src/main/webapp/i18n/de/programmingExercise.json
+++ b/src/main/webapp/i18n/de/programmingExercise.json
@@ -22,7 +22,8 @@
             },
             "cleanup": {
                 "successMessage": "Die Bereinigung war erfolgreich. Alle Build-Pläne wurden gelöscht. Die Studierenden können ihre Teilnahme wieder aufnehmen.",
-                "successMessageWithRepositories": "Die Bereinigung verlief erfolgreich. Alle Build-Pläne und Repositories wurden gelöscht. Alle Beteiligungen wurden als abgeschlossen gekennzeichnet."
+                "successMessageWithRepositories": "Die Bereinigung verlief erfolgreich. Alle Build-Pläne und Repositories wurden gelöscht. Alle Beteiligungen wurden als abgeschlossen gekennzeichnet.",
+                "successMessageCleanup": "Die Bereinigung verlief erfolgreich. Alle Studierenden Repositories wurden gelöscht."
             },
             "reset": {
                 "pleaseSelectOperations": "Bitte wählen Sie die durchzuführenden Operationen für <strong>{{ title }}</strong> aus:",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -134,6 +134,10 @@
             "falseName": "Entered name is incorrect. Please try again!",
             "notSet": "Not set",
             "startExamToolTip": "Button will be activated 5 minutes before the exam start.",
+            "cleanup": {
+                "title": "Cleanup",
+                "question": "Are you sure you want to clean up the exam <strong>{{ title }}</strong>? This will delete all student programming exercise repositories in the exam. This action can <strong class='text-danger'>NOT</strong> be undone!"
+            },
             "validation": {
                 "startAndEndMustBeSet": "The start and end date must be set for the exam",
                 "atLeastOneExercisePerExerciseGroup": "All exercise groups must have at least one exercise.",

--- a/src/main/webapp/i18n/en/programmingExercise.json
+++ b/src/main/webapp/i18n/en/programmingExercise.json
@@ -20,6 +20,11 @@
                 "studentRepos": "Additionally delete all student repositories (Be careful: this can NOT be undone!). Before you activate this option, we recommend that you archive the exercise first!",
                 "baseReposBuildPlans": "Additionally delete template, solution, test, and auxiliary repos and build plans (Be careful: this can NOT be undone!). Before you activate this option, we recommend that you back up these build plans and repos first!"
             },
+            "cleanup": {
+                "successMessage": "Cleanup was successful. All build plans were deleted. Students can resume their participation.",
+                "successMessageWithRepositories": "Cleanup was successful. All build plans and repositories were deleted. All participations are marked as completed.",
+                "successMessageCleanup": "Cleanup was successful. All student repositories were deleted."
+            },
             "reset": {
                 "pleaseSelectOperations": "Please select the operations you want to perform on <strong>{{ title }}</strong>:",
                 "deleteBuildPlans": {

--- a/src/test/javascript/spec/component/shared/course-exam-archive-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/course-exam-archive-button.component.spec.ts
@@ -92,7 +92,7 @@ describe('Course Exam Archive Button Component', () => {
             tick();
 
             expect(comp.canArchive()).toBeFalse();
-            expect(comp.canCleanupCourse()).toBeFalse();
+            expect(comp.canCleanup()).toBeFalse();
             expect(comp.canDownloadArchive()).toBeFalse();
         }));
     });
@@ -112,7 +112,7 @@ describe('Course Exam Archive Button Component', () => {
             tick();
 
             expect(comp.canArchive()).toBeFalse();
-            expect(comp.canCleanupCourse()).toBeFalse();
+            expect(comp.canCleanup()).toBeFalse();
             expect(comp.canDownloadArchive()).toBeFalse();
         }));
     });
@@ -130,7 +130,7 @@ describe('Course Exam Archive Button Component', () => {
             tick();
 
             expect(comp.canArchive()).toBeTrue();
-            expect(comp.canCleanupCourse()).toBeFalse();
+            expect(comp.canCleanup()).toBeFalse();
             expect(comp.canDownloadArchive()).toBeFalse();
         }));
     });
@@ -152,7 +152,7 @@ describe('Course Exam Archive Button Component', () => {
 
         it('should not display an archive course button', fakeAsync(() => {
             expect(comp.canArchive()).toBeTrue();
-            expect(comp.canCleanupCourse()).toBeTrue();
+            expect(comp.canCleanup()).toBeTrue();
             expect(comp.canDownloadArchive()).toBeTrue();
         }));
 
@@ -163,7 +163,7 @@ describe('Course Exam Archive Button Component', () => {
             const alertService = TestBed.inject(AlertService);
             const alertServiceSpy = jest.spyOn(alertService, 'success');
 
-            comp.cleanupCourse();
+            comp.cleanup();
 
             expect(cleanupStub).toHaveBeenCalledOnce();
             expect(alertServiceSpy).toHaveBeenCalledOnce();
@@ -237,7 +237,7 @@ describe('Course Exam Archive Button Component', () => {
 
         it('should display an archive button', fakeAsync(() => {
             expect(comp.canArchive()).toBeTrue();
-            expect(comp.canCleanupCourse()).toBeFalse();
+            expect(comp.canCleanup()).toBeFalse();
             expect(comp.canDownloadArchive()).toBeTrue();
         }));
 
@@ -246,10 +246,10 @@ describe('Course Exam Archive Button Component', () => {
             const cleanupStub = jest.spyOn(courseManagementService, 'cleanupCourse').mockReturnValue(of(response));
 
             comp.archiveMode = 'Exam';
-            comp.cleanupCourse();
+            comp.cleanup();
 
             expect(cleanupStub).not.toHaveBeenCalled();
-            expect(comp.canCleanupCourse()).toBeFalse();
+            expect(comp.canCleanup()).toBeFalse();
         }));
 
         it('should download archive for exam', () => {

--- a/src/test/javascript/spec/component/shared/course-exam-archive-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/course-exam-archive-button.component.spec.ts
@@ -235,13 +235,13 @@ describe('Course Exam Archive Button Component', () => {
             jest.restoreAllMocks();
         });
 
-        it('should display an archive button', fakeAsync(() => {
+        it('should display an archive and cleanup button', fakeAsync(() => {
             expect(comp.canArchive()).toBeTrue();
-            expect(comp.canCleanup()).toBeFalse();
+            expect(comp.canCleanup()).toBeTrue();
             expect(comp.canDownloadArchive()).toBeTrue();
         }));
 
-        it('should not cleanup archive for exam', fakeAsync(() => {
+        it('should cleanup archive for exam', fakeAsync(() => {
             const response: HttpResponse<void> = new HttpResponse({ status: 200 });
             const cleanupStub = jest.spyOn(courseManagementService, 'cleanupCourse').mockReturnValue(of(response));
 
@@ -249,7 +249,7 @@ describe('Course Exam Archive Button Component', () => {
             comp.cleanup();
 
             expect(cleanupStub).not.toHaveBeenCalled();
-            expect(comp.canCleanup()).toBeFalse();
+            expect(comp.canCleanup()).toBeTrue();
         }));
 
         it('should download archive for exam', () => {


### PR DESCRIPTION
Additionally: 
* Remove code for an edge case which led to issues when starting Artemis on secondary nodes
* Cleanup repositories for exercises (and thus courses and exams) in parallel
* Add audit logs when instructors cleanup courses and exams


### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.

### Motivation and Context
We want to be able to cleanup student repositories in exams as well

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Completed exam with programming exercises

1. Archive the exam
2. Download the archive
3. Cleanup the exam
4. Make sure all student repositories on Bitbucket / Gitlab have been deleted
5. Make sure all entries in the participation page of the exam exercise do not include build plans more repository entries anymore and are marked as Finished

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://ls1intum.github.io/Artemis/user/exam_mode/) as reference.
6. ...

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [x] Test 1
- [ ] Test 2
