### PR TITLE
`File upload exercises`: Fix an issue with old file submissions not being deleted

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
@@ -1,14 +1,12 @@
 package de.tum.in.www1.artemis.domain;
 
+import java.net.URI;
 import java.nio.file.Path;
 
 import javax.persistence.*;
 
-import org.apache.commons.lang3.math.NumberUtils;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.in.www1.artemis.exception.FilePathParsingException;
 import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
 
@@ -37,25 +35,9 @@ public class FileUploadSubmission extends Submission {
     @PostRemove
     public void onDelete() {
         if (filePath != null) {
-            Path actualPath = getActualPathForPublicPath(filePath);
+            Path actualPath = FilePathService.actualPathForPublicPath(URI.create(filePath));
             fileService.schedulePathForDeletion(actualPath, 0);
         }
-    }
-
-    private Path getActualPathForPublicPath(String filePath) {
-        // Note: This method duplicates functionality from actualPathForPublicPath on FilePathService
-        // but to avoid this entity depending on the FilePathService service this is separate.
-
-        final var splittedPath = filePath.split("/");
-        final var shouldBeExerciseId = splittedPath.length >= 5 ? splittedPath[4] : null;
-        if (!NumberUtils.isCreatable(shouldBeExerciseId)) {
-            throw new FilePathParsingException("Unexpected String in upload file path. Should contain the exercise ID: " + shouldBeExerciseId);
-        }
-        final var exerciseId = Long.parseLong(shouldBeExerciseId);
-
-        Path submissionDirectory = FileUploadSubmission.buildFilePath(exerciseId, getId());
-        Path fileName = Path.of(filePath).getFileName();
-        return submissionDirectory.resolve(fileName);
     }
 
     public String getFilePath() {

--- a/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
@@ -4,8 +4,11 @@ import java.nio.file.Path;
 
 import javax.persistence.*;
 
+import org.apache.commons.lang3.math.NumberUtils;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.in.www1.artemis.exception.FilePathParsingException;
 import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
 
@@ -34,8 +37,25 @@ public class FileUploadSubmission extends Submission {
     @PostRemove
     public void onDelete() {
         if (filePath != null) {
-            fileService.schedulePathForDeletion(Path.of(filePath), 0);
+            Path actualPath = getActualPathForPublicPath(filePath);
+            fileService.schedulePathForDeletion(actualPath, 0);
         }
+    }
+
+    private Path getActualPathForPublicPath(String filePath) {
+        // Note: This method duplicates functionality from actualPathForPublicPath on FilePathService
+        // but to avoid this entity depending on the FilePathService service this is separate.
+
+        final var splittedPath = filePath.split("/");
+        final var shouldBeExerciseId = splittedPath.length >= 5 ? splittedPath[4] : null;
+        if (!NumberUtils.isCreatable(shouldBeExerciseId)) {
+            throw new FilePathParsingException("Unexpected String in upload file path. Should contain the exercise ID: " + shouldBeExerciseId);
+        }
+        final var exerciseId = Long.parseLong(shouldBeExerciseId);
+
+        Path submissionDirectory = FileUploadSubmission.buildFilePath(exerciseId, getId());
+        Path fileName = Path.of(filePath).getFileName();
+        return submissionDirectory.resolve(fileName);
     }
 
     public String getFilePath() {

--- a/src/main/java/de/tum/in/www1/artemis/service/FilePathService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FilePathService.java
@@ -90,7 +90,7 @@ public class FilePathService {
      * @param publicPath the public file url to convert
      * @return the actual path to that file in the local filesystem
      */
-    public Path actualPathForPublicPath(URI publicPath) {
+    public static Path actualPathForPublicPath(URI publicPath) {
         // first extract the filename from the url
         String uriPath = publicPath.getPath();
         Path path = Path.of(uriPath);
@@ -129,7 +129,7 @@ public class FilePathService {
         return null;
     }
 
-    private Path actualPathForPublicAttachmentUnitFilePath(URI publicPath, String filename) {
+    private static Path actualPathForPublicAttachmentUnitFilePath(URI publicPath, String filename) {
         Path path = Path.of(publicPath.getPath());
         if (!publicPath.toString().contains("/slide")) {
             String attachmentUnitId = path.getName(4).toString();
@@ -148,7 +148,7 @@ public class FilePathService {
         }
     }
 
-    private Path actualPathForPublicFileUploadExercisesFilePath(URI publicPath, String filename) {
+    private static Path actualPathForPublicFileUploadExercisesFilePath(URI publicPath, String filename) {
         Path path = Path.of(publicPath.getPath());
         try {
             String expectedExerciseId = path.getName(3).toString();

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -768,6 +768,10 @@ public class FileService implements DisposableBean {
                     log.info("Delete file {}", path);
                     Files.delete(path);
                 }
+                else {
+                    log.error("Deleting the file {} did not work because it does not exist", path);
+                }
+
                 futures.remove(path);
             }
             catch (IOException e) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This fixes the issue https://github.com/ls1intum/Artemis/issues/7275.

### Description
<!-- Describe your changes in detail -->
The FileUploadSubmission class contains the filePath attribute which is a public path and has to be converted to an actual path on the file system before being used. In this case the onDelete() function did not convert the path and therefore no old submission file from a file upload exercise could ever be deleted. 
I think this is where the breaking change happened: https://github.com/ls1intum/Artemis/commit/aca8f44609161249ada52ede6028091c2096e2c0#diff-afbf7c4cfa2c701ea17f5d3fc9cae4f94e88f182921364471f35e9f3355e0302R37
Since i wanted to avoid using the FilePathService inside of an entity, i reverted back to the implementation before it broke.
I also added an error message to FileService's schedulePathForDeletion when the file to-be-deleted does not exist to catch such errors reliably in the future.

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Programming Exercise with Complaints enabled

1. Upload a file to the file upload exercise.
2. Upload another file to replace the old submission.
3. Acknowledge the old submission file has been deleted and only the new one is left.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
