### PR TITLE
`General`: Make markdown editor resizable by default

### DIFF
--- a/src/main/webapp/app/admin/legal/legal-document-update.component.html
+++ b/src/main/webapp/app/admin/legal/legal-document-update.component.html
@@ -9,7 +9,6 @@
             (markdownChange)="checkUnsavedChanges($event)"
             [resizableMinHeight]="minHeight"
             [resizableMaxHeight]="maxHeight"
-            [enableResize]="true"
             [enableFileUpload]="false"
             [minHeightEditor]="700"
             class="markdown-editor"

--- a/src/main/webapp/app/course/tutorial-groups/tutorial-groups-management/tutorial-groups/crud/tutorial-group-form/tutorial-group-form.component.html
+++ b/src/main/webapp/app/course/tutorial-groups/tutorial-groups-management/tutorial-groups/crud/tutorial-group-form/tutorial-group-form.component.html
@@ -143,13 +143,7 @@
                     <a href="https://guides.github.com/features/mastering-markdown/"> GitHub Markdown Guide</a>
                 </small>
                 <!-- not included in reactive form -->
-                <jhi-markdown-editor
-                    aria-describedby="additionalInfoHelp"
-                    id="additionalInfo"
-                    class="markdown-editor"
-                    [(markdown)]="additionalInformation"
-                    [enableResize]="true"
-                ></jhi-markdown-editor>
+                <jhi-markdown-editor aria-describedby="additionalInfoHelp" id="additionalInfo" class="markdown-editor" [(markdown)]="additionalInformation"></jhi-markdown-editor>
             </div>
             <hr />
             <div class="form-check">

--- a/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-announcement-dialog/exam-live-announcement-create-modal.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-announcement-dialog/exam-live-announcement-create-modal.component.html
@@ -16,7 +16,6 @@
                 [colorCommands]="[]"
                 [defaultCommands]="COMMANDS"
                 (markdownChange)="textContentChanged($event)"
-                [enableResize]="true"
             ></jhi-markdown-editor>
         </div>
         <ng-container *ngIf="announcement">

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.html
@@ -230,19 +230,19 @@
             <h5 class="pb-1" jhiTranslate="artemisApp.examManagement.sections.text">Exam Texts</h5>
             <div class="form-group">
                 <label for="startText" jhiTranslate="artemisApp.examManagement.startText">>Start Text</label>
-                <jhi-markdown-editor id="startText" class="markdown-editor" [(markdown)]="exam.startText" [enableResize]="true"></jhi-markdown-editor>
+                <jhi-markdown-editor id="startText" class="markdown-editor" [(markdown)]="exam.startText"></jhi-markdown-editor>
             </div>
             <div class="form-group">
                 <label for="startText" jhiTranslate="artemisApp.examManagement.endText">End Text</label>
-                <jhi-markdown-editor id="endText" class="markdown-editor" [(markdown)]="exam.endText" [enableResize]="true"></jhi-markdown-editor>
+                <jhi-markdown-editor id="endText" class="markdown-editor" [(markdown)]="exam.endText"></jhi-markdown-editor>
             </div>
             <div class="form-group">
                 <label for="startText" jhiTranslate="artemisApp.examManagement.confirmationStartText">Confirmation Start Text</label>
-                <jhi-markdown-editor id="confirmationStartText" class="markdown-editor" [(markdown)]="exam.confirmationStartText" [enableResize]="true"></jhi-markdown-editor>
+                <jhi-markdown-editor id="confirmationStartText" class="markdown-editor" [(markdown)]="exam.confirmationStartText"></jhi-markdown-editor>
             </div>
             <div class="form-group">
                 <label for="startText" jhiTranslate="artemisApp.examManagement.confirmationEndText">Confirmation End Text</label>
-                <jhi-markdown-editor id="confirmationEndText" class="markdown-editor" [(markdown)]="exam.confirmationEndText" [enableResize]="true"></jhi-markdown-editor>
+                <jhi-markdown-editor id="confirmationEndText" class="markdown-editor" [(markdown)]="exam.confirmationEndText"></jhi-markdown-editor>
             </div>
             <div>
                 <button type="button" class="btn btn-secondary" (click)="resetToPreviousState()">

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
@@ -157,7 +157,6 @@
                 [domainCommands]="domainCommandsProblemStatement"
                 [(markdown)]="fileUploadExercise.problemStatement"
                 [editorMode]="EditorMode.LATEX"
-                [enableResize]="true"
             ></jhi-markdown-editor>
         </div>
         <!-- TODO we want to have a file upload here and store a PDF, not a text. We could allow to add text in the sample_solution_explanation field -->
@@ -168,7 +167,6 @@
                 [domainCommands]="domainCommandsSampleSolution"
                 [(markdown)]="fileUploadExercise.exampleSolution"
                 [editorMode]="EditorMode.LATEX"
-                [enableResize]="true"
             ></jhi-markdown-editor>
         </div>
         <div class="form-group" *ngIf="!isExamMode">

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
@@ -190,7 +190,6 @@
                 [domainCommands]="domainCommandsProblemStatement"
                 [(markdown)]="modelingExercise.problemStatement"
                 [editorMode]="EditorMode.LATEX"
-                [enableResize]="true"
             ></jhi-markdown-editor>
         </div>
         <div class="form-group">
@@ -210,7 +209,6 @@
                 [domainCommands]="domainCommandsSampleSolution"
                 [(markdown)]="modelingExercise.exampleSolutionExplanation"
                 [editorMode]="EditorMode.LATEX"
-                [enableResize]="true"
             ></jhi-markdown-editor>
         </div>
         <div class="form-group" *ngIf="!isExamMode">

--- a/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.html
@@ -8,7 +8,7 @@
         (markdownChange)="updateProblemStatement($event)"
         (onPreviewSelect)="generateHtml()"
         [showDefaultPreview]="false"
-        [enableResize]="false"
+        [minHeightEditor]="500"
     >
         <jhi-programming-exercise-instructions
             id="preview"
@@ -60,6 +60,4 @@
             class="editable-instruction-container__status__testcase"
         ></jhi-programming-exercise-instruction-instructor-analysis>
     </div>
-    <!-- Required for resizing; don't remove empty span -->
-    <fa-icon *ngIf="enableResize" [icon]="faGripLines" class="rg-bottom text-lightgrey"><span></span></fa-icon>
 </div>

--- a/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
@@ -1,7 +1,5 @@
 import { AfterViewInit, Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild, ViewEncapsulation } from '@angular/core';
 import { AlertService } from 'app/core/util/alert.service';
-import { Interactable } from '@interactjs/core/Interactable';
-import interact from 'interactjs';
 import { Observable, Subject, Subscription, of, throwError } from 'rxjs';
 import { catchError, map as rxMap, switchMap, tap } from 'rxjs/operators';
 import { TaskCommand } from 'app/shared/markdown-editor/domainCommands/programming-exercise/task.command';
@@ -40,8 +38,6 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
 
     savingInstructions = false;
     unsavedChangesValue = false;
-
-    interactResizable: Interactable;
 
     testCaseSubscription: Subscription;
     forceRenderSubscription: Subscription;
@@ -120,36 +116,6 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     }
 
     ngAfterViewInit() {
-        this.interactResizable = interact('.editable-instruction-container')
-            .resizable({
-                // Enable resize from top edge; triggered by class rg-top
-                edges: { left: false, right: false, bottom: '.rg-bottom', top: false },
-                // Set min and max height
-                modifiers: [
-                    // Set maximum width
-                    interact.modifiers!.restrictSize({
-                        min: { width: 0, height: 200 },
-                        max: { width: 2000, height: 1200 },
-                    }),
-                ],
-                inertia: true,
-            })
-            .on('resizestart', function (event: any) {
-                event.target.classList.add('card-resizable');
-            })
-            .on('resizeend', (event: any) => {
-                event.target.classList.remove('card-resizable');
-                this.markdownEditor.aceEditorContainer.getEditor().resize();
-            })
-            .on('resizemove', function (event: any) {
-                // The first child is the markdown editor.
-                const target = event.target.children && event.target.children[0];
-                if (target) {
-                    // Update element height
-                    target.style.height = event.rect.height + 'px';
-                }
-            });
-
         // If forced to render, generate the instruction HTML.
         if (this.forceRender) {
             this.forceRenderSubscription = this.forceRender.subscribe(() => this.generateHtml());

--- a/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.scss
+++ b/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.scss
@@ -22,6 +22,11 @@
         overflow: hidden;
     }
 
+    .markdown-editor {
+        border-left: var(--border-color) 1px solid;
+        border-right: var(--border-color) 1px solid;
+    }
+
     .instructions__content__markdown {
         background-color: var(--markdown-preview-editor-background);
     }
@@ -61,10 +66,5 @@
         &__item {
             flex: 1;
         }
-    }
-
-    .rg-bottom {
-        align-self: center;
-        cursor: row-resize;
     }
 }

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-form.scss
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-form.scss
@@ -1,7 +1,3 @@
-.form__editable-instructions ::ng-deep .editable-instruction-container__editor {
-    height: 500px;
-}
-
 .label-preview {
     font-size: 9pt;
 }

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
@@ -192,7 +192,6 @@
                     #markdownEditor
                     [markdown]="questionEditorText"
                     [showPreviewButton]="false"
-                    [enableResize]="true"
                     [domainCommands]="dragAndDropQuestionDomainCommands"
                     (markdownChange)="changesInMarkdown($event)"
                     (textWithDomainCommandsFound)="domainCommandsFound($event)"
@@ -207,7 +206,6 @@
                             #markdownEditor
                             [markdown]="questionEditorText"
                             [showPreviewButton]="false"
-                            [enableResize]="true"
                             [domainCommands]="dragAndDropQuestionDomainCommands"
                             (markdownChange)="changesInMarkdown($event)"
                             (textWithDomainCommandsFound)="domainCommandsFound($event)"

--- a/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
@@ -101,7 +101,6 @@
                     [markdown]="questionEditorText"
                     [showPreviewButton]="true"
                     [showVisualModeButton]="true"
-                    [enableResize]="true"
                     [domainCommands]="commandMultipleChoiceQuestions"
                     (markdownChange)="changesInMarkdown()"
                     (textWithDomainCommandsFound)="domainCommandsFound($event)"

--- a/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-update.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-update.component.html
@@ -68,7 +68,6 @@
                         (markdownChange)="updateHintContent($event)"
                         [resizableMinHeight]="MarkdownEditorHeight.SMALL"
                         [resizableMaxHeight]="MarkdownEditorHeight.LARGE"
-                        [enableResize]="true"
                         [domainCommands]="domainCommands"
                         [editorMode]="editorMode"
                     ></jhi-markdown-editor>

--- a/src/main/webapp/app/exercises/shared/structured-grading-criterion/grading-instructions-details/grading-instructions-details.component.html
+++ b/src/main/webapp/app/exercises/shared/structured-grading-criterion/grading-instructions-details/grading-instructions-details.component.html
@@ -146,7 +146,6 @@
                 [domainCommands]="domainCommands"
                 (markdownChange)="prepareForSave()"
                 (textWithDomainCommandsFound)="domainCommandsFound($event)"
-                [enableResize]="true"
             ></jhi-markdown-editor>
         </div>
         <!--- End of Edit Text Mode --->
@@ -164,7 +163,6 @@
                 (markdownChange)="prepareForSave()"
                 (textWithDomainCommandsFound)="setExerciseGradingInstructionText($event)"
                 [enableFileUpload]="false"
-                [enableResize]="true"
                 [showEditButton]="false"
                 [showPreviewButton]="false"
             ></jhi-markdown-editor>

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
@@ -160,7 +160,6 @@
                 [domainCommands]="domainCommandsProblemStatement"
                 [(markdown)]="textExercise.problemStatement"
                 [editorMode]="EditorMode.LATEX"
-                [enableResize]="true"
             ></jhi-markdown-editor>
         </div>
         <div class="form-group">
@@ -171,7 +170,6 @@
                 [domainCommands]="domainCommandsSampleSolution"
                 [(markdown)]="textExercise.exampleSolution"
                 [editorMode]="EditorMode.LATEX"
-                [enableResize]="true"
             ></jhi-markdown-editor>
         </div>
         <div class="form-group" *ngIf="!isExamMode">

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/text-unit-form/text-unit-form.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/text-unit-form/text-unit-form.component.html
@@ -40,7 +40,6 @@
                     id="content"
                     class="markdown-editor"
                     [(markdown)]="content"
-                    [enableResize]="true"
                     (markdownChange)="onMarkdownChange($event)"
                 ></jhi-markdown-editor>
             </div>

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
@@ -4,7 +4,7 @@
         <ng-container ngbNavItem="editor_edit">
             <a ngbNavLink class="btn-sm text-normal px-2 py-0 m-0" *ngIf="showEditButton">{{ 'entity.action.edit' | artemisTranslate }}</a>
             <ng-template ngbNavContent>
-                <div [ngStyle]="{ 'minHeight.px': minHeightEditor }" class="height-100 border-0 markdown-editor d-flex flex-column" [id]="uniqueMarkdownEditorId">
+                <div [ngStyle]="{ 'minHeight.px': minHeightEditor }" class="height-100 markdown-editor d-flex flex-column" [id]="uniqueMarkdownEditorId">
                     <jhi-ace-editor
                         #aceEditor
                         [mode]="aceEditorOptions.mode"

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
@@ -161,7 +161,7 @@ export class MarkdownEditorComponent implements AfterViewInit {
 
     /** Resizable constants **/
     @Input()
-    enableResize = false;
+    enableResize = true;
     @Input()
     resizableMaxHeight = MarkdownEditorHeight.LARGE;
     @Input()

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.html
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.html
@@ -3,7 +3,6 @@
         class="markdown-editor background-editor-color w-100"
         [markdown]="content"
         (markdownChange)="updateField($event)"
-        [enableResize]="true"
         [resizableMinHeight]="editorHeight"
         (onEditSelect)="previewMode = false"
         (onPreviewSelect)="previewMode = true"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
This PR closes #7385. Default behavior should be resizable markdown editors (it can still be disabled with `enableResize=false`).
This PR also removes unnecessary on-top built resizing for programming instruction editor.


### Steps for Testing
Look for markdown editors and verify that they are resizable and look/work correctly, especially for:
- Programming instructions editor (edit/create new programming exercise)
- Code of Conduct/Registration Confirmation Message (edit/create course)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
programming exercise instructions:
![image](https://github.com/ls1intum/Artemis/assets/78978542/00cf9940-1386-4fb9-9791-55b9c8b0ad99)
 course code of conduct: 
![image](https://github.com/ls1intum/Artemis/assets/78978542/a82cf934-a066-493c-8eb2-761ea2fa86e4)

