### PR TITLE
`Development`: Fix e2e tests for exam information pages

### DIFF
--- a/src/main/webapp/app/exam/participate/general-information/exam-general-information.component.html
+++ b/src/main/webapp/app/exam/participate/general-information/exam-general-information.component.html
@@ -6,9 +6,9 @@
         <table class="table table-borderless mx-auto d-block">
             <tbody>
                 <tr *ngIf="isTestExam">
-                    <th class="text-end text-right">{{ 'artemisApp.examManagement.testExam.examMode' | artemisTranslate }}:</th>
+                    <th>{{ 'artemisApp.examManagement.testExam.examMode' | artemisTranslate }}:</th>
                     <td>
-                        <span class="mx-2 badge bg-primary">{{ 'artemisApp.examManagement.testExam.testExam' | artemisTranslate }}</span>
+                        <span class="badge bg-primary">{{ 'artemisApp.examManagement.testExam.testExam' | artemisTranslate }}</span>
                     </td>
                 </tr>
                 <tr *ngIf="exam?.moduleNumber">

--- a/src/main/webapp/app/exam/participate/general-information/exam-general-information.component.html
+++ b/src/main/webapp/app/exam/participate/general-information/exam-general-information.component.html
@@ -23,6 +23,10 @@
                     <th>{{ 'artemisApp.examManagement.examiner' | artemisTranslate }}:</th>
                     <td>{{ exam.examiner }}</td>
                 </tr>
+                <tr *ngIf="exam?.title" id="exam-title">
+                    <th>{{ 'artemisApp.examManagement.examTitle' | artemisTranslate }}:</th>
+                    <td>{{ exam.title }}</td>
+                </tr>
                 <ng-container *ngIf="exam && !isTestExam && exam.startDate">
                     <tr *ngIf="isExamOverMultipleDays; else examSingleDay">
                         <th>{{ 'artemisApp.exam.time' | artemisTranslate }}:</th>

--- a/src/main/webapp/app/exam/participate/summary/exam-result-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-result-summary.component.html
@@ -1,5 +1,5 @@
 <div>
-    <h2 id="exam-title">
+    <h2>
         <ng-container>
             {{ 'artemisApp.exam.examSummary.examResults' | artemisTranslate }}
         </ng-container>

--- a/src/main/webapp/app/exam/participate/summary/result-overview/exam-result-overview.component.html
+++ b/src/main/webapp/app/exam/participate/summary/result-overview/exam-result-overview.component.html
@@ -74,7 +74,7 @@
                             *ngIf="studentExamWithGrade.studentResult.overallScoreAchieved !== undefined; else totalScoreNotDefinedPlaceholder"
                             [class]="hasPassed ? 'text-success' : 'text-danger'"
                         >
-                            {{ studentExamWithGrade.studentResult.overallScoreAchieved }}%
+                            {{ overallAchievedPercentageRoundedByCourseSettings }}%
                         </span>
                         <ng-template #totalScoreNotDefinedPlaceholder>
                             <span>-</span>

--- a/src/main/webapp/app/exam/participate/summary/result-overview/exam-result-overview.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/result-overview/exam-result-overview.component.ts
@@ -12,7 +12,6 @@ import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { roundScorePercentSpecifiedByCourseSettings } from 'app/shared/util/utils';
 import { getLatestResultOfStudentParticipation } from 'app/exercises/shared/participation/participation.utils';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { Course } from 'app/entities/course.model';
 
 type ExerciseInfo = {
     icon: IconProp;
@@ -52,8 +51,6 @@ export class ExamResultOverviewComponent implements OnInit, OnChanges {
     overallAchievedPercentageRoundedByCourseSettings = 0;
     isBonusGradingKeyDisplayed = false;
 
-    course: Course | undefined = undefined;
-
     exerciseInfos: Record<number, ExerciseInfo>;
 
     /**
@@ -87,12 +84,11 @@ export class ExamResultOverviewComponent implements OnInit, OnChanges {
         this.showIncludedInScoreColumn = this.containsExerciseThatIsNotIncludedCompletely();
         this.maxPoints = this.studentExamWithGrade?.maxPoints ?? 0;
         this.isBonusGradingKeyDisplayed = this.studentExamWithGrade.studentResult.gradeWithBonus?.bonusGrade != undefined;
-        this.course = this.studentExamWithGrade.studentExam?.exam?.course;
 
         this.overallAchievedPoints = this.studentExamWithGrade?.studentResult.overallPointsAchieved ?? 0;
         this.overallAchievedPercentageRoundedByCourseSettings = roundScorePercentSpecifiedByCourseSettings(
             (this.studentExamWithGrade.studentResult.overallScoreAchieved ?? 0) / 100,
-            this.course,
+            this.studentExamWithGrade.studentExam?.exam?.course,
         );
 
         this.exerciseInfos = this.getExerciseInfos();
@@ -178,13 +174,14 @@ export class ExamResultOverviewComponent implements OnInit, OnChanges {
             return undefined;
         }
 
+        const course = this.studentExamWithGrade.studentExam?.exam?.course;
         if (result.achievedScore !== undefined) {
-            return roundScorePercentSpecifiedByCourseSettings(result.achievedScore / 100, this.course);
+            return roundScorePercentSpecifiedByCourseSettings(result.achievedScore / 100, course);
         }
 
         const canCalculatePercentage = result.maxScore && result.achievedPoints !== undefined;
         if (canCalculatePercentage) {
-            return roundScorePercentSpecifiedByCourseSettings(result.achievedPoints! / result.maxScore, this.course);
+            return roundScorePercentSpecifiedByCourseSettings(result.achievedPoints! / result.maxScore, course);
         }
 
         return undefined;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Currently, the Cypress E2E Tests are failing because in https://github.com/ls1intum/Artemis/pull/7204 the actual exam title was removed from the dom element `exam-title`.
This PR shall fix the issue.

### Description
<!-- Describe your changes in detail -->

Adding the exam title to the general information of an exam to fix the tests.
_(Also a very small change fixing misaligned styling of a badge)_

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students
- 1 Exam with 33.3333333% of total achieved points _(e.g. a text exercise with 1/3 points)_

1. Verify that E2E tests are not failing anymore
2. Navigate to the Exam cover page and see that the exam title is displayed in the general information overview
3. Navigate to the student review page and see that the exam title is displayed in the general information overview
4. Verify that the total achieved percentage is rounded according to the course settings

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Rounding points
| Before                                                                                                                                        | After                                                                                                                                          |
|-----------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1248" alt="exam cover page after" src="https://github.com/ls1intum/Artemis/assets/63976129/97dd2369-f9eb-4df8-b19a-9c8ca7651096"> | <img width="1248" alt="exam cover page before" src="https://github.com/ls1intum/Artemis/assets/63976129/6b73e064-63a1-4da5-a2f0-86a5e0bbfdb8"> |


Aligning test exam badge & displaying exam title
| Before                                                                                                            | After                                                                                                             |
|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
| <img width="1248" src="https://github.com/ls1intum/Artemis/assets/63976129/ea3d9869-2a44-4593-ab70-cb5b095a87a8"> | <img width="1248" src="https://github.com/ls1intum/Artemis/assets/63976129/5bc90789-f387-4f17-baa0-090caa3cf512"> |



