### PR TITLE
`Development`: Fix deprecated configuration in jest.config.js

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,53 @@
-const esModules = ['lodash-es', 'franc-min', 'trigram-utils', 'n-gram', 'collapse-white-space', '@angular/animations', '@angular/common', '@ls1intum/apollon',
-    '@angular/compiler', '@angular/core', '@angular/forms', '@angular/localize', '@angular/platform-browser', '@angular/platform-browser-dynamic', '@angular/router',
-    '@ngx-translate/core', '@ngx-translate/http-loader', '@fortawesome/angular-fontawesome', '@angular/cdk', '@angular/material', '@angular/cdk', 'dayjs/esm',
-    'rxjs/operators', '@ng-bootstrap/ng-bootstrap', 'ngx-webstorage', '@ctrl/ngx-emoji-mart', 'ngx-device-detector', '@swimlane/ngx-charts',
-    '@angular/service-worker', '@danielmoncada/angular-datetime-picker', '@flaviosantoro92/ngx-datatable', 'd3-color', 'd3-interpolate', 'd3-transition', 'd3-brush',
-    'd3-drag', 'd3-selection', 'd3-scale', 'd3-array', 'd3-format', 'd3-shape', 'd3-path', 'd3-ease', 'd3-time', 'd3-hierarchy', 'ngx-infinite-scroll', 'internmap',
-    '@swimlane/ngx-graph'].join('|');
+const esModules = [
+    'lodash-es',
+    'franc-min',
+    'trigram-utils',
+    'n-gram',
+    'collapse-white-space',
+    '@angular/animations',
+    '@angular/common',
+    '@ls1intum/apollon',
+    '@angular/compiler',
+    '@angular/core',
+    '@angular/forms',
+    '@angular/localize',
+    '@angular/platform-browser',
+    '@angular/platform-browser-dynamic',
+    '@angular/router',
+    '@ngx-translate/core',
+    '@ngx-translate/http-loader',
+    '@fortawesome/angular-fontawesome',
+    '@angular/cdk',
+    '@angular/material',
+    '@angular/cdk',
+    'dayjs/esm',
+    'rxjs/operators',
+    '@ng-bootstrap/ng-bootstrap',
+    'ngx-webstorage',
+    '@ctrl/ngx-emoji-mart',
+    'ngx-device-detector',
+    '@swimlane/ngx-charts',
+    '@angular/service-worker',
+    '@danielmoncada/angular-datetime-picker',
+    '@flaviosantoro92/ngx-datatable',
+    'd3-color',
+    'd3-interpolate',
+    'd3-transition',
+    'd3-brush',
+    'd3-drag',
+    'd3-selection',
+    'd3-scale',
+    'd3-array',
+    'd3-format',
+    'd3-shape',
+    'd3-path',
+    'd3-ease',
+    'd3-time',
+    'd3-hierarchy',
+    'ngx-infinite-scroll',
+    'internmap',
+    '@swimlane/ngx-graph',
+].join('|');
 
 const {
     compilerOptions: { baseUrl = './' },
@@ -12,25 +55,24 @@ const {
 
 module.exports = {
     globalSetup: 'jest-preset-angular/global-setup',
-    globals: {
-        'ts-jest': {
-            tsconfig: '<rootDir>/tsconfig.spec.json',
-            stringifyContentPathRegex: '\\.html$',
-            isolatedModules: true,
-            diagnostics: {
-                ignoreCodes: [151001],
-            },
-        },
-    },
     testEnvironmentOptions: {
-        url: 'https://artemis.fake/test'
+        url: 'https://artemis.fake/test',
     },
     roots: ['<rootDir>', `<rootDir>/${baseUrl}`],
     modulePaths: [`<rootDir>/${baseUrl}`],
     setupFiles: ['jest-date-mock'],
     cacheDirectory: '<rootDir>/build/jest-cache',
     coverageDirectory: '<rootDir>/build/test-results/',
-    reporters: ['default', ['jest-junit', { outputDirectory: '<rootDir>/build/test-results/', outputName: 'TESTS-results-jest.xml' }]],
+    reporters: [
+        'default',
+        [
+            'jest-junit',
+            {
+                outputDirectory: '<rootDir>/build/test-results/',
+                outputName: 'TESTS-results-jest.xml',
+            },
+        ],
+    ],
     collectCoverageFrom: ['src/main/webapp/**/*.{js,jsx,ts,tsx}', '!src/main/webapp/**/*.module.{js,jsx,ts,tsx}'],
     coveragePathIgnorePatterns: [
         '/node_modules/',
@@ -53,7 +95,7 @@ module.exports = {
         'src/main/webapp/app/exercises/modeling/manage/modeling-exercise.route.ts',
         'src/main/webapp/app/exam/manage/exam-management.route.ts',
         'src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint.route.ts',
-        'src/main/webapp/app/core/config/prod.config.ts'
+        'src/main/webapp/app/core/config/prod.config.ts',
     ],
     coverageThreshold: {
         global: {
@@ -64,13 +106,23 @@ module.exports = {
             lines: 85.8,
         },
     },
-    coverageReporters: ["clover", "json", "lcov", "text-summary"],
+    coverageReporters: ['clover', 'json', 'lcov', 'text-summary'],
     setupFilesAfterEnv: ['<rootDir>/src/test/javascript/spec/jest-test-setup.ts', 'jest-extended/all'],
     moduleFileExtensions: ['ts', 'html', 'js', 'json', 'mjs'],
     resolver: '<rootDir>/jest.resolver.js',
     transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
     transform: {
-        '^.+\\.(ts|js|mjs|html|svg)$': 'jest-preset-angular',
+        '^.+\\.(ts|js|mjs|html|svg)$': [
+            'jest-preset-angular',
+            {
+                tsconfig: '<rootDir>/tsconfig.spec.json',
+                stringifyContentPathRegex: '\\.html$',
+                isolatedModules: true,
+                diagnostics: {
+                    ignoreCodes: [151001],
+                },
+            },
+        ],
     },
     modulePathIgnorePatterns: [],
     testTimeout: 3000,
@@ -84,7 +136,7 @@ module.exports = {
         '<rootDir>/src/test/javascript/spec/util/**/*.spec.ts',
         '<rootDir>/src/test/javascript/spec/interceptor/**/*.spec.ts',
         '<rootDir>/src/test/javascript/spec/config/**/*.spec.ts',
-        '<rootDir>/src/test/javascript/spec/core/**/*.spec.ts'
+        '<rootDir>/src/test/javascript/spec/core/**/*.spec.ts',
     ],
     moduleNameMapper: {
         '^app/(.*)': '<rootDir>/src/main/webapp/app/$1',
@@ -94,6 +146,6 @@ module.exports = {
         '@env': '<rootDir>/src/main/webapp/environments/environment',
         '@src/(.*)': '<rootDir>/src/src/$1',
         '@state/(.*)': '<rootDir>/src/app/state/$1',
-        "^lodash-es$": "lodash"
+        '^lodash-es$': 'lodash',
     },
 };


### PR DESCRIPTION
### Checklist

#### General

- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context

When running tests, the following warning appeared, often several times, which clutters the test output:

```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```

### Description

As suggested by the warning and in the [docs for jest-preset-angular](https://thymikee.github.io/jest-preset-angular/docs/getting-started/options#brief-explanation-of-config), the ts-jest options were now moved from the global ts-jest configuration to the jest-preset-angular transform.

### Steps for Testing

1. Run tests
2. No warnings
3. Tests succeed

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2