### PR TITLE
`General`: Only collapse exercise section when clicking section title

### DIFF
--- a/src/main/webapp/app/overview/course-exercises/course-exercises-grouped-by-category.component.html
+++ b/src/main/webapp/app/overview/course-exercises/course-exercises-grouped-by-category.component.html
@@ -2,9 +2,9 @@
     {{ 'artemisApp.courseOverview.exerciseList.noExerciseMatchesSearchAndFilters' | artemisTranslate }}
 </div>
 <ng-template #exercisesWithAppliedSearchAndFilters>
-    <div class="exercise-row-container mb-3" *ngFor="let exerciseGroupKey of Object.keys(exerciseGroups)" (click)="toggleGroupCategoryCollapse(exerciseGroupKey)">
+    <div class="exercise-row-container mb-3" *ngFor="let exerciseGroupKey of Object.keys(exerciseGroups)">
         <ng-container *ngIf="exerciseGroups[exerciseGroupKey].exercises.length">
-            <div class="control-label d-flex align-items-center">
+            <div class="control-label d-flex align-items-center" (click)="toggleGroupCategoryCollapse(exerciseGroupKey)">
                 <div class="icon-container pe-3">
                     <fa-icon
                         [icon]="faChevronRight"


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.

### Description
<!-- Describe your changes in detail -->
Fixes https://github.com/ls1intum/Artemis/issues/7400

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Students
- 1 Programming Exercise

1. Go to the student exercise view (timeframe)
2. Click on `Clone Repository`
3. See that the exercise section does not collapse (see the screencast for the wrong behaviour)

### Screenshots
The exercise section should not collapse!

https://github.com/ls1intum/Artemis/assets/63976129/44caf717-9064-4d0c-a78f-3785c275c4c3



