### PR TITLE
`Development`: Prepare message notifications asynchronously

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/CreatedConversationMessage.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/CreatedConversationMessage.java
@@ -1,0 +1,16 @@
+package de.tum.in.www1.artemis.domain.metis;
+
+import java.util.Set;
+
+import de.tum.in.www1.artemis.domain.User;
+import de.tum.in.www1.artemis.domain.metis.conversation.Conversation;
+
+/**
+ * Encapsulates data needed after a new message has been created in a conversation. This data is used to send notifications to involved users about the new message asynchronously
+ *
+ * @param messageWithHiddenDetails the new message with hidden details, i.e. conversation details
+ * @param completeConversation     the conversation without hidden details
+ * @param mentionedUsers           users mentioned in the message
+ */
+public record CreatedConversationMessage(Post messageWithHiddenDetails, Conversation completeConversation, Set<User> mentionedUsers) {
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/ConversationMessagingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/ConversationMessagingService.java
@@ -132,11 +132,10 @@ public class ConversationMessagingService extends PostingService {
         User author = message.getAuthor();
         Conversation conversation = createdConversationMessage.completeConversation();
         Course course = conversation.getCourse();
-        Set<User> mentionedUsers = parseUserMentions(course, message.getContent());
         Set<ConversationWebSocketRecipientSummary> webSocketRecipients = getWebSocketRecipients(conversation).collect(Collectors.toSet());
         Set<User> broadcastRecipients = webSocketRecipients.stream().map(ConversationWebSocketRecipientSummary::user).collect(Collectors.toSet());
         // Add all mentioned users, including the author (if mentioned). Since working with sets, there are no duplicate user entries
-        broadcastRecipients.addAll(mentionedUsers);
+        broadcastRecipients.addAll(createdConversationMessage.mentionedUsers());
 
         // Websocket notification 1: this notifies everyone including the author that there is a new message
         broadcastForPost(new PostDTO(message, MetisCrudAction.CREATE), course, broadcastRecipients);
@@ -158,7 +157,7 @@ public class ConversationMessagingService extends PostingService {
 
         // creation of message posts should not trigger entity creation alert
         // Websocket notification 3
-        Set<User> notificationRecipients = filterNotificationRecipients(author, conversation, webSocketRecipients, mentionedUsers);
+        Set<User> notificationRecipients = filterNotificationRecipients(author, conversation, webSocketRecipients, createdConversationMessage.mentionedUsers());
         conversationNotificationService.notifyAboutNewMessage(message, notificationRecipients, course);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import de.tum.in.www1.artemis.domain.metis.CreatedConversationMessage;
 import de.tum.in.www1.artemis.domain.metis.Post;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastStudent;
 import de.tum.in.www1.artemis.service.metis.ConversationMessagingService;
@@ -51,8 +52,10 @@ public class ConversationMessageResource {
     @PostMapping("courses/{courseId}/messages")
     @EnforceAtLeastStudent
     public ResponseEntity<Post> createMessage(@PathVariable Long courseId, @Valid @RequestBody Post post) throws URISyntaxException {
-        Post createdMessage = conversationMessagingService.createMessage(courseId, post);
-        return ResponseEntity.created(new URI("/api/courses/" + courseId + "/messages/" + createdMessage.getId())).body(createdMessage);
+        CreatedConversationMessage createdMessageData = conversationMessagingService.createMessage(courseId, post);
+        conversationMessagingService.notifyAboutMessageCreation(createdMessageData);
+        return ResponseEntity.created(new URI("/api/courses/" + courseId + "/messages/" + createdMessageData.messageWithHiddenDetails().getId()))
+                .body(createdMessageData.messageWithHiddenDetails());
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [ ] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [ ] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, on the process of sending a WebSocket message itself is done asynchronously. Querying the recipients from the database and other preparations are done synchronously.

### Description
<!-- Describe your changes in detail -->
When a new message is written by a user in a conversation, the logic related to WebSocket messages is now asynchronously executed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 2 students
- 1 Course with messaging enabled

1. Write messages as student 1 in any conversation that both students are a member of (e.g. a course-wide channel)
2. Confirm, that both users see new messages, if both have the conversation open
3. Confirm that student 2 sees notifications, if they are on a different page than the messages tab

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
No UI changes