### PR TITLE
`Development`: Improve metrics performance by reducing lookahead periods.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/MetricsBean.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/MetricsBean.java
@@ -62,7 +62,7 @@ public class MetricsBean {
      * Some metrics (e.g. the number of upcoming exercises) are calculated for multiple lookahead periods.
      * Each period/range is exposed as metrics with a according tag "range"
      */
-    private static final int[] MINUTE_RANGES_LOOKAHEAD = { 15, 30, 45, 60, 120 };
+    private static final int[] MINUTE_RANGES_LOOKAHEAD = { 15 };
 
     private final MeterRegistry meterRegistry;
 
@@ -209,9 +209,6 @@ public class MetricsBean {
     private void registerWebsocketMetrics() {
         // Publish the number of currently (via WebSockets) connected sessions
         Gauge.builder("artemis.instance.websocket.sessions", webSocketHandler, MetricsBean::extractWebsocketSessionCount).strongReference(true)
-                .description("Number of sessions connected to this Artemis instance").register(meterRegistry);
-        // TODO: DEPRECATED metric with same value - Should be removed after October 2023
-        Gauge.builder("artemis.instance.websocket.users", webSocketHandler, MetricsBean::extractWebsocketSessionCount).strongReference(true)
                 .description("Number of sessions connected to this Artemis instance").register(meterRegistry);
 
         // Publish the number of currently (via WebSockets) connected users

--- a/src/main/java/de/tum/in/www1/artemis/config/MetricsBean.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/MetricsBean.java
@@ -61,6 +61,7 @@ public class MetricsBean {
     /**
      * Some metrics (e.g. the number of upcoming exercises) are calculated for multiple lookahead periods.
      * Each period/range is exposed as metrics with a according tag "range"
+     * NOTE: we reduced the intervals temporarily until more intervals are necessary
      */
     private static final int[] MINUTE_RANGES_LOOKAHEAD = { 15 };
 

--- a/src/test/java/de/tum/in/www1/artemis/config/MetricsBeanTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/config/MetricsBeanTest.java
@@ -356,6 +356,7 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         // Should now have one active user
         assertMetricEquals(1, "artemis.scheduled.exercises.due.student_multiplier.active.14", "exerciseType", ExerciseType.QUIZ.toString(), "range", "15");
 
+        /* These tests are currently disabled because the available ranges have been adjusted and only one range (15 minutes) is available
         // Only one quiz is released within the next 30 minutes
         assertMetricEquals(1, "artemis.scheduled.exercises.release.count", "exerciseType", ExerciseType.QUIZ.toString(), "range", "30");
         assertMetricEquals(3 * 1, "artemis.scheduled.exercises.release.student_multiplier", "exerciseType", ExerciseType.QUIZ.toString(), "range", "30");
@@ -391,13 +392,14 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
         // One text exercise is released within the next 30 minutes
         assertMetricEquals(1, "artemis.scheduled.exercises.release.count", "exerciseType", ExerciseType.TEXT.toString(), "range", "30");
+        */
     }
 
     @Test
     void testPrometheusMetricsExams() {
         var users = userUtilService.addUsers(TEST_PREFIX, 3, 0, 0, 0);
         var course = courseUtilService.createCourse();
-        var exam1 = examUtilService.addExam(course, ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(20), ZonedDateTime.now().plusMinutes(40));
+        var exam1 = examUtilService.addExam(course, ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(10), ZonedDateTime.now().plusMinutes(40));
         var registeredExamUser1 = new ExamUser();
         registeredExamUser1.setUser(users.get(0));
         registeredExamUser1.setExam(exam1);
@@ -415,7 +417,7 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         examUtilService.addExerciseGroupsAndExercisesToExam(exam1, false);
         courseRepository.save(course);
 
-        var exam2 = examUtilService.addExam(course, ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(65), ZonedDateTime.now().plusMinutes(85));
+        var exam2 = examUtilService.addExam(course, ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(12), ZonedDateTime.now().plusMinutes(85));
         var registeredExamUser3 = new ExamUser();
         registeredExamUser3.setUser(users.get(0));
         registeredExamUser3.setExam(exam2);
@@ -429,6 +431,11 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
         metricsBean.recalculateMetrics();
 
+        // Two exams start within the next 11520 minutes, but have the same users (-> Users are only counted once)
+        assertMetricEquals(2, "artemis.scheduled.exams.release.count", "range", "15");
+        assertMetricEquals(1 * 2, "artemis.scheduled.exams.release.student_multiplier", "range", "15");
+
+        /* These tests are currently disabled because the available ranges have been adjusted and only one range (15 minutes) is available
         // One exam ends within the next 60 minutes
         assertMetricEquals(1, "artemis.scheduled.exams.due.count", "range", "60");
         assertMetricEquals(1 * 2, "artemis.scheduled.exams.due.student_multiplier", "range", "60"); // 2 students are registered for the exam
@@ -437,7 +444,7 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         assertMetricEquals(2, "artemis.scheduled.exams.due.count", "range", "120");
         assertMetricEquals(1 * 2, "artemis.scheduled.exams.due.student_multiplier", "range", "120"); // 2 + 1 students are registered for the exam, but they are duplicate users
 
-        // No exam starts within the next 15 minutes
+        // No exams start within the next 15 minutes
         assertMetricEquals(0, "artemis.scheduled.exams.release.count", "range", "15");
         assertMetricEquals(0, "artemis.scheduled.exams.release.student_multiplier", "range", "15");
 
@@ -448,6 +455,7 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         // Two exams start within the next 120 minutes, but have the same users (-> Users are only counted once)
         assertMetricEquals(2, "artemis.scheduled.exams.release.count", "range", "120");
         assertMetricEquals(1 * 2, "artemis.scheduled.exams.release.student_multiplier", "range", "120");
+        */
 
         var registeredExamUser4 = new ExamUser();
         registeredExamUser4.setUser(users.get(2));
@@ -459,12 +467,12 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
         metricsBean.recalculateMetrics();
 
-        // Two exams start within the next 120 minutes, but have the same users (-> Users are only counted once)
-        assertMetricEquals(2, "artemis.scheduled.exams.release.count", "range", "120");
-        assertMetricEquals(1 * 2 + 1 * 1, "artemis.scheduled.exams.release.student_multiplier", "range", "120");
+        // Two exams start within the next 15 minutes, but have the same users (-> Users are only counted once)
+        assertMetricEquals(2, "artemis.scheduled.exams.release.count", "range", "15");
+        assertMetricEquals(1 * 2 + 1 * 1, "artemis.scheduled.exams.release.student_multiplier", "range", "15");
 
         // Exam exercises are not returned in the exercises metrics
-        assertMetricEquals(0, "artemis.scheduled.exercises.due.count", "exerciseType", ExerciseType.QUIZ.toString(), "range", "60");
+        assertMetricEquals(0, "artemis.scheduled.exercises.due.count", "exerciseType", ExerciseType.QUIZ.toString(), "range", "15");
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/config/MetricsBeanTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/config/MetricsBeanTest.java
@@ -331,11 +331,11 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         course1.setStudentGroupName(TEST_PREFIX + "course1students");
 
         course1.addExercises(exerciseRepository
-                .save(QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().plusMinutes(25), ZonedDateTime.now().plusMinutes(55), QuizMode.SYNCHRONIZED, course1)));
-        course1.addExercises(
-                exerciseRepository.save(QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(3), QuizMode.SYNCHRONIZED, course1)));
+                .save(QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().plusMinutes(5), ZonedDateTime.now().plusMinutes(55), QuizMode.SYNCHRONIZED, course1)));
         course1.addExercises(exerciseRepository
-                .save(textExerciseUtilService.createIndividualTextExercise(course1, ZonedDateTime.now().plusMinutes(1), ZonedDateTime.now().plusMinutes(25), null)));
+                .save(QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().plusMinutes(1), ZonedDateTime.now().plusMinutes(3), QuizMode.SYNCHRONIZED, course1)));
+        course1.addExercises(exerciseRepository
+                .save(textExerciseUtilService.createIndividualTextExercise(course1, ZonedDateTime.now().plusMinutes(1), ZonedDateTime.now().plusMinutes(12), null)));
         courseRepository.save(course1);
 
         metricsBean.recalculateMetrics();
@@ -356,13 +356,9 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         // Should now have one active user
         assertMetricEquals(1, "artemis.scheduled.exercises.due.student_multiplier.active.14", "exerciseType", ExerciseType.QUIZ.toString(), "range", "15");
 
-        /* These tests are currently disabled because the available ranges have been adjusted and only one range (15 minutes) is available
-        // Only one quiz is released within the next 30 minutes
-        assertMetricEquals(1, "artemis.scheduled.exercises.release.count", "exerciseType", ExerciseType.QUIZ.toString(), "range", "30");
-        assertMetricEquals(3 * 1, "artemis.scheduled.exercises.release.student_multiplier", "exerciseType", ExerciseType.QUIZ.toString(), "range", "30");
-
-        // Only one active user
-        assertMetricEquals(1, "artemis.scheduled.exercises.release.student_multiplier.active.14", "exerciseType", ExerciseType.QUIZ.toString(), "range", "30");
+        // Two quizzes are released within the next 15 minutes, but have the same users (-> Users are only counted once)
+        assertMetricEquals(2, "artemis.scheduled.exercises.release.count", "exerciseType", ExerciseType.QUIZ.toString(), "range", "15");
+        assertMetricEquals(3 * 1, "artemis.scheduled.exercises.release.student_multiplier", "exerciseType", ExerciseType.QUIZ.toString(), "range", "15");
 
         // Add activity to another user
         quizExerciseUtilService.saveQuizSubmission(exerciseUtilService.getFirstExerciseWithType(course1, QuizExercise.class), ParticipationFactory.generateQuizSubmission(true),
@@ -371,11 +367,7 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         metricsBean.recalculateMetrics();
 
         // Should now have two active users
-        assertMetricEquals(2, "artemis.scheduled.exercises.release.student_multiplier.active.14", "exerciseType", ExerciseType.QUIZ.toString(), "range", "30");
-
-        // Both quizzes end within the next 120 minutes, but have the same users (-> Users are only counted once)
-        assertMetricEquals(2, "artemis.scheduled.exercises.due.count", "exerciseType", ExerciseType.QUIZ.toString(), "range", "120");
-        assertMetricEquals(3 * 1, "artemis.scheduled.exercises.due.student_multiplier", "exerciseType", ExerciseType.QUIZ.toString(), "range", "120");
+        assertMetricEquals(2, "artemis.scheduled.exercises.release.student_multiplier.active.14", "exerciseType", ExerciseType.QUIZ.toString(), "range", "15");
 
         var course2 = courseUtilService.createCourse();
         course2.setStudentGroupName(TEST_PREFIX + "course2students");
@@ -386,20 +378,19 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
         metricsBean.recalculateMetrics();
 
-        // 3 quizzes end within the next 120 minutes, and are in two different courses -> 6 different users in total
-        assertMetricEquals(3, "artemis.scheduled.exercises.due.count", "exerciseType", ExerciseType.QUIZ.toString(), "range", "120");
-        assertMetricEquals(3 * 2, "artemis.scheduled.exercises.due.student_multiplier", "exerciseType", ExerciseType.QUIZ.toString(), "range", "120");
+        // 2 quizzes end within the next 15 minutes, and are in two different courses -> 6 different users in total
+        assertMetricEquals(2, "artemis.scheduled.exercises.due.count", "exerciseType", ExerciseType.QUIZ.toString(), "range", "15");
+        assertMetricEquals(3 * 2, "artemis.scheduled.exercises.due.student_multiplier", "exerciseType", ExerciseType.QUIZ.toString(), "range", "15");
 
         // One text exercise is released within the next 30 minutes
-        assertMetricEquals(1, "artemis.scheduled.exercises.release.count", "exerciseType", ExerciseType.TEXT.toString(), "range", "30");
-        */
+        assertMetricEquals(1, "artemis.scheduled.exercises.release.count", "exerciseType", ExerciseType.TEXT.toString(), "range", "15");
     }
 
     @Test
     void testPrometheusMetricsExams() {
         var users = userUtilService.addUsers(TEST_PREFIX, 3, 0, 0, 0);
         var course = courseUtilService.createCourse();
-        var exam1 = examUtilService.addExam(course, ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(10), ZonedDateTime.now().plusMinutes(40));
+        var exam1 = examUtilService.addExam(course, ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(2), ZonedDateTime.now().plusMinutes(10));
         var registeredExamUser1 = new ExamUser();
         registeredExamUser1.setUser(users.get(0));
         registeredExamUser1.setExam(exam1);
@@ -417,7 +408,7 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
         examUtilService.addExerciseGroupsAndExercisesToExam(exam1, false);
         courseRepository.save(course);
 
-        var exam2 = examUtilService.addExam(course, ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(12), ZonedDateTime.now().plusMinutes(85));
+        var exam2 = examUtilService.addExam(course, ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(5), ZonedDateTime.now().plusMinutes(12));
         var registeredExamUser3 = new ExamUser();
         registeredExamUser3.setUser(users.get(0));
         registeredExamUser3.setExam(exam2);
@@ -431,31 +422,13 @@ class MetricsBeanTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
         metricsBean.recalculateMetrics();
 
-        // Two exams start within the next 11520 minutes, but have the same users (-> Users are only counted once)
+        // Two exams start within the next 15 minutes, but have the same users (-> Users are only counted once)
         assertMetricEquals(2, "artemis.scheduled.exams.release.count", "range", "15");
         assertMetricEquals(1 * 2, "artemis.scheduled.exams.release.student_multiplier", "range", "15");
 
-        /* These tests are currently disabled because the available ranges have been adjusted and only one range (15 minutes) is available
-        // One exam ends within the next 60 minutes
-        assertMetricEquals(1, "artemis.scheduled.exams.due.count", "range", "60");
-        assertMetricEquals(1 * 2, "artemis.scheduled.exams.due.student_multiplier", "range", "60"); // 2 students are registered for the exam
-
         // Two exams ends within the next 120 minutes
-        assertMetricEquals(2, "artemis.scheduled.exams.due.count", "range", "120");
-        assertMetricEquals(1 * 2, "artemis.scheduled.exams.due.student_multiplier", "range", "120"); // 2 + 1 students are registered for the exam, but they are duplicate users
-
-        // No exams start within the next 15 minutes
-        assertMetricEquals(0, "artemis.scheduled.exams.release.count", "range", "15");
-        assertMetricEquals(0, "artemis.scheduled.exams.release.student_multiplier", "range", "15");
-
-        // One exam starts within the next 30 minutes
-        assertMetricEquals(1, "artemis.scheduled.exams.release.count", "range", "30");
-        assertMetricEquals(1 * 2, "artemis.scheduled.exams.release.student_multiplier", "range", "30"); // 2 registered students
-
-        // Two exams start within the next 120 minutes, but have the same users (-> Users are only counted once)
-        assertMetricEquals(2, "artemis.scheduled.exams.release.count", "range", "120");
-        assertMetricEquals(1 * 2, "artemis.scheduled.exams.release.student_multiplier", "range", "120");
-        */
+        assertMetricEquals(2, "artemis.scheduled.exams.due.count", "range", "15");
+        assertMetricEquals(1 * 2, "artemis.scheduled.exams.due.student_multiplier", "range", "15"); // 2 + 1 students are registered for the exam, but they are duplicate users
 
         var registeredExamUser4 = new ExamUser();
         registeredExamUser4.setUser(users.get(2));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
Calculating the metrics currently takes around 5 seconds in the TUM production environment.
This should be reduced to decrease the database load.

### Description
Remove some of the available lookahead periods: Instead of calculating metrics for 15, 30, 45, 60 and 120 minute periods, only a 15 minute period is now taken into account.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- Access to the prometheus metrics

1. Check the exposed metrics at `ARTEMIS_HOST/management/prometheus` and check that no metrics with `range` != `15` exist.
2. Validate that the existing metrics are still calculated as expected (note that the calculation might be delayed and not real-time)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->