### PR TITLE
`Exam mode`: Hide test exam specific details from normal exam checklist

### DIFF
--- a/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.html
@@ -206,29 +206,31 @@
                     </td>
                     <td>
                         <span>{{ 'artemisApp.examManagement.checklist.descriptionItem.examDetails' | artemisTranslate }}</span>
-                        <hr />
-                        <span>{{ 'artemisApp.examManagement.checklist.testExam.detailsHintForTestExams' | artemisTranslate }} :</span>
-                        <!-- Additional hints for test exams, as several steps are automated compared to the normal exam and therefore do not need to be performed by the user -->
-                        <ul class="list-unstyled" *ngIf="isTestExam">
-                            <li class="list-group-item border-1">
-                                <span>
-                                    <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
-                                    <span>{{ 'artemisApp.examManagement.checklist.testExam.studentRegistration' | artemisTranslate }}</span>
-                                </span>
-                            </li>
-                            <li class="list-group-item border-1">
-                                <span>
-                                    <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
-                                    <span>{{ 'artemisApp.studentExams.studentExamStatusTestExam' | artemisTranslate }}</span>
-                                </span>
-                            </li>
-                            <li class="list-group-item border-1">
-                                <span>
-                                    <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
-                                    <span>{{ 'artemisApp.examManagement.checklist.testExam.instantResults' | artemisTranslate }}</span>
-                                </span>
-                            </li>
-                        </ul>
+                        <ng-container *ngIf="isTestExam">
+                            <hr />
+                            <span>{{ 'artemisApp.examManagement.checklist.testExam.detailsHintForTestExams' | artemisTranslate }} :</span>
+                            <!-- Additional hints for test exams, as several steps are automated compared to the normal exam and therefore do not need to be performed by the user -->
+                            <ul class="list-unstyled">
+                                <li class="list-group-item border-1">
+                                    <span>
+                                        <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
+                                        <span>{{ 'artemisApp.examManagement.checklist.testExam.studentRegistration' | artemisTranslate }}</span>
+                                    </span>
+                                </li>
+                                <li class="list-group-item border-1">
+                                    <span>
+                                        <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
+                                        <span>{{ 'artemisApp.studentExams.studentExamStatusTestExam' | artemisTranslate }}</span>
+                                    </span>
+                                </li>
+                                <li class="list-group-item border-1">
+                                    <span>
+                                        <jhi-checklist-check [checkAttribute]="true"></jhi-checklist-check>
+                                        <span>{{ 'artemisApp.examManagement.checklist.testExam.instantResults' | artemisTranslate }}</span>
+                                    </span>
+                                </li>
+                            </ul>
+                        </ng-container>
                     </td>
                     <td>
                         <a id="editButton_table" [routerLink]="getExamRoutesByIdentifier('edit')" class="btn btn-warning">
@@ -288,7 +290,6 @@
                                 examChecklist && examChecklist.numberOfGeneratedStudentExams !== null && examChecklist.numberOfGeneratedStudentExams !== 0 && numberOfStarted > 0
                             "
                         >
-                            <!-- -->
                             <span>{{ 'artemisApp.examManagement.checklist.textitems.startedExam' | artemisTranslate }} :</span>
                             <div class="pt-2">
                                 <jhi-progress-bar


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
Details that are `test exam` specific are displayed within the checklist of a normal exam.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Exam 
- 1 Test Exam

1. View the exam checklist for the normal exam and see that `For test exams, the following applies:` is **not** displayed
2. View the exam checklist for the test exam and see that `For test exams, the following applies:` with 3 described checked steps

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Normal Exam
| Before                                                                                                                                        | After                                                                                                                                          |
|-----------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1248" alt="exam cover page after" src="https://github.com/ls1intum/Artemis/assets/63976129/37a39e11-8a08-4d4c-99fb-1de10ee62676"> | <img width="1248" alt="exam cover page before" src="https://github.com/ls1intum/Artemis/assets/63976129/8b4e20c5-d96a-4c85-9d84-b9cb86fb06bb"> |


Test Exam
| Before                                                                                                                                        | After                                                                                                                                          |
|-----------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1248" alt="exam summary before" src="https://github.com/ls1intum/Artemis/assets/63976129/65392b9d-0480-4b9b-b1d2-8d299fe90eae">   | <img width="1248" alt="exam summary before" src="https://github.com/ls1intum/Artemis/assets/63976129/65392b9d-0480-4b9b-b1d2-8d299fe90eae">    |




