### PR TITLE
`Development`: Add tests for repository export dialog

### DIFF
--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-repo-export-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-repo-export-dialog.component.spec.ts
@@ -124,6 +124,23 @@ describe('ProgrammingAssessmentRepoExportDialogComponent', () => {
         expect(exportReposStub).toHaveBeenCalledOnce();
     }));
 
+    it('Should not change the ExportOptions during export', fakeAsync(() => {
+        comp.participationIdList = [];
+        comp.participantIdentifierList = 'ab12cde, cd34efg';
+        comp.ngOnInit();
+
+        const copyOfExportOptions = { ...comp.repositoryExportOptions };
+
+        const httpResponse = createBlobHttpResponse();
+        const exportReposStub = jest.spyOn(repoExportService, 'exportReposByParticipantIdentifiers').mockReturnValue(of(httpResponse));
+        fixture.detectChanges();
+
+        comp.exportRepos();
+        tick();
+        expect(comp.repositoryExportOptions).toEqual(copyOfExportOptions);
+        expect(exportReposStub).toHaveBeenCalledOnce();
+    }));
+
     it('Export of multiple repos download multiple files', fakeAsync(() => {
         const programmingExercise2 = new ProgrammingExercise(new Course(), undefined);
         programmingExercise2.id = 43;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### Client
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.


### Motivation and Context
This PR adds tests for this PR #7367. The changing of the `repositoryExportOptions` in the `exportRepos()` function caused the previous bugs.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Test Coverage
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| programming-assessment-repo-export-dialog.component.ts | 86.66% | ✅                           |

