### PR TITLE
`General`: Remove create exercise button for tutors

### DIFF
--- a/src/main/webapp/app/course/manage/course-exercise-card.component.html
+++ b/src/main/webapp/app/course/manage/course-exercise-card.component.html
@@ -4,7 +4,7 @@
             <span> {{ exerciseCount }} </span>
             <span [jhiTranslate]="headingJhiTranslate"></span>
         </h5>
-        <div class="ms-auto">
+        <div *ngIf="course.isAtLeastEditor" class="ms-auto">
             <ng-content select="[exerciseCreateButtons]"></ng-content>
         </div>
         <button class="btn question-collapse" (click)="isCollapsed = !isCollapsed" [attr.aria-expanded]="!isCollapsed" [attr.aria-controls]="'collapseQuestion'">

--- a/src/main/webapp/app/course/manage/course-exercise-card.component.html
+++ b/src/main/webapp/app/course/manage/course-exercise-card.component.html
@@ -4,7 +4,7 @@
             <span> {{ exerciseCount }} </span>
             <span [jhiTranslate]="headingJhiTranslate"></span>
         </h5>
-        <div *ngIf="course.isAtLeastEditor" class="ms-auto">
+        <div *ngIf="course?.isAtLeastEditor" class="ms-auto">
             <ng-content select="[exerciseCreateButtons]"></ng-content>
         </div>
         <button class="btn question-collapse" (click)="isCollapsed = !isCollapsed" [attr.aria-expanded]="!isCollapsed" [attr.aria-controls]="'collapseQuestion'">


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://ls1intum.github.io/Artemis/dev/guidelines/client/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix visual bug where buttons were displayed to tutors that do not work for them.

### Description
<!-- Describe your changes in detail -->
In the course exercise overview tutors had the buttons to import and create exercises even though they should not be visible and they do not work. This PR fixes the buttons to only be displayed for editors and above.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Editor/Instructor
- 1 Tutor
- 1 Course

1. Log in to Artemis
2. Navigate to the exercise management page of the course under the course management
3. Check that tutors do **not** have the buttons
4. Check that editors/instructors have the buttons

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1725" alt="Bildschirmfoto 2023-10-16 um 18 12 16" src="https://github.com/ls1intum/Artemis/assets/38322605/b6180fbf-b499-4a8b-8c59-41952ba30291">