### PR TITLE
`Adaptive learning`: Fix accessibility of competency relation editor for instructors

### DIFF
--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
@@ -107,6 +107,7 @@
                         [nodes]="nodes"
                         [links]="edges"
                         [clusters]="clusters"
+                        [update$]="update$"
                     >
                         <ng-template #defsTemplate>
                             <svg:marker id="arrow" viewBox="0 -5 10 10" refX="8" refY="0" markerWidth="4" markerHeight="4" orient="auto">

--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
@@ -23,7 +23,7 @@
         </div>
     </div>
 
-    <div *ngIf="showRelations" class="container mt-3 mb-3">
+    <div class="container mx-0 mt-3 mb-3 mw-100">
         <ngb-accordion [closeOthers]="true">
             <ngb-panel id="panel-1">
                 <ng-template ngbPanelTitle
@@ -80,7 +80,7 @@
                                 </select>
                             </div>
                         </div>
-                        <div class="col">
+                        <div class="col-auto">
                             <input
                                 type="button"
                                 class="btn btn-primary"
@@ -122,7 +122,7 @@
 
                         <ng-template #nodeTemplate let-node>
                             <svg:g class="node">
-                                <svg:rect [attr.width]="node.dimension.width" [attr.height]="node.dimension.height" [attr.fill]="node.data.color" />
+                                <svg:rect [attr.width]="node.dimension.width" [attr.height]="node.dimension.height" />
                                 <svg:text alignment-baseline="central" [attr.x]="10" [attr.y]="node.dimension.height / 2">
                                     {{ node.label }}
                                 </svg:text>

--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
@@ -101,7 +101,6 @@
                     <ngx-graph
                         class="m-1 chart-container"
                         layout="dagreCluster"
-                        [view]="[1200, 600]"
                         [enableZoom]="false"
                         [draggingEnabled]="false"
                         [nodes]="nodes"

--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.scss
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.scss
@@ -39,3 +39,22 @@
         fill: var(--primary);
     }
 }
+
+#arrow {
+    stroke: var(--body-color);
+    fill: var(--body-color);
+}
+
+.edge {
+    stroke: var(--body-color) !important;
+    marker-end: url(#arrow);
+}
+
+.text-path {
+    fill: var(--body-color);
+}
+
+::ng-deep .accordion-body {
+    overflow: hidden;
+    max-height: 60vh;
+}

--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.scss
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.scss
@@ -29,3 +29,13 @@
 .border-danger {
     border-color: var(--danger);
 }
+
+.node {
+    text {
+        fill: var(--body-color);
+    }
+
+    rect {
+        fill: var(--primary);
+    }
+}

--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.ts
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.ts
@@ -299,7 +299,7 @@ export class CompetencyManagementComponent implements OnInit, OnDestroy {
     removeRelation(edge: Edge) {
         this.competencyService.removeCompetencyRelation(Number(edge.source), Number(edge.data.id), this.courseId).subscribe({
             next: () => {
-                const index = this.edges.indexOf(edge);
+                const index = this.edges.findIndex((e) => e.id === edge.id);
                 this.edges.splice(index, 1);
                 this.update$.next(true);
             },

--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.ts
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.ts
@@ -26,7 +26,6 @@ export class CompetencyManagementComponent implements OnInit, OnDestroy {
     competencies: Competency[] = [];
     prerequisites: Competency[] = [];
 
-    showRelations = false;
     tailCompetency?: number;
     headCompetency?: number;
     relationType?: string;
@@ -63,7 +62,6 @@ export class CompetencyManagementComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit(): void {
-        this.showRelations = this.accountService.isAdmin(); // beta feature
         this.activatedRoute.parent!.params.subscribe((params) => {
             this.courseId = params['courseId'];
             if (this.courseId) {

--- a/src/main/webapp/app/course/learning-paths/learning-path-graph/learning-path-graph.component.html
+++ b/src/main/webapp/app/course/learning-paths/learning-path-graph/learning-path-graph.component.html
@@ -28,7 +28,7 @@
         </ng-template>
         <ng-template #linkTemplate let-link>
             <svg:g class="edge">
-                <svg:path class="line" stroke-width="2"></svg:path>
+                <svg:path class="line" stroke-width="2" marker-end="url(#arrow)"></svg:path>
             </svg:g>
         </ng-template>
         <ng-template #clusterTemplate let-cluster>

--- a/src/test/javascript/spec/component/competencies/competency-management.component.spec.ts
+++ b/src/test/javascript/spec/component/competencies/competency-management.component.spec.ts
@@ -13,7 +13,7 @@ import { HttpResponse } from '@angular/common/http';
 import { AccountService } from 'app/core/auth/account.service';
 import { ArtemisTestModule } from '../../test.module';
 import { CompetencyCardStubComponent } from './competency-card-stub.component';
-import { NgbModal, NgbModalRef, NgbPanel, NgbProgressbar } from '@ng-bootstrap/ng-bootstrap';
+import { NgbAccordion, NgbModal, NgbModalRef, NgbPanel, NgbProgressbar } from '@ng-bootstrap/ng-bootstrap';
 import { AlertService } from 'app/core/util/alert.service';
 import { MockNgbModalService } from '../../helpers/mocks/service/mock-ngb-modal.service';
 import { PrerequisiteImportComponent } from 'app/course/competencies/competency-management/prerequisite-import.component';
@@ -43,7 +43,7 @@ describe('CompetencyManagementComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([]), NgbProgressbar],
+            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([]), NgbProgressbar, NgbAccordion],
             declarations: [
                 CompetencyManagementComponent,
                 CompetencyCardStubComponent,


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, the Competency Relation Editor is only accessible to admins. This PR allows Instructors to configure these relations.

### Description
<!-- Describe your changes in detail -->
This PR
- grants instructors access to the competency relation editor
- improves some related styling issues
- prevents full reload of data on adding/removing relations

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course with multiple Competencies

1. Log in to Artemis
2. Navigate to Course Administration > Competency Management
3. Make sure the Competency Relation Editor is visible
4. Make sure the editor takes up the full-screen width
5. Make sure the editor doesn't close when adding or removing relations

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [competency-management.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5584/latest/artifact/shared/Coverage-Report-Client-Tests/app/course/competencies/competency-management/competency-management.component.ts.html) | 80.1% | ✅ |

 

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![chrome_ZrzhEWpPl9](https://github.com/ls1intum/Artemis/assets/44003963/4e643610-96ff-4fa5-b11e-0234df57b3e2)
