### PR TITLE
`Development`: Add drag-and-drop exercise generation tests

### DIFF
--- a/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-detail.component.spec.ts
@@ -124,6 +124,25 @@ describe('ApollonDiagramDetail Component', () => {
         fixture.componentInstance.ngOnDestroy();
     });
 
+    it('validateGeneration', async () => {
+        const nonInteractiveModel = { ...model, interactive: { ...model.interactive, elements: [] } };
+
+        // setup
+        const div = document.createElement('div');
+        fixture.componentInstance.editorContainer = new ElementRef(div);
+        fixture.componentInstance.apollonDiagram = diagram;
+        fixture.componentInstance.initializeApollonEditor(nonInteractiveModel);
+        const errorSpy = jest.spyOn(alertService, 'error');
+
+        // test
+        await addDelay(500);
+        await fixture.componentInstance.generateExercise();
+        expect(errorSpy).toHaveBeenCalledOnce();
+
+        // clear the set time interval
+        fixture.componentInstance.ngOnDestroy();
+    });
+
     it('downloadSelection', async () => {
         const div = document.createElement('div');
         fixture.componentInstance.editorContainer = new ElementRef(div);

--- a/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-detail.component.spec.ts
@@ -19,7 +19,6 @@ import * as testClassDiagram from '../../util/modeling/test-models/class-diagram
 import { UMLModel } from '@ls1intum/apollon';
 import { ElementRef } from '@angular/core';
 import { Text } from '@ls1intum/apollon/lib/es5/utils/svg/text';
-import { addDelay } from '../../helpers/utils/general.utils';
 
 // has to be overridden, because jsdom does not provide a getBBox() function for SVGTextElements
 Text.size = () => {
@@ -93,7 +92,7 @@ describe('ApollonDiagramDetail Component', () => {
         expect(fixture.componentInstance.apollonEditor).toBeTruthy();
 
         // test
-        await addDelay(500);
+        await fixture.componentInstance.apollonEditor.nextRender;
         await fixture.componentInstance.saveDiagram();
         expect(updateStub).toHaveBeenCalledOnce();
         // clear the set time interval
@@ -116,7 +115,7 @@ describe('ApollonDiagramDetail Component', () => {
         const successSpy = jest.spyOn(alertService, 'success');
 
         // test
-        await addDelay(500);
+        await fixture.componentInstance.apollonEditor?.nextRender;
         await fixture.componentInstance.generateExercise();
         expect(successSpy).toHaveBeenCalledOnce();
 
@@ -135,7 +134,7 @@ describe('ApollonDiagramDetail Component', () => {
         const errorSpy = jest.spyOn(alertService, 'error');
 
         // test
-        await addDelay(500);
+        await fixture.componentInstance.apollonEditor?.nextRender;
         await fixture.componentInstance.generateExercise();
         expect(errorSpy).toHaveBeenCalledOnce();
 
@@ -151,9 +150,10 @@ describe('ApollonDiagramDetail Component', () => {
         fixture.componentInstance.apollonDiagram = diagram;
         fixture.componentInstance.initializeApollonEditor(model);
         // ApollonEditor is the child
-        await addDelay(300).then(() => {
-            expect(div.children).toHaveLength(1);
-        });
+
+        await fixture.componentInstance.apollonEditor?.nextRender;
+        expect(div.children).toHaveLength(1);
+
         // set selection
         fixture.componentInstance.apollonEditor!.selection = { elements: model.elements.map((element) => element.id), relationships: [] };
         fixture.detectChanges();

--- a/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-detail.component.spec.ts
@@ -92,7 +92,7 @@ describe('ApollonDiagramDetail Component', () => {
         expect(fixture.componentInstance.apollonEditor).toBeTruthy();
 
         // test
-        await fixture.componentInstance.apollonEditor.nextRender;
+        await fixture.componentInstance.apollonEditor?.nextRender;
         await fixture.componentInstance.saveDiagram();
         expect(updateStub).toHaveBeenCalledOnce();
         // clear the set time interval

--- a/src/test/javascript/spec/component/apollon-diagrams/exercise-generation/apollon-quiz-exercise-generation.component.spec.ts
+++ b/src/test/javascript/spec/component/apollon-diagrams/exercise-generation/apollon-quiz-exercise-generation.component.spec.ts
@@ -12,7 +12,6 @@ import * as testClassDiagram from '../../../util/modeling/test-models/class-diag
 import { Text } from '@ls1intum/apollon/lib/es5/utils/svg/text';
 import { MockTranslateService } from '../../../helpers/mocks/service/mock-translate.service';
 import { MockRouter } from '../../../helpers/mocks/mock-router';
-import { addDelay } from '../../../helpers/utils/general.utils';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ApollonQuizExerciseGenerationComponent } from 'app/exercises/quiz/manage/apollon-diagrams/exercise-generation/apollon-quiz-exercise-generation.component';
 import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
@@ -103,7 +102,7 @@ describe('ApollonQuizExerciseGeneration Component', () => {
         jest.spyOn(module, 'generateDragAndDropQuizExercise').mockReturnValue(quizExercise);
         const ngbModalSpy = jest.spyOn(ngbModal, 'close');
 
-        await addDelay(500);
+        await fixture.componentInstance.apollonEditor?.nextRender;
         // test
         await fixture.componentInstance.save();
         expect(ngbModalSpy).toHaveBeenCalledOnce();

--- a/src/test/javascript/spec/component/apollon-diagrams/exercise-generation/quiz-exercise-generator.spec.ts
+++ b/src/test/javascript/spec/component/apollon-diagrams/exercise-generation/quiz-exercise-generator.spec.ts
@@ -19,7 +19,6 @@ import { MockRouter } from '../../../helpers/mocks/mock-router';
 import { MockLocalStorageService } from '../../../helpers/mocks/service/mock-local-storage.service';
 import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
 import * as testClassDiagram from '../../../util/modeling/test-models/class-diagram.json';
-import { addDelay } from '../../../helpers/utils/general.utils';
 
 // has to be overridden, because jsdom does not provide a getBBox() function for SVGTextElements
 Text.size = () => {
@@ -72,7 +71,6 @@ describe('QuizExercise Generator', () => {
         const classDiagram: UMLModel = testClassDiagram as UMLModel;
         const interactiveElements: Selection = classDiagram.interactive;
         const exerciseTitle = 'GenerateDragAndDropExerciseTest';
-        await addDelay(300);
         const generatedExercise = await generateDragAndDropQuizExercise(course, exerciseTitle, classDiagram, fileUploaderService, quizExerciseService);
         expect(generatedExercise).toBeTruthy();
         expect(generatedExercise.title).toEqual(exerciseTitle);

--- a/src/test/javascript/spec/component/modeling-editor/modeling-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-editor/modeling-editor.component.spec.ts
@@ -12,7 +12,6 @@ import { ModelingEditorComponent } from 'app/exercises/modeling/shared/modeling-
 import * as testClassDiagram from '../../util/modeling/test-models/class-diagram.json';
 import { GuidedTourService } from 'app/guided-tour/guided-tour.service';
 import { ArtemisTestModule } from '../../test.module';
-import { addDelay } from '../../helpers/utils/general.utils';
 import { cloneDeep } from 'lodash-es';
 import { SimpleChange } from '@angular/core';
 import { MockComponent, MockProvider } from 'ng-mocks';
@@ -63,10 +62,10 @@ describe('ModelingEditorComponent', () => {
         const editor: ApollonEditor = component['apollonEditor'] as ApollonEditor;
         // Check that editor exists
         expect(editor).toBeDefined();
-        await addDelay(500).then(() => {
-            // check that editor contains elements of our model (direct equality check won't work somehow due to missing properties)
-            expect(editor.model.elements.map((e) => e.id)).toEqual(classDiagram.elements.map((e) => e.id));
-        });
+        await editor.nextRender;
+
+        // check that editor contains elements of our model (direct equality check won't work somehow due to missing properties)
+        expect(editor.model.elements.map((e) => e.id)).toEqual(classDiagram.elements.map((e) => e.id));
     });
 
     it('ngOnDestroy', () => {
@@ -94,14 +93,14 @@ describe('ModelingEditorComponent', () => {
         // note: using cloneDeep a default value exists, which would prevent the comparison below to pass, therefore we need to remove it here
         changedModel.default = undefined;
         // test
-        await addDelay(100);
+        await component.apollonEditor?.nextRender;
         component.ngOnChanges({
             umlModel: {
                 currentValue: changedModel,
                 previousValue: model,
             } as SimpleChange,
         });
-        await addDelay(100);
+        await component.apollonEditor?.nextRender;
         const componentModel = component['apollonEditor']!.model as UMLModel;
         expect(componentModel).toEqual(changedModel);
     });
@@ -253,25 +252,24 @@ describe('ModelingEditorComponent', () => {
         let updateSpyCallCount = 0;
         let currentUmlName = personUML.name;
 
-        await addDelay(500).then(() => {
-            subject.next(currentUmlName);
-            expect(updateSpy).toHaveBeenLastCalledWith(currentUmlName, false);
-            updateSpyCallCount++;
-            expect(updateSpy).toHaveBeenCalledTimes(updateSpyCallCount);
+        await fixture.componentInstance.apollonEditor?.nextRender;
+        subject.next(currentUmlName);
+        expect(updateSpy).toHaveBeenLastCalledWith(currentUmlName, false);
+        updateSpyCallCount++;
+        expect(updateSpy).toHaveBeenCalledTimes(updateSpyCallCount);
 
-            currentUmlName = studentUML.name;
-            subject.next(currentUmlName);
-            expect(updateSpy).toHaveBeenLastCalledWith(currentUmlName, false);
+        currentUmlName = studentUML.name;
+        subject.next(currentUmlName);
+        expect(updateSpy).toHaveBeenLastCalledWith(currentUmlName, false);
 
-            updateSpyCallCount++;
-            expect(updateSpy).toHaveBeenCalledTimes(updateSpyCallCount);
+        updateSpyCallCount++;
+        expect(updateSpy).toHaveBeenCalledTimes(updateSpyCallCount);
 
-            currentUmlName = associationUML.name;
-            subject.next(currentUmlName);
-            expect(updateSpy).toHaveBeenLastCalledWith(currentUmlName, false);
+        currentUmlName = associationUML.name;
+        subject.next(currentUmlName);
+        expect(updateSpy).toHaveBeenLastCalledWith(currentUmlName, false);
 
-            updateSpyCallCount++;
-            expect(updateSpy).toHaveBeenCalledTimes(updateSpyCallCount);
-        });
+        updateSpyCallCount++;
+        expect(updateSpy).toHaveBeenCalledTimes(updateSpyCallCount);
     });
 });

--- a/src/test/javascript/spec/helpers/utils/general.utils.ts
+++ b/src/test/javascript/spec/helpers/utils/general.utils.ts
@@ -37,8 +37,3 @@ export const triggerChanges = (comp: OnChanges, ...changes: Array<{ property: st
     }, {});
     comp.ngOnChanges(simpleChanges);
 };
-
-// delay is used to ensure apollon editor and redux store is not null (because of React 18 behaviour)
-export const addDelay = async (timeInMs: number) => {
-    return new Promise((res) => setTimeout(res, timeInMs));
-};


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.


### Motivation and Context
This PR adds tests for the validation of drag and drop exercises. In #7261 there have been alerts added to improve the UX works. The test of this PR ensure that the user keeps updated if there is input missing.

### Steps for Testing
see that all affected tests are passing 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

