### PR TITLE
`Tutorial groups`: Change channel prefix for tutorial-groups

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupChannelManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupChannelManagementService.java
@@ -250,7 +250,7 @@ public class TutorialGroupChannelManagementService {
         Function<TutorialGroup, String> determineInitialTutorialGroupChannelName = (TutorialGroup tg) -> {
             var cleanedTitle = tg.getTitle().replaceAll("\\s", "-").toLowerCase();
             // we use $ as prefix to make sure that the channel name is unique (users not allowed to start channel names with $)
-            return "$" + cleanedTitle.substring(0, Math.min(cleanedTitle.length(), 19));
+            return "tutorgroup-" + cleanedTitle.substring(0, Math.min(cleanedTitle.length(), 18));
         };
 
         var channelName = determineInitialTutorialGroupChannelName.apply(tutorialGroup);
@@ -260,14 +260,14 @@ public class TutorialGroupChannelManagementService {
 
         // try to make it unique by adding a random number to the end of the channel name
         // if already max length remove the last 3 characters to get some space to try to make it unique
-        if (channelName.length() == 20) {
-            channelName = channelName.substring(0, 17);
+        if (channelName.length() == 30) {
+            channelName = channelName.substring(0, 27);
         }
-        while (!channelRepository.findChannelByCourseIdAndName(tutorialGroup.getCourse().getId(), channelName).isEmpty() && channelName.length() <= 20) {
+        while (!channelRepository.findChannelByCourseIdAndName(tutorialGroup.getCourse().getId(), channelName).isEmpty() && channelName.length() <= 30) {
             channelName += ThreadLocalRandom.current().nextInt(0, 10);
         }
 
-        if (channelName.length() > 20) {
+        if (channelName.length() > 30) {
             // very unlikely to happen
             throw new IllegalStateException("Could not create a unique channel name for tutorial group with id " + tutorialGroup.getId());
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupChannelManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupChannelManagementService.java
@@ -249,7 +249,6 @@ public class TutorialGroupChannelManagementService {
     private String determineUniqueTutorialGroupChannelName(TutorialGroup tutorialGroup) {
         Function<TutorialGroup, String> determineInitialTutorialGroupChannelName = (TutorialGroup tg) -> {
             var cleanedTitle = tg.getTitle().replaceAll("\\s", "-").toLowerCase();
-            // we use $ as prefix to make sure that the channel name is unique (users not allowed to start channel names with $)
             return "tutorgroup-" + cleanedTitle.substring(0, Math.min(cleanedTitle.length(), 18));
         };
 

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/AbstractTutorialGroupIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/AbstractTutorialGroupIntegrationTest.java
@@ -292,7 +292,7 @@ abstract class AbstractTutorialGroupIntegrationTest extends AbstractSpringIntegr
 
         Function<TutorialGroup, String> expectedTutorialGroupName = (TutorialGroup tg) -> {
             var cleanedTitle = tg.getTitle().replaceAll("\\s", "-").toLowerCase();
-            return "$" + cleanedTitle.substring(0, Math.min(cleanedTitle.length(), 19));
+            return "tutorgroup-" + cleanedTitle.substring(0, Math.min(cleanedTitle.length(), 18));
         };
         var tutorialGroupFromDb = tutorialGroupRepository.findByIdWithTeachingAssistantAndRegistrationsElseThrow(tutorialGroup.getId());
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).
- [x] I modified multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Automatically generated channels for lecture, exercises and exam have a certain prefix (`lecture-`, `exercise-`, `exam-`). This PR introduces such a prefix for tutorial-group channels.

### Description
<!-- Describe your changes in detail -->
The automatically generated channel name for tutorial groups is prefixed with `tutorgroup-`, instead of `$`. Additionally, the maximum allowed length for the name got increased to 30, which is the same length as for other channels.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course

1. Create or edit the global tutorial group configuration of the course: Make sure that "Use Artemis managed Tutorial Group Channels" is enabled
2. Create a tutorial group
3. A channel should be created in the form of `tutorgroup-title-of-tutorgroup`

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
