### PR TITLE
`Development`: Fix flaky ResultListenerIntegrationTest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,12 +86,12 @@ jobs:
       run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-tests-mysql:
-#      needs: [ server-tests ]
+      needs: [ server-tests ]
       runs-on: ubuntu-latest
       timeout-minutes: 120
       # Limit the number of concurrent mysql tests to one in total
-#      concurrency:
-#          group: server-tests-mysql
+      concurrency:
+          group: server-tests-mysql
       steps:
           - uses: actions/checkout@v4
           - name: Setup Java
@@ -140,12 +140,12 @@ jobs:
             run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-tests-postgres:
-#      needs: [ server-tests ]
+      needs: [ server-tests ]
       runs-on: ubuntu-latest
       timeout-minutes: 150
       # Limit the number of concurrent postgres tests to one in total
-#      concurrency:
-#          group: server-tests-postgres
+      concurrency:
+          group: server-tests-postgres
       steps:
           - uses: actions/checkout@v4
           - name: Setup Java

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,12 +86,12 @@ jobs:
       run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-tests-mysql:
-      needs: [ server-tests ]
+#      needs: [ server-tests ]
       runs-on: ubuntu-latest
       timeout-minutes: 120
       # Limit the number of concurrent mysql tests to one in total
-      concurrency:
-          group: server-tests-mysql
+#      concurrency:
+#          group: server-tests-mysql
       steps:
           - uses: actions/checkout@v4
           - name: Setup Java
@@ -140,12 +140,12 @@ jobs:
             run: bash supporting_scripts/extract_number_of_server_starts.sh
 
   server-tests-postgres:
-      needs: [ server-tests ]
+#      needs: [ server-tests ]
       runs-on: ubuntu-latest
       timeout-minutes: 150
       # Limit the number of concurrent postgres tests to one in total
-      concurrency:
-          group: server-tests-postgres
+#      concurrency:
+#          group: server-tests-postgres
       steps:
           - uses: actions/checkout@v4
           - name: Setup Java

--- a/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
@@ -97,7 +97,7 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
         // Prevents the ParticipantScoreScheduleService from scheduling tasks related to prior results
         ReflectionTestUtils.setField(participantScoreScheduleService, "lastScheduledRun", Optional.of(Instant.now()));
 
-        ParticipantScoreScheduleService.DEFAULT_WAITING_TIME_FOR_SCHEDULED_TASKS = 200;
+        ParticipantScoreScheduleService.DEFAULT_WAITING_TIME_FOR_SCHEDULED_TASKS = 100;
         participantScoreScheduleService.activate();
         ZonedDateTime pastReleaseDate = ZonedDateTime.now().minusDays(5);
         ZonedDateTime pastDueDate = ZonedDateTime.now().minusDays(3);

--- a/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
@@ -4,9 +4,10 @@ import static de.tum.in.www1.artemis.service.util.RoundingUtil.round;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
@@ -16,6 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationLocalCILocalVCTest;
 import de.tum.in.www1.artemis.course.CourseUtilService;
@@ -92,8 +94,11 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
 
     @BeforeEach
     void setupTestScenario() {
+        // Prevents the ParticipantScoreScheduleService from scheduling tasks related to prior results
+        ReflectionTestUtils.setField(participantScoreScheduleService, "lastScheduledRun", Optional.of(Instant.now()));
+
+        ParticipantScoreScheduleService.DEFAULT_WAITING_TIME_FOR_SCHEDULED_TASKS = 200;
         participantScoreScheduleService.activate();
-        ParticipantScoreScheduleService.DEFAULT_WAITING_TIME_FOR_SCHEDULED_TASKS = 50;
         ZonedDateTime pastReleaseDate = ZonedDateTime.now().minusDays(5);
         ZonedDateTime pastDueDate = ZonedDateTime.now().minusDays(3);
         ZonedDateTime pastAssessmentDueDate = ZonedDateTime.now().minusDays(2);
@@ -103,7 +108,6 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
         idOfStudent1 = student1.getId();
         // creating course
         Course course = courseUtilService.createCourse();
-        Long idOfCourse = course.getId();
         TextExercise textExercise = textExerciseUtilService.createIndividualTextExercise(course, pastReleaseDate, pastDueDate, pastAssessmentDueDate);
         idOfIndividualTextExercise = textExercise.getId();
         Exercise teamExercise = textExerciseUtilService.createTeamTextExercise(course, pastReleaseDate, pastDueDate, pastAssessmentDueDate);
@@ -422,7 +426,7 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
 
         // Wait for the scheduler to execute its task
         participantScoreScheduleService.executeScheduledTasks();
-        await().atMost(Duration.ofSeconds(30)).until(() -> participantScoreScheduleService.isIdle());
+        await().until(() -> participantScoreScheduleService.isIdle());
 
         var savedParticipantScores = participantScoreRepository.findAllByExercise(exercise);
         assertThat(savedParticipantScores).isNotEmpty();


### PR DESCRIPTION
### Checklist
#### General
- [x] The changed server tests succeed **locally** and on **Bamboo** and on **GitHub Actions**.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/guidelines/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
The tests in ResultListenerIntegrationTest were flaky. The tests' failed against MySQL and Postgres because of many scheduled tasks and slower database access.

### Description
The tests are fixed by setting _lastScheduledRun_ in _ParticipantScoreScheduleService_. Setting the value to _Instant.now()_ prevents the ScheduleService from calculating the scores of results unrelated to this tests (Results created in prior tests). Additionally, the schedule delay has been increased to account for slower database access.

MySQL run without failing ResultListenerIntegrationTest(s):
https://github.com/ls1intum/Artemis/actions/runs/6419281166/job/17428804520?pr=7326

Postgres run without failing ResultListenerIntegrationTest(s):
https://github.com/ls1intum/Artemis/actions/runs/6419281166/job/17428804757?pr=7326

### Steps for Testing
**Test changes only**

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2