### PR TITLE
Update setup documentation and fix bugs

### DIFF
--- a/docker/gitlab-gitlabci.yml
+++ b/docker/gitlab-gitlabci.yml
@@ -4,34 +4,13 @@
 
 services:
     gitlab:
-        # TODO: check if more settings can also be integrated into gitlab.yml
         extends:
             file: ./gitlab.yml
             service: gitlab
-        volumes:
-            - artemis-gitlab-data:/var/opt/gitlab
-            - artemis-gitlab-logs:/var/log/gitlab
-            - artemis-gitlab-config:/etc/gitlab
         environment:
             GITLAB_OMNIBUS_CONFIG: |
-                external_url "${GIT_SERVER_NAME}"
-                prometheus_monitoring['enable'] = false
-                gitlab_rails['gitlab_shell_ssh_port'] = 2222
-                gitlab_rails['monitoring_whitelist'] = ['0.0.0.0/0']
-                letsencrypt['enable'] = ${SSL_ENABLED}
-                letsencrypt['auto_renew_hour'] = "12"
-                letsencrypt['auto_renew_minute'] = "30"
-                letsencrypt['auto_renew_day_of_month'] = "*/7"
-        ports:
-            - "2222:22"
-            - "80:80"
-            - "443:443"
-        # expose the ports to make them reachable docker internally even if the external port mapping changes
-        expose:
-            - "22"
-            - "80"
-            - "443"
-        shm_size: "256m"
+                external_url "http://host.docker.internal:8081"
+                nginx['listen_port'] = 80
     gitlab-runner:
         image: docker.io/gitlab/gitlab-runner:latest
         pull_policy: always

--- a/docs/dev/setup/gitlabci-gitlab.rst
+++ b/docs/dev/setup/gitlabci-gitlab.rst
@@ -28,62 +28,60 @@ For a production setup of GitLab, also see the documentation of the GitLab and J
 GitLab
 """"""
 
-1. Depending on your operating system, it is necessary to update the host file of your machine to include the following line:
+1. Depending on your operating system and your docker installation, it is necessary to update the host file of your machine to include the following line:
 
     .. code:: text
 
         127.0.0.1       host.docker.internal
         ::1             host.docker.internal
 
-2. Configure GitLab
+2. Start GitLab and the GitLab Runner
     .. code:: bash
 
-        cp docker/env.example.gitlab-gitlabci.txt docker/.env
+        docker-compose -f docker/gitlab-gitlabci.yml up -d
 
-3. Start GitLab and the GitLab Runner
+3. Get your GitLab root password
     .. code:: bash
 
-        docker-compose -f docker/gitlab-gitlabci.yml --env-file docker/.env up --build -d
+        docker exec artemis-gitlab grep 'Password:' /etc/gitlab/initial_root_password
 
-4. Get your GitLab root password
-    .. code:: bash
+4. Generate an access token
+    Go to ``http://localhost:8081/-/profile/personal_access_tokens`` and generate an access token with all scopes.
+    This token is used for generating a runner token and in the Artemis configuration as ``artemis.version-control.token``.
 
-        docker exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
-
-5. Generate an access token
-    Go to ``http://host.docker.internal/-/profile/personal_access_tokens`` and generate an access token with all scopes.
-    This token is used in the Artemis configuration as ``artemis.version-control.token``.
-
-6. Allow outbound requests to local network
+5. Allow outbound requests to local network
     For setting up the webhook between Artemis and GitLab, it is necessary to allow requests to the local network.
-    Go to ``http://host.docker.internal/admin/application_settings/network`` and allow the outbound requests.
+    Go to ``http://localhost:8081/admin/application_settings/network`` and allow the outbound requests.
     More information about this aspect can be found in the `GitLab setup instructions <#gitlab-access-token>`__ (step 12).
 
 GitLab Runner
 """""""""""""
 
-1. Register a new runner
-    Login to your GitLab instance and open ``http://host.docker.internal/admin/runners``.
-    Click on ``Register an instance runner`` and copy the registration token.
+1. Create a runner token
+    In order to create a token which can be used to register a runner, execute the command below with the personal access token generated before.
 
+    .. code:: bash
+
+        curl --request POST --header "PRIVATE-TOKEN: <gitlab-personal-access-token>" \
+        --data "runner_type=instance_type" \
+        --data "run_untagged=true" \
+        --data "access_level=not_protected" \
+         "http://host.docker.internal:8081/api/v4/user/runners"
+
+1. Register a new runner
     Then execute this command with the registration token:
 
     .. code:: bash
 
-        docker exec -it gitlab-runner gitlab-runner register \
+        docker exec -it artemis-gitlab-runner gitlab-runner register \
         --non-interactive \
         --executor "docker" \
         --docker-image alpine:latest \
-        --url http://host.docker.internal:80 \
-        --registration-token "PROJECT_REGISTRATION_TOKEN" \
-        --description "docker-runner" \
-        --maintenance-note "Test Runner" \
-        --tag-list "docker,artemis" \
-        --run-untagged="true" \
-        --locked="false" \
-        --access-level="not_protected"
+        --url http://host.docker.internal:8081 \
+        --token "REGISTRATION_TOKEN" \
+        --description "docker-runner"
 
-    You should now find the runner in the list of runners (``http://host.docker.internal/admin/runners``)
+    You should now find the runner in the list of runners (``http://localhost:8081/admin/runners``)
 
 .. note::
     Adding a runner in a production setup works the same way.
@@ -116,7 +114,7 @@ Artemis
                 login:
                     account-name: TUM
             version-control:
-                url: http://host.docker.internal:80
+                url: http://localhost:8081
                 user: root
                 password: password # change this value
                 token: gitlab-personal-access-token # change this value

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIProgrammingLanguageFeatureService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIProgrammingLanguageFeatureService.java
@@ -16,7 +16,7 @@ import de.tum.in.www1.artemis.service.programming.ProgrammingLanguageFeatureServ
 public class GitLabCIProgrammingLanguageFeatureService extends ProgrammingLanguageFeatureService {
 
     public GitLabCIProgrammingLanguageFeatureService() {
-        programmingLanguageFeatures.put(EMPTY, new ProgrammingLanguageFeature(EMPTY, false, false, false, false, false, List.of(), false, true, false));
-        programmingLanguageFeatures.put(JAVA, new ProgrammingLanguageFeature(JAVA, false, false, false, true, false, List.of(PLAIN_MAVEN, MAVEN_MAVEN), true, true, false));
+        programmingLanguageFeatures.put(EMPTY, new ProgrammingLanguageFeature(EMPTY, false, false, false, false, false, List.of(), false, false, false));
+        programmingLanguageFeatures.put(JAVA, new ProgrammingLanguageFeature(JAVA, false, false, false, true, false, List.of(PLAIN_MAVEN, MAVEN_MAVEN), false, false, false));
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlabci/GitLabCIService.java
@@ -40,6 +40,8 @@ import de.tum.in.www1.artemis.service.hestia.TestwiseCoverageService;
 @Service
 public class GitLabCIService extends AbstractContinuousIntegrationService {
 
+    private static final String GITLAB_CI_FILE_EXTENSION = ".yml";
+
     private static final Logger log = LoggerFactory.getLogger(GitLabCIService.class);
 
     private static final String VARIABLE_BUILD_DOCKER_IMAGE_NAME = "ARTEMIS_BUILD_DOCKER_IMAGE";
@@ -126,7 +128,7 @@ public class GitLabCIService extends AbstractContinuousIntegrationService {
             project.setSharedRunnersEnabled(true);
             project.setAutoDevopsEnabled(false);
 
-            final String buildPlanUrl = buildPlanService.generateBuildPlanURL(exercise);
+            final String buildPlanUrl = buildPlanService.generateBuildPlanURL(exercise) + "&file-extension=" + GITLAB_CI_FILE_EXTENSION;
             project.setCiConfigPath(buildPlanUrl);
 
             projectApi.updateProject(project);


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).

### Motivation and Context
Experimental support for GitLab CI was introduced with #6044 quite a time ago.

Since then, different changes in Artemis and in GitLab itself made the implementation and documentation outdated. As we are further developing the integration of GitLab CI into Artemis, this PR cleans up the code and provides a working setup.

### Description
- As #5915 restructured the docker compose setup, there were some relicts of configuration not needed. These are now removed to use the general GitLab docker compose setup with only minimal changes.
- We clarified the documentation and updated the steps to create a GitLab runner according to the newly introduced method for the [new token architecture](https://docs.gitlab.com/ee/architecture/blueprints/runner_tokens/index.html).
- Lastly, we implemented a small bug fix related to the URL used for accessing the build plan in Artemis. (This is needed, as GitLab only accepts URLs ending with `.yml` or `.yaml`)

### Steps for Testing
`Note`: You cannot test this PR on one of the test servers. You have to use the local setup as there is no test server configured with GitLab CI.

`Local Setup Instructions`: https://artemis-platform--6044.org.readthedocs.build/en/6044/dev/setup/#gitlab-ci-and-gitlab-setup

Please test the "normal" programming exercise workflow. Additional features (static code analysis etc.) and exams are not implemented yet (see #6044).

1. Create a new programming exercise
2. Check if the template, solution and test repository are created in GitLab
3. Start the programming exercise
4. Open the repository in GitLab
5. Access the build plan with the URL you find in  `Settings` > `CI/CD` > `General Pipelines` > `CI/CD configuration file`
6. Commit changes to the code
7. Check if the pipeline is running in GitLab
8. View the feedback in Artemis

### Review Progress

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

