### PR TITLE
`Iris`: Add per-user rate limit

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/iris/settings/IrisSubSettings.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/iris/settings/IrisSubSettings.java
@@ -32,6 +32,10 @@ public class IrisSubSettings extends DomainObject {
     @Column(name = "preferredModel")
     private String preferredModel;
 
+    @Nullable
+    @Column(name = "rateLimit")
+    private Integer rateLimit;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -56,5 +60,14 @@ public class IrisSubSettings extends DomainObject {
 
     public void setPreferredModel(@Nullable String preferredModel) {
         this.preferredModel = preferredModel;
+    }
+
+    @Nullable
+    public Integer getRateLimit() {
+        return rateLimit;
+    }
+
+    public void setRateLimit(@Nullable Integer rateLimit) {
+        this.rateLimit = rateLimit;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/iris/IrisMessageRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/iris/IrisMessageRepository.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.artemis.repository.iris;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import javax.validation.constraints.NotNull;
@@ -25,6 +26,25 @@ public interface IrisMessageRepository extends JpaRepository<IrisMessage, Long> 
             AND m.sender <> 'ARTEMIS'
             """)
     List<IrisMessage> findAllExceptSystemMessagesWithContentBySessionId(Long sessionId);
+
+    /**
+     * Counts the number of LLM responses the user got within the given timeframe.
+     *
+     * @param userId the id of the user
+     * @param start  the start of the timeframe
+     * @param end    the end of the timeframe
+     * @return the number of chat messages sent by the user within the given timeframe
+     */
+    @Query("""
+            SELECT COUNT(DISTINCT m)
+            FROM IrisMessage m
+            LEFT JOIN m.session as s
+            WHERE type(s) = de.tum.in.www1.artemis.domain.iris.session.IrisChatSession
+            AND s.user.id = :userId
+            AND m.sender = 'LLM'
+            AND m.sentAt BETWEEN :start AND :end
+            """)
+    int countLlmResponsesOfUserWithinTimeframe(Long userId, ZonedDateTime start, ZonedDateTime end);
 
     @NotNull
     default IrisMessage findByIdElseThrow(long messageId) throws EntityNotFoundException {

--- a/src/main/java/de/tum/in/www1/artemis/service/iris/IrisRateLimitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/iris/IrisRateLimitService.java
@@ -1,0 +1,54 @@
+package de.tum.in.www1.artemis.service.iris;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import de.tum.in.www1.artemis.domain.User;
+import de.tum.in.www1.artemis.repository.iris.IrisMessageRepository;
+
+@Service
+@Profile("iris")
+public class IrisRateLimitService {
+
+    private final IrisMessageRepository irisMessageRepository;
+
+    private final IrisSettingsService irisSettingsService;
+
+    public IrisRateLimitService(IrisMessageRepository irisMessageRepository, IrisSettingsService irisSettingsService) {
+        this.irisMessageRepository = irisMessageRepository;
+        this.irisSettingsService = irisSettingsService;
+    }
+
+    public RateLimitDTO getRateLimit(User user) {
+        var globalSettings = irisSettingsService.getGlobalSettings();
+        var irisChatSettings = globalSettings.getIrisChatSettings();
+        var start = ZonedDateTime.now().minusHours(3);
+        var end = ZonedDateTime.now();
+        var currentRateLimit = irisMessageRepository.countLlmResponsesOfUserWithinTimeframe(user.getId(), start, end);
+        var maxRateLimit = Objects.requireNonNullElse(irisChatSettings.getRateLimit(), -1);
+
+        return new RateLimitDTO(currentRateLimit, maxRateLimit);
+    }
+
+    /**
+     * DTO for the rate limit.
+     *
+     * @param currentRateLimit the current rate limit
+     * @param maxRateLimit     the max rate limit
+     */
+    public record RateLimitDTO(int currentRateLimit, int maxRateLimit) {
+
+        /**
+         * Checks if the rate limit is exceeded.
+         * It is exceeded if the maxRateLimit is set and the currentRateLimit is greater or equal to the maxRateLimit.
+         *
+         * @return true if the rate limit is exceeded, false otherwise
+         */
+        public boolean isRateLimitExceeded() {
+            return maxRateLimit != -1 && currentRateLimit >= maxRateLimit;
+        }
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/iris/IrisSettingsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/iris/IrisSettingsService.java
@@ -381,6 +381,7 @@ public class IrisSettingsService {
         }
         target.setEnabled(source.isEnabled());
         target.setPreferredModel(source.getPreferredModel());
+        target.setRateLimit(source.getRateLimit());
         if (!Objects.equals(source.getTemplate(), target.getTemplate())) {
             target.setTemplate(source.getTemplate());
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/iris/exception/IrisException.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/iris/exception/IrisException.java
@@ -21,6 +21,12 @@ public class IrisException extends HttpStatusException {
         this.translationParams = translationParams;
     }
 
+    public IrisException(String defaultMessage, Status status, String entityName, String translationKey, Map<String, Object> translationParams) {
+        super(ErrorConstants.DEFAULT_TYPE, defaultMessage, status, entityName, translationKey, getAlertParameters(translationKey, translationParams));
+        this.translationKey = translationKey;
+        this.translationParams = translationParams;
+    }
+
     public String getTranslationKey() {
         return translationKey;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/iris/exception/IrisRateLimitExceededException.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/iris/exception/IrisRateLimitExceededException.java
@@ -1,0 +1,19 @@
+package de.tum.in.www1.artemis.service.iris.exception;
+
+import java.util.Map;
+
+import org.zalando.problem.Status;
+
+import de.tum.in.www1.artemis.service.iris.IrisRateLimitService;
+
+public class IrisRateLimitExceededException extends IrisException {
+
+    public IrisRateLimitExceededException(int currentRateLimit, int maxRateLimit) {
+        super("You have exceeded the rate limit of Iris", Status.TOO_MANY_REQUESTS, "Iris", "artemisApp.exerciseChatbot.errors.rateLimitExceeded",
+                Map.of("currentRateLimit", currentRateLimit, "maxRateLimit", maxRateLimit));
+    }
+
+    public IrisRateLimitExceededException(IrisRateLimitService.RateLimitDTO rateLimit) {
+        this(rateLimit.currentRateLimit(), rateLimit.maxRateLimit());
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/iris/IrisSessionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/iris/IrisSessionResource.java
@@ -19,6 +19,7 @@ import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastStudent;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.connectors.iris.IrisHealthIndicator;
 import de.tum.in.www1.artemis.service.connectors.iris.dto.IrisStatusDTO;
+import de.tum.in.www1.artemis.service.iris.IrisRateLimitService;
 import de.tum.in.www1.artemis.service.iris.IrisSessionService;
 import de.tum.in.www1.artemis.service.iris.IrisSettingsService;
 
@@ -44,9 +45,11 @@ public class IrisSessionResource {
 
     private final IrisHealthIndicator irisHealthIndicator;
 
+    private final IrisRateLimitService irisRateLimitService;
+
     public IrisSessionResource(ProgrammingExerciseRepository programmingExerciseRepository, AuthorizationCheckService authCheckService,
             IrisChatSessionRepository irisChatSessionRepository, UserRepository userRepository, IrisSessionService irisSessionService, IrisSettingsService irisSettingsService,
-            IrisHealthIndicator irisHealthIndicator) {
+            IrisHealthIndicator irisHealthIndicator, IrisRateLimitService irisRateLimitService) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.authCheckService = authCheckService;
         this.irisChatSessionRepository = irisChatSessionRepository;
@@ -54,6 +57,7 @@ public class IrisSessionResource {
         this.irisSessionService = irisSessionService;
         this.irisSettingsService = irisSettingsService;
         this.irisHealthIndicator = irisHealthIndicator;
+        this.irisRateLimitService = irisRateLimitService;
     }
 
     /**
@@ -125,7 +129,7 @@ public class IrisSessionResource {
      */
     @GetMapping("/sessions/{sessionId}/active")
     @EnforceAtLeastStudent
-    public ResponseEntity<Boolean> isIrisActive(@PathVariable Long sessionId) {
+    public ResponseEntity<IrisHealthDTO> isIrisActive(@PathVariable Long sessionId) {
         var session = irisChatSessionRepository.findByIdElseThrow(sessionId);
         var user = userRepository.getUser();
         irisSessionService.checkHasAccessToIrisSession(session, user);
@@ -138,6 +142,12 @@ public class IrisSessionResource {
             specificModelStatus = Arrays.stream(modelStatuses).filter(x -> x.model().equals(settings.getIrisChatSettings().getPreferredModel()))
                     .anyMatch(x -> x.status() == IrisStatusDTO.ModelStatus.UP);
         }
-        return ResponseEntity.ok(specificModelStatus);
+
+        var rateLimit = irisRateLimitService.getRateLimit(user);
+
+        return ResponseEntity.ok(new IrisHealthDTO(specificModelStatus, rateLimit.currentRateLimit(), rateLimit.maxRateLimit()));
+    }
+
+    public record IrisHealthDTO(boolean active, int currentRateLimit, int maxRateLimit) {
     }
 }

--- a/src/main/resources/config/liquibase/changelog/20230922222222_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230922222222_changelog.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="20230922222222" author="morrien">
+        <addColumn tableName="iris_sub_settings">
+            <column name="rate_limit" type="integer"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -61,6 +61,7 @@
     <include file="classpath:config/liquibase/changelog/20230713113211_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230907114600_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20230907225501_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20230922222222_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command 'date '+%Y%m%d%H%M%S'' to get the current date and time in the correct format -->

--- a/src/main/webapp/app/entities/iris/iris-errors.model.ts
+++ b/src/main/webapp/app/entities/iris/iris-errors.model.ts
@@ -16,6 +16,7 @@ export enum IrisErrorMessageKey {
     PARSE_RESPONSE = 'artemisApp.exerciseChatbot.errors.parseResponse',
     TECHNICAL_ERROR_RESPONSE = 'artemisApp.exerciseChatbot.errors.technicalError',
     IRIS_NOT_AVAILABLE = 'artemisApp.exerciseChatbot.errors.irisNotAvailable',
+    RATE_LIMIT_EXCEEDED = 'artemisApp.exerciseChatbot.errors.rateLimitExceeded',
 }
 
 export interface IrisErrorType {
@@ -42,6 +43,7 @@ const IrisErrors: IrisErrorType[] = [
     { key: IrisErrorMessageKey.FORBIDDEN, fatal: true },
     { key: IrisErrorMessageKey.TECHNICAL_ERROR_RESPONSE, fatal: true },
     { key: IrisErrorMessageKey.IRIS_NOT_AVAILABLE, fatal: true },
+    { key: IrisErrorMessageKey.RATE_LIMIT_EXCEEDED, fatal: true },
 ];
 
 export const errorMessages: Readonly<{ [key in IrisErrorMessageKey]: IrisErrorType }> = Object.freeze(

--- a/src/main/webapp/app/entities/iris/settings/iris-sub-settings.model.ts
+++ b/src/main/webapp/app/entities/iris/settings/iris-sub-settings.model.ts
@@ -6,4 +6,5 @@ export class IrisSubSettings implements BaseEntity {
     enabled = false;
     template?: IrisTemplate;
     preferredModel?: string;
+    rateLimit?: number;
 }

--- a/src/main/webapp/app/iris/exercise-chatbot/exercise-chatwidget/exercise-chat-widget.component.html
+++ b/src/main/webapp/app/iris/exercise-chatbot/exercise-chatwidget/exercise-chat-widget.component.html
@@ -11,21 +11,26 @@
                         <fa-icon [icon]="faCircleInfo" class="info-button"></fa-icon>
                     </a>
                 </h3>
-                <div class="button-container">
-                    <button *ngIf="isClearChatEnabled()" id="clear-chat-session" (click)="onClearSession(clearConfirmModal)" class="header-icon">
-                        <fa-icon [icon]="faTrash"></fa-icon>
-                    </button>
-                    <button *ngIf="!fullSize; else compressButton" (click)="maximizeScreen()" class="header-icon">
-                        <fa-icon [icon]="faExpand"></fa-icon>
-                    </button>
-                    <ng-template #compressButton>
-                        <button (click)="minimizeScreen()" class="header-icon">
-                            <fa-icon [icon]="faCompress"></fa-icon>
+                <div>
+                    <div class="button-container">
+                        <span *ngIf="maxRateLimit >= 0" class="rate-limit" [ngbTooltip]="'artemisApp.exerciseChatbot.rateLimitTooltip' | artemisTranslate"
+                            >{{ currentRateLimit }}/{{ maxRateLimit }}</span
+                        >
+                        <button *ngIf="isClearChatEnabled()" id="clear-chat-session" (click)="onClearSession(clearConfirmModal)" class="header-icon">
+                            <fa-icon [icon]="faTrash"></fa-icon>
                         </button>
-                    </ng-template>
-                    <button (click)="closeChat()" class="header-icon">
-                        <fa-icon [icon]="faXmark"></fa-icon>
-                    </button>
+                        <button *ngIf="!fullSize; else compressButton" (click)="maximizeScreen()" class="header-icon">
+                            <fa-icon [icon]="faExpand"></fa-icon>
+                        </button>
+                        <ng-template #compressButton>
+                            <button (click)="minimizeScreen()" class="header-icon">
+                                <fa-icon [icon]="faCompress"></fa-icon>
+                            </button>
+                        </ng-template>
+                        <button (click)="closeChat()" class="header-icon">
+                            <fa-icon [icon]="faXmark"></fa-icon>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -59,7 +64,7 @@
                                 style="all: unset; display: flex; align-items: flex-start; justify-content: space-between; cursor: pointer"
                                 (click)="resendMessage(message)"
                                 [disabled]="resendAnimationActive"
-                                *ngIf="i === messages.length - 1 && message.sender === SENDER_USER && !this.isLoading"
+                                *ngIf="i === messages.length - 1 && message.sender === SENDER_USER && !this.isLoading && !(maxRateLimit >= 0 && currentRateLimit >= maxRateLimit)"
                             >
                                 <fa-icon [icon]="faRedo" size="sm" [ngClass]="resendAnimationActive ? 'fa-pulse' : ''"></fa-icon>
                             </button>

--- a/src/main/webapp/app/iris/exercise-chatbot/exercise-chatwidget/exercise-chat-widget.component.scss
+++ b/src/main/webapp/app/iris/exercise-chatbot/exercise-chatwidget/exercise-chat-widget.component.scss
@@ -10,6 +10,8 @@
 .button-container {
     display: flex;
     align-items: center;
+    color: var(--secondary);
+    font-size: 16px;
 }
 
 .chat-widget {
@@ -45,6 +47,14 @@
     background: transparent;
     color: var(--secondary);
     font-size: 16px;
+}
+
+.rate-limit {
+    padding-right: 6px;
+    margin-right: 3px;
+    border-right-color: var(--secondary);
+    border-right-style: solid;
+    border-right-width: 2px;
 }
 
 .info-button {

--- a/src/main/webapp/app/iris/exercise-chatbot/exercise-chatwidget/exercise-chat-widget.component.ts
+++ b/src/main/webapp/app/iris/exercise-chatbot/exercise-chatwidget/exercise-chat-widget.component.ts
@@ -115,6 +115,8 @@ export class ExerciseChatWidgetComponent implements OnInit, OnDestroy, AfterView
     exerciseId: number;
     sessionService: IrisSessionService;
     shouldShowEmptyMessageError = false;
+    currentRateLimit: number;
+    maxRateLimit: number;
 
     // User preferences
     userAccepted: boolean;
@@ -128,6 +130,7 @@ export class ExerciseChatWidgetComponent implements OnInit, OnDestroy, AfterView
     public ButtonType = ButtonType;
     readonly IrisLogoSize = IrisLogoSize;
     private navigationSubscription: Subscription;
+    private readonly MAX_INT_JAVA = 2147483647;
 
     constructor(
         private dialog: MatDialog,
@@ -174,6 +177,8 @@ export class ExerciseChatWidgetComponent implements OnInit, OnDestroy, AfterView
             if (this.error) {
                 this.getConvertedErrorMap();
             }
+            this.currentRateLimit = state.currentRateLimit;
+            this.maxRateLimit = state.maxRateLimit;
         });
 
         // Focus on message textarea
@@ -359,14 +364,7 @@ export class ExerciseChatWidgetComponent implements OnInit, OnDestroy, AfterView
                 .dispatchAndThen(new StudentMessageSentAction(message, timeoutId))
                 .then(() => this.httpMessageService.createMessage(<number>this.sessionId, message).toPromise())
                 .then(() => this.scrollToBottom('smooth'))
-                .catch((error: HttpErrorResponse) => {
-                    if (error.status === 403) {
-                        this.stateStore.dispatch(new ConversationErrorOccurredAction(IrisErrorMessageKey.IRIS_DISABLED));
-                    } else {
-                        this.stateStore.dispatch(new ConversationErrorOccurredAction(IrisErrorMessageKey.SEND_MESSAGE_FAILED));
-                    }
-                    this.scrollToBottom('smooth');
-                });
+                .catch(this.handleIrisError);
             this.newMessageTextContent = '';
         }
         this.scrollToBottom('smooth');
@@ -605,7 +603,7 @@ export class ExerciseChatWidgetComponent implements OnInit, OnDestroy, AfterView
 
     resendMessage(message: IrisClientMessage) {
         this.resendAnimationActive = true;
-        message.messageDifferentiator = message.id;
+        message.messageDifferentiator = message.id ?? Math.floor(Math.random() * this.MAX_INT_JAVA);
 
         const timeoutId = setTimeout(() => {
             // will be cleared by the store automatically
@@ -614,21 +612,34 @@ export class ExerciseChatWidgetComponent implements OnInit, OnDestroy, AfterView
         }, 20000);
         this.stateStore
             .dispatchAndThen(new StudentMessageSentAction(message, timeoutId))
-            .then(() => this.httpMessageService.resendMessage(<number>this.sessionId, message).toPromise())
+            .then(() => {
+                if (message.id) {
+                    return this.httpMessageService.resendMessage(<number>this.sessionId, message).toPromise();
+                } else {
+                    return this.httpMessageService.createMessage(<number>this.sessionId, message).toPromise();
+                }
+            })
             .then(() => {
                 this.scrollToBottom('smooth');
             })
-            .catch((error: HttpErrorResponse) => {
-                if (error.status === 403) {
-                    this.stateStore.dispatch(new ConversationErrorOccurredAction(IrisErrorMessageKey.IRIS_DISABLED));
-                } else {
-                    this.stateStore.dispatch(new ConversationErrorOccurredAction(IrisErrorMessageKey.SEND_MESSAGE_FAILED));
-                }
-            })
+            .catch(this.handleIrisError)
             .finally(() => {
                 this.resendAnimationActive = false;
                 this.scrollToBottom('smooth');
             });
+    }
+
+    private handleIrisError(error: HttpErrorResponse) {
+        switch (error.status) {
+            case 403:
+                this.stateStore.dispatch(new ConversationErrorOccurredAction(IrisErrorMessageKey.IRIS_DISABLED));
+                break;
+            case 429:
+                this.stateStore.dispatch(new ConversationErrorOccurredAction(IrisErrorMessageKey.RATE_LIMIT_EXCEEDED));
+                break;
+            default:
+                this.stateStore.dispatch(new ConversationErrorOccurredAction(IrisErrorMessageKey.SEND_MESSAGE_FAILED));
+        }
     }
 
     isSendMessageFailedError(): boolean {

--- a/src/main/webapp/app/iris/heartbeat.service.ts
+++ b/src/main/webapp/app/iris/heartbeat.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { IrisStateStore } from 'app/iris/state-store.service';
-import { IrisHttpSessionService } from 'app/iris/http-session.service';
+import { HeartbeatDTO, IrisHttpSessionService } from 'app/iris/http-session.service';
 import { HttpResponse } from '@angular/common/http';
-import { ConversationErrorOccurredAction, MessageStoreAction, isSessionReceivedAction } from 'app/iris/state-store.model';
+import { ConversationErrorOccurredAction, MessageStoreAction, RateLimitUpdatedAction, isSessionReceivedAction } from 'app/iris/state-store.model';
 import { IrisErrorMessageKey } from 'app/entities/iris/iris-errors.model';
 import { Subscription } from 'rxjs';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
@@ -53,8 +53,13 @@ export class IrisHeartbeatService implements OnDestroy {
         this.httpSessionService
             .getHeartbeat(sessionId)
             .toPromise()
-            .then((response: HttpResponse<boolean>) => {
-                if (!response.body!) {
+            .then((response: HttpResponse<HeartbeatDTO>) => {
+                if (response.body) {
+                    if (!response.body.active) {
+                        this.stateStore.dispatch(new ConversationErrorOccurredAction(IrisErrorMessageKey.IRIS_NOT_AVAILABLE));
+                    }
+                    this.stateStore.dispatch(new RateLimitUpdatedAction(response.body!.currentRateLimit, response.body!.maxRateLimit));
+                } else {
                     this.stateStore.dispatch(new ConversationErrorOccurredAction(IrisErrorMessageKey.IRIS_NOT_AVAILABLE));
                 }
             });

--- a/src/main/webapp/app/iris/http-session.service.ts
+++ b/src/main/webapp/app/iris/http-session.service.ts
@@ -4,6 +4,11 @@ import { Observable } from 'rxjs';
 import { IrisSession } from 'app/entities/iris/iris-session.model';
 
 type EntityResponseType = HttpResponse<IrisSession>;
+export class HeartbeatDTO {
+    active: boolean;
+    currentRateLimit: number;
+    maxRateLimit: number;
+}
 
 /**
  * The `IrisHttpSessionService` provides methods for retrieving existing or creating new Iris sessions.
@@ -40,7 +45,7 @@ export class IrisHttpSessionService {
      * @param sessionId The ID of the session to check.
      * @return An Observable of the HTTP response containing a boolean value indicating the session's heartbeat status.
      */
-    getHeartbeat(sessionId: number): Observable<HttpResponse<boolean>> {
-        return this.http.get<boolean>(`${this.resourceUrl}/sessions/${sessionId}/active`, { observe: 'response' });
+    getHeartbeat(sessionId: number): Observable<HttpResponse<HeartbeatDTO>> {
+        return this.http.get<HeartbeatDTO>(`${this.resourceUrl}/sessions/${sessionId}/active`, { observe: 'response' });
     }
 }

--- a/src/main/webapp/app/iris/settings/iris-settings-update/iris-settings-update.component.html
+++ b/src/main/webapp/app/iris/settings/iris-settings-update/iris-settings-update.component.html
@@ -11,6 +11,7 @@
             [models]="irisModels ?? []"
             [templateOptional]="settingType !== GLOBAL"
             [modelOptional]="settingType !== GLOBAL"
+            [rateLimitSettable]="settingType === GLOBAL"
         ></jhi-iris-sub-settings-update>
     </div>
     <hr class="hr" />

--- a/src/main/webapp/app/iris/settings/iris-settings-update/iris-sub-settings-update/iris-sub-settings-update.component.html
+++ b/src/main/webapp/app/iris/settings/iris-settings-update/iris-sub-settings-update/iris-sub-settings-update.component.html
@@ -3,7 +3,7 @@
     <label class="form-check-label" for="flexSwitchCheckDefault" jhiTranslate="artemisApp.iris.settings.subSettings.enabled-disabled"> Enabled/Disabled </label>
 </div>
 <span><span class="fw-bold" jhiTranslate="artemisApp.iris.settings.subSettings.preferredModel">Preferred Model</span>: </span>
-<div *ngIf="true" ngbDropdown class="d-inline-block me-2">
+<div ngbDropdown class="d-inline-block me-2">
     <button class="btn btn-outline-primary w-100" id="dropdownBasic1" ngbDropdownToggle>
         {{ getSelectedModelName() }}
     </button>
@@ -16,6 +16,13 @@
         </button>
     </div>
 </div>
+
+<div *ngIf="rateLimitSettable">
+    <label class="form-check-label" for="rateLimit" jhiTranslate="artemisApp.iris.settings.subSettings.rateLimit">Rate Limit</label>
+    <jhi-help-icon [text]="'artemisApp.iris.settings.subSettings.rateLimitTooltip'"></jhi-help-icon>
+    <input id="rateLimit" name="rateLimit" class="form-control" type="number" [customMin]="-1" [customMax]="1000000" [(ngModel)]="subSettings!.rateLimit" />
+</div>
+
 <div class="mb-3">
     <label class="form-label fs-4 fw-bold" for="template-editor" jhiTranslate="artemisApp.iris.settings.subSettings.template.title"> Template </label>
     <div *ngIf="templateOptional" class="form-check form-switch">

--- a/src/main/webapp/app/iris/settings/iris-settings-update/iris-sub-settings-update/iris-sub-settings-update.component.ts
+++ b/src/main/webapp/app/iris/settings/iris-settings-update/iris-sub-settings-update/iris-sub-settings-update.component.ts
@@ -20,6 +20,9 @@ export class IrisSubSettingsUpdateComponent {
     @Input()
     templateOptional = false;
 
+    @Input()
+    rateLimitSettable = false;
+
     previousTemplate?: IrisTemplate;
 
     onInheritTemplateChanged() {

--- a/src/main/webapp/app/iris/state-store.model.ts
+++ b/src/main/webapp/app/iris/state-store.model.ts
@@ -9,6 +9,7 @@ export enum ActionType {
     STUDENT_MESSAGE_SENT = 'student-message-sent',
     SESSION_CHANGED = 'session-changed',
     RATE_MESSAGE_SUCCESS = 'rate-message-success',
+    RATE_LIMIT_UPDATED = 'rate-limit-updated',
 }
 
 export interface MessageStoreAction {
@@ -89,6 +90,17 @@ export class RateMessageSuccessAction implements MessageStoreAction {
     }
 }
 
+export class RateLimitUpdatedAction implements MessageStoreAction {
+    readonly type: ActionType;
+
+    public constructor(
+        public readonly currentRateLimit: number,
+        public readonly maxRateLimit: number,
+    ) {
+        this.type = ActionType.RATE_LIMIT_UPDATED;
+    }
+}
+
 export function isNumNewMessagesResetAction(action: MessageStoreAction): action is NumNewMessagesResetAction {
     return action.type === ActionType.NUM_NEW_MESSAGES_RESET;
 }
@@ -117,6 +129,10 @@ export function isRateMessageSuccessAction(action: MessageStoreAction): action i
     return action.type === ActionType.RATE_MESSAGE_SUCCESS;
 }
 
+export function isRateLimitUpdatedAction(action: MessageStoreAction): action is RateLimitUpdatedAction {
+    return action.type === ActionType.RATE_LIMIT_UPDATED;
+}
+
 export class MessageStoreState {
     public constructor(
         public messages: ReadonlyArray<IrisMessage>,
@@ -125,5 +141,7 @@ export class MessageStoreState {
         public numNewMessages: number,
         public error: IrisErrorType | null,
         public serverResponseTimeout: ReturnType<typeof setTimeout> | null,
+        public currentRateLimit: number,
+        public maxRateLimit: number,
     ) {}
 }

--- a/src/main/webapp/i18n/de/exerciseChatbot.json
+++ b/src/main/webapp/i18n/de/exerciseChatbot.json
@@ -51,9 +51,11 @@
                 "noResponse": "Es wurde keine Antwort von Iris empfangen. Bitte kontaktiere einen Administrator, wenn das Problem weiterhin besteht.",
                 "parseResponse": "Ein Fehler ist beim Parsen der Antwort von Iris aufgetreten. Ursache: {{ cause }}",
                 "technicalError": "Es ist ein technischer Fehler aufgetreten. Bitte wende dich an Artemis Administratoren sollte der Fehler weiterhin zu sehen sein.",
-                "irisNotAvailable": "Iris antwortet nicht. Bitte versuche es später!"
+                "irisNotAvailable": "Iris antwortet nicht. Bitte versuche es später!",
+                "rateLimitExceeded": "Du hast die maximale Anzahl von Nachrichten, die du in einem 3-Stunden-Zeitfenster an Iris senden kannst, überschritten. Bitte versuche es später erneut!"
             },
-            "firstMessage": "Hallo, ich bin Iris! Ich kann dir bei deiner Programmieraufgabe helfen. Du kannst <a href='/about-iris' target='_blank'>hier</a> mehr über mich erfahren."
+            "firstMessage": "Hallo, ich bin Iris! Ich kann dir bei deiner Programmieraufgabe helfen. Du kannst <a href='/about-iris' target='_blank'>hier</a> mehr über mich erfahren.",
+            "rateLimitTooltip": "Dies ist die maximale Anzahl von Nachrichten, die du in einem 3-Stunden-Zeitfenster an Iris senden kannst."
         }
     }
 }

--- a/src/main/webapp/i18n/de/iris.json
+++ b/src/main/webapp/i18n/de/iris.json
@@ -27,6 +27,8 @@
                     "enabled-disabled": "Aktiviert/Deaktiviert",
                     "preferredModel": "Präferiertes Modell",
                     "inheritModel": "Vererbe Modell",
+                    "rateLimit": "Rate Limit",
+                    "rateLimitTooltip": "Die maximale Anzahl an Antworten, die ein Benutzer vom LLM in einem bestimmten Zeitraum erhalten kann. Der Zeitraum beträgt derzeit 3h.",
                     "template": {
                         "title": "Template",
                         "inherit": "Inherit Template"

--- a/src/main/webapp/i18n/en/exerciseChatbot.json
+++ b/src/main/webapp/i18n/en/exerciseChatbot.json
@@ -51,9 +51,11 @@
                 "noResponse": "No response from Iris was received.",
                 "parseResponse": "An error occurred while parsing the response from Iris. Cause: {{ cause }}",
                 "technicalError": "There has been a technical error. Please contact Artemis Administrators if this error message persists.",
-                "irisNotAvailable": "Iris is not available. Please try again later!"
+                "irisNotAvailable": "Iris is not available. Please try again later!",
+                "rateLimitExceeded": "You have exceeded the maximum number of messages you can send to Iris in a 3 hour window. Please try again later!"
             },
-            "firstMessage": "Hi, I'm Iris! I can help you with your programming exercise. You can learn more about me <a href='/about-iris' target='_blank'>here</a>."
+            "firstMessage": "Hi, I'm Iris! I can help you with your programming exercise. You can learn more about me <a href='/about-iris' target='_blank'>here</a>.",
+            "rateLimitTooltip": "This is the maximum number of messages you can send to Iris in a 3 hour window."
         }
     }
 }

--- a/src/main/webapp/i18n/en/iris.json
+++ b/src/main/webapp/i18n/en/iris.json
@@ -26,7 +26,9 @@
                     "inheritHestiaSettings": "Inherit Hestia Settings",
                     "enabled-disabled": "Enabled/Disabled",
                     "preferredModel": "Preferred Model",
-                    "inheritModel": "Inherit Modell",
+                    "inheritModel": "Inherit Model",
+                    "rateLimit": "Rate Limit",
+                    "rateLimitTooltip": "The maximum number of answers a user can receive from the LLM in a given time period. The time period is currently 3h.",
                     "template": {
                         "title": "Template",
                         "inherit": "Inherit Template"

--- a/src/test/java/de/tum/in/www1/artemis/iris/IrisSessionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/iris/IrisSessionIntegrationTest.java
@@ -13,6 +13,7 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.iris.session.IrisChatSession;
 import de.tum.in.www1.artemis.domain.iris.session.IrisSession;
 import de.tum.in.www1.artemis.repository.iris.IrisChatSessionRepository;
+import de.tum.in.www1.artemis.web.rest.iris.IrisSessionResource.IrisHealthDTO;
 
 class IrisSessionIntegrationTest extends AbstractIrisIntegrationTest {
 
@@ -70,17 +71,18 @@ class IrisSessionIntegrationTest extends AbstractIrisIntegrationTest {
     void isActive() throws Exception {
         var irisSession = request.postWithResponseBody("/api/iris/programming-exercises/" + exercise.getId() + "/sessions", null, IrisSession.class, HttpStatus.CREATED);
         var settings = irisSettingsService.getGlobalSettings();
+        irisRequestMockProvider.mockStatusResponse();
+        irisRequestMockProvider.mockStatusResponse();
+        irisRequestMockProvider.mockStatusResponse();
+
         settings.getIrisChatSettings().setPreferredModel("TEST_MODEL_UP");
         irisSettingsService.saveGlobalIrisSettings(settings);
-        irisRequestMockProvider.mockStatusResponse();
-        irisRequestMockProvider.mockStatusResponse();
-        irisRequestMockProvider.mockStatusResponse();
-        assertThat(request.get("/api/iris/sessions/" + irisSession.getId() + "/active", HttpStatus.OK, Boolean.class)).isTrue();
+        assertThat(request.get("/api/iris/sessions/" + irisSession.getId() + "/active", HttpStatus.OK, IrisHealthDTO.class).active()).isTrue();
         settings.getIrisChatSettings().setPreferredModel("TEST_MODEL_DOWN");
         irisSettingsService.saveGlobalIrisSettings(settings);
-        assertThat(request.get("/api/iris/sessions/" + irisSession.getId() + "/active", HttpStatus.OK, Boolean.class)).isFalse();
+        assertThat(request.get("/api/iris/sessions/" + irisSession.getId() + "/active", HttpStatus.OK, IrisHealthDTO.class).active()).isFalse();
         settings.getIrisChatSettings().setPreferredModel("TEST_MODEL_NA");
         irisSettingsService.saveGlobalIrisSettings(settings);
-        assertThat(request.get("/api/iris/sessions/" + irisSession.getId() + "/active", HttpStatus.OK, Boolean.class)).isFalse();
+        assertThat(request.get("/api/iris/sessions/" + irisSession.getId() + "/active", HttpStatus.OK, IrisHealthDTO.class).active()).isFalse();
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/iris/IrisWebsocketTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/iris/IrisWebsocketTest.java
@@ -57,7 +57,7 @@ class IrisWebsocketTest extends AbstractIrisIntegrationTest {
         message.setMessageDifferentiator(101010);
         irisWebsocketService.sendMessage(message);
         verify(websocketMessagingService, times(1)).sendMessageToUser(eq(TEST_PREFIX + "student1"), eq("/topic/iris/sessions/" + irisSession.getId()),
-                eq(new IrisWebsocketService.IrisWebsocketDTO(message)));
+                eq(new IrisWebsocketService.IrisWebsocketDTO(message, null)));
     }
 
     private IrisMessageContent createMockContent(IrisMessage message) {

--- a/src/test/javascript/spec/component/iris/state-store.service.spec.ts
+++ b/src/test/javascript/spec/component/iris/state-store.service.spec.ts
@@ -6,6 +6,7 @@ import {
     HistoryMessageLoadedAction,
     MessageStoreState,
     NumNewMessagesResetAction,
+    RateLimitUpdatedAction,
     RateMessageSuccessAction,
     SessionReceivedAction,
     StudentMessageSentAction,
@@ -363,6 +364,40 @@ describe('IrisStateStore', () => {
         const state2 = (await promise2) as MessageStoreState;
 
         expect(state2.messages).toHaveLength(2);
+    });
+
+    it('should update below rate limit state', async () => {
+        const obs = stateStore.getState();
+
+        const promise = obs.pipe(skip(1), take(1)).toPromise();
+
+        stateStore.dispatch(new RateLimitUpdatedAction(1, 2));
+
+        const state = (await promise) as MessageStoreState;
+
+        expect(state).toStrictEqual({
+            ...mockState,
+            error: null,
+            currentRateLimit: 1,
+            maxRateLimit: 2,
+        });
+    });
+
+    it('should update above rate limit state', async () => {
+        const obs = stateStore.getState();
+
+        const promise = obs.pipe(skip(1), take(1)).toPromise();
+
+        stateStore.dispatch(new RateLimitUpdatedAction(2, 2));
+
+        const state = (await promise) as MessageStoreState;
+
+        expect(state).toStrictEqual({
+            ...mockState,
+            error: errorMessages[IrisErrorMessageKey.RATE_LIMIT_EXCEEDED],
+            currentRateLimit: 2,
+            maxRateLimit: 2,
+        });
     });
 });
 

--- a/src/test/javascript/spec/helpers/sample/iris-sample-data.ts
+++ b/src/test/javascript/spec/helpers/sample/iris-sample-data.ts
@@ -74,4 +74,6 @@ export const mockState = {
     numNewMessages: 0,
     sessionId: 0,
     serverResponseTimeout: null,
+    currentRateLimit: -1,
+    maxRateLimit: -1,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [ ] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [ ] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.
#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [ ] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://ls1intum.github.io/Artemis/user/exam_mode/) as reference.
4. ...

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
