### PR TITLE
`Communication`: Speedup messaging

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/ConversationWebSocketRecipientSummary.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ConversationWebSocketRecipientSummary.java
@@ -4,9 +4,10 @@ package de.tum.in.www1.artemis.domain;
  * Stores the user of a conversation participant, who is supposed to receive a websocket message and stores whether
  * the corresponding conversation is hidden by the user.
  *
- * @param user                   the user who is a member of the conversation
+ * @param userId                 the id of the user who is a member of the conversation
+ * @param userLogin              the login of the user who is a member of the conversation
  * @param isConversationHidden   true if the user has hidden the conversation
  * @param isAtLeastTutorInCourse true if the user is at least a tutor in the course
  */
-public record ConversationWebSocketRecipientSummary(User user, boolean isConversationHidden, boolean isAtLeastTutorInCourse) {
+public record ConversationWebSocketRecipientSummary(Long userId, String userLogin, boolean isConversationHidden, boolean isAtLeastTutorInCourse) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/User.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/User.java
@@ -186,11 +186,9 @@ public class User extends AbstractAuditingEntity implements Participant {
     private ZonedDateTime irisAccepted = null;
 
     public User() {
-        super();
     }
 
     public User(Long id, String login) {
-        super();
         this.setId(id);
         this.login = login;
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/User.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/User.java
@@ -185,6 +185,16 @@ public class User extends AbstractAuditingEntity implements Participant {
     @Column(name = "iris_accepted")
     private ZonedDateTime irisAccepted = null;
 
+    public User() {
+        super();
+    }
+
+    public User(Long id, String login) {
+        super();
+        this.setId(id);
+        this.login = login;
+    }
+
     public String getLogin() {
         return login;
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
@@ -125,20 +125,16 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
             SELECT NEW de.tum.in.www1.artemis.domain.ConversationWebSocketRecipientSummary (
                 user,
                 CASE WHEN cp.isHidden = true THEN true ELSE false END,
-                CASE WHEN atLeastTutors.id IS NOT null THEN true ELSE false END
+                CASE WHEN ug.group = :teachingAssistantGroupName OR ug.group = :editorGroupName OR ug.group = :instructorGroupName THEN true ELSE false END
             )
             FROM User user
             JOIN UserGroup ug ON ug.userId = user.id
-            LEFT JOIN Course students ON ug.group = students.studentGroupName
-            LEFT JOIN Course atLeastTutors ON (atLeastTutors.teachingAssistantGroupName = ug.group
-                OR atLeastTutors.editorGroupName = ug.group
-                OR atLeastTutors.instructorGroupName = ug.group
-            )
             LEFT JOIN ConversationParticipant cp ON cp.user.id = user.id AND cp.conversation.id = :conversationId
-            WHERE user.isDeleted = false
-            AND (students.id = :courseId OR atLeastTutors.id = :courseId)
+            WHERE user.isDeleted = false AND (ug.group = :studentGroupName OR ug.group = :teachingAssistantGroupName OR ug.group = :editorGroupName OR ug.group = :instructorGroupName)
             """)
-    Set<ConversationWebSocketRecipientSummary> findAllWebSocketRecipientsInCourseForConversation(@Param("courseId") Long courseId, @Param("conversationId") Long conversationId);
+    Set<ConversationWebSocketRecipientSummary> findAllWebSocketRecipientsInCourseForConversation(@Param("conversationId") Long conversationId,
+            @Param("studentGroupName") String studentGroupName, @Param("teachingAssistantGroupName") String teachingAssistantGroupName,
+            @Param("editorGroupName") String editorGroupName, @Param("instructorGroupName") String instructorGroupName);
 
     /**
      * Searches for users in a group by their login or full name.

--- a/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
@@ -123,7 +123,8 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
 
     @Query("""
             SELECT NEW de.tum.in.www1.artemis.domain.ConversationWebSocketRecipientSummary (
-                user,
+                user.id,
+                user.login,
                 CASE WHEN cp.isHidden = true THEN true ELSE false END,
                 CASE WHEN ug.group = :teachingAssistantGroupName OR ug.group = :editorGroupName OR ug.group = :instructorGroupName THEN true ELSE false END
             )

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerPostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerPostService.java
@@ -84,7 +84,7 @@ public class AnswerPostService extends PostingService {
         AnswerPost savedAnswerPost = answerPostRepository.save(answerPost);
         postRepository.save(post);
 
-        this.preparePostAndBroadcast(savedAnswerPost, course);
+        preparePostAndBroadcast(savedAnswerPost, course);
         sendNotification(post, answerPost, course);
 
         return savedAnswerPost;

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/ConversationMessagingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/ConversationMessagingService.java
@@ -131,8 +131,9 @@ public class ConversationMessagingService extends PostingService {
     private void notifyAboutMessageCreation(User author, Conversation conversation, Course course, Post createdMessage, Set<User> mentionedUsers) {
         Set<ConversationWebSocketRecipientSummary> webSocketRecipients = getWebSocketRecipients(conversation).collect(Collectors.toSet());
         log.info("      getWebSocketRecipients DONE");
-        Set<User> broadcastRecipients = webSocketRecipients.stream().map(ConversationWebSocketRecipientSummary::user).collect(Collectors.toSet());
+        Set<User> broadcastRecipients = webSocketRecipients.stream().map(summary -> new User(summary.userId(), summary.userLogin())).collect(Collectors.toSet());
         // Add all mentioned users, including the author (if mentioned). Since working with sets, there are no duplicate user entries
+        mentionedUsers = mentionedUsers.stream().map(user -> new User(user.getId(), user.getLogin())).collect(Collectors.toSet());
         broadcastRecipients.addAll(mentionedUsers);
 
         // Websocket notification 1: this notifies everyone including the author that there is a new message
@@ -179,12 +180,13 @@ public class ConversationMessagingService extends PostingService {
     private Set<User> filterNotificationRecipients(User author, Conversation conversation, Set<ConversationWebSocketRecipientSummary> webSocketRecipients,
             Set<User> mentionedUsers) {
         // Initialize filter with check for author
-        Predicate<ConversationWebSocketRecipientSummary> filter = recipientSummary -> !Objects.equals(recipientSummary.user().getId(), author.getId());
+        Predicate<ConversationWebSocketRecipientSummary> filter = recipientSummary -> !Objects.equals(recipientSummary.userId(), author.getId());
 
         if (conversation instanceof Channel channel) {
             // If a channel is not an announcement channel, filter out users, that hid the conversation
             if (!channel.getIsAnnouncementChannel()) {
-                filter = filter.and(recipientSummary -> !recipientSummary.isConversationHidden() || mentionedUsers.contains(recipientSummary.user()));
+                filter = filter.and(
+                        recipientSummary -> !recipientSummary.isConversationHidden() || mentionedUsers.contains(new User(recipientSummary.userId(), recipientSummary.userLogin())));
             }
 
             // If a channel is not visible to students, filter out participants that are only students
@@ -196,7 +198,7 @@ public class ConversationMessagingService extends PostingService {
             filter = filter.and(recipientSummary -> !recipientSummary.isConversationHidden());
         }
 
-        return webSocketRecipients.stream().filter(filter).map(ConversationWebSocketRecipientSummary::user).collect(Collectors.toSet());
+        return webSocketRecipients.stream().filter(filter).map(summary -> new User(summary.userId(), summary.userLogin())).collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
@@ -128,7 +128,9 @@ public abstract class PostingService {
      */
     protected Stream<ConversationWebSocketRecipientSummary> getWebSocketRecipients(Conversation conversation) {
         if (conversation instanceof Channel channel && channel.getIsCourseWide()) {
-            return userRepository.findAllWebSocketRecipientsInCourseForConversation(conversation.getCourse().getId(), conversation.getId()).stream();
+            Course course = conversation.getCourse();
+            return userRepository.findAllWebSocketRecipientsInCourseForConversation(conversation.getId(), course.getStudentGroupName(), course.getTeachingAssistantGroupName(),
+                    course.getEditorGroupName(), course.getInstructorGroupName()).stream();
         }
 
         return conversationParticipantRepository.findConversationParticipantWithUserGroupsByConversationId(conversation.getId()).stream()

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
@@ -134,7 +134,8 @@ public abstract class PostingService {
         }
 
         return conversationParticipantRepository.findConversationParticipantWithUserGroupsByConversationId(conversation.getId()).stream()
-                .map(participant -> new ConversationWebSocketRecipientSummary(participant.getUser(), participant.getIsHidden() != null && participant.getIsHidden(),
+                .map(participant -> new ConversationWebSocketRecipientSummary(participant.getUser().getId(), participant.getUser().getLogin(),
+                        participant.getIsHidden() != null && participant.getIsHidden(),
                         authorizationCheckService.isAtLeastTeachingAssistantInCourse(conversation.getCourse(), participant.getUser())));
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -236,7 +236,7 @@ public class ConversationService {
         var remainingUsers = existingUsers.stream().filter(user -> !usersToBeDeregistered.contains(user)).collect(Collectors.toSet());
         var participantsToRemove = conversationParticipantRepository.findConversationParticipantsByConversationIdAndUserIds(conversation.getId(),
                 usersToBeDeregistered.stream().map(User::getId).collect(Collectors.toSet()));
-        if (participantsToRemove.size() > 0) {
+        if (!participantsToRemove.isEmpty()) {
             conversationParticipantRepository.deleteAll(participantsToRemove);
             broadcastOnConversationMembershipChannel(course, MetisCrudAction.DELETE, conversation, usersToBeDeregistered);
             broadcastOnConversationMembershipChannel(course, MetisCrudAction.UPDATE, conversation, remainingUsers);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/AnswerMessageResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/AnswerMessageResource.java
@@ -37,7 +37,7 @@ public class AnswerMessageResource {
     @PostMapping("courses/{courseId}/answer-messages")
     @EnforceAtLeastStudent
     public ResponseEntity<AnswerPost> createAnswerMessage(@PathVariable Long courseId, @RequestBody AnswerPost answerMessage) throws URISyntaxException {
-        log.info("POST createAnswerMessage invoked for course {} with message {}", courseId, answerMessage.getContent());
+        log.debug("POST createAnswerMessage invoked for course {} with message {}", courseId, answerMessage.getContent());
         long start = System.nanoTime();
         AnswerPost createdAnswerMessage = answerMessageService.createAnswerMessage(courseId, answerMessage);
         // creation of answerMessage should not trigger alert
@@ -57,7 +57,7 @@ public class AnswerMessageResource {
     @PutMapping("courses/{courseId}/answer-messages/{answerMessageId}")
     @EnforceAtLeastStudent
     public ResponseEntity<AnswerPost> updateAnswerMessage(@PathVariable Long courseId, @PathVariable Long answerMessageId, @RequestBody AnswerPost answerMessage) {
-        log.info("PUT updateAnswerMessage invoked for course {} with message {}", courseId, answerMessage.getContent());
+        log.debug("PUT updateAnswerMessage invoked for course {} with message {}", courseId, answerMessage.getContent());
         long start = System.nanoTime();
         AnswerPost updatedAnswerMessage = answerMessageService.updateAnswerMessage(courseId, answerMessageId, answerMessage);
         log.info("updateAnswerMessage took {}", TimeLogUtil.formatDurationFrom(start));
@@ -75,7 +75,7 @@ public class AnswerMessageResource {
     @DeleteMapping("courses/{courseId}/answer-messages/{answerMessageId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Void> deleteAnswerMessage(@PathVariable Long courseId, @PathVariable Long answerMessageId) {
-        log.info("PUT deleteAnswerMessage invoked for course {} on message {}", courseId, answerMessageId);
+        log.debug("PUT deleteAnswerMessage invoked for course {} on message {}", courseId, answerMessageId);
         long start = System.nanoTime();
         answerMessageService.deleteAnswerMessageById(courseId, answerMessageId);
         log.info("deleteAnswerMessage took {}", TimeLogUtil.formatDurationFrom(start));

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/AnswerMessageResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/AnswerMessageResource.java
@@ -3,6 +3,8 @@ package de.tum.in.www1.artemis.web.rest.metis;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,10 +12,13 @@ import org.springframework.web.bind.annotation.*;
 import de.tum.in.www1.artemis.domain.metis.AnswerPost;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastStudent;
 import de.tum.in.www1.artemis.service.metis.AnswerMessageService;
+import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 
 @RestController
 @RequestMapping("/api")
 public class AnswerMessageResource {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final AnswerMessageService answerMessageService;
 
@@ -31,10 +36,12 @@ public class AnswerMessageResource {
      */
     @PostMapping("courses/{courseId}/answer-messages")
     @EnforceAtLeastStudent
-    public ResponseEntity<AnswerPost> createAnswerPost(@PathVariable Long courseId, @RequestBody AnswerPost answerMessage) throws URISyntaxException {
+    public ResponseEntity<AnswerPost> createAnswerMessage(@PathVariable Long courseId, @RequestBody AnswerPost answerMessage) throws URISyntaxException {
+        log.info("POST createAnswerMessage invoked for course {} with message {}", courseId, answerMessage.getContent());
+        long start = System.nanoTime();
         AnswerPost createdAnswerMessage = answerMessageService.createAnswerMessage(courseId, answerMessage);
-
         // creation of answerMessage should not trigger alert
+        log.info("createAnswerMessage took {}", TimeLogUtil.formatDurationFrom(start));
         return ResponseEntity.created(new URI("/api/courses" + courseId + "/answer-messages/" + createdAnswerMessage.getId())).body(createdAnswerMessage);
     }
 
@@ -49,8 +56,11 @@ public class AnswerMessageResource {
      */
     @PutMapping("courses/{courseId}/answer-messages/{answerMessageId}")
     @EnforceAtLeastStudent
-    public ResponseEntity<AnswerPost> updateAnswerPost(@PathVariable Long courseId, @PathVariable Long answerMessageId, @RequestBody AnswerPost answerMessage) {
+    public ResponseEntity<AnswerPost> updateAnswerMessage(@PathVariable Long courseId, @PathVariable Long answerMessageId, @RequestBody AnswerPost answerMessage) {
+        log.info("PUT updateAnswerMessage invoked for course {} with message {}", courseId, answerMessage.getContent());
+        long start = System.nanoTime();
         AnswerPost updatedAnswerMessage = answerMessageService.updateAnswerMessage(courseId, answerMessageId, answerMessage);
+        log.info("updateAnswerMessage took {}", TimeLogUtil.formatDurationFrom(start));
         return new ResponseEntity<>(updatedAnswerMessage, null, HttpStatus.OK);
     }
 
@@ -64,9 +74,11 @@ public class AnswerMessageResource {
      */
     @DeleteMapping("courses/{courseId}/answer-messages/{answerMessageId}")
     @EnforceAtLeastStudent
-    public ResponseEntity<Void> deleteAnswerPost(@PathVariable Long courseId, @PathVariable Long answerMessageId) {
+    public ResponseEntity<Void> deleteAnswerMessage(@PathVariable Long courseId, @PathVariable Long answerMessageId) {
+        log.info("PUT deleteAnswerMessage invoked for course {} on message {}", courseId, answerMessageId);
+        long start = System.nanoTime();
         answerMessageService.deleteAnswerMessageById(courseId, answerMessageId);
-
+        log.info("deleteAnswerMessage took {}", TimeLogUtil.formatDurationFrom(start));
         // deletion of answerMessages should not trigger alert
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/AnswerPostResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/AnswerPostResource.java
@@ -40,7 +40,7 @@ public class AnswerPostResource {
     @PostMapping("courses/{courseId}/answer-posts")
     @EnforceAtLeastStudent
     public ResponseEntity<AnswerPost> createAnswerPost(@PathVariable Long courseId, @RequestBody AnswerPost answerPost) throws URISyntaxException {
-        log.info("POST createAnswerPost invoked for course {} with post {}", courseId, answerPost.getContent());
+        log.debug("POST createAnswerPost invoked for course {} with post {}", courseId, answerPost.getContent());
         long start = System.nanoTime();
         AnswerPost createdAnswerPost = answerPostService.createAnswerPost(courseId, answerPost);
         log.info("createAnswerPost took {}", TimeLogUtil.formatDurationFrom(start));
@@ -59,7 +59,7 @@ public class AnswerPostResource {
     @PutMapping("courses/{courseId}/answer-posts/{answerPostId}")
     @EnforceAtLeastStudent
     public ResponseEntity<AnswerPost> updateAnswerPost(@PathVariable Long courseId, @PathVariable Long answerPostId, @RequestBody AnswerPost answerPost) {
-        log.info("PUT updateAnswerPost invoked for course {} with post {}", courseId, answerPost.getContent());
+        log.debug("PUT updateAnswerPost invoked for course {} with post {}", courseId, answerPost.getContent());
         long start = System.nanoTime();
         AnswerPost updatedAnswerPost = answerPostService.updateAnswerPost(courseId, answerPostId, answerPost);
         log.info("updatedAnswerPost took {}", TimeLogUtil.formatDurationFrom(start));
@@ -77,7 +77,7 @@ public class AnswerPostResource {
     @DeleteMapping("courses/{courseId}/answer-posts/{answerPostId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Void> deleteAnswerPost(@PathVariable Long courseId, @PathVariable Long answerPostId) {
-        log.info("PUT deleteAnswerPost invoked for course {} on post {}", courseId, answerPostId);
+        log.debug("PUT deleteAnswerPost invoked for course {} on post {}", courseId, answerPostId);
         long start = System.nanoTime();
         answerPostService.deleteAnswerPostById(courseId, answerPostId);
         log.info("deleteAnswerPost took {}", TimeLogUtil.formatDurationFrom(start));

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/AnswerPostResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/AnswerPostResource.java
@@ -3,7 +3,8 @@ package de.tum.in.www1.artemis.web.rest.metis;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import de.tum.in.www1.artemis.domain.metis.AnswerPost;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastStudent;
 import de.tum.in.www1.artemis.service.metis.AnswerPostService;
+import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 
 /**
  * REST controller for managing AnswerPost.
@@ -19,10 +21,9 @@ import de.tum.in.www1.artemis.service.metis.AnswerPostService;
 @RequestMapping("/api")
 public class AnswerPostResource {
 
-    private final AnswerPostService answerPostService;
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @Value("${jhipster.clientApp.name}")
-    private String applicationName;
+    private final AnswerPostService answerPostService;
 
     public AnswerPostResource(AnswerPostService answerPostService) {
         this.answerPostService = answerPostService;
@@ -39,7 +40,10 @@ public class AnswerPostResource {
     @PostMapping("courses/{courseId}/answer-posts")
     @EnforceAtLeastStudent
     public ResponseEntity<AnswerPost> createAnswerPost(@PathVariable Long courseId, @RequestBody AnswerPost answerPost) throws URISyntaxException {
+        log.info("POST createAnswerPost invoked for course {} with post {}", courseId, answerPost.getContent());
+        long start = System.nanoTime();
         AnswerPost createdAnswerPost = answerPostService.createAnswerPost(courseId, answerPost);
+        log.info("createAnswerPost took {}", TimeLogUtil.formatDurationFrom(start));
         return ResponseEntity.created(new URI("/api/courses" + courseId + "/answer-posts/" + createdAnswerPost.getId())).body(createdAnswerPost);
     }
 
@@ -55,7 +59,10 @@ public class AnswerPostResource {
     @PutMapping("courses/{courseId}/answer-posts/{answerPostId}")
     @EnforceAtLeastStudent
     public ResponseEntity<AnswerPost> updateAnswerPost(@PathVariable Long courseId, @PathVariable Long answerPostId, @RequestBody AnswerPost answerPost) {
+        log.info("PUT updateAnswerPost invoked for course {} with post {}", courseId, answerPost.getContent());
+        long start = System.nanoTime();
         AnswerPost updatedAnswerPost = answerPostService.updateAnswerPost(courseId, answerPostId, answerPost);
+        log.info("updatedAnswerPost took {}", TimeLogUtil.formatDurationFrom(start));
         return new ResponseEntity<>(updatedAnswerPost, null, HttpStatus.OK);
     }
 
@@ -70,7 +77,10 @@ public class AnswerPostResource {
     @DeleteMapping("courses/{courseId}/answer-posts/{answerPostId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Void> deleteAnswerPost(@PathVariable Long courseId, @PathVariable Long answerPostId) {
+        log.info("PUT deleteAnswerPost invoked for course {} on post {}", courseId, answerPostId);
+        long start = System.nanoTime();
         answerPostService.deleteAnswerPostById(courseId, answerPostId);
+        log.info("deleteAnswerPost took {}", TimeLogUtil.formatDurationFrom(start));
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
@@ -32,7 +32,7 @@ import tech.jhipster.web.util.PaginationUtil;
 @RequestMapping("/api")
 public class ConversationMessageResource {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final ConversationMessagingService conversationMessagingService;
 
@@ -106,7 +106,10 @@ public class ConversationMessageResource {
     @PutMapping("courses/{courseId}/messages/{messageId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Post> updateMessage(@PathVariable Long courseId, @PathVariable Long messageId, @RequestBody Post messagePost) {
+        log.info("PUT updateMessage invoked for course {} with post {}", courseId, messagePost.getContent());
+        long start = System.nanoTime();
         Post updatedMessagePost = conversationMessagingService.updateMessage(courseId, messageId, messagePost);
+        log.info("updateMessage took {}", TimeLogUtil.formatDurationFrom(start));
         return new ResponseEntity<>(updatedMessagePost, null, HttpStatus.OK);
     }
 
@@ -121,8 +124,11 @@ public class ConversationMessageResource {
     @DeleteMapping("courses/{courseId}/messages/{messageId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Void> deleteMessage(@PathVariable Long courseId, @PathVariable Long messageId) {
+        log.info("DELETE deleteMessage invoked for course {} on message {}", courseId, messageId);
+        long start = System.nanoTime();
         conversationMessagingService.deleteMessageById(courseId, messageId);
         // deletion of message posts should not trigger entity deletion alert
+        log.info("deleteMessage took {}", TimeLogUtil.formatDurationFrom(start));
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
@@ -51,7 +51,7 @@ public class ConversationMessageResource {
     @PostMapping("courses/{courseId}/messages")
     @EnforceAtLeastStudent
     public ResponseEntity<Post> createMessage(@PathVariable Long courseId, @Valid @RequestBody Post post) throws URISyntaxException {
-        log.info("POST createMessage invoked for course {} with post {}", courseId, post.getContent());
+        log.debug("POST createMessage invoked for course {} with post {}", courseId, post.getContent());
         long start = System.nanoTime();
         Post createdMessage = conversationMessagingService.createMessage(courseId, post);
         log.info("createMessage took {}", TimeLogUtil.formatDurationFrom(start));
@@ -106,7 +106,7 @@ public class ConversationMessageResource {
     @PutMapping("courses/{courseId}/messages/{messageId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Post> updateMessage(@PathVariable Long courseId, @PathVariable Long messageId, @RequestBody Post messagePost) {
-        log.info("PUT updateMessage invoked for course {} with post {}", courseId, messagePost.getContent());
+        log.debug("PUT updateMessage invoked for course {} with post {}", courseId, messagePost.getContent());
         long start = System.nanoTime();
         Post updatedMessagePost = conversationMessagingService.updateMessage(courseId, messageId, messagePost);
         log.info("updateMessage took {}", TimeLogUtil.formatDurationFrom(start));
@@ -124,7 +124,7 @@ public class ConversationMessageResource {
     @DeleteMapping("courses/{courseId}/messages/{messageId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Void> deleteMessage(@PathVariable Long courseId, @PathVariable Long messageId) {
-        log.info("DELETE deleteMessage invoked for course {} on message {}", courseId, messageId);
+        log.debug("DELETE deleteMessage invoked for course {} on message {}", courseId, messageId);
         long start = System.nanoTime();
         conversationMessagingService.deleteMessageById(courseId, messageId);
         // deletion of message posts should not trigger entity deletion alert

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/ConversationMessageResource.java
@@ -51,7 +51,10 @@ public class ConversationMessageResource {
     @PostMapping("courses/{courseId}/messages")
     @EnforceAtLeastStudent
     public ResponseEntity<Post> createMessage(@PathVariable Long courseId, @Valid @RequestBody Post post) throws URISyntaxException {
+        log.info("POST createMessage invoked for course {} with post {}", courseId, post.getContent());
+        long start = System.nanoTime();
         Post createdMessage = conversationMessagingService.createMessage(courseId, post);
+        log.info("createMessage took {}", TimeLogUtil.formatDurationFrom(start));
         return ResponseEntity.created(new URI("/api/courses/" + courseId + "/messages/" + createdMessage.getId())).body(createdMessage);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/PostResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/PostResource.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import javax.validation.Valid;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +22,7 @@ import de.tum.in.www1.artemis.domain.metis.Post;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastStudent;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastTutor;
 import de.tum.in.www1.artemis.service.metis.PostService;
+import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 import de.tum.in.www1.artemis.web.rest.dto.PostContextFilter;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 import io.swagger.annotations.ApiParam;
@@ -31,6 +34,8 @@ import tech.jhipster.web.util.PaginationUtil;
 @RestController
 @RequestMapping("/api")
 public class PostResource {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final PostService postService;
 
@@ -52,7 +57,10 @@ public class PostResource {
     @PostMapping("courses/{courseId}/posts")
     @EnforceAtLeastStudent
     public ResponseEntity<Post> createPost(@PathVariable Long courseId, @Valid @RequestBody Post post) throws URISyntaxException {
+        log.info("POST createPost invoked for course {} with post {}", courseId, post.getContent());
+        long start = System.nanoTime();
         Post createdPost = postService.createPost(courseId, post);
+        log.info("createPost took {}", TimeLogUtil.formatDurationFrom(start));
         return ResponseEntity.created(new URI("/api/courses/" + courseId + "/posts/" + createdPost.getId())).body(createdPost);
     }
 
@@ -68,7 +76,10 @@ public class PostResource {
     @PutMapping("courses/{courseId}/posts/{postId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Post> updatePost(@PathVariable Long courseId, @PathVariable Long postId, @RequestBody Post post) {
+        log.info("PUT updatePost invoked for course {} with post {}", courseId, post.getContent());
+        long start = System.nanoTime();
         Post updatedPost = postService.updatePost(courseId, postId, post);
+        log.info("updatePost took {}", TimeLogUtil.formatDurationFrom(start));
         return new ResponseEntity<>(updatedPost, null, HttpStatus.OK);
     }
 
@@ -133,7 +144,10 @@ public class PostResource {
     @DeleteMapping("courses/{courseId}/posts/{postId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Void> deletePost(@PathVariable Long courseId, @PathVariable Long postId) {
+        log.info("DELETE deletePost invoked for course {} on post {}", courseId, postId);
+        long start = System.nanoTime();
         postService.deletePostById(courseId, postId);
+        log.info("deletePost took {}", TimeLogUtil.formatDurationFrom(start));
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, postService.getEntityName(), postId.toString())).build();
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/PostResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/PostResource.java
@@ -57,7 +57,7 @@ public class PostResource {
     @PostMapping("courses/{courseId}/posts")
     @EnforceAtLeastStudent
     public ResponseEntity<Post> createPost(@PathVariable Long courseId, @Valid @RequestBody Post post) throws URISyntaxException {
-        log.info("POST createPost invoked for course {} with post {}", courseId, post.getContent());
+        log.debug("POST createPost invoked for course {} with post {}", courseId, post.getContent());
         long start = System.nanoTime();
         Post createdPost = postService.createPost(courseId, post);
         log.info("createPost took {}", TimeLogUtil.formatDurationFrom(start));
@@ -76,7 +76,7 @@ public class PostResource {
     @PutMapping("courses/{courseId}/posts/{postId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Post> updatePost(@PathVariable Long courseId, @PathVariable Long postId, @RequestBody Post post) {
-        log.info("PUT updatePost invoked for course {} with post {}", courseId, post.getContent());
+        log.debug("PUT updatePost invoked for course {} with post {}", courseId, post.getContent());
         long start = System.nanoTime();
         Post updatedPost = postService.updatePost(courseId, postId, post);
         log.info("updatePost took {}", TimeLogUtil.formatDurationFrom(start));
@@ -144,7 +144,7 @@ public class PostResource {
     @DeleteMapping("courses/{courseId}/posts/{postId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Void> deletePost(@PathVariable Long courseId, @PathVariable Long postId) {
-        log.info("DELETE deletePost invoked for course {} on post {}", courseId, postId);
+        log.debug("DELETE deletePost invoked for course {} on post {}", courseId, postId);
         long start = System.nanoTime();
         postService.deletePostById(courseId, postId);
         log.info("deletePost took {}", TimeLogUtil.formatDurationFrom(start));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The query for retrieving recipients for WebSocket messages takes too much time on production systems.

### Description
<!-- Describe your changes in detail -->
The query does not return the whole user anymore. Additionally, the join with the course table has been removed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 2 Students
- 1 Course with messaging enabled

1. Write messages in the on the messaging page, a lecture details page, and an exercise details page as student 1 in channels, group chats and direct chats that both students are a member of
2. Student 1 should see the message without much delay
3. Student 2 should see a notification (if not on the same page as student 1) or the message without much delay if they have opened the conversation. 
4. Student 2 does not receive duplicate notifications if mentioned
5. If student 1 writes in a channel or group chat that student 2 isn't a member of, student 2 does not receive notifications

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
No UI Changes