### PR TITLE
`Development`: Fix flaky ParticipantScoreIntegrationTest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
       run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-tests-mysql:
-      # needs: [ server-tests ]
+      needs: [ server-tests ]
       runs-on: ubuntu-latest
       timeout-minutes: 120
       # Limit the number of concurrent mysql tests to one in total
@@ -140,7 +140,7 @@ jobs:
             run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-tests-postgres:
-      # needs: [ server-tests ]
+      needs: [ server-tests ]
       runs-on: ubuntu-latest
       timeout-minutes: 150
       # Limit the number of concurrent postgres tests to one in total

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
       run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-tests-mysql:
-      needs: [ server-tests ]
+      # needs: [ server-tests ]
       runs-on: ubuntu-latest
       timeout-minutes: 120
       # Limit the number of concurrent mysql tests to one in total
@@ -140,7 +140,7 @@ jobs:
             run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-tests-postgres:
-      needs: [ server-tests ]
+      # needs: [ server-tests ]
       runs-on: ubuntu-latest
       timeout-minutes: 150
       # Limit the number of concurrent postgres tests to one in total

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
@@ -3,8 +3,10 @@ package de.tum.in.www1.artemis.assessment;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationLocalCILocalVCTest;
 import de.tum.in.www1.artemis.competency.CompetencyUtilService;
@@ -97,7 +100,10 @@ class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationLocalCILo
 
     @BeforeEach
     void setupTestScenario() {
-        ParticipantScoreScheduleService.DEFAULT_WAITING_TIME_FOR_SCHEDULED_TASKS = 50;
+        // Prevents the ParticipantScoreScheduleService from scheduling tasks related to prior results
+        ReflectionTestUtils.setField(participantScoreScheduleService, "lastScheduledRun", Optional.of(Instant.now()));
+
+        ParticipantScoreScheduleService.DEFAULT_WAITING_TIME_FOR_SCHEDULED_TASKS = 200;
         participantScoreScheduleService.activate();
         ZonedDateTime pastTimestamp = ZonedDateTime.now().minusDays(5);
         // creating the users student1, tutor1 and instructors1


### PR DESCRIPTION
### Checklist
#### General
- [x] The changed server tests succeed **locally** and on **Bamboo** and on **GitHub Actions**.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
All tests in ParticipantScoreIntegrationTest were flaky. The tests' setup method contains multiple awaits that regularly timed out for MySQL and Postgres because of many scheduled tasks and slower database access.

### Description
The tests are fixed by setting _lastScheduledRun_ in _ParticipantScoreScheduleService_. Setting the value to _Instant.now()_ prevents the ScheduleService from calculating the scores of results unrelated to these tests (Results created in prior tests).

MySQL run without failing ParticipantScoreIntegrationTest(s):
https://github.com/ls1intum/Artemis/actions/runs/6409225735/job/17416448781?pr=7321

Postgres run without failing ParticipantScoreIntegrationTest(s): https://github.com/ls1intum/Artemis/actions/runs/6409225735/job/17406613029?pr=7321

### Steps for Testing
**Test changes only**

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2