### PR TITLE
`Development`: Fix running server tests on windows

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -14,6 +14,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1076,12 +1077,11 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         assertThat(archive).isNotNull();
 
         // Extract the archive
-        zipFileTestUtilService.extractZipFileRecursively(archive.getAbsolutePath());
-        String extractedArchiveDir = archive.getPath().substring(0, archive.getPath().length() - 4);
+        Path extractedArchiveDir = zipFileTestUtilService.extractZipFileRecursively(archive.getAbsolutePath());
 
         // Check that the dummy files we created exist in the archive.
         List<Path> filenames;
-        try (var files = Files.walk(Path.of(extractedArchiveDir))) {
+        try (var files = Files.walk(extractedArchiveDir)) {
             filenames = files.filter(Files::isRegularFile).map(Path::getFileName).toList();
         }
 
@@ -1095,6 +1095,9 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
         savedSubmission = submissions.stream().filter(submission -> submission instanceof ModelingSubmission).findFirst().orElseThrow();
         assertSubmissionFilename(filenames, savedSubmission, ".json");
+
+        FileUtils.deleteDirectory(extractedArchiveDir.toFile());
+        FileUtils.delete(archive);
     }
 
     private void assertSubmissionFilename(List<Path> expectedFilenames, Submission submission, String filenameExtension) {

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -923,7 +923,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         StudentExam submittedStudentExam = studentExamRepository.findById(studentExamForTestExam1.getId()).orElseThrow();
         assertThat(submittedStudentExam.isSubmitted()).isTrue();
 
-        verify(programmingExerciseParticipationService).lockStudentRepository(programmingExercise, participation);
+        verify(programmingExerciseParticipationService, timeout(1000)).lockStudentRepository(programmingExercise, participation);
         verify(programmingTriggerService, timeout(4000)).triggerBuildForParticipations(List.of(participation));
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/CourseBitbucketBambooJiraIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/CourseBitbucketBambooJiraIntegrationTest.java
@@ -695,7 +695,7 @@ class CourseBitbucketBambooJiraIntegrationTest extends AbstractSpringIntegration
         courseTestService.testArchiveCourseWithQuizExerciseCannotExportExerciseDetails();
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     @MethodSource("provideFileNameAndErrorMsg")
     void testArchiveCourseWithQuizExerciseCannotExportMCOrSAAnswersSubmission(String dynamicFilenamePart, String dynamicErrorMsgPart) throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
@@ -12,8 +12,6 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -97,21 +95,18 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // file locking issues
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds() throws Exception {
         programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds();
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // git file locking issues
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionAnonymizationCombining() throws Exception {
         programmingExerciseIntegrationTestService.testExportSubmissionAnonymizationCombining();
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // git file locking issues
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
         programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
@@ -630,7 +625,6 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // git file locking issues
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void importProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest() throws Exception {
         programmingExerciseIntegrationTestService.importProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest();
@@ -751,7 +745,6 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // git file locking issues
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void resetTestCaseWeights_asInstructor() throws Exception {
         programmingExerciseIntegrationTestService.resetTestCaseWeights_asInstructor();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
@@ -11,8 +11,6 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -85,14 +83,12 @@ class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpringInte
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // git file locking issues
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds() throws Exception {
         programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds();
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // file locking issues
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionAnonymizationCombining() throws Exception {
         programmingExerciseIntegrationTestService.testExportSubmissionAnonymizationCombining();
@@ -212,7 +208,6 @@ class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpringInte
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // git file locking issues
     @WithMockUser(username = TEST_PREFIX + "instructoralt1", roles = "INSTRUCTOR")
     void testGetProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
         programmingExerciseIntegrationTestService.testGetProgrammingExercise_instructorNotInCourse_forbidden();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -241,6 +241,9 @@ class ProgrammingExerciseIntegrationTestService {
         if (downloadedFile != null && downloadedFile.exists()) {
             FileUtils.forceDelete(downloadedFile);
         }
+        if (repoDownloadClonePath != null && Files.exists(Path.of(repoDownloadClonePath))) {
+            FileUtils.deleteDirectory(new File(repoDownloadClonePath));
+        }
         if (localGit != null) {
             localGit.close();
         }
@@ -1794,8 +1797,6 @@ class ProgrammingExerciseIntegrationTestService {
         var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), null);
         doReturn(repository1).when(gitService).getOrCheckoutRepository(eq(participation1.getVcsRepositoryUrl()), anyString(), anyBoolean());
         doReturn(repository2).when(gitService).getOrCheckoutRepository(eq(participation2.getVcsRepositoryUrl()), anyString(), anyBoolean());
-
-        FileUtils.deleteDirectory(jPlagReposDir.toFile());
     }
 
     void testGetPlagiarismResult() throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -154,6 +154,9 @@ class ProgrammingExerciseIntegrationTestService {
     @Autowired
     private ProgrammingExerciseTestRepository programmingExerciseTestRepository;
 
+    @Autowired
+    private ZipFileTestUtilService zipFileTestUtilService;
+
     private Course course;
 
     public ProgrammingExercise programmingExercise;
@@ -490,7 +493,7 @@ class ProgrammingExerciseIntegrationTestService {
         // Checks
         assertThat(entries).anyMatch(entry -> entry.endsWith("Test.java"));
         Optional<Path> extractedRepo1 = entries.stream()
-                .filter(entry -> entry.toString().endsWith(Path.of("-" + String.valueOf(participation1.getId()) + "-student-submission.git", ".git").toString())).findFirst();
+                .filter(entry -> entry.toString().endsWith(Path.of("-" + participation1.getId() + "-student-submission.git", ".git").toString())).findFirst();
         assertThat(extractedRepo1).isPresent();
         try (Git downloadedGit = Git.open(extractedRepo1.get().toFile())) {
             RevCommit commit = downloadedGit.log().setMaxCount(1).call().iterator().next();
@@ -505,8 +508,7 @@ class ProgrammingExerciseIntegrationTestService {
      * @return the list of files that the {@code downloadedFile} contained.
      */
     private List<Path> unzipExportedFile() throws Exception {
-        (new ZipFileTestUtilService()).extractZipFileRecursively(downloadedFile.getAbsolutePath());
-        Path extractedZipDir = Path.of(downloadedFile.getPath().substring(0, downloadedFile.getPath().length() - 4));
+        Path extractedZipDir = zipFileTestUtilService.extractZipFileRecursively(downloadedFile.getAbsolutePath());
         try (var files = Files.walk(extractedZipDir)) {
             return files.toList();
         }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -1720,8 +1720,8 @@ class ProgrammingExerciseIntegrationTestService {
 
         try (ZipFile zipFile = new ZipFile(jplagZipArchive)) {
             assertThat(zipFile.getEntry("overview.json")).isNotNull();
-            assertThat(zipFile.getEntry("files/Submission-1.java/Submission-1.java")).isNotNull();
-            assertThat(zipFile.getEntry("files/Submission-2.java/Submission-2.java")).isNotNull();
+            assertThat(zipFile.getEntry(Path.of("files/Submission-1.java/Submission-1.java").toString())).isNotNull();
+            assertThat(zipFile.getEntry(Path.of("files/Submission-2.java/Submission-2.java").toString())).isNotNull();
 
             // it is random which of the following two exists, but one of them must be part of the zip file
             var json1 = zipFile.getEntry("Submission-2.java-Submission-1.java.json");

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -170,11 +170,15 @@ class ProgrammingExerciseIntegrationTestService {
 
     private Git localGit;
 
+    private File remoteRepoFile;
+
     private Git remoteGit;
 
     private File localRepoFile2;
 
     private Git localGit2;
+
+    private File remoteRepo2File;
 
     private Git remoteGit2;
 
@@ -204,18 +208,18 @@ class ProgrammingExerciseIntegrationTestService {
 
         localRepoFile = Files.createTempDirectory("repo").toFile();
         localGit = LocalRepository.initialize(localRepoFile, defaultBranch);
-        File originRepoFile = Files.createTempDirectory("repoOrigin").toFile();
-        remoteGit = LocalRepository.initialize(originRepoFile, defaultBranch);
+        remoteRepoFile = Files.createTempDirectory("repoOrigin").toFile();
+        remoteGit = LocalRepository.initialize(remoteRepoFile, defaultBranch);
         StoredConfig config = localGit.getRepository().getConfig();
-        config.setString("remote", "origin", "url", originRepoFile.getAbsolutePath());
+        config.setString("remote", "origin", "url", remoteRepoFile.getAbsolutePath());
         config.save();
 
         localRepoFile2 = Files.createTempDirectory("repo2").toFile();
         localGit2 = LocalRepository.initialize(localRepoFile2, defaultBranch);
-        File originRepoFile2 = Files.createTempDirectory("repoOrigin").toFile();
-        remoteGit2 = LocalRepository.initialize(originRepoFile2, defaultBranch);
+        remoteRepo2File = Files.createTempDirectory("repoOrigin").toFile();
+        remoteGit2 = LocalRepository.initialize(remoteRepo2File, defaultBranch);
         StoredConfig config2 = localGit2.getRepository().getConfig();
-        config2.setString("remote", "origin", "url", originRepoFile2.getAbsolutePath());
+        config2.setString("remote", "origin", "url", remoteRepo2File.getAbsolutePath());
         config2.save();
 
         // TODO use createProgrammingExercise or setupTemplateAndPush to create actual content (based on the template repos) in this repository
@@ -230,27 +234,36 @@ class ProgrammingExerciseIntegrationTestService {
 
         // we use the temp repository as remote origin for all repositories that are created during the
         // TODO: distinguish between template, test and solution
-        doReturn(new GitUtilService.MockFileRepositoryUrl(originRepoFile)).when(versionControlService).getCloneRepositoryUrl(anyString(), anyString());
+        doReturn(new GitUtilService.MockFileRepositoryUrl(remoteRepoFile)).when(versionControlService).getCloneRepositoryUrl(anyString(), anyString());
     }
 
     void tearDown() throws IOException {
         if (downloadedFile != null && downloadedFile.exists()) {
             FileUtils.forceDelete(downloadedFile);
         }
-        if (localRepoFile != null && localRepoFile.exists()) {
-            FileUtils.deleteDirectory(localRepoFile);
-        }
         if (localGit != null) {
             localGit.close();
         }
-        if (remoteGit != null) {
-            remoteGit.close();
+        if (localRepoFile != null && localRepoFile.exists()) {
+            FileUtils.deleteDirectory(localRepoFile);
         }
         if (localGit2 != null) {
             localGit2.close();
         }
+        if (localRepoFile2 != null && localRepoFile2.exists()) {
+            FileUtils.deleteDirectory(localRepoFile2);
+        }
+        if (remoteGit != null) {
+            remoteGit.close();
+        }
+        if (remoteRepoFile != null && remoteRepoFile.exists()) {
+            FileUtils.deleteDirectory(remoteRepoFile);
+        }
         if (remoteGit2 != null) {
             remoteGit2.close();
+        }
+        if (remoteRepo2File != null && remoteRepo2File.exists()) {
+            FileUtils.deleteDirectory(remoteRepo2File);
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -240,9 +240,6 @@ class ProgrammingExerciseIntegrationTestService {
         if (localRepoFile != null && localRepoFile.exists()) {
             FileUtils.deleteDirectory(localRepoFile);
         }
-        if (repoDownloadClonePath != null && Files.exists(Path.of(repoDownloadClonePath))) {
-            FileUtils.deleteDirectory(new File(repoDownloadClonePath));
-        }
         if (localGit != null) {
             localGit.close();
         }
@@ -1784,6 +1781,8 @@ class ProgrammingExerciseIntegrationTestService {
         var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), null);
         doReturn(repository1).when(gitService).getOrCheckoutRepository(eq(participation1.getVcsRepositoryUrl()), anyString(), anyBoolean());
         doReturn(repository2).when(gitService).getOrCheckoutRepository(eq(participation2.getVcsRepositoryUrl()), anyString(), anyBoolean());
+
+        FileUtils.deleteDirectory(jPlagReposDir.toFile());
     }
 
     void testGetPlagiarismResult() throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -244,9 +244,6 @@ class ProgrammingExerciseIntegrationTestService {
         if (downloadedFile != null && downloadedFile.exists()) {
             FileUtils.forceDelete(downloadedFile);
         }
-        if (repoDownloadClonePath != null && Files.exists(Path.of(repoDownloadClonePath))) {
-            FileUtils.deleteDirectory(new File(repoDownloadClonePath));
-        }
         if (localGit != null) {
             localGit.close();
         }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
@@ -1405,11 +1405,10 @@ public class ProgrammingExerciseTestService {
             Files.delete(embeddedFilePath2);
         }
         // Recursively unzip the exported file, to make sure there is no erroneous content
-        zipFileTestUtilService.extractZipFileRecursively(zipFile.getAbsolutePath());
-        String extractedZipDir = zipFile.getPath().substring(0, zipFile.getPath().length() - 4);
+        Path extractedZipDir = zipFileTestUtilService.extractZipFileRecursively(zipFile.getAbsolutePath());
 
         // Check that the contents we created exist in the unzipped exported folder
-        try (var files = Files.walk(Path.of(extractedZipDir))) {
+        try (var files = Files.walk(extractedZipDir)) {
             List<Path> listOfIncludedFiles = files.filter(Files::isRegularFile).map(Path::getFileName).toList();
             assertThat(listOfIncludedFiles).anyMatch((filename) -> filename.toString().matches(".*-exercise.zip"))
                     .anyMatch((filename) -> filename.toString().matches(".*-solution.zip")).anyMatch((filename) -> filename.toString().matches(".*-tests.zip"))
@@ -1420,23 +1419,28 @@ public class ProgrammingExerciseTestService {
                         .anyMatch((filename) -> filename.toString().equals(embeddedFileName2));
             }
         }
+
+        FileUtils.deleteDirectory(extractedZipDir.toFile());
+        FileUtils.delete(zipFile);
     }
 
     void exportProgrammingExerciseInstructorMaterial_problemStatementNull_success() throws Exception {
         var zipFile = exportProgrammingExerciseInstructorMaterial(HttpStatus.OK, true, true, false);
         await().until(zipFile::exists);
         assertThat(zipFile).isNotNull();
-        zipFileTestUtilService.extractZipFileRecursively(zipFile.getAbsolutePath());
-        String extractedZipDir = zipFile.getPath().substring(0, zipFile.getPath().length() - 4);
+        Path extractedZipDir = zipFileTestUtilService.extractZipFileRecursively(zipFile.getAbsolutePath());
 
         // Check that the contents we created exist in the unzipped exported folder
-        try (var files = Files.walk(Path.of(extractedZipDir))) {
+        try (var files = Files.walk(extractedZipDir)) {
             List<Path> listOfIncludedFiles = files.filter(Files::isRegularFile).map(Path::getFileName).toList();
             assertThat(listOfIncludedFiles).anyMatch((filename) -> filename.toString().matches(".*-exercise.zip"))
                     .anyMatch((filename) -> filename.toString().matches(".*-solution.zip")).anyMatch((filename) -> filename.toString().matches(".*-tests.zip"))
                     .anyMatch((filename) -> filename.toString().matches(EXPORTED_EXERCISE_DETAILS_FILE_PREFIX + ".*.json"));
 
         }
+
+        FileUtils.deleteDirectory(extractedZipDir.toFile());
+        FileUtils.delete(zipFile);
     }
 
     // Test
@@ -1573,8 +1577,7 @@ public class ProgrammingExerciseTestService {
         assertThat(updatedCourse.getCourseArchivePath()).isNotEmpty();
         // extract archive content and check that all expected files exist.
         Path courseArchivePath = courseArchivesDirPath.resolve(updatedCourse.getCourseArchivePath());
-        zipFileTestUtilService.extractZipFileRecursively(courseArchivePath.toString());
-        String extractedArchiveDir = updatedCourse.getCourseArchivePath().substring(0, updatedCourse.getCourseArchivePath().length() - 4);
+        Path extractedArchiveDir = zipFileTestUtilService.extractZipFileRecursively(courseArchivePath.toString());
         try (var files = Files.walk(courseArchivesDirPath.resolve(extractedArchiveDir))) {
             assertThat(files).map(Path::getFileName).anyMatch((filename) -> filename.toString().matches(".*-exercise.zip"))
                     .anyMatch((filename) -> filename.toString().matches(".*-solution.zip")).anyMatch((filename) -> filename.toString().matches(".*-tests.zip"))
@@ -1582,6 +1585,9 @@ public class ProgrammingExerciseTestService {
                     .anyMatch((filename) -> filename.toString().matches(EXPORTED_EXERCISE_DETAILS_FILE_PREFIX + ".*.json"))
                     .anyMatch((filename) -> filename.toString().matches(".*student1.zip"));
         }
+
+        FileUtils.deleteDirectory(extractedArchiveDir.toFile());
+        FileUtils.delete(courseArchivePath.toFile());
     }
 
     // Test
@@ -1615,14 +1621,16 @@ public class ProgrammingExerciseTestService {
 
         // Extract the archive
         Path archivePath = optionalExportedCourse.get();
-        zipFileTestUtilService.extractZipFileRecursively(archivePath.toString());
-        String extractedArchiveDir = archivePath.toString().substring(0, archivePath.toString().length() - 4);
+        Path extractedArchiveDir = zipFileTestUtilService.extractZipFileRecursively(archivePath.toString());
 
         // Check that the dummy files we created exist in the archive
-        try (var files = Files.walk(Path.of(extractedArchiveDir))) {
+        try (var files = Files.walk(extractedArchiveDir)) {
             var filenames = files.filter(Files::isRegularFile).map(Path::getFileName).toList();
             assertThat(filenames).contains(Path.of("Template.java"), Path.of("Solution.java"), Path.of("Tests.java"), Path.of("HelloWorld.java"));
         }
+
+        FileUtils.deleteDirectory(extractedArchiveDir.toFile());
+        FileUtils.delete(archivePath.toFile());
     }
 
     private void createCourseWithProgrammingExerciseAndParticipationWithFiles() throws GitAPIException, IOException {
@@ -1770,14 +1778,16 @@ public class ProgrammingExerciseTestService {
         assertThat(archive).exists();
 
         // Extract the archive
-        zipFileTestUtilService.extractZipFileRecursively(archive.getAbsolutePath());
-        String extractedArchiveDir = archive.getPath().substring(0, archive.getPath().length() - 4);
+        Path extractedArchiveDir = zipFileTestUtilService.extractZipFileRecursively(archive.getAbsolutePath());
 
         // Check that the dummy files we created exist in the archive
-        try (var files = Files.walk(Path.of(extractedArchiveDir))) {
-            var filenames = files.filter(Files::isRegularFile).map(Path::getFileName).toList();
-            assertThat(filenames).contains(Path.of("HelloWorld.java"), Path.of("Template.java"), Path.of("Solution.java"), Path.of("Tests.java"));
+        try (var files = Files.walk(extractedArchiveDir)) {
+            var filenames = files.filter(Files::isRegularFile).map(Path::getFileName).map(Path::toString).toList();
+            assertThat(filenames).contains("HelloWorld.java", "Template.java", "Solution.java", "Tests.java");
         }
+
+        FileUtils.deleteDirectory(extractedArchiveDir.toFile());
+        FileUtils.delete(archive);
     }
 
     private ProgrammingExerciseStudentParticipation createStudentParticipationWithSubmission(ExerciseMode exerciseMode) {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
@@ -1578,16 +1578,13 @@ public class ProgrammingExerciseTestService {
         // extract archive content and check that all expected files exist.
         Path courseArchivePath = courseArchivesDirPath.resolve(updatedCourse.getCourseArchivePath());
         Path extractedArchiveDir = zipFileTestUtilService.extractZipFileRecursively(courseArchivePath.toString());
-        try (var files = Files.walk(courseArchivesDirPath.resolve(extractedArchiveDir))) {
+        try (var files = Files.walk(extractedArchiveDir)) {
             assertThat(files).map(Path::getFileName).anyMatch((filename) -> filename.toString().matches(".*-exercise.zip"))
                     .anyMatch((filename) -> filename.toString().matches(".*-solution.zip")).anyMatch((filename) -> filename.toString().matches(".*-tests.zip"))
                     .anyMatch((filename) -> filename.toString().matches(EXPORTED_EXERCISE_PROBLEM_STATEMENT_FILE_PREFIX + ".*.md"))
                     .anyMatch((filename) -> filename.toString().matches(EXPORTED_EXERCISE_DETAILS_FILE_PREFIX + ".*.json"))
                     .anyMatch((filename) -> filename.toString().matches(".*student1.zip"));
         }
-
-        FileUtils.deleteDirectory(extractedArchiveDir.toFile());
-        FileUtils.delete(courseArchivePath.toFile());
     }
 
     // Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
@@ -24,8 +24,6 @@ import org.eclipse.jgit.merge.MergeStrategy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.mockito.MockedStatic;
 import org.mockito.stubbing.Answer;
 import org.slf4j.LoggerFactory;
@@ -649,91 +647,90 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // git file locking issues
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testPullChanges() throws Exception {
         String fileName = "remoteFile";
 
         // Create a commit for the local and the remote repository
         request.postWithoutLocation(studentRepoBaseUrl + participation.getId() + "/commit", null, HttpStatus.OK, null);
-        var remoteRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepository.originRepoFile.toPath(), null);
+        try (var remoteRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepository.originRepoFile.toPath(), null)) {
 
-        // Create file in the remote repository
-        Path filePath = Path.of(studentRepository.originRepoFile.toString()).resolve(fileName);
-        Files.createFile(filePath);
+            // Create file in the remote repository
+            Path filePath = studentRepository.originRepoFile.toPath().resolve(fileName);
+            Files.createFile(filePath);
 
-        // Check if the file exists in the remote repository and that it doesn't yet exist in the local repository
-        assertThat(Path.of(studentRepository.originRepoFile.toString()).resolve(fileName)).exists();
-        assertThat(Path.of(studentRepository.localRepoFile.toString()).resolve(fileName)).doesNotExist();
+            // Check if the file exists in the remote repository and that it doesn't yet exist in the local repository
+            assertThat(studentRepository.originRepoFile.toPath().resolve(fileName)).exists();
+            assertThat(studentRepository.localRepoFile.toPath().resolve(fileName)).doesNotExist();
 
-        // Stage all changes and make a second commit in the remote repository
-        gitService.stageAllChanges(remoteRepository);
-        GitService.commit(studentRepository.originGit).setMessage("TestCommit").setAllowEmpty(true).setCommitter("testname", "test@email").call();
+            // Stage all changes and make a second commit in the remote repository
+            gitService.stageAllChanges(remoteRepository);
+            GitService.commit(studentRepository.originGit).setMessage("TestCommit").setAllowEmpty(true).setCommitter("testname", "test@email").call();
 
-        // Checks if the current commit is not equal on the local and the remote repository
-        assertThat(studentRepository.getAllLocalCommits().get(0)).isNotEqualTo(studentRepository.getAllOriginCommits().get(0));
+            // Checks if the current commit is not equal on the local and the remote repository
+            assertThat(studentRepository.getAllLocalCommits().get(0)).isNotEqualTo(studentRepository.getAllOriginCommits().get(0));
 
-        // Execute the Rest call
-        request.get(studentRepoBaseUrl + participation.getId() + "/pull", HttpStatus.OK, Void.class);
+            // Execute the Rest call
+            request.get(studentRepoBaseUrl + participation.getId() + "/pull", HttpStatus.OK, Void.class);
 
-        // Check if the current commit is the same on the local and the remote repository and if the file exists on the local repository
-        assertThat(studentRepository.getAllLocalCommits().get(0)).isEqualTo(studentRepository.getAllOriginCommits().get(0));
-        assertThat(Path.of(studentRepository.localRepoFile.toString()).resolve(fileName)).exists();
-
+            // Check if the current commit is the same on the local and the remote repository and if the file exists on the local repository
+            assertThat(studentRepository.getAllLocalCommits().get(0)).isEqualTo(studentRepository.getAllOriginCommits().get(0));
+            assertThat(studentRepository.localRepoFile.toPath().resolve(fileName)).exists();
+        }
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS) // git file locking issues
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testResetToLastCommit() throws Exception {
         String fileName = "testFile";
-        var localRepo = gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepository.localRepoFile.toPath(), null);
-        var remoteRepo = gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepository.originRepoFile.toPath(), null);
+        try (var localRepo = gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepository.localRepoFile.toPath(), null);
+                var remoteRepo = gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepository.originRepoFile.toPath(), null)) {
 
-        // Check status of git before the commit
-        var receivedStatusBeforeCommit = request.get(studentRepoBaseUrl + participation.getId(), HttpStatus.OK, RepositoryStatusDTO.class);
-        assertThat(receivedStatusBeforeCommit.repositoryStatus()).hasToString("UNCOMMITTED_CHANGES");
+            // Check status of git before the commit
+            var receivedStatusBeforeCommit = request.get(studentRepoBaseUrl + participation.getId(), HttpStatus.OK, RepositoryStatusDTO.class);
+            assertThat(receivedStatusBeforeCommit.repositoryStatus()).hasToString("UNCOMMITTED_CHANGES");
 
-        // Create a commit for the local and the remote repository
-        request.postWithoutLocation(studentRepoBaseUrl + participation.getId() + "/commit", null, HttpStatus.OK, null);
+            // Create a commit for the local and the remote repository
+            request.postWithoutLocation(studentRepoBaseUrl + participation.getId() + "/commit", null, HttpStatus.OK, null);
 
-        // Check status of git after the commit
-        var receivedStatusAfterCommit = request.get(studentRepoBaseUrl + participation.getId(), HttpStatus.OK, RepositoryStatusDTO.class);
-        assertThat(receivedStatusAfterCommit.repositoryStatus()).hasToString("CLEAN");
+            // Check status of git after the commit
+            var receivedStatusAfterCommit = request.get(studentRepoBaseUrl + participation.getId(), HttpStatus.OK, RepositoryStatusDTO.class);
+            assertThat(receivedStatusAfterCommit.repositoryStatus()).hasToString("CLEAN");
 
-        // Create file in the local repository and commit it
-        Path localFilePath = Path.of(studentRepository.localRepoFile + "/" + fileName);
-        var localFile = Files.createFile(localFilePath).toFile();
-        // write content to the created file
-        FileUtils.write(localFile, "local", Charset.defaultCharset());
-        gitService.stageAllChanges(localRepo);
-        GitService.commit(studentRepository.localGit).setMessage("local").call();
+            // Create file in the local repository and commit it
+            Path localFilePath = Path.of(studentRepository.localRepoFile + "/" + fileName);
+            var localFile = Files.createFile(localFilePath).toFile();
+            // write content to the created file
+            FileUtils.write(localFile, "local", Charset.defaultCharset());
+            gitService.stageAllChanges(localRepo);
+            GitService.commit(studentRepository.localGit).setMessage("local").call();
 
-        // Create file in the remote repository and commit it
-        Path remoteFilePath = Path.of(studentRepository.originRepoFile + "/" + fileName);
-        var remoteFile = Files.createFile(remoteFilePath).toFile();
-        // write content to the created file
-        FileUtils.write(remoteFile, "remote", Charset.defaultCharset());
-        gitService.stageAllChanges(remoteRepo);
-        GitService.commit(studentRepository.originGit).setMessage("remote").call();
+            // Create file in the remote repository and commit it
+            Path remoteFilePath = Path.of(studentRepository.originRepoFile + "/" + fileName);
+            var remoteFile = Files.createFile(remoteFilePath).toFile();
+            // write content to the created file
+            FileUtils.write(remoteFile, "remote", Charset.defaultCharset());
+            gitService.stageAllChanges(remoteRepo);
+            GitService.commit(studentRepository.originGit).setMessage("remote").call();
 
-        // Merge the two and a conflict will occur
-        studentRepository.localGit.fetch().setRemote("origin").call();
-        List<Ref> refs = studentRepository.localGit.branchList().setListMode(ListBranchCommand.ListMode.REMOTE).call();
-        var result = studentRepository.localGit.merge().include(refs.get(0).getObjectId()).setStrategy(MergeStrategy.RESOLVE).call();
-        var status = studentRepository.localGit.status().call();
-        assertThat(status.getConflicting()).isNotEmpty();
-        assertThat(result.getMergeStatus()).isEqualTo(MergeResult.MergeStatus.CONFLICTING);
+            // Merge the two and a conflict will occur
+            studentRepository.localGit.fetch().setRemote("origin").call();
+            List<Ref> refs = studentRepository.localGit.branchList().setListMode(ListBranchCommand.ListMode.REMOTE).call();
+            var result = studentRepository.localGit.merge().include(refs.get(0).getObjectId()).setStrategy(MergeStrategy.RESOLVE).call();
+            var status = studentRepository.localGit.status().call();
+            assertThat(status.getConflicting()).isNotEmpty();
+            assertThat(result.getMergeStatus()).isEqualTo(MergeResult.MergeStatus.CONFLICTING);
 
-        // Execute the reset Rest call
-        request.postWithoutLocation(studentRepoBaseUrl + participation.getId() + "/reset", null, HttpStatus.OK, null);
+            // Execute the reset Rest call
+            request.postWithoutLocation(studentRepoBaseUrl + participation.getId() + "/reset", null, HttpStatus.OK, null);
 
-        // Check the git status after the reset
-        status = studentRepository.localGit.status().call();
-        assertThat(status.getConflicting()).isEmpty();
-        assertThat(studentRepository.getAllLocalCommits().get(0)).isEqualTo(studentRepository.getAllOriginCommits().get(0));
-        var receivedStatusAfterReset = request.get(studentRepoBaseUrl + participation.getId(), HttpStatus.OK, RepositoryStatusDTO.class);
-        assertThat(receivedStatusAfterReset.repositoryStatus()).hasToString("CLEAN");
+            // Check the git status after the reset
+            status = studentRepository.localGit.status().call();
+            assertThat(status.getConflicting()).isEmpty();
+            assertThat(studentRepository.getAllLocalCommits().get(0)).isEqualTo(studentRepository.getAllOriginCommits().get(0));
+            var receivedStatusAfterReset = request.get(studentRepoBaseUrl + participation.getId(), HttpStatus.OK, RepositoryStatusDTO.class);
+            assertThat(receivedStatusAfterReset.repositoryStatus()).hasToString("CLEAN");
+        }
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/metis/linkpreview/LinkPreviewIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/linkpreview/LinkPreviewIntegrationTest.java
@@ -13,11 +13,11 @@ import org.springframework.cache.CacheManager;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
+import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.LinkPreviewDTO;
 
-class LinkPreviewIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
+class LinkPreviewIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "linkpreviewintegrationtest";
 

--- a/src/test/java/de/tum/in/www1/artemis/notification/SingleUserNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/SingleUserNotificationServiceTest.java
@@ -318,7 +318,7 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationIndepen
      * Test for checkNotificationForExerciseRelease method with a past assessment due date
      */
     @Test
-    void testCheckNotificationForAssessmentExerciseSubmission_currentOrPastAssessmentDueDate() {
+    void testCheckNotificationForAssessmentExerciseSubmission_pastAssessmentDueDate() {
         exercise = TextExerciseFactory.generateTextExercise(null, null, ZonedDateTime.now().minusMinutes(1), course);
         singleUserNotificationService.checkNotificationForAssessmentExerciseSubmission(exercise, user, result);
         assertThat(notificationRepository.findAll()).as("One new notification should have been created").hasSize(1);

--- a/src/test/java/de/tum/in/www1/artemis/notification/SingleUserNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/SingleUserNotificationServiceTest.java
@@ -315,21 +315,11 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationIndepen
     }
 
     /**
-     * Test for checkNotificationForAssessmentExerciseSubmission method with an undefined release date
-     */
-    @Test
-    void testCheckNotificationForAssessmentExerciseSubmission_undefinedAssessmentDueDate() {
-        exercise = TextExerciseFactory.generateTextExercise(null, null, null, course);
-        singleUserNotificationService.checkNotificationForAssessmentExerciseSubmission(exercise, user, result);
-        verify(singleUserNotificationService).checkNotificationForAssessmentExerciseSubmission(exercise, user, result);
-    }
-
-    /**
-     * Test for checkNotificationForExerciseRelease method with a current or past release date
+     * Test for checkNotificationForExerciseRelease method with a past assessment due date
      */
     @Test
     void testCheckNotificationForAssessmentExerciseSubmission_currentOrPastAssessmentDueDate() {
-        exercise = TextExerciseFactory.generateTextExercise(null, null, ZonedDateTime.now(), course);
+        exercise = TextExerciseFactory.generateTextExercise(null, null, ZonedDateTime.now().minusMinutes(1), course);
         singleUserNotificationService.checkNotificationForAssessmentExerciseSubmission(exercise, user, result);
         assertThat(notificationRepository.findAll()).as("One new notification should have been created").hasSize(1);
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/DataExportCreationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/DataExportCreationServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -168,8 +169,7 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
         assertThat(dataExportFromDb.getCreatedDate()).isNotNull();
         assertThat(dataExportFromDb.getCreationFinishedDate()).isNotNull();
         // extract zip file and check content
-        zipFileTestUtilService.extractZipFileRecursively(dataExportFromDb.getFilePath());
-        Path extractedZipDirPath = Path.of(dataExportFromDb.getFilePath().substring(0, dataExportFromDb.getFilePath().length() - 4));
+        Path extractedZipDirPath = zipFileTestUtilService.extractZipFileRecursively(dataExportFromDb.getFilePath());
         Predicate<Path> generalUserInformationCsv = path -> "general_user_information.csv".equals(path.getFileName().toString());
         Predicate<Path> readmeMd = path -> "README.md".equals(path.getFileName().toString());
         Predicate<Path> courseDir = path -> path.getFileName().toString().startsWith("course_short");
@@ -186,6 +186,8 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
             assertCorrectContentForExercise(exercisePath, true, assessmentDueDateInTheFuture);
         }
 
+        org.apache.commons.io.FileUtils.deleteDirectory(extractedZipDirPath.toFile());
+        org.apache.commons.io.FileUtils.delete(new File(dataExportFromDb.getFilePath()));
     }
 
     private void assertCommunicationDataCsvFile(Path courseDirPath) {
@@ -459,8 +461,7 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
         assertThat(dataExportFromDb.getCreatedBy()).isNotNull();
         assertThat(dataExportFromDb.getCreationFinishedDate()).isNotNull();
         // extract zip file and check content
-        zipFileTestUtilService.extractZipFileRecursively(dataExportFromDb.getFilePath());
-        Path extractedZipDirPath = Path.of(dataExportFromDb.getFilePath().substring(0, dataExportFromDb.getFilePath().length() - 4));
+        Path extractedZipDirPath = zipFileTestUtilService.extractZipFileRecursively(dataExportFromDb.getFilePath());
         var courseDirPath = getCourseOrExamDirectoryPath(extractedZipDirPath, "exam");
         assertCommunicationDataCsvFile(courseDirPath);
         var examsDirPath = courseDirPath.resolve("exams");
@@ -469,6 +470,9 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
         for (var exerciseDirPath : getExerciseDirectoryPaths(examDirPath)) {
             assertCorrectContentForExercise(exerciseDirPath, false, false);
         }
+
+        org.apache.commons.io.FileUtils.deleteDirectory(extractedZipDirPath.toFile());
+        org.apache.commons.io.FileUtils.delete(new File(dataExportFromDb.getFilePath()));
     }
 
     private void addOnlyAnswerPostReactionInCourse(Course course) {
@@ -486,13 +490,15 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
         var dataExport = initDataExport();
         dataExportCreationService.createDataExport(dataExport);
         var dataExportFromDb = dataExportRepository.findByIdElseThrow(dataExport.getId());
-        zipFileTestUtilService.extractZipFileRecursively(dataExportFromDb.getFilePath());
-        Path extractedZipDirPath = Path.of(dataExportFromDb.getFilePath().substring(0, dataExportFromDb.getFilePath().length() - 4));
+        Path extractedZipDirPath = zipFileTestUtilService.extractZipFileRecursively(dataExportFromDb.getFilePath());
         var courseDirPath = getCourseOrExamDirectoryPath(extractedZipDirPath, "examNoResults");
         assertCommunicationDataCsvFile(courseDirPath);
         assertThat(courseDirPath).isDirectoryContaining(path -> path.getFileName().toString().startsWith("exam"));
         var examDirPath = getCourseOrExamDirectoryPath(courseDirPath, "exam");
         getExerciseDirectoryPaths(examDirPath).forEach(this::assertNoResultsFile);
+
+        org.apache.commons.io.FileUtils.deleteDirectory(extractedZipDirPath.toFile());
+        org.apache.commons.io.FileUtils.delete(new File(dataExportFromDb.getFilePath()));
     }
 
     @Test
@@ -505,8 +511,7 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
         var dataExport = initDataExport();
         dataExportCreationService.createDataExport(dataExport);
         var dataExportFromDb = dataExportRepository.findByIdElseThrow(dataExport.getId());
-        zipFileTestUtilService.extractZipFileRecursively(dataExportFromDb.getFilePath());
-        Path extractedZipDirPath = Path.of(dataExportFromDb.getFilePath().substring(0, dataExportFromDb.getFilePath().length() - 4));
+        Path extractedZipDirPath = zipFileTestUtilService.extractZipFileRecursively(dataExportFromDb.getFilePath());
         var courseDirPath = getCourseOrExamDirectoryPath(extractedZipDirPath, courseShortName);
         assertCommunicationDataCsvFile(courseDirPath);
         var exercisesDirPath = courseDirPath.resolve("exercises");
@@ -514,6 +519,9 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
         for (var exerciseDirectory : getExerciseDirectoryPaths(exercisesDirPath)) {
             assertCorrectContentForExercise(exerciseDirectory, true, assessmentDueDateInTheFuture);
         }
+
+        org.apache.commons.io.FileUtils.deleteDirectory(extractedZipDirPath.toFile());
+        org.apache.commons.io.FileUtils.delete(new File(dataExportFromDb.getFilePath()));
     }
 
     private void addOnlyAnswerPostInCourse(Course course) {
@@ -559,14 +567,16 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
         courseUtilService.updateCourseGroups("abc", course, "");
         dataExportCreationService.createDataExport(dataExport);
         var dataExportFromDb = dataExportRepository.findByIdElseThrow(dataExport.getId());
-        zipFileTestUtilService.extractZipFileRecursively(dataExportFromDb.getFilePath());
-        Path extractedZipDirPath = Path.of(dataExportFromDb.getFilePath().substring(0, dataExportFromDb.getFilePath().length() - 4));
+        Path extractedZipDirPath = zipFileTestUtilService.extractZipFileRecursively(dataExportFromDb.getFilePath());
         var courseDirPath = getCourseOrExamDirectoryPath(extractedZipDirPath, courseShortName);
         var exercisesDirPath = courseDirPath.resolve("exercises");
         assertThat(courseDirPath).isDirectoryContaining(exercisesDirPath::equals);
         for (var exerciseDirectory : getExerciseDirectoryPaths(exercisesDirPath)) {
             assertCorrectContentForExercise(exerciseDirectory, true, assessmentDueDateInTheFuture);
         }
+
+        org.apache.commons.io.FileUtils.deleteDirectory(extractedZipDirPath.toFile());
+        org.apache.commons.io.FileUtils.delete(new File(dataExportFromDb.getFilePath()));
     }
 
     private DataExport initDataExport() {

--- a/src/test/java/de/tum/in/www1/artemis/service/DataExportCreationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/DataExportCreationServiceTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -63,9 +62,6 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
     private static final String FILE_FORMAT_ZIP = ".zip";
 
     private static final String FILE_FORMAT_CSV = ".csv";
-
-    @Value("${artemis.repo-download-clone-path}")
-    private Path repoDownloadClonePath;
 
     @Autowired
     private ZipFileTestUtilService zipFileTestUtilService;
@@ -195,9 +191,6 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
     private Course prepareCourseDataForDataExportCreation(boolean assessmentDueDateInTheFuture, String courseShortName) throws Exception {
         var userLogin = TEST_PREFIX + "student1";
         String validModel = FileUtils.loadFileFromResources("test-data/model-submission/model.54727.json");
-        if (!Files.exists(repoDownloadClonePath)) {
-            Files.createDirectories(repoDownloadClonePath);
-        }
         Course course1;
         if (assessmentDueDateInTheFuture) {
             course1 = courseUtilService.addCourseWithExercisesAndSubmissionsWithAssessmentDueDatesInTheFuture(courseShortName, TEST_PREFIX, "", 4, 2, 1, 1, true, 1, validModel);
@@ -266,9 +259,6 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
 
     private Exam prepareExamDataForDataExportCreation(String courseShortName) throws Exception {
         String validModel = FileUtils.loadFileFromResources("test-data/model-submission/model.54727.json");
-        if (!Files.exists(repoDownloadClonePath)) {
-            Files.createDirectories(repoDownloadClonePath);
-        }
         var userForExport = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
         var course = courseUtilService.createCourseWithCustomStudentUserGroupWithExamAndExerciseGroupAndExercisesAndGradingScale(userForExport, TEST_PREFIX + "student",
                 courseShortName, true, true);

--- a/src/test/java/de/tum/in/www1/artemis/service/DataExportCreationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/DataExportCreationServiceTest.java
@@ -266,12 +266,12 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
 
     private Exam prepareExamDataForDataExportCreation(String courseShortName) throws Exception {
         String validModel = FileUtils.loadFileFromResources("test-data/model-submission/model.54727.json");
-        var userForExport = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        var course = courseUtilService.createCourseWithCustomStudentUserGroupWithExamAndExerciseGroupAndExercisesAndGradingScale(userForExport, TEST_PREFIX + "student",
-                courseShortName, true, true);
         if (!Files.exists(repoDownloadClonePath)) {
             Files.createDirectories(repoDownloadClonePath);
         }
+        var userForExport = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
+        var course = courseUtilService.createCourseWithCustomStudentUserGroupWithExamAndExerciseGroupAndExercisesAndGradingScale(userForExport, TEST_PREFIX + "student",
+                courseShortName, true, true);
         programmingExerciseTestService.setup(this, versionControlService, continuousIntegrationService);
         var exam = course.getExams().iterator().next();
         exam = examRepository.findWithExerciseGroupsExercisesParticipationsAndSubmissionsById(exam.getId()).orElseThrow();

--- a/src/test/java/de/tum/in/www1/artemis/service/DataExportCreationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/DataExportCreationServiceTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -62,6 +63,9 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
     private static final String FILE_FORMAT_ZIP = ".zip";
 
     private static final String FILE_FORMAT_CSV = ".csv";
+
+    @Value("${artemis.repo-download-clone-path}")
+    private Path repoDownloadClonePath;
 
     @Autowired
     private ZipFileTestUtilService zipFileTestUtilService;
@@ -191,6 +195,9 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
     private Course prepareCourseDataForDataExportCreation(boolean assessmentDueDateInTheFuture, String courseShortName) throws Exception {
         var userLogin = TEST_PREFIX + "student1";
         String validModel = FileUtils.loadFileFromResources("test-data/model-submission/model.54727.json");
+        if (!Files.exists(repoDownloadClonePath)) {
+            Files.createDirectories(repoDownloadClonePath);
+        }
         Course course1;
         if (assessmentDueDateInTheFuture) {
             course1 = courseUtilService.addCourseWithExercisesAndSubmissionsWithAssessmentDueDatesInTheFuture(courseShortName, TEST_PREFIX, "", 4, 2, 1, 1, true, 1, validModel);
@@ -262,6 +269,9 @@ class DataExportCreationServiceTest extends AbstractSpringIntegrationBambooBitbu
         var userForExport = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
         var course = courseUtilService.createCourseWithCustomStudentUserGroupWithExamAndExerciseGroupAndExercisesAndGradingScale(userForExport, TEST_PREFIX + "student",
                 courseShortName, true, true);
+        if (!Files.exists(repoDownloadClonePath)) {
+            Files.createDirectories(repoDownloadClonePath);
+        }
         programmingExerciseTestService.setup(this, versionControlService, continuousIntegrationService);
         var exam = course.getExams().iterator().next();
         exam = examRepository.findWithExerciseGroupsExercisesParticipationsAndSubmissionsById(exam.getId()).orElseThrow();

--- a/src/test/java/de/tum/in/www1/artemis/service/FilePathServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FilePathServiceTest.java
@@ -8,10 +8,10 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
+import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.exception.FilePathParsingException;
 
-class FilePathServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
+class FilePathServiceTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private FilePathService filePathService;

--- a/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
@@ -46,15 +46,20 @@ class FileServiceTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final URI VALID_BACKGROUND_PATH = URI.create("/api/uploads/images/drag-and-drop/backgrounds/1/BackgroundFile.jpg");
 
-    private static final URI VALID_INTENDED_BACKGROUND_PATH = URI.create("/api/" + FilePathService.getDragAndDropBackgroundFilePath() + "/");
+    private static final URI VALID_INTENDED_BACKGROUND_PATH = createURIWithPath("/api/", FilePathService.getDragAndDropBackgroundFilePath());
 
     private static final URI INVALID_BACKGROUND_PATH = URI.create("/api/uploads/images/drag-and-drop/backgrounds/1/../../../exam-users/signatures/some-file.png");
 
     private static final URI VALID_DRAGITEM_PATH = URI.create("/api/uploads/images/drag-and-drop/drag-items/1/PictureFile.jpg");
 
-    private static final URI VALID_INTENDED_DRAGITEM_PATH = URI.create("/api/" + FilePathService.getDragItemFilePath() + "/");
+    private static final URI VALID_INTENDED_DRAGITEM_PATH = createURIWithPath("/api/", FilePathService.getDragItemFilePath());
 
     private static final URI INVALID_DRAGITEM_PATH = URI.create("/api/uploads/images/drag-and-drop/drag-items/1/../../../exam-users/signatures/some-file.png");
+
+    private static URI createURIWithPath(String prefix, Path path) {
+        String replacementForWindows = path.toString().replace('\\', '/');
+        return URI.create(prefix + replacementForWindows + '/');
+    }
 
     @AfterEach
     void cleanup() throws IOException {

--- a/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -41,7 +40,7 @@ public class ZipFileTestUtilService {
                 String currentEntry = entry.getName();
                 File destFile = new File(newPath, currentEntry);
 
-                if (!destFile.toPath().normalize().startsWith(Path.of(newPath))) {
+                if (!destFile.getCanonicalPath().startsWith(newPath)) {
                     fail("Bad zip entry");
                 }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
@@ -45,6 +45,10 @@ public class ZipFileTestUtilService {
                     fail("Bad zip entry");
                 }
 
+                File destinationParent = destFile.getParentFile();
+                // create the parent directory structure if needed
+                destinationParent.mkdirs();
+
                 if (!entry.isDirectory()) {
                     FileUtils.copyInputStreamToFile(zip.getInputStream(entry), destFile);
                 }

--- a/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
@@ -30,9 +30,10 @@ public class ZipFileTestUtilService {
         try (ZipFile zip = new ZipFile(file)) {
             String newPath = zipFile.substring(0, zipFile.length() - 4);
 
-            new File(newPath).mkdir();
-            Enumeration<? extends ZipEntry> zipFileEntries = zip.entries();
+            File parentFolder = new File(newPath);
+            parentFolder.mkdir();
 
+            Enumeration<? extends ZipEntry> zipFileEntries = zip.entries();
             // Process each entry
             while (zipFileEntries.hasMoreElements()) {
                 // grab a zip file entry
@@ -40,7 +41,7 @@ public class ZipFileTestUtilService {
                 String currentEntry = entry.getName();
                 File destFile = new File(newPath, currentEntry);
 
-                if (!destFile.getCanonicalPath().startsWith(newPath)) {
+                if (!destFile.getCanonicalPath().startsWith(parentFolder.getCanonicalPath())) {
                     fail("Bad zip entry");
                 }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -22,9 +23,10 @@ public class ZipFileTestUtilService {
      * Extracts a zip file recursively.
      *
      * @param zipFile The path to the zip file
+     * @return path to the directory containing the exported files
      * @throws IOException if something goes wrong
      */
-    public void extractZipFileRecursively(String zipFile) throws IOException {
+    public Path extractZipFileRecursively(String zipFile) throws IOException {
         File file = new File(zipFile);
 
         try (ZipFile zip = new ZipFile(file)) {
@@ -58,6 +60,7 @@ public class ZipFileTestUtilService {
                     extractZipFileRecursively(destFile.getAbsolutePath());
                 }
             }
+            return parentFolder.toPath();
         }
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.util;
 
+import static org.assertj.core.api.Assertions.fail;
+
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -37,6 +40,10 @@ public class ZipFileTestUtilService {
                 ZipEntry entry = zipFileEntries.nextElement();
                 String currentEntry = entry.getName();
                 File destFile = new File(newPath, currentEntry);
+
+                if (!destFile.toPath().normalize().startsWith(Path.of(newPath))) {
+                    fail("Bad zip entry");
+                }
 
                 if (!entry.isDirectory()) {
                     FileUtils.copyInputStreamToFile(zip.getInputStream(entry), destFile);

--- a/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
@@ -1,14 +1,12 @@
 package de.tum.in.www1.artemis.util;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import org.apache.commons.io.FileUtils;
 import org.springframework.stereotype.Service;
 
 /**
@@ -40,25 +38,9 @@ public class ZipFileTestUtilService {
                 ZipEntry entry = zipFileEntries.nextElement();
                 String currentEntry = entry.getName();
                 File destFile = new File(newPath, currentEntry);
-                File destinationParent = destFile.getParentFile();
-
-                // create the parent directory structure if needed
-                destinationParent.mkdirs();
 
                 if (!entry.isDirectory()) {
-                    int currentByte;
-                    // establish buffer for writing file
-                    byte[] data = new byte[BUFFER];
-                    try (BufferedInputStream is = new BufferedInputStream(zip.getInputStream(entry));
-                            FileOutputStream fos = new FileOutputStream(destFile);
-                            BufferedOutputStream dest = new BufferedOutputStream(fos, BUFFER)) {
-
-                        // write the current file to disk
-                        // read and write until last byte is encountered
-                        while ((currentByte = is.read(data, 0, BUFFER)) != -1) {
-                            dest.write(data, 0, currentByte);
-                        }
-                    }
+                    FileUtils.copyInputStreamToFile(zip.getInputStream(entry), destFile);
                 }
 
                 if (currentEntry.endsWith(".zip")) {

--- a/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
@@ -23,7 +23,6 @@ public class ZipFileTestUtilService {
      * @throws IOException if something goes wrong
      */
     public void extractZipFileRecursively(String zipFile) throws IOException {
-        int BUFFER = 2048;
         File file = new File(zipFile);
 
         try (ZipFile zip = new ZipFile(file)) {

--- a/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
@@ -39,7 +39,7 @@ public class ZipFileTestUtilService {
                 // grab a zip file entry
                 ZipEntry entry = zipFileEntries.nextElement();
                 String currentEntry = entry.getName();
-                File destFile = new File(newPath, currentEntry);
+                File destFile = new File(parentFolder, currentEntry);
 
                 if (!destFile.getCanonicalPath().startsWith(parentFolder.getCanonicalPath())) {
                     fail("Bad zip entry");

--- a/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ZipFileTestUtilService.java
@@ -28,45 +28,43 @@ public class ZipFileTestUtilService {
         int BUFFER = 2048;
         File file = new File(zipFile);
 
-        ZipFile zip = new ZipFile(file);
-        String newPath = zipFile.substring(0, zipFile.length() - 4);
+        try (ZipFile zip = new ZipFile(file)) {
+            String newPath = zipFile.substring(0, zipFile.length() - 4);
 
-        new File(newPath).mkdir();
-        Enumeration<? extends ZipEntry> zipFileEntries = zip.entries();
+            new File(newPath).mkdir();
+            Enumeration<? extends ZipEntry> zipFileEntries = zip.entries();
 
-        // Process each entry
-        while (zipFileEntries.hasMoreElements()) {
-            // grab a zip file entry
-            ZipEntry entry = zipFileEntries.nextElement();
-            String currentEntry = entry.getName();
-            File destFile = new File(newPath, currentEntry);
-            File destinationParent = destFile.getParentFile();
+            // Process each entry
+            while (zipFileEntries.hasMoreElements()) {
+                // grab a zip file entry
+                ZipEntry entry = zipFileEntries.nextElement();
+                String currentEntry = entry.getName();
+                File destFile = new File(newPath, currentEntry);
+                File destinationParent = destFile.getParentFile();
 
-            // create the parent directory structure if needed
-            destinationParent.mkdirs();
+                // create the parent directory structure if needed
+                destinationParent.mkdirs();
 
-            if (!entry.isDirectory()) {
-                BufferedInputStream is = new BufferedInputStream(zip.getInputStream(entry));
-                int currentByte;
-                // establish buffer for writing file
-                byte[] data = new byte[BUFFER];
+                if (!entry.isDirectory()) {
+                    int currentByte;
+                    // establish buffer for writing file
+                    byte[] data = new byte[BUFFER];
+                    try (BufferedInputStream is = new BufferedInputStream(zip.getInputStream(entry));
+                            FileOutputStream fos = new FileOutputStream(destFile);
+                            BufferedOutputStream dest = new BufferedOutputStream(fos, BUFFER)) {
 
-                // write the current file to disk
-                FileOutputStream fos = new FileOutputStream(destFile);
-                BufferedOutputStream dest = new BufferedOutputStream(fos, BUFFER);
-
-                // read and write until last byte is encountered
-                while ((currentByte = is.read(data, 0, BUFFER)) != -1) {
-                    dest.write(data, 0, currentByte);
+                        // write the current file to disk
+                        // read and write until last byte is encountered
+                        while ((currentByte = is.read(data, 0, BUFFER)) != -1) {
+                            dest.write(data, 0, currentByte);
+                        }
+                    }
                 }
-                dest.flush();
-                dest.close();
-                is.close();
-            }
 
-            if (currentEntry.endsWith(".zip")) {
-                // found a zip file, try to open
-                extractZipFileRecursively(destFile.getAbsolutePath());
+                if (currentEntry.endsWith(".zip")) {
+                    // found a zip file, try to open
+                    extractZipFileRecursively(destFile.getAbsolutePath());
+                }
             }
         }
     }


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
This PR fixes a few issues present when running the server tests locally on Windows.

### Description
- The method `extractZipFileRecursively` opened a ZipFile, but was not closing it, leading to issues when deleting the file later on. I also simplified the Method.
- `extractZipFileRecursively()` now directly returns the created folder to access its files later in the test.
- The `FileServiceTest` was using `URL.create()` after calling `toString()` on a `Path`. On Windows, Paths contain backslashes, but URIs can only contain forward slashes. We now replace backslashes with forward slashes.
- Fixes multiple occurrences of temporary files that got created but never deleted.
- Removes `@DisableOnOs` annotations and fixes unclosed test resources.
- Refactored and improved some places.

### Steps for Testing
code review
run the tests on Windows if you own a Windows setup.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2