### PR TITLE
`Development`: Only run badge update job if the label is a lock label

### DIFF
--- a/.github/workflows/pullrequest-unlabeled.yml
+++ b/.github/workflows/pullrequest-unlabeled.yml
@@ -9,6 +9,7 @@ jobs:
   update_badges:
     name: Update test server badges
     runs-on: ubuntu-latest
+    if: startsWith(github.event.label.name, 'lock:artemis-test')
 
     steps:
       - name: Get badge id


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested _in a separate fork of Artemis_
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The new workflow for when a lock label is removed is currently always running, even for non-lock labels. This takes an unecessary amount of time.

### Description
<!-- Describe your changes in detail -->
This PR fixes this by adding an if statement to the job. This reduces the run time by >10x.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
N/A

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1