### PR TITLE
`Communication`: Enable reactions if only messaging is enabled

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerPostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerPostService.java
@@ -142,7 +142,8 @@ public class AnswerPostService extends PostingService {
      * @param courseId   id of the course the answer post belongs to
      */
     public void updateWithReaction(AnswerPost answerPost, Reaction reaction, Long courseId) {
-        final Course course = preCheckUserAndCourseForCommunication(reaction.getUser(), courseId);
+        final Course course = preCheckUserAndCourseForCommunicationOrMessaging(reaction.getUser(), courseId);
+
         answerPost.addReaction(reaction);
         AnswerPost updatedAnswerPost = answerPostRepository.save(answerPost);
         updatedAnswerPost.getPost().setConversation(answerPost.getPost().getConversation());

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
@@ -229,7 +229,7 @@ public class PostService extends PostingService {
      * @param courseId id of course the post belongs to
      */
     public void removeReaction(Post post, Reaction reaction, Long courseId) {
-        final Course course = preCheckUserAndCourseForCommunicationOrMessaging(reaction.getUser(), courseId);
+        preCheckUserAndCourseForCommunicationOrMessaging(reaction.getUser(), courseId);
 
         post.removeReaction(reaction);
         postRepository.save(post);

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
@@ -214,6 +214,11 @@ public class PostService extends PostingService {
      */
     public void addReaction(Post post, Reaction reaction, Long courseId) {
         final Course course = preCheckUserAndCourseForCommunication(reaction.getUser(), courseId);
+
+        if (!course.getCourseInformationSharingConfiguration().isMessagingEnabled()) {
+            throw new BadRequestAlertException("Messaging is not enabled for this course", getEntityName(), "400", true);
+        }
+
         post.addReaction(reaction);
         Post updatedPost = postRepository.save(post);
         updatedPost.setConversation(post.getConversation());
@@ -228,7 +233,12 @@ public class PostService extends PostingService {
      * @param courseId id of course the post belongs to
      */
     public void removeReaction(Post post, Reaction reaction, Long courseId) {
-        preCheckUserAndCourseForCommunication(reaction.getUser(), courseId);
+        final Course course = preCheckUserAndCourseForCommunication(reaction.getUser(), courseId);
+
+        if (!course.getCourseInformationSharingConfiguration().isMessagingEnabled()) {
+            throw new BadRequestAlertException("Messaging is not enabled for this course", getEntityName(), "400", true);
+        }
+
         post.removeReaction(reaction);
         postRepository.save(post);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
@@ -213,11 +213,7 @@ public class PostService extends PostingService {
      * @param courseId id of course the post belongs to
      */
     public void addReaction(Post post, Reaction reaction, Long courseId) {
-        final Course course = preCheckUserAndCourseForCommunication(reaction.getUser(), courseId);
-
-        if (!course.getCourseInformationSharingConfiguration().isMessagingEnabled()) {
-            throw new BadRequestAlertException("Messaging is not enabled for this course", getEntityName(), "400", true);
-        }
+        final Course course = preCheckUserAndCourseForCommunicationOrMessaging(reaction.getUser(), courseId);
 
         post.addReaction(reaction);
         Post updatedPost = postRepository.save(post);
@@ -233,11 +229,7 @@ public class PostService extends PostingService {
      * @param courseId id of course the post belongs to
      */
     public void removeReaction(Post post, Reaction reaction, Long courseId) {
-        final Course course = preCheckUserAndCourseForCommunication(reaction.getUser(), courseId);
-
-        if (!course.getCourseInformationSharingConfiguration().isMessagingEnabled()) {
-            throw new BadRequestAlertException("Messaging is not enabled for this course", getEntityName(), "400", true);
-        }
+        final Course course = preCheckUserAndCourseForCommunicationOrMessaging(reaction.getUser(), courseId);
 
         post.removeReaction(reaction);
         postRepository.save(post);

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
@@ -194,6 +194,10 @@ public abstract class PostingService {
 
     protected Course preCheckUserAndCourseForCommunicationOrMessaging(User user, Long courseId) {
         final Course course = courseRepository.findByIdElseThrow(courseId);
+        return preCheckUserAndCourseForCommunicationOrMessaging(user, course);
+    }
+
+    protected Course preCheckUserAndCourseForCommunicationOrMessaging(User user, Course course) {
         authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.STUDENT, course, user);
 
         if (course.getCourseInformationSharingConfiguration() == CourseInformationSharingConfiguration.DISABLED) {

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
 
 import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.enumeration.CourseInformationSharingConfiguration;
 import de.tum.in.www1.artemis.domain.metis.*;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.metis.conversation.Conversation;
@@ -184,6 +185,16 @@ public abstract class PostingService {
 
         if (!courseRepository.isMessagingEnabled(course.getId())) {
             throw new BadRequestAlertException("Messaging is not enabled for this course", getEntityName(), "400", true);
+        }
+        return course;
+    }
+
+    protected Course preCheckUserAndCourseForCommunicationOrMessaging(User user, Long courseId) {
+        final Course course = courseRepository.findByIdElseThrow(courseId);
+        authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.STUDENT, course, user);
+
+        if (course.getCourseInformationSharingConfiguration() == CourseInformationSharingConfiguration.DISABLED) {
+            throw new BadRequestAlertException("Communication and messaging is disabled for this course", getEntityName(), "400", true);
         }
         return course;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/ReactionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/ReactionService.java
@@ -130,6 +130,7 @@ public class ReactionService {
             updatedPost = updatedAnswerPost.getPost();
             // remove and add operations on sets identify an AnswerPost by its id; to update a certain property of an existing answer post,
             // we need to remove the existing AnswerPost (based on unchanged id in updatedAnswerPost) and add the updatedAnswerPost afterwards
+            postService.preCheckUserAndCourseForCommunicationOrMessaging(reaction.getUser(), course);
             updatedPost.removeAnswerPost(updatedAnswerPost);
             updatedPost.addAnswerPost(updatedAnswerPost);
         }

--- a/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
@@ -7,14 +7,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import javax.validation.*;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -24,12 +24,11 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
+import de.tum.in.www1.artemis.domain.enumeration.CourseInformationSharingConfiguration;
 import de.tum.in.www1.artemis.domain.enumeration.SortingOrder;
-import de.tum.in.www1.artemis.domain.metis.AnswerPost;
-import de.tum.in.www1.artemis.domain.metis.Post;
-import de.tum.in.www1.artemis.domain.metis.PostSortCriterion;
-import de.tum.in.www1.artemis.domain.metis.Reaction;
+import de.tum.in.www1.artemis.domain.metis.*;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.metis.ReactionRepository;
@@ -57,6 +56,9 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private ConversationUtilService conversationUtilService;
 
+    @Autowired
+    private CourseRepository courseRepository;
+
     private List<Post> existingPostsWithAnswers;
 
     private List<Post> existingConversationPosts;
@@ -64,6 +66,8 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     private List<AnswerPost> existingAnswerPosts;
 
     private Long courseId;
+
+    private Course course;
 
     private Validator validator;
 
@@ -91,7 +95,8 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         // get all answerPosts
         existingAnswerPosts = existingPostsWithAnswers.stream().map(Post::getAnswers).flatMap(Collection::stream).toList();
 
-        courseId = existingPostsWithAnswers.get(0).getExercise().getCourseViaExerciseGroupOrCourseMember().getId();
+        course = existingPostsWithAnswers.get(0).getExercise().getCourseViaExerciseGroupOrCourseMember();
+        courseId = course.getId();
     }
 
     @AfterEach
@@ -103,12 +108,21 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     // CREATE
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("courseConfigurationProvider")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testCreateOwnPostReaction() throws Exception {
+    void testCreateOwnPostReaction(CourseInformationSharingConfiguration courseInformationSharingConfiguration, boolean shouldBeAllowed) throws Exception {
         // student 1 is the author of the post and reacts on this post
         Post postReactedOn = existingPostsWithAnswers.get(0);
         Reaction reactionToSaveOnPost = createReactionOnPost(postReactedOn);
+
+        course.setCourseInformationSharingConfiguration(courseInformationSharingConfiguration);
+        courseRepository.save(course);
+
+        if (!shouldBeAllowed) {
+            request.postWithResponseBody("/api/courses/" + courseId + "/postings/reactions", reactionToSaveOnPost, Reaction.class, HttpStatus.BAD_REQUEST);
+            return;
+        }
 
         Reaction createdReaction = request.postWithResponseBody("/api/courses/" + courseId + "/postings/reactions", reactionToSaveOnPost, Reaction.class, HttpStatus.CREATED);
         checkCreatedReaction(reactionToSaveOnPost, createdReaction);
@@ -129,12 +143,22 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         assertThat(postRepository.findPostByIdElseThrow(postReactedOn.getId()).getVoteCount()).isEqualTo(postReactedOn.getVoteCount() + 1);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("courseConfigurationProvider")
     @WithMockUser(username = TEST_PREFIX + "tutor2", roles = "USER")
-    void testCreateOwnPostReactionOnAnotherUsersConversationMessage() throws Exception {
+    void testCreateOwnPostReactionOnAnotherUsersConversationMessage(CourseInformationSharingConfiguration courseInformationSharingConfiguration, boolean shouldBeAllowed)
+            throws Exception {
         // tutor1 is the author of the message and tutor2 reacts on this post
         Post messageReactedOn = existingConversationPosts.get(0);
         Reaction reactionToSaveOnMessage = createReactionOnPost(messageReactedOn);
+
+        course.setCourseInformationSharingConfiguration(courseInformationSharingConfiguration);
+        courseRepository.save(course);
+
+        if (!shouldBeAllowed) {
+            request.postWithResponseBody("/api/courses/" + courseId + "/postings/reactions", reactionToSaveOnMessage, Reaction.class, HttpStatus.BAD_REQUEST);
+            return;
+        }
 
         Reaction createdReaction = request.postWithResponseBody("/api/courses/" + courseId + "/postings/reactions", reactionToSaveOnMessage, Reaction.class, HttpStatus.CREATED);
         checkCreatedReaction(reactionToSaveOnMessage, createdReaction);
@@ -170,12 +194,21 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         assertThat(response).isNull();
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("courseConfigurationProvider")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testCreateOwnAnswerPostReaction() throws Exception {
+    void testCreateOwnAnswerPostReaction(CourseInformationSharingConfiguration courseInformationSharingConfiguration, boolean shouldBeAllowed) throws Exception {
         // student 1 is the author of the answer post and reacts on this answer post
         AnswerPost answerPostReactedOn = existingAnswerPosts.get(0);
         Reaction reactionToSaveOnAnswerPost = createReactionOnAnswerPost(answerPostReactedOn);
+
+        course.setCourseInformationSharingConfiguration(courseInformationSharingConfiguration);
+        courseRepository.save(course);
+
+        if (!shouldBeAllowed) {
+            request.postWithResponseBody("/api/courses/" + courseId + "/postings/reactions", reactionToSaveOnAnswerPost, Reaction.class, HttpStatus.BAD_REQUEST);
+            return;
+        }
 
         Reaction createdReaction = request.postWithResponseBody("/api/courses/" + courseId + "/postings/reactions", reactionToSaveOnAnswerPost, Reaction.class, HttpStatus.CREATED);
         checkCreatedReaction(reactionToSaveOnAnswerPost, createdReaction);
@@ -344,16 +377,25 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     // DELETE
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("courseConfigurationProvider")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testDeleteOwnPostReaction() throws Exception {
+    void testDeleteOwnPostReaction(CourseInformationSharingConfiguration courseInformationSharingConfiguration, boolean shouldBeAllowed) throws Exception {
         // student 1 is the author of the post and reacts on this post
         Post postReactedOn = existingPostsWithAnswers.get(0);
         Reaction reactionToSaveOnPost = createReactionOnPost(postReactedOn);
 
         Reaction reactionToBeDeleted = request.postWithResponseBody("/api/courses/" + courseId + "/postings/reactions", reactionToSaveOnPost, Reaction.class, HttpStatus.CREATED);
 
+        course.setCourseInformationSharingConfiguration(courseInformationSharingConfiguration);
+        courseRepository.save(course);
+
         // student 1 deletes their reaction on this post
+        if (!shouldBeAllowed) {
+            request.delete("/api/courses/" + courseId + "/postings/reactions/" + reactionToBeDeleted.getId(), HttpStatus.BAD_REQUEST);
+            return;
+        }
+
         request.delete("/api/courses/" + courseId + "/postings/reactions/" + reactionToBeDeleted.getId(), HttpStatus.OK);
 
         assertThat(postReactedOn.getReactions()).hasSameSizeAs(reactionRepository.findReactionsByPostId(postReactedOn.getId()));
@@ -380,16 +422,25 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         assertThat(postRepository.findPostByIdElseThrow(postReactedOn.getId()).getVoteCount()).isEqualTo(postReactedOn.getVoteCount());
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("courseConfigurationProvider")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testDeleteOwnAnswerPostReaction() throws Exception {
+    void testDeleteOwnAnswerPostReaction(CourseInformationSharingConfiguration courseInformationSharingConfiguration, boolean shouldBeAllowed) throws Exception {
         // student 1 is the author of the post and reacts on this post
         AnswerPost answerPostReactedOn = existingAnswerPosts.get(0);
         Reaction reactionToSaveOnPost = createReactionOnAnswerPost(answerPostReactedOn);
 
         Reaction reactionToBeDeleted = request.postWithResponseBody("/api/courses/" + courseId + "/postings/reactions", reactionToSaveOnPost, Reaction.class, HttpStatus.CREATED);
 
+        course.setCourseInformationSharingConfiguration(courseInformationSharingConfiguration);
+        courseRepository.save(course);
+
         // student 1 deletes their reaction on this post
+        if (!shouldBeAllowed) {
+            request.delete("/api/courses/" + courseId + "/postings/reactions/" + reactionToBeDeleted.getId(), HttpStatus.BAD_REQUEST);
+            return;
+        }
+
         request.delete("/api/courses/" + courseId + "/postings/reactions/" + reactionToBeDeleted.getId(), HttpStatus.OK);
         assertThat(answerPostReactedOn.getReactions()).hasSameSizeAs(reactionRepository.findReactionsByPostId(answerPostReactedOn.getId()));
         assertThat(reactionRepository.findById(reactionToBeDeleted.getId())).isEmpty();
@@ -490,5 +541,10 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         assertThat(createdReaction.getAnswerPost()).isEqualTo(expectedReaction.getAnswerPost());
 
         conversationUtilService.assertSensitiveInformationHidden(createdReaction);
+    }
+
+    private static List<Arguments> courseConfigurationProvider() {
+        return List.of(Arguments.of(CourseInformationSharingConfiguration.DISABLED, false), Arguments.of(CourseInformationSharingConfiguration.COMMUNICATION_AND_MESSAGING, true),
+                Arguments.of(CourseInformationSharingConfiguration.COMMUNICATION_ONLY, true), Arguments.of(CourseInformationSharingConfiguration.MESSAGING_ONLY, true));
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Reactions only work if communication is enabled

### Description
<!-- Describe your changes in detail -->
Reactions now also work, if only messaging is enabled.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Instructor
- 1 Course with only messaging enabled

1. Check that you can react to messages and replies as both users and they get updated for the other user
2. Enable communication, disable messaging
3. Check that you can react to posts and replies as both users and reactions get updated for the other user

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
No UI changes