### PR TITLE
`Development`: Allow native apps to access code of conduct template

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
@@ -314,7 +314,7 @@ public class FileResource {
      * @return The requested file, 403 if the logged-in user is not allowed to access it, or 404 if the file doesn't exist
      */
     @GetMapping("files/templates/code-of-conduct")
-    @EnforceAtLeastInstructor
+    @EnforceAtLeastStudent
     public ResponseEntity<byte[]> getCourseCodeOfConduct() throws IOException {
         var templatePath = Path.of("templates", "codeofconduct", "README.md");
         log.debug("REST request to get template : {}", templatePath);

--- a/src/main/resources/templates/codeofconduct/README.md
+++ b/src/main/resources/templates/codeofconduct/README.md
@@ -1,4 +1,5 @@
 <!-- Code of Conduct Template: Adapt to your demands -->
+<!-- Important: This template will directly be shown on the iOS and Android client if a course has no explicit code of conduct set. -->
 
 We as students, tutors, and instructors pledge to make participation in our course a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 


### PR DESCRIPTION
On the native applications, we have to enforce that students accept a code of conduct before accessing the messaging features due to play store and app store guidelines.

However, some courses do not have a code of conduct set. In these cases, we want to, instead, query the code of conduct template and show it to the user. 

With this PR, we allow all students to query the code of conduct template, so that we can download it on the native apps.

See PRs:
- https://github.com/ls1intum/artemis-android/pull/5 
- https://github.com/ls1intum/artemis-ios/pull/37