### PR TITLE
`Development`: Fix unclosed input streams

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -181,7 +181,7 @@ public class FileService implements DisposableBean {
             filePath = generateFilePath(filenamePrefix, fileExtension, path);
         }
         try {
-            FileUtils.copyToFile(file.getInputStream(), filePath.toFile());
+            FileUtils.copyInputStreamToFile(file.getInputStream(), filePath.toFile());
 
             return generateResponsePath(filePath, markdown);
         }
@@ -344,7 +344,7 @@ public class FileService implements DisposableBean {
             return;
         }
 
-        FileUtils.copyToFile(resource.getInputStream(), targetPath.toFile());
+        FileUtils.copyInputStreamToFile(resource.getInputStream(), targetPath.toFile());
 
         if (targetPath.endsWith("gradlew")) {
             targetPath.toFile().setExecutable(true);

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
@@ -201,7 +201,7 @@ public class FileUploadSubmissionService extends SubmissionService {
         final Path filePath = dirPath.resolve(filename);
         final File savedFile = filePath.toFile();
 
-        FileUtils.copyToFile(file.getInputStream(), savedFile);
+        FileUtils.copyInputStreamToFile(file.getInputStream(), savedFile);
 
         return filePath;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/RepositoryService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/RepositoryService.java
@@ -188,7 +188,6 @@ public class RepositoryService {
         File file = checkIfPathAndFileAreValidAndReturnSafeFile(repository, safePath);
         FileUtils.copyToFile(inputStream, file);
         repository.setContent(null); // invalidate cache
-        inputStream.close();
     }
 
     /**
@@ -207,7 +206,6 @@ public class RepositoryService {
         File keep = new File(repository.getLocalPath().resolve(safePath).resolve(".keep"), repository);
         FileUtils.copyToFile(inputStream, keep);
         repository.setContent(null); // invalidate cache
-        inputStream.close();
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
@@ -170,8 +170,9 @@ public abstract class RepositoryResource {
 
         return executeAndCheckForExceptions(() -> {
             Repository repository = getRepository(domainId, RepositoryActionType.WRITE, true);
-            InputStream inputStream = request.getInputStream();
-            repositoryService.createFile(repository, filePath, inputStream);
+            try (var inputStream = request.getInputStream()) {
+                repositoryService.createFile(repository, filePath, inputStream);
+            }
             return new ResponseEntity<>(HttpStatus.OK);
         });
     }
@@ -189,8 +190,9 @@ public abstract class RepositoryResource {
 
         return executeAndCheckForExceptions(() -> {
             Repository repository = getRepository(domainId, RepositoryActionType.WRITE, true);
-            InputStream inputStream = request.getInputStream();
-            repositoryService.createFolder(repository, folderPath, inputStream);
+            try (InputStream inputStream = request.getInputStream()) {
+                repositoryService.createFolder(repository, folderPath, inputStream);
+            }
             return new ResponseEntity<>(HttpStatus.OK);
         });
     }
@@ -389,8 +391,8 @@ public abstract class RepositoryResource {
             throw new IOException("File could not be found.");
         }
 
-        InputStream inputStream = new ByteArrayInputStream(submission.getFileContent().getBytes(StandardCharsets.UTF_8));
-        FileUtils.copyToFile(inputStream, file.get());
-        inputStream.close();
+        try (var inputStream = new ByteArrayInputStream(submission.getFileContent().getBytes(StandardCharsets.UTF_8))) {
+            FileUtils.copyToFile(inputStream, file.get());
+        }
     }
 }


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).

### Motivation and Context
While reviewing #7322 I noticed that the `FileUtils` class has two methods `copyToFile()` and `copyInputStreamToFile()`. They differ in the fact that only the sencond method closes the given input stream, and `copyToFile()` leaves the straem open.

### Description
This PR replaces `copyToFile()` with `copyInputStreamToFile()` where applicabel, and replaces explicit `close()` calls with try-with-ressources blocks.

### Steps for Testing
code review

### Review Progress

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
