### PR TITLE
`Development`: Fix websocket reconnect on logout and login

### DIFF
--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -59,9 +59,13 @@ export class AccountService implements IAccountService {
         // We only subscribe the feature toggle updates when the user is logged in, otherwise we unsubscribe them.
         if (user) {
             this.websocketService.enableReconnect();
+            this.websocketService.connect();
             this.featureToggleService.subscribeFeatureToggleUpdates();
         } else {
             this.websocketService.disableReconnect();
+            if (this.websocketService.isConnected()) {
+                this.websocketService.disconnect();
+            }
             this.featureToggleService.unsubscribeFeatureToggleUpdates();
         }
     }
@@ -141,7 +145,6 @@ export class AccountService implements IAccountService {
                 map((response: HttpResponse<User>) => {
                     const user = response.body!;
                     if (user) {
-                        this.websocketService.connect();
                         this.userIdentity = user;
 
                         // improved error tracking in sentry
@@ -157,10 +160,6 @@ export class AccountService implements IAccountService {
                     return this.userIdentity;
                 }),
                 catchError(() => {
-                    // this will be called during logout
-                    if (this.websocketService.isConnected()) {
-                        this.websocketService.disconnect();
-                    }
                     this.userIdentity = undefined;
                     return of(undefined);
                 }),

--- a/src/test/javascript/spec/helpers/mocks/service/mock-websocket.service.ts
+++ b/src/test/javascript/spec/helpers/mocks/service/mock-websocket.service.ts
@@ -10,6 +10,10 @@ export class MockWebsocketService implements IWebsocketService {
 
     enableReconnect(): void {}
 
+    isConnected(): boolean {
+        return true;
+    }
+
     receive(): Observable<any> {
         return of();
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.

### Motivation and Context
The web socket subscriptions were not properly reset during logout. This PR fixes this
