### PR TITLE
`General`: Fix display of user group and categories selection

### DIFF
--- a/src/main/webapp/content/scss/themes/theme-dark.scss
+++ b/src/main/webapp/content/scss/themes/theme-dark.scss
@@ -27,6 +27,14 @@ html {
     .mat-mdc-menu-trigger.mat-mdc-button:hover {
         background-color: $neutral-dark-l-5;
     }
+
+    .mat-mdc-option.mdc-list-item {
+        background-color: $neutral-dark-l-5;
+
+        &:hover {
+            background-color: $neutral-dark-l-10;
+        }
+    }
 }
 
 @import '../global';

--- a/src/main/webapp/content/scss/themes/theme-default.scss
+++ b/src/main/webapp/content/scss/themes/theme-default.scss
@@ -27,6 +27,14 @@ html {
     .mat-mdc-menu-trigger.mat-mdc-button:hover {
         background-color: $gray-200;
     }
+
+    .mat-mdc-option.mdc-list-item {
+        background-color: $gray-100;
+
+        &:hover {
+            background-color: $white;
+        }
+    }
 }
 
 @import '../global';


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Administrator
- 1 Student
- 1 Course with user groups

1. `Administrator`: Navigate to `Server Administration` > `User management` > `Edit`
2. Adjust the user groups
3. Verify that the selection is easy to read and the background is not transparent

You can also verify it by checking the badges of exercises
1. Edit an existing exercise
2. Add categories
3. See that the background is not transparent


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1

### Screenshots

| Before (transparent, hard to read)                                                                                                       | After (not transparent, easy to read)                                                                                                    |
|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1248" alt="broken light mode" src="https://github.com/ls1intum/Artemis/assets/63976129/12b7c24b-bee2-41e6-9f4f-7527ce82d4db"> | <img width="1248" alt="fixed light mode" src="https://github.com/ls1intum/Artemis/assets/63976129/4c301508-4272-4e2d-a0a1-a5df29c54bcc"> |
| <img width="1248" alt="broken dark mode" src="https://github.com/ls1intum/Artemis/assets/63976129/4bf9a23c-44e9-408a-8cf5-ac0c7124e04c"> | <img width="1248" alt="fixed dark mode" src="https://github.com/ls1intum/Artemis/assets/63976129/f00ab1e6-8105-40ed-966b-64b7ab08209d">  |

Fixed aswell at other places, e.g. for the categories selection of exercises
![image](https://github.com/ls1intum/Artemis/assets/63976129/c9b0ca88-e130-4913-a9e3-812c93cd0cde)
