### PR TITLE
`Development`: Cleanup temporary files when running tests

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
@@ -118,6 +118,9 @@ class ExamUserIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJi
     @AfterEach
     void tearDown() throws Exception {
         programmingExerciseTestService.tearDown();
+        for (LocalRepository studentRepo : studentRepos) {
+            studentRepo.resetLocalRepo();
+        }
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -473,6 +473,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         // TODO: test the conduction / submission of the test exams, in particular that the summary includes all submissions
 
         deleteExamWithInstructor(testExam1);
+        repo.resetLocalRepo();
     }
 
     private void assertParticipationAndSubmissions(StudentExam response, User user) {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseScheduleServiceTest.java
@@ -113,7 +113,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
     }
 
     @AfterEach
-    void tearDown() throws InterruptedException {
+    void tearDown() throws Exception {
         // not yet finished scheduled futures may otherwise affect following tests
         scheduleService.clearAllTasks();
 
@@ -124,6 +124,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
         bambooRequestMockProvider.reset();
         bitbucketRequestMockProvider.reset();
+        studentRepository.resetLocalRepo();
     }
 
     private void verifyLockStudentRepositoryAndParticipationOperation(boolean wasCalled, long timeoutInMs) {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
@@ -136,6 +136,8 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
 
     private final LocalRepository studentRepository = new LocalRepository(defaultBranch);
 
+    private LocalRepository templateRepository;
+
     private final List<BuildLogEntry> logs = new ArrayList<>();
 
     private final BuildLogEntry buildLogEntry = new BuildLogEntry(ZonedDateTime.now(), "Checkout to revision e65aa77cc0380aeb9567ccceb78aca416d86085b has failed.");
@@ -184,7 +186,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
         programmingExercise.setTestRepositoryUrl(localRepoUrl.toString());
 
         // Create template repo
-        LocalRepository templateRepository = new LocalRepository(defaultBranch);
+        templateRepository = new LocalRepository(defaultBranch);
         templateRepository.configureRepos("templateLocalRepo", "templateOriginRepo");
 
         // add file to the template repo folder
@@ -234,13 +236,13 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
 
         // Add the appender to the logger, the addAppender is outdated now
         logger.addAppender(listAppender);
-        templateRepository.resetLocalRepo();
     }
 
     @AfterEach
     void tearDown() throws IOException {
         reset(gitService);
         studentRepository.resetLocalRepo();
+        templateRepository.resetLocalRepo();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
@@ -234,6 +234,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
 
         // Add the appender to the logger, the addAppender is outdated now
         logger.addAppender(listAppender);
+        templateRepository.resetLocalRepo();
     }
 
     @AfterEach
@@ -631,6 +632,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
                 .getOrCheckoutRepository(instructorAssignmentParticipation.getVcsRepositoryUrl(), true, defaultBranch);
 
         request.put(studentRepoBaseUrl + instructorAssignmentParticipation.getId() + "/files?commit=true", List.of(), HttpStatus.OK);
+        instructorAssignmentRepository.resetLocalRepo();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.hestia;
 
 import java.time.ZonedDateTime;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +52,12 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractSpringInte
         Course course = courseUtilService.addEmptyCourse();
         userUtilService.addUsers(TEST_PREFIX, 1, 1, 1, 1);
         exercise = ProgrammingExerciseFactory.generateProgrammingExercise(ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(7), course);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        solutionRepo.resetLocalRepo();
+        templateRepo.resetLocalRepo();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
@@ -2,9 +2,11 @@ package de.tum.in.www1.artemis.hestia;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,6 +67,12 @@ class ProgrammingExerciseGitDiffReportServiceTest extends AbstractSpringIntegrat
         userUtilService.addUsers(TEST_PREFIX, 1, 1, 1, 1);
         final Course course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         exercise = exerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        templateRepo.resetLocalRepo();
+        solutionRepo.resetLocalRepo();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/hestia/StructuralTestCaseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/StructuralTestCaseServiceTest.java
@@ -3,8 +3,10 @@ package de.tum.in.www1.artemis.hestia;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.io.IOException;
 import java.time.ZonedDateTime;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,6 +61,12 @@ class StructuralTestCaseServiceTest extends AbstractSpringIntegrationBambooBitbu
         Course course = courseUtilService.addEmptyCourse();
         userUtilService.addUsers(TEST_PREFIX, 0, 0, 0, 1);
         exercise = ProgrammingExerciseFactory.generateProgrammingExercise(ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(7), course);
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        solutionRepo.resetLocalRepo();
+        testRepo.resetLocalRepo();
     }
 
     private void addTestCaseToExercise(String name) {

--- a/src/test/java/de/tum/in/www1/artemis/hestia/TestwiseCoverageReportServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/TestwiseCoverageReportServiceTest.java
@@ -2,9 +2,11 @@ package de.tum.in.www1.artemis.hestia;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,6 +80,11 @@ class TestwiseCoverageReportServiceTest extends AbstractSpringIntegrationBambooB
         var solutionParticipation = solutionProgrammingExerciseRepository.findWithEagerResultsAndSubmissionsByProgrammingExerciseId(programmingExercise.getId()).orElseThrow();
         solutionSubmission = programmingExerciseUtilService.createProgrammingSubmission(solutionParticipation, false);
         programmingExercise = programmingExerciseRepository.findByIdElseThrow(programmingExercise.getId());
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        solutionRepo.resetLocalRepo();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/hestia/behavioral/BehavioralTestCaseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/behavioral/BehavioralTestCaseServiceTest.java
@@ -2,11 +2,10 @@ package de.tum.in.www1.artemis.hestia.behavioral;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.util.HashSet;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
@@ -78,6 +77,11 @@ class BehavioralTestCaseServiceTest extends AbstractSpringIntegrationBambooBitbu
         final Course course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise(false, true, ProgrammingLanguage.JAVA);
         exercise = exerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
         exercise.setTestwiseCoverageEnabled(true);
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        solutionRepo.resetLocalRepo();
     }
 
     private ProgrammingExerciseTestCase addTestCaseToExercise(String name) {

--- a/src/test/java/de/tum/in/www1/artemis/iris/IrisMessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/iris/IrisMessageIntegrationTest.java
@@ -51,6 +51,8 @@ class IrisMessageIntegrationTest extends AbstractIrisIntegrationTest {
 
     private ProgrammingExercise exercise;
 
+    private LocalRepository repository;
+
     @BeforeEach
     void initTestCase() {
         userUtilService.addUsers(TEST_PREFIX, 2, 0, 0, 0);
@@ -59,6 +61,7 @@ class IrisMessageIntegrationTest extends AbstractIrisIntegrationTest {
         exercise = exerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
         activateIrisFor(course);
         activateIrisFor(exercise);
+        repository = new LocalRepository("main");
     }
 
     @Test
@@ -69,9 +72,9 @@ class IrisMessageIntegrationTest extends AbstractIrisIntegrationTest {
         messageToSend.setMessageDifferentiator(1453);
 
         irisRequestMockProvider.mockMessageResponse("Hello World");
-        var savedExercise = irisUtilTestService.setupTemplate(exercise, new LocalRepository("main"));
+        var savedExercise = irisUtilTestService.setupTemplate(exercise, repository);
         var exerciseParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(savedExercise, TEST_PREFIX + "student1");
-        irisUtilTestService.setupStudentParticipation(exerciseParticipation, new LocalRepository("main"));
+        irisUtilTestService.setupStudentParticipation(exerciseParticipation, repository);
         activateIrisFor(savedExercise);
 
         var irisMessage = request.postWithResponseBody("/api/iris/sessions/" + irisSession.getId() + "/messages", messageToSend, IrisMessage.class, HttpStatus.CREATED);
@@ -115,9 +118,9 @@ class IrisMessageIntegrationTest extends AbstractIrisIntegrationTest {
         var irisSession = irisSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         IrisMessage messageToSend1 = createDefaultMockMessage(irisSession);
 
-        var savedExercise = irisUtilTestService.setupTemplate(exercise, new LocalRepository("main"));
+        var savedExercise = irisUtilTestService.setupTemplate(exercise, repository);
         var exerciseParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(savedExercise, TEST_PREFIX + "student1");
-        irisUtilTestService.setupStudentParticipation(exerciseParticipation, new LocalRepository("main"));
+        irisUtilTestService.setupStudentParticipation(exerciseParticipation, repository);
         activateIrisFor(savedExercise);
 
         var irisMessage1 = request.postWithResponseBody("/api/iris/sessions/" + irisSession.getId() + "/messages", messageToSend1, IrisMessage.class, HttpStatus.CREATED);
@@ -239,9 +242,9 @@ class IrisMessageIntegrationTest extends AbstractIrisIntegrationTest {
         IrisMessage messageToSend = createDefaultMockMessage(irisSession);
 
         irisRequestMockProvider.mockMessageError();
-        var savedExercise = irisUtilTestService.setupTemplate(exercise, new LocalRepository("main"));
+        var savedExercise = irisUtilTestService.setupTemplate(exercise, repository);
         var exerciseParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(savedExercise, TEST_PREFIX + "student1");
-        irisUtilTestService.setupStudentParticipation(exerciseParticipation, new LocalRepository("main"));
+        irisUtilTestService.setupStudentParticipation(exerciseParticipation, repository);
         activateIrisFor(savedExercise);
 
         request.postWithResponseBody("/api/iris/sessions/" + irisSession.getId() + "/messages", messageToSend, IrisMessage.class, HttpStatus.CREATED);
@@ -259,9 +262,9 @@ class IrisMessageIntegrationTest extends AbstractIrisIntegrationTest {
         IrisMessage messageToSend = createDefaultMockMessage(irisSession);
 
         irisRequestMockProvider.mockMessageResponse(null);
-        var savedExercise = irisUtilTestService.setupTemplate(exercise, new LocalRepository("main"));
+        var savedExercise = irisUtilTestService.setupTemplate(exercise, repository);
         var exerciseParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(savedExercise, TEST_PREFIX + "student1");
-        irisUtilTestService.setupStudentParticipation(exerciseParticipation, new LocalRepository("main"));
+        irisUtilTestService.setupStudentParticipation(exerciseParticipation, repository);
         activateIrisFor(savedExercise);
 
         request.postWithResponseBody("/api/iris/sessions/" + irisSession.getId() + "/messages", messageToSend, IrisMessage.class, HttpStatus.CREATED);

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCIntegrationTest.java
@@ -86,8 +86,7 @@ class LocalVCIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
         localVCLocalCITestService.testPushReturnsError(someRepository.localGit, student1Login, projectKey, repositorySlug, NOT_FOUND);
 
         // Cleanup
-        someRepository.localGit.close();
-        FileUtils.deleteDirectory(someRepository.localRepoFile);
+        someRepository.resetLocalRepo();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCIIntegrationTest.java
@@ -369,6 +369,7 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
         // Instructor should be able to read and write.
         localVCLocalCITestService.testFetchSuccessful(teamLocalRepository.localGit, instructor1Login, projectKey1, teamRepositorySlug);
         localVCLocalCITestService.testPushSuccessful(teamLocalRepository.localGit, instructor1Login, projectKey1, teamRepositorySlug);
+        teamLocalRepository.resetLocalRepo();
     }
 
     private LocalRepository prepareTeamExerciseAndRepository() throws GitAPIException, IOException, URISyntaxException {

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
@@ -373,6 +373,7 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         var repo = new LocalRepository(defaultBranch);
         repo.configureRepos("studentRepo", "studentOriginRepo");
         programmingExerciseTestService.setupRepositoryMocksParticipant(programmingExercise, userLogin, repo, practiceMode);
+        repo.resetLocalRepo();
     }
 
     @Test
@@ -492,6 +493,7 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
 
         request.putWithResponseBody("/api/exercises/" + programmingExercise.getId() + "/request-feedback", null, ProgrammingExerciseStudentParticipation.class,
                 HttpStatus.BAD_REQUEST);
+        localRepo.resetLocalRepo();
     }
 
     @Test
@@ -547,6 +549,7 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         assertThat(response.getIndividualDueDate()).isNotNull().isBefore(ZonedDateTime.now());
 
         verify(programmingExerciseParticipationService).lockStudentRepositoryAndParticipation(programmingExercise, participation);
+        localRepo.resetLocalRepo();
     }
 
     @Test
@@ -562,6 +565,7 @@ class ParticipationIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         var updatedParticipation = request.putWithResponseBody("/api/exercises/" + programmingExercise.getId() + "/resume-programming-participation/" + participation.getId(), null,
                 ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
         assertThat(updatedParticipation.getInitializationState()).isEqualTo(InitializationState.INITIALIZED);
+        localRepo.resetLocalRepo();
     }
 
     @Test


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).


### Motivation and Context
Similar to PR #7051 this PR fixes other instances where temporary files get created but not correctly cleaned up when running the server tests.

### Steps for Testing
code review

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
