### PR TITLE
`Development`: Avoid unnecessary fetching of messages and posts

### DIFF
--- a/src/main/webapp/app/overview/course-discussion/course-discussion.component.ts
+++ b/src/main/webapp/app/overview/course-discussion/course-discussion.component.ts
@@ -74,7 +74,7 @@ export class CourseDiscussionComponent extends CourseDiscussionDirective impleme
             });
         });
         this.postsSubscription = this.metisService.posts.pipe().subscribe((posts: Post[]) => {
-            this.posts = posts;
+            this.posts = posts.slice();
             this.isLoading = false;
         });
         this.totalItemsSubscription = this.metisService.totalNumberOfPosts.pipe().subscribe((totalItems: number) => {

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -479,9 +479,10 @@ export class MetisService implements OnDestroy {
                 case MetisPostAction.CREATE:
                     if (
                         postDTO.post.conversation?.id !== undefined &&
-                        postDTO.post.conversation.id === this.currentPostContextFilter.conversationId // is message in active conversation
+                        postDTO.post.conversation.id === this.currentPostContextFilter.conversationId &&
+                        (!this.currentPostContextFilter.searchText || postDTO.post.content?.toLowerCase().includes(this.currentPostContextFilter.searchText.toLowerCase()))
                     ) {
-                        // we can add the sent post to the cached posts without violating the current context filter setting
+                        // we can add the received conversation message to the cached messages without violating the current context filter setting
                         this.cachedPosts = [postDTO.post, ...this.cachedPosts];
                     }
                     this.addTags(postDTO.post.tags);

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -476,10 +476,14 @@ export class MetisService implements OnDestroy {
             });
 
             if (
-                (postDTO.post.courseWideContext && this.currentPostContextFilter.courseWideContexts?.includes(postDTO.post.courseWideContext)) ||
-                (postDTO.post.lecture?.id !== undefined && this.currentPostContextFilter.lectureIds?.includes(postDTO.post.lecture.id)) ||
-                (postDTO.post.exercise?.id !== undefined && this.currentPostContextFilter.exerciseIds?.includes(postDTO.post.exercise.id)) ||
-                (postDTO.post.conversation?.id !== undefined && postDTO.post.conversation.id === this.currentPostContextFilter.conversationId)
+                (postDTO.post.conversation?.id !== undefined && postDTO.post.conversation.id === this.currentPostContextFilter.conversationId) || // is message in active conversation
+                (postDTO.post.courseWideContext && this.currentPostContextFilter.courseWideContexts?.includes(postDTO.post.courseWideContext)) || // is course-wide post matching current filter
+                (postDTO.post.lecture?.id !== undefined && this.currentPostContextFilter.lectureIds?.includes(postDTO.post.lecture.id)) || // is lecture post in current filter
+                (postDTO.post.exercise?.id !== undefined && this.currentPostContextFilter.exerciseIds?.includes(postDTO.post.exercise.id)) || // is exercise post matching current filter
+                (!postDTO.post.conversation &&
+                    this.currentPostContextFilter.courseWideContexts === undefined &&
+                    this.currentPostContextFilter.lectureIds === undefined &&
+                    this.currentPostContextFilter.exerciseIds === undefined) // is any kind of Q&A post and no filter is set
             )
                 switch (postDTO.action) {
                     case MetisPostAction.CREATE:
@@ -509,7 +513,7 @@ export class MetisService implements OnDestroy {
                 }
             // emit updated version of cachedPosts to subscribing components
             if (PageType.OVERVIEW === this.pageType) {
-                // by invoking the getFilteredPosts method with forceUpdate set to true, i.e. refetch currently displayed posts from server
+                // by invoking the getFilteredPosts method with forceUpdate set to false, i.e. without fetching posts from server, unless the postContextFilter changed
                 const oldPage = this.currentPostContextFilter.page;
                 const oldPageSize = this.currentPostContextFilter.pageSize;
                 this.currentPostContextFilter.pageSize = oldPageSize! * (oldPage! + 1);

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -502,19 +502,18 @@ export class MetisService implements OnDestroy {
                 default:
                     break;
             }
-            // emit updated version of cachedPosts to subscribing components
+            // emit updated version of cachedPosts to subscribing components...
             if (PageType.OVERVIEW === this.pageType) {
-                // by invoking the getFilteredPosts method with forceUpdate set to false, i.e. without fetching posts from server, unless the postContextFilter changed
                 const oldPage = this.currentPostContextFilter.page;
                 const oldPageSize = this.currentPostContextFilter.pageSize;
                 this.currentPostContextFilter.pageSize = oldPageSize! * (oldPage! + 1);
                 this.currentPostContextFilter.page = 0;
-                // force update only when receiving a new Q&A post
+                // ...by invoking the getFilteredPosts method with forceUpdate set to true iff receiving a new Q&A post, i.e. fetching posts from server only in this case
                 this.getFilteredPosts(this.currentPostContextFilter, !postDTO.post.conversation && postDTO.action === MetisPostAction.CREATE, this.currentConversation);
                 this.currentPostContextFilter.pageSize = oldPageSize;
                 this.currentPostContextFilter.page = oldPage;
             } else {
-                // by invoking the getFilteredPosts method with forceUpdate set to false, i.e. without fetching posts from server
+                // ...by invoking the getFilteredPosts method with forceUpdate set to false, i.e. without fetching posts from server
                 this.getFilteredPosts(this.currentPostContextFilter, false);
             }
         });

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -477,13 +477,13 @@ export class MetisService implements OnDestroy {
 
             if (
                 (postDTO.post.conversation?.id !== undefined && postDTO.post.conversation.id === this.currentPostContextFilter.conversationId) || // is message in active conversation
-                (postDTO.post.courseWideContext && this.currentPostContextFilter.courseWideContexts?.includes(postDTO.post.courseWideContext)) || // is course-wide post matching current filter
-                (postDTO.post.lecture?.id !== undefined && this.currentPostContextFilter.lectureIds?.includes(postDTO.post.lecture.id)) || // is lecture post in current filter
-                (postDTO.post.exercise?.id !== undefined && this.currentPostContextFilter.exerciseIds?.includes(postDTO.post.exercise.id)) || // is exercise post matching current filter
                 (!postDTO.post.conversation &&
                     this.currentPostContextFilter.courseWideContexts === undefined &&
                     this.currentPostContextFilter.lectureIds === undefined &&
-                    this.currentPostContextFilter.exerciseIds === undefined) // is any kind of Q&A post and no filter is set
+                    this.currentPostContextFilter.exerciseIds === undefined) || // is any kind of Q&A post and no filter is set
+                (postDTO.post.courseWideContext && this.currentPostContextFilter.courseWideContexts?.includes(postDTO.post.courseWideContext)) || // is course-wide post matching current filter
+                (postDTO.post.lecture?.id !== undefined && this.currentPostContextFilter.lectureIds?.includes(postDTO.post.lecture.id)) || // is lecture post in current filter
+                (postDTO.post.exercise?.id !== undefined && this.currentPostContextFilter.exerciseIds?.includes(postDTO.post.exercise.id)) // is exercise post matching current filter
             )
                 switch (postDTO.action) {
                     case MetisPostAction.CREATE:

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -484,7 +484,7 @@ export class MetisService implements OnDestroy {
                 switch (postDTO.action) {
                     case MetisPostAction.CREATE:
                         // we can add the sent post to the cached posts without violating the current context filter setting
-                        this.cachedPosts.push(postDTO.post);
+                        this.cachedPosts = [postDTO.post, ...this.cachedPosts];
                         this.addTags(postDTO.post.tags);
                         break;
                     case MetisPostAction.UPDATE:
@@ -514,7 +514,7 @@ export class MetisService implements OnDestroy {
                 const oldPageSize = this.currentPostContextFilter.pageSize;
                 this.currentPostContextFilter.pageSize = oldPageSize! * (oldPage! + 1);
                 this.currentPostContextFilter.page = 0;
-                this.getFilteredPosts(this.currentPostContextFilter, true, this.currentConversation);
+                this.getFilteredPosts(this.currentPostContextFilter, false, this.currentConversation);
                 this.currentPostContextFilter.pageSize = oldPageSize;
                 this.currentPostContextFilter.page = oldPage;
             } else {

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -950,7 +950,7 @@ Course Info Bar
     box-shadow: 3px 3px 6px $mat-autocomplete-visible-box-shadow;
 }
 
-.mat-select-panel {
+.cdk-overlay-container .cdk-overlay-pane .mat-select-panel {
     background: $metis-course-discussion-select-bg;
     -webkit-box-shadow: 3px 3px 6px $mat-autocomplete-visible-box-shadow;
     -moz-box-shadow: 3px 3px 6px $mat-autocomplete-visible-box-shadow;

--- a/src/test/javascript/spec/service/metis/metis.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/metis.service.spec.ts
@@ -551,7 +551,7 @@ describe('Metis Service', () => {
         }));
 
         it.each([MetisPostAction.CREATE, MetisPostAction.UPDATE, MetisPostAction.DELETE])(
-            'should not call postService.getPosts() if postContextFilter does not change and forceUpdate is false',
+            'should not call postService.getPosts() for new or updated messages received over WebSocket',
             (action: MetisPostAction) => {
                 // Setup
                 const channel = 'someChannel';

--- a/src/test/javascript/spec/service/metis/metis.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/metis.service.spec.ts
@@ -592,7 +592,6 @@ describe('Metis Service', () => {
             metisService.setPageType(PageType.OVERVIEW);
             metisService.createWebsocketSubscription(channel);
 
-            // set currentPostContextFilter with search text
             jest.spyOn(postService, 'getPosts').mockReturnValue(
                 of(
                     new HttpResponse({
@@ -604,7 +603,9 @@ describe('Metis Service', () => {
                 ),
             );
 
+            // set currentPostContextFilter with search text
             metisService.getFilteredPosts({ conversationId: mockPostDTO.post.conversation?.id, searchText: 'Search text' } as PostContextFilter);
+
             // Emulate receiving a message matching the search text
             mockReceiveObservable.next(mockPostDTO);
             // Emulate receiving a message not matching the search text

--- a/src/test/javascript/spec/service/metis/metis.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/metis.service.spec.ts
@@ -13,7 +13,7 @@ import { AnswerPost } from 'app/entities/metis/answer-post.model';
 import { ReactionService } from 'app/shared/metis/reaction.service';
 import { MockReactionService } from '../../helpers/mocks/service/mock-reaction.service';
 import { Reaction } from 'app/entities/metis/reaction.model';
-import { CourseWideContext, DisplayPriority, MetisPostAction, MetisWebsocketChannelPrefix, PageType } from 'app/shared/metis/metis.util';
+import { CourseWideContext, DisplayPriority, MetisPostAction, MetisWebsocketChannelPrefix, PageType, PostContextFilter } from 'app/shared/metis/metis.util';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
 import { Router } from '@angular/router';
@@ -561,14 +561,17 @@ describe('Metis Service', () => {
                 };
                 const mockReceiveObservable = new Subject();
                 websocketServiceReceiveStub.mockReturnValue(mockReceiveObservable.asObservable());
-                const getPostsSpy = jest.spyOn(postService, 'getPosts');
                 metisService.setPageType(PageType.OVERVIEW);
                 metisService.createWebsocketSubscription(channel);
+
+                // set currentPostContextFilter appropriately
+                metisService.getFilteredPosts({ conversationId: mockPostDTO.post.conversation?.id } as PostContextFilter);
 
                 // Ensure subscribe to websocket was called
                 expect(websocketService.subscribe).toHaveBeenCalled();
 
                 // Emulate receiving a message
+                const getPostsSpy = jest.spyOn(postService, 'getPosts');
                 mockReceiveObservable.next(mockPostDTO);
 
                 // Ensure getPosts() was not called


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When a client receives a new or updated Q&A post or conversation message via WebSocket, it currently fetches the last 50 messages, despite the WebSocket message providing all necessary information for appropriate client updates. Particularly when numerous users are online simultaneously, this approach generates a substantial number of unnecessary GET requests that the servers must process.

### Description
<!-- Describe your changes in detail -->
Upon receiving a WebSocket message for an updated or created post/message, the client now updates the list of stored posts/messages accordingly without triggering an unnecessary REST request. The only exception is, when new Q&A posts are received. Adapting this use case would require to implement the server-side filtering in the client-side. However, since this use case is deprecated, it will not be changed in this PR.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 2 Students
- 1 Course with messaging and communication

1. Write messages/posts. Also react, edit, reply, and resolve messages/posts
2. Confirm (with the help of the Chrome developer tools) that GET /posts or GET /messages requests are only made (besides loading a page initially) if:
     1. another conversation is opened on the messages tab
     2. a new Q&A post is created (communication tab)
     3. you search for messages/posts or change other filtering settings

In all other cases, neither the author nor another involved course member (2nd student) makes GET requests

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [course-discussion.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5567/latest/artifact/shared/Coverage-Report-Client-Tests/app/overview/course-discussion/course-discussion.component.ts.html) | 95.28% | ✅ |
| [metis.service.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5567/latest/artifact/shared/Coverage-Report-Client-Tests/app/shared/metis/metis.service.ts.html) | 95.58% | ✅ |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
No major UI changes (just a bugfix, because the post context filter was transparent):
before: 
![before](https://github.com/ls1intum/Artemis/assets/44754405/f6a0c799-4f22-4926-9c4c-258700627b5c)

after:
![after](https://github.com/ls1intum/Artemis/assets/44754405/7f7abd32-442c-4969-915b-9a04181b65f3)

