### PR TITLE
`Development`: e2e tests remove exam title check

### DIFF
--- a/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamParticipation.cy.ts
@@ -101,7 +101,6 @@ describe('Exam participation', () => {
                     examParticipation.verifyTextExerciseOnFinalPage(exercise.additionalData!.textFixture!);
                 }
             }
-            examParticipation.checkExamTitle(examTitle);
 
             cy.login(instructor);
             examManagement.verifySubmitted(course.id!, exam.id!, studentTwoName);
@@ -198,7 +197,6 @@ describe('Exam participation', () => {
             examParticipation.handInEarly();
             examStartEnd.pressShowSummary();
             examParticipation.verifyTextExerciseOnFinalPage(textFixtureShort);
-            examParticipation.checkExamTitle(examTitle);
 
             cy.login(instructor);
             examManagement.verifySubmitted(course.id!, exam.id!, studentTwoName);
@@ -220,7 +218,6 @@ describe('Exam participation', () => {
             examParticipation.handInEarly();
             examStartEnd.pressShowSummary();
             examParticipation.verifyTextExerciseOnFinalPage(textExercise.additionalData!.textFixture!);
-            examParticipation.checkExamTitle(examTitle);
 
             cy.login(instructor);
             examManagement.verifySubmitted(course.id!, exam.id!, studentThreeName);
@@ -236,12 +233,10 @@ describe('Exam participation', () => {
             examParticipation.handInEarly();
             examStartEnd.pressShowSummary();
             examParticipation.verifyTextExerciseOnFinalPage(textExercise.additionalData!.textFixture!);
-            examParticipation.checkExamTitle(examTitle);
 
             cy.reload();
 
             examParticipation.verifyTextExerciseOnFinalPage(textExercise.additionalData!.textFixture!);
-            examParticipation.checkExamTitle(examTitle);
 
             cy.login(instructor);
             examManagement.verifySubmitted(course.id!, exam.id!, studentFourName);
@@ -292,7 +287,6 @@ describe('Exam participation', () => {
             });
             examStartEnd.pressShowSummary();
             examParticipation.verifyTextExerciseOnFinalPage(textExercise.additionalData!.textFixture!);
-            examParticipation.checkExamTitle(examTitle);
 
             cy.login(instructor);
             examManagement.verifySubmitted(course.id!, exam.id!, studentFourName);

--- a/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamTestRun.cy.ts
@@ -131,7 +131,6 @@ describe('Exam test run', () => {
                 examParticipation.verifyTextExerciseOnFinalPage(exercise.additionalData!.textFixture!);
             }
         }
-        examParticipation.checkExamTitle(examTitle);
         examTestRun.openTestRunPage(course, exam);
         examTestRun.getStarted(testRun.id).contains('Yes');
         examTestRun.getSubmitted(testRun.id).contains('Yes');

--- a/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamParticipation.cy.ts
@@ -80,7 +80,6 @@ describe('Test exam participation', () => {
                     examParticipation.verifyTextExerciseOnFinalPage(exercise.additionalData!.textFixture!);
                 }
             }
-            examParticipation.checkExamTitle(examTitle);
         });
 
         it('Using save and continue to navigate within exam', () => {
@@ -165,7 +164,6 @@ describe('Test exam participation', () => {
                 expect(request.response!.statusCode).to.eq(200);
             });
             examParticipation.verifyTextExerciseOnFinalPage(textExercise.additionalData!.textFixture!);
-            examParticipation.checkExamTitle(examTitle);
         });
     });
 

--- a/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamTestRun.cy.ts
@@ -130,7 +130,6 @@ describe('Test exam test run', () => {
                 examParticipation.verifyTextExerciseOnFinalPage(exercise.additionalData!.textFixture!);
             }
         }
-        examParticipation.checkExamTitle(examTitle);
         examTestRun.openTestRunPage(course, exam);
         examTestRun.getStarted(testRun.id).contains('Yes');
         examTestRun.getSubmitted(testRun.id).contains('Yes');

--- a/src/test/cypress/support/pageobjects/exam/ExamParticipation.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamParticipation.ts
@@ -99,10 +99,6 @@ export class ExamParticipation {
         getExercise(exerciseID).find('.exercise-title').contains(title);
     }
 
-    checkExamTitle(title: string) {
-        cy.get('#exam-title').contains(title);
-    }
-
     getResultScore() {
         cy.reloadUntilFound('#result-score');
         return cy.get('#result-score');


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


### Description
<!-- Describe your changes in detail -->
In the PR https://github.com/ls1intum/Artemis/pull/7204 the exam title was removed from the exam overview page. This PR removes the e2e checks, which checked the exam title on that page and now causes e2e tests to fail. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
