### PR TITLE
`Development`: Fix an issue in the documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ jobs:
           username: ${{ secrets.DOCS_SSH_USER }}
           key: ${{ secrets.DOCS_SSH_KEY }}
           proxy_host: ${{ secrets.DEPLOYMENT_GATEWAY_HOST }}
-          proxy_username: ${{ secretsDEPLOYMENT_GATEWAY_USER }}
+          proxy_username: ${{ secrets.DEPLOYMENT_GATEWAY_USER }}
           proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           proxy_port: ${{ secrets.DEPLOYMENT_GATEWAY_PORT }}
           script: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
           username: ${{ secrets.DOCS_SSH_USER }}
           key: ${{ secrets.DOCS_SSH_KEY }}
           proxy_host: ${{ secrets.DEPLOYMENT_GATEWAY_HOST }}
-          proxy_username: ${{ secretsDEPLOYMENT_GATEWAY_USER }}
+          proxy_username: ${{ secrets.DEPLOYMENT_GATEWAY_USER }}
           proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           proxy_port: ${{ secrets.DEPLOYMENT_GATEWAY_PORT }}
           source: "public"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,11 +57,11 @@ jobs:
         with:
           host: docs.artemis.cit.tum.de
           username: ${{ secrets.DOCS_SSH_USER }}
-          key: ${{ secrets.DOCS_SSH_PRIVATE }}
-          proxy_host: ${{ secrets.PROXY_HOST }}
-          proxy_username: ${{ secrets.PROXY_USERNAME }}
-          proxy_key: ${{ secrets.PROXY_KEY }}
-          proxy_port: ${{ secrets.PROXY_PORT }}
+          key: ${{ secrets.DOCS_SSH_KEY }}
+          proxy_host: ${{ secrets.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ secretsDEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ secrets.DEPLOYMENT_GATEWAY_PORT }}
           source: "public"
           target: ${{ secrets.DOCS_HOME }}
       - name: Move site to www
@@ -69,11 +69,11 @@ jobs:
         with:
           host: docs.artemis.cit.tum.de
           username: ${{ secrets.DOCS_SSH_USER }}
-          key: ${{ secrets.DOCS_SSH_PRIVATE }}
-          proxy_host: ${{ secrets.PROXY_HOST }}
-          proxy_username: ${{ secrets.PROXY_USERNAME }}
-          proxy_key: ${{ secrets.PROXY_KEY }}
-          proxy_port: ${{ secrets.PROXY_PORT }}
+          key: ${{ secrets.DOCS_SSH_KEY }}
+          proxy_host: ${{ secrets.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ secretsDEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ secrets.DEPLOYMENT_GATEWAY_PORT }}
           script: |
               rm -rf ${{ secrets.DOCS_WWW }}/*
               mv -f public/* ${{ secrets.DOCS_WWW }}/


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/Artemis/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/Artemis/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
This is a hot fix for [Development: Migrate documentation to docs.artemis.cit.tum.de #7298](https://github.com/ls1intum/Artemis/pull/7298) configuring the variable names of the docs deployment workflow to match the repository-wide naming conventions.

### Description
On `.github/workflows/docs.yml`, the variable names for the GitHub repository secrets were updated. The following variables were renamed:

- DOCS_SSH_PRIVATE -> DOCS_SSH_KEY
- PROXY_HOST -> DEPLOYMENT_GATEWAY_HOST
- PROXY_USERNAME -> DEPLOYMENT_GATEWAY_USER
- PROXY_KEY -> DEPLOYMENT_GATEWAY_SSH_KEY
- PROXY_PORT -> DEPLOYMENT_GATEWAY_PORT

Because the new variable names are already configured as secrets, this hotfix should repair the `documentation` workflow.

### Steps for Testing

The workflow has been tested on a separate repository using an identical environment. This PR does not modify the functionality of Artemis.