### PR TITLE
`Text exercises`: Fix missing feedback view on submission list

### DIFF
--- a/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
@@ -172,6 +172,7 @@ describe('ParticipationSubmissionComponent', () => {
         expect(findAllSubmissionsOfParticipationStub).toHaveBeenCalledOnce();
         expect(comp.participation).toEqual(participation);
         expect(comp.submissions).toEqual(submissions);
+        expect(comp.participation?.submissions).toEqual(submissions);
 
         // check if delete button is available
         const deleteButton = debugElement.query(By.css('#deleteButton'));


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
While testing #7252 with different exercise types, I noticed that for text exercises always `late submission without feedback` is shown on the submissions list of a student. This PR fixes this

### Description
The mehtod `isParticipationInDueTime` expects `participation.submissions` to be set, but they were not in this case. The participation now gets linked with its submissions.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Text Exercise

1. Participate in the text exercise as a student
2. As an instructor, navigate to Participations -> click on the number of submissions
3. Check that the result is clickable and the feedback is shown.

### Review Progress

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Screenshots
old:

![grafik](https://github.com/ls1intum/Artemis/assets/26540346/25a212ee-e068-4dc9-abda-8c7445bc1ce8)

new: 
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/7cb9fe3d-f5d5-4b18-9db8-f7d073e0c99e)

