### PR TITLE
`General`: Hide several buttons in course management when tutors should not see them 

### DIFF
--- a/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.html
+++ b/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.html
@@ -39,7 +39,7 @@
                         <span *ngIf="submission.latestResult?.score != undefined">{{ submission.latestResult!.score }}%</span>
                     </td>
                     <td>
-                        <span *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR', 'ROLE_EDITOR', 'ROLE_TA']">
+                        <span>
                             <a
                                 *ngIf="submission.participation!.exercise!.type === ExerciseType.TEXT"
                                 [routerLink]="[

--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
@@ -10,7 +10,7 @@
             <h2 jhiTranslate="artemisApp.competency.manageCompetencies.title">Competency Management</h2>
             <jhi-documentation-button [type]="documentationType"></jhi-documentation-button>
         </div>
-        <div class="ms-auto text-truncate justify-content-end" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
+        <div class="ms-auto text-truncate justify-content-end">
             <button class="btn btn-primary" id="competencyImportButton" (click)="openImportModal()">
                 <fa-icon [icon]="faPlus"></fa-icon>
                 <span>{{ 'artemisApp.competency.manageCompetencies.import' | artemisTranslate }}</span>
@@ -189,16 +189,11 @@
                         <span>{{ 'global.generic.' + (competency.optional ? 'yes' : 'no') | artemisTranslate }}</span>
                     </td>
                     <td class="text-end">
-                        <a
-                            *jhiHasAnyAuthority="['ROLE_INSTRUCTOR', 'ROLE_ADMIN']"
-                            class="btn btn-sm btn-primary"
-                            [routerLink]="['/course-management', courseId, 'competency-management', competency.id, 'edit']"
-                        >
+                        <a class="btn btn-sm btn-primary" [routerLink]="['/course-management', courseId, 'competency-management', competency.id, 'edit']">
                             <fa-icon [icon]="faPencilAlt"></fa-icon>
                             <span class="d-none d-md-inline">{{ 'entity.action.edit' | artemisTranslate }}</span>
                         </a>
                         <button
-                            *jhiHasAnyAuthority="['ROLE_INSTRUCTOR', 'ROLE_ADMIN']"
                             jhiDeleteButton
                             [entityTitle]="competency.title || ''"
                             [deleteQuestion]="'artemisApp.competency.competencyCard.delete.question'"
@@ -216,7 +211,7 @@
 
     <div class="d-flex flex-wrap">
         <h2 jhiTranslate="artemisApp.competency.prerequisite.managePrerequisites.title">Prerequisite Management</h2>
-        <div class="ms-auto text-truncate justify-content-end" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
+        <div class="ms-auto text-truncate justify-content-end">
             <a class="btn btn-primary" (click)="openPrerequisiteSelectionModal()">
                 <fa-icon [icon]="faPlus"></fa-icon>
                 <span>{{ 'artemisApp.competency.prerequisite.managePrerequisites.select' | artemisTranslate }}</span>
@@ -257,12 +252,7 @@
                         </div>
                     </td>
                     <td class="text-end">
-                        <button
-                            *jhiHasAnyAuthority="['ROLE_INSTRUCTOR', 'ROLE_ADMIN']"
-                            id="removeButton"
-                            class="btn btn-secondary btn-sm"
-                            (click)="removePrerequisite(prerequisite.id!)"
-                        >
+                        <button id="removeButton" class="btn btn-secondary btn-sm" (click)="removePrerequisite(prerequisite.id!)">
                             <fa-icon [icon]="faTimes"></fa-icon> {{ 'artemisApp.competency.competencyCard.remove' | artemisTranslate }}
                         </button>
                     </td>

--- a/src/main/webapp/app/course/competencies/competency.service.ts
+++ b/src/main/webapp/app/course/competencies/competency.service.ts
@@ -118,13 +118,17 @@ export class CompetencyService {
         if (res.body?.lectureUnits) {
             res.body.lectureUnits = this.lectureUnitService.convertLectureUnitArrayDatesFromServer(res.body.lectureUnits);
         }
-        if (res.body?.exercises) {
-            res.body.exercises = ExerciseService.convertExercisesDateFromServer(res.body.exercises);
-            res.body.exercises.forEach((exercise) => ExerciseService.parseExerciseCategories(exercise));
-        }
         if (res.body?.course) {
             this.accountService.setAccessRightsForCourse(res.body.course);
         }
+        if (res.body?.exercises) {
+            res.body.exercises = ExerciseService.convertExercisesDateFromServer(res.body.exercises);
+            res.body.exercises.forEach((exercise) => {
+                ExerciseService.parseExerciseCategories(exercise);
+                this.accountService.setAccessRightsForExercise(exercise);
+            });
+        }
+
         return res;
     }
 

--- a/src/main/webapp/app/course/competencies/competency.service.ts
+++ b/src/main/webapp/app/course/competencies/competency.service.ts
@@ -7,6 +7,7 @@ import { map, tap } from 'rxjs/operators';
 import { EntityTitleService, EntityType } from 'app/shared/layouts/navbar/entity-title.service';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { convertDateFromClient, convertDateFromServer } from 'app/utils/date.utils';
+import { AccountService } from 'app/core/auth/account.service';
 
 type EntityResponseType = HttpResponse<Competency>;
 type EntityArrayResponseType = HttpResponse<Competency[]>;
@@ -21,6 +22,7 @@ export class CompetencyService {
         private httpClient: HttpClient,
         private entityTitleService: EntityTitleService,
         private lectureUnitService: LectureUnitService,
+        private accountService: AccountService,
     ) {}
 
     getAllForCourse(courseId: number): Observable<EntityArrayResponseType> {
@@ -119,6 +121,9 @@ export class CompetencyService {
         if (res.body?.exercises) {
             res.body.exercises = ExerciseService.convertExercisesDateFromServer(res.body.exercises);
             res.body.exercises.forEach((exercise) => ExerciseService.parseExerciseCategories(exercise));
+        }
+        if (res.body?.course) {
+            this.accountService.setAccessRightsForCourse(res.body.course);
         }
         return res;
     }

--- a/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.html
+++ b/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.html
@@ -192,20 +192,16 @@
                                 </a>
                             </ng-template>
 
-                            <ng-container *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
-                                <ng-container
-                                    class="col-lg-3 col-md-6 col-sm-6"
-                                    *ngIf="
-                                        course?.isAtLeastInstructor && isExamMode && !isTestRun && exam?.numberOfCorrectionRoundsInExam && exam!.numberOfCorrectionRoundsInExam! > 1
-                                    "
-                                >
-                                    <jhi-second-correction-enable-button
-                                        class="me-1 mb-1"
-                                        (ngModelChange)="toggleSecondCorrection(exercise.id!)"
-                                        [secondCorrectionEnabled]="exercise.secondCorrectionEnabled"
-                                        [togglingSecondCorrectionButton]="isTogglingSecondCorrection.get(exercise.id!)!"
-                                    ></jhi-second-correction-enable-button>
-                                </ng-container>
+                            <ng-container
+                                class="col-lg-3 col-md-6 col-sm-6"
+                                *ngIf="course?.isAtLeastInstructor && isExamMode && !isTestRun && exam?.numberOfCorrectionRoundsInExam && exam!.numberOfCorrectionRoundsInExam! > 1"
+                            >
+                                <jhi-second-correction-enable-button
+                                    class="me-1 mb-1"
+                                    (ngModelChange)="toggleSecondCorrection(exercise.id!)"
+                                    [secondCorrectionEnabled]="exercise.secondCorrectionEnabled"
+                                    [togglingSecondCorrectionButton]="isTogglingSecondCorrection.get(exercise.id!)!"
+                                ></jhi-second-correction-enable-button>
                             </ng-container>
                         </td>
                     </tr>

--- a/src/main/webapp/app/course/learning-paths/learning-path-management/learning-path-health-status-warning.component.html
+++ b/src/main/webapp/app/course/learning-paths/learning-path-management/learning-path-health-status-warning.component.html
@@ -2,7 +2,7 @@
     <div>
         <h5 class="alert-heading">{{ getWarningTitle(status) | artemisTranslate }}</h5>
         <p>{{ getWarningBody(status) | artemisTranslate }}</p>
-        <button *jhiHasAnyAuthority="['ROLE_INSTRUCTOR', 'ROLE_ADMIN']" type="button" class="btn btn-primary" (click)="onButtonClicked.emit()">
+        <button type="button" class="btn btn-primary" (click)="onButtonClicked.emit()">
             <span ngbTooltip="{{ getWarningHint(status) | artemisTranslate }}">{{ getWarningAction(status) | artemisTranslate }}</span>
         </button>
     </div>

--- a/src/main/webapp/app/course/learning-paths/learning-path-management/learning-path-management.component.html
+++ b/src/main/webapp/app/course/learning-paths/learning-path-management/learning-path-management.component.html
@@ -11,7 +11,6 @@
         <div>
             <button
                 id="enable-learning-paths-button"
-                *jhiHasAnyAuthority="['ROLE_INSTRUCTOR', 'ROLE_ADMIN']"
                 type="button"
                 class="btn btn-primary"
                 (click)="enableLearningPaths()"

--- a/src/main/webapp/app/course/manage/course-management-tab-bar/course-management-tab-bar.component.html
+++ b/src/main/webapp/app/course/manage/course-management-tab-bar/course-management-tab-bar.component.html
@@ -79,7 +79,7 @@
             <jhi-course-exam-archive-button *ngIf="course.isAtLeastInstructor" [archiveMode]="'Course'" [course]="course" class="archive-button"></jhi-course-exam-archive-button>
             <button
                 id="delete-course"
-                *jhiHasAnyAuthority="['ROLE_ADMIN']"
+                *jhiHasAnyAuthority="'ROLE_ADMIN'"
                 [buttonSize]="ButtonSize.MEDIUM"
                 jhiDeleteButton
                 [entityTitle]="course.title || ''"

--- a/src/main/webapp/app/exam/manage/exam-management.component.html
+++ b/src/main/webapp/app/exam/manage/exam-management.component.html
@@ -2,12 +2,12 @@
     <div class="d-flex flex-wrap align-items-center">
         <h4 id="course-page-heading" jhiTranslate="artemisApp.examManagement.title">Exams</h4>
         <jhi-documentation-button [type]="documentationType"></jhi-documentation-button>
-        <div class="ms-auto text-truncate justify-content-end" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
-            <a class="btn btn-primary me-1" *ngIf="course.isAtLeastInstructor" (click)="openImportModal()">
+        <div class="ms-auto text-truncate justify-content-end" *ngIf="course.isAtLeastInstructor">
+            <a class="btn btn-primary me-1" (click)="openImportModal()">
                 <fa-icon [icon]="faPlus"></fa-icon>
                 <span>{{ 'artemisApp.examManagement.importExam' | artemisTranslate }}</span>
             </a>
-            <a class="btn btn-primary jh-create-entity create-exam" id="create-exam" *ngIf="course.isAtLeastInstructor" [routerLink]="['new']">
+            <a class="btn btn-primary jh-create-entity create-exam" id="create-exam" [routerLink]="['new']">
                 <fa-icon [icon]="faPlus"></fa-icon>
                 <span>{{ 'artemisApp.examManagement.createExam' | artemisTranslate }}</span>
             </a>

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -44,87 +44,69 @@
         <div class="d-flex justify-content-end" style="flex: 1">
             <div class="d-flex flex-column justify-content-center">
                 <div class="btn-group flex-btn-group-container">
-                    <div class="btn-group-vertical me-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR', 'ROLE_EDITOR']" style="justify-content: end">
-                        <a
-                            *ngIf="course?.isAtLeastEditor"
-                            [routerLink]="[exerciseGroup.id, 'file-upload-exercises', 'new']"
-                            class="btn btn-info btn-sm me-1 mb-1"
-                            style="max-height: 44%"
-                        >
+                    <div class="btn-group-vertical me-1 mb-1" *ngIf="course?.isAtLeastEditor" style="justify-content: end">
+                        <a [routerLink]="[exerciseGroup.id, 'file-upload-exercises', 'new']" class="btn btn-info btn-sm me-1 mb-1" style="max-height: 44%">
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.fileUploadExercise.home.createLabel' | artemisTranslate }}</span>
                             <fa-icon [icon]="faFileUpload"></fa-icon>
                         </a>
-                        <a *ngIf="course?.isAtLeastEditor" (click)="openImportModal(exerciseGroup, exerciseType.FILE_UPLOAD)" class="btn btn-info btn-sm me-1 mb-1">
+                        <a (click)="openImportModal(exerciseGroup, exerciseType.FILE_UPLOAD)" class="btn btn-info btn-sm me-1 mb-1">
                             <fa-icon [icon]="faFileImport"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.fileUploadExercise.home.importLabel' | artemisTranslate }}</span>
                             <fa-icon [icon]="faFileUpload"></fa-icon>
                         </a>
                     </div>
-                    <div class="btn-group-vertical me-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR', 'ROLE_EDITOR']" style="justify-content: end">
-                        <a
-                            *ngIf="course?.isAtLeastEditor"
-                            [routerLink]="[exerciseGroup.id, 'quiz-exercises', 'new']"
-                            class="add-quiz-exercise btn btn-info btn-sm me-1 mb-1"
-                            style="max-height: 44%"
-                        >
+                    <div class="btn-group-vertical me-1 mb-1" *ngIf="course?.isAtLeastEditor" style="justify-content: end">
+                        <a [routerLink]="[exerciseGroup.id, 'quiz-exercises', 'new']" class="add-quiz-exercise btn btn-info btn-sm me-1 mb-1" style="max-height: 44%">
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.quizExercise.home.createLabel' | artemisTranslate }}</span>
                             <fa-icon [icon]="faCheckDouble"></fa-icon>
                         </a>
-                        <a *ngIf="course?.isAtLeastEditor" (click)="openImportModal(exerciseGroup, exerciseType.QUIZ)" class="btn btn-info btn-sm me-1 mb-1">
+                        <a (click)="openImportModal(exerciseGroup, exerciseType.QUIZ)" class="btn btn-info btn-sm me-1 mb-1">
                             <fa-icon [icon]="faFileImport"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.quizExercise.home.importLabel' | artemisTranslate }}</span>
                             <fa-icon [icon]="faCheckDouble"></fa-icon>
                         </a>
                     </div>
-                    <div class="btn-group-vertical me-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR', 'ROLE_EDITOR']">
-                        <a *ngIf="course?.isAtLeastEditor" [routerLink]="[exerciseGroup.id, 'text-exercises', 'new']" class="add-text-exercise btn btn-info btn-sm me-1 mb-1">
+                    <div class="btn-group-vertical me-1 mb-1" *ngIf="course?.isAtLeastEditor">
+                        <a [routerLink]="[exerciseGroup.id, 'text-exercises', 'new']" class="add-text-exercise btn btn-info btn-sm me-1 mb-1">
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.textExercise.home.createLabel' | artemisTranslate }}</span>
                             <fa-icon [icon]="faFont"></fa-icon>
                         </a>
-                        <a *ngIf="course?.isAtLeastEditor" (click)="openImportModal(exerciseGroup, exerciseType.TEXT)" class="btn btn-info btn-sm me-1 mb-1">
+                        <a (click)="openImportModal(exerciseGroup, exerciseType.TEXT)" class="btn btn-info btn-sm me-1 mb-1">
                             <fa-icon [icon]="faFileImport"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.textExercise.home.importLabel' | artemisTranslate }}</span>
                             <fa-icon [icon]="faFont"></fa-icon>
                         </a>
                     </div>
-                    <div class="btn-group-vertical me-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR', 'ROLE_EDITOR']">
-                        <a
-                            *ngIf="course?.isAtLeastEditor"
-                            [routerLink]="[exerciseGroup.id, 'modeling-exercises', 'new']"
-                            class="add-modeling-exercise btn btn-info btn-sm me-1 mb-1"
-                        >
+                    <div class="btn-group-vertical me-1 mb-1" *ngIf="course?.isAtLeastEditor">
+                        <a [routerLink]="[exerciseGroup.id, 'modeling-exercises', 'new']" class="add-modeling-exercise btn btn-info btn-sm me-1 mb-1">
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.modelingExercise.home.createLabel' | artemisTranslate }}</span>
                             <fa-icon [icon]="faProjectDiagram"></fa-icon>
                         </a>
-                        <a *ngIf="course?.isAtLeastEditor" (click)="openImportModal(exerciseGroup, exerciseType.MODELING)" class="btn btn-info btn-sm me-1 mb-1">
+                        <a (click)="openImportModal(exerciseGroup, exerciseType.MODELING)" class="btn btn-info btn-sm me-1 mb-1">
                             <fa-icon [icon]="faFileImport"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.modelingExercise.home.importLabel' | artemisTranslate }}</span>
                             <fa-icon [icon]="faProjectDiagram"></fa-icon>
                         </a>
                     </div>
-                    <div class="btn-group-vertical me-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR', 'ROLE_EDITOR']">
-                        <a
-                            *ngIf="course?.isAtLeastEditor"
-                            [routerLink]="[exerciseGroup.id, 'programming-exercises', 'new']"
-                            class="add-programming-exercise btn btn-info btn-sm me-1 mb-1"
-                        >
+                    <div class="btn-group-vertical me-1 mb-1" *ngIf="course?.isAtLeastEditor">
+                        <a [routerLink]="[exerciseGroup.id, 'programming-exercises', 'new']" class="add-programming-exercise btn btn-info btn-sm me-1 mb-1">
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.programmingExercise.home.createLabel' | artemisTranslate }}</span>
                             <fa-icon [icon]="faKeyboard"></fa-icon>
                         </a>
-                        <a *ngIf="course?.isAtLeastEditor" (click)="openImportModal(exerciseGroup, exerciseType.PROGRAMMING)" class="btn btn-info btn-sm me-1 mb-1">
+                        <a (click)="openImportModal(exerciseGroup, exerciseType.PROGRAMMING)" class="btn btn-info btn-sm me-1 mb-1">
                             <fa-icon [icon]="faFileImport"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.programmingExercise.home.importLabel' | artemisTranslate }}</span>
                             <fa-icon [icon]="faKeyboard"></fa-icon>
                         </a>
                     </div>
                     <div class="btn-group-vertical me-1 mb-1">
-                        <div class="d-flex flex-column me-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR', 'ROLE_EDITOR']">
-                            <a *ngIf="course?.isAtLeastEditor" [routerLink]="[exerciseGroup.id, 'edit']" class="edit-group btn btn-warning btn-sm me-1 mb-1">
+                        <div class="d-flex flex-column me-1 mb-1" *ngIf="course?.isAtLeastEditor">
+                            <a [routerLink]="[exerciseGroup.id, 'edit']" class="edit-group btn btn-warning btn-sm me-1 mb-1">
                                 <fa-icon [icon]="faWrench"></fa-icon>
                                 <span class="d-none d-xl-inline">{{ 'entity.action.edit' | artemisTranslate }}</span>
                             </a>

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.html
@@ -63,7 +63,7 @@
                     <span *ngIf="!modelingExercise.exampleSolutionPublicationDate" jhiTranslate="artemisApp.exercise.dateNotSet"></span>
                 </dd>
             </dl>
-            <ng-container *jhiHasAnyAuthority="['ROLE_ADMIN']">
+            <ng-container *jhiHasAnyAuthority="'ROLE_ADMIN'">
                 <dl class="row-md">
                     <dt>
                         <span jhiTranslate="artemisApp.modelingExercise.clusters">Clusters</span>

--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.html
@@ -36,7 +36,7 @@
         Only show download all checkbox for instructors & admins.
         -->
         <ng-container *ngIf="isAtLeastInstructor && !singleParticipantMode && !isRepoExportForMultipleExercises">
-            <div *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" class="checkbox">
+            <div class="checkbox">
                 <label class="control-label">
                     <input class="form-check-input" type="checkbox" name="allStudents" [(ngModel)]="repositoryExportOptions.exportAllParticipants" />
                     <strong [jhiTranslate]="'artemisApp.programmingExercise.export.' + (programmingExercises[0].teamMode ? 'downloadAllTeams' : 'downloadAllStudents')">

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component.html
@@ -2,7 +2,7 @@
     <div class="col-md-8 offset-md-2 text-center">
         <h3>{{ quizExercise.title }}</h3>
 
-        <button *jhiHasAnyAuthority="['ROLE_TA', 'ROLE_EDITOR', 'ROLE_INSTRUCTOR', 'ROLE_ADMIN']" class="btn btn-primary btn-sm float-end" (click)="recalculate()">
+        <button *ngIf="quizExercise.isAtLeastTutor" class="btn btn-primary btn-sm float-end" (click)="recalculate()">
             <fa-icon [icon]="faSync" [fixedWidth]="true"></fa-icon>&nbsp;{{ 'artemisApp.showStatistic.recalculateStatistics' | artemisTranslate }}
         </button>
 

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
@@ -31,13 +31,11 @@
                 *ngIf="exercise.isAtLeastInstructor && exam?.numberOfCorrectionRoundsInExam && exam?.numberOfCorrectionRoundsInExam! > 1 && isExamMode && !isTestRun"
                 class="d-inline-block"
             >
-                <ng-container *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
-                    <jhi-second-correction-enable-button
-                        (ngModelChange)="toggleSecondCorrection()"
-                        [secondCorrectionEnabled]="secondCorrectionEnabled"
-                        [togglingSecondCorrectionButton]="togglingSecondCorrectionButton"
-                    ></jhi-second-correction-enable-button>
-                </ng-container>
+                <jhi-second-correction-enable-button
+                    (ngModelChange)="toggleSecondCorrection()"
+                    [secondCorrectionEnabled]="secondCorrectionEnabled"
+                    [togglingSecondCorrectionButton]="togglingSecondCorrectionButton"
+                ></jhi-second-correction-enable-button>
             </div>
         </div>
 

--- a/src/main/webapp/app/exercises/shared/submission-export/submission-export-dialog.component.html
+++ b/src/main/webapp/app/exercises/shared/submission-export/submission-export-dialog.component.html
@@ -19,7 +19,7 @@
         Only show download all checkbox for instructors & admins.
         -->
         <ng-container *ngIf="exercise.isAtLeastInstructor">
-            <div *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" class="checkbox">
+            <div class="checkbox">
                 <label class="control-label">
                     <input class="form-check-input" type="checkbox" name="allStudents" [(ngModel)]="submissionExportOptions.exportAllParticipants" />
                     <strong [jhiTranslate]="'artemisApp.instructorDashboard.exportSubmissions.downloadAllStudents'"> Or download the submissions of all students }} </strong>

--- a/src/main/webapp/app/exercises/text/manage/tutor-effort/tutor-effort-statistics.component.html
+++ b/src/main/webapp/app/exercises/text/manage/tutor-effort/tutor-effort-statistics.component.html
@@ -1,7 +1,7 @@
 <div>
     <div class="d-flex flex-row justify-content-between align items center">
         <h4 jhiTranslate="artemisApp.textExercise.tutorEffortStatistics.title"></h4>
-        <button *jhiHasAnyAuthority="['ROLE_INSTRUCTOR', 'ROLE_ADMIN']" class="btn btn-primary btn-sm mb-2" (click)="loadTutorEfforts()">
+        <button class="btn btn-primary btn-sm mb-2" (click)="loadTutorEfforts()">
             <fa-icon [icon]="faSync" [fixedWidth]="true"></fa-icon>&nbsp;{{ 'artemisApp.showStatistic.recalculateStatistics' | artemisTranslate }}
         </button>
     </div>

--- a/src/main/webapp/app/overview/course-competencies/course-competencies-details.component.html
+++ b/src/main/webapp/app/overview/course-competencies/course-competencies-details.component.html
@@ -31,7 +31,7 @@
             </div>
             <div class="col-auto">
                 <a
-                    *jhiHasAnyAuthority="['ROLE_INSTRUCTOR', 'ROLE_ADMIN']"
+                    *ngIf="competency.course?.isAtLeastInstructor"
                     class="btn btn-sm btn-warning float-end"
                     [routerLink]="['/course-management', courseId, 'competency-management', competency.id, 'edit']"
                 >

--- a/src/main/webapp/app/overview/course-competencies/course-competencies-details.component.ts
+++ b/src/main/webapp/app/overview/course-competencies/course-competencies-details.component.ts
@@ -52,7 +52,6 @@ export class CourseCompetenciesDetailsComponent implements OnInit {
         this.competencyService.findById(this.competencyId!, this.courseId!).subscribe({
             next: (resp) => {
                 this.competency = resp.body!;
-                console.log(this.competency);
                 if (this.competency && this.competency.exercises) {
                     // Add exercises as lecture units for display
                     this.competency.lectureUnits = this.competency.lectureUnits ?? [];

--- a/src/main/webapp/app/overview/course-competencies/course-competencies-details.component.ts
+++ b/src/main/webapp/app/overview/course-competencies/course-competencies-details.component.ts
@@ -52,6 +52,7 @@ export class CourseCompetenciesDetailsComponent implements OnInit {
         this.competencyService.findById(this.competencyId!, this.courseId!).subscribe({
             next: (resp) => {
                 this.competency = resp.body!;
+                console.log(this.competency);
                 if (this.competency && this.competency.exercises) {
                     // Add exercises as lecture units for display
                     this.competency.lectureUnits = this.competency.lectureUnits ?? [];

--- a/src/main/webapp/app/shared/auth/has-any-authority.directive.ts
+++ b/src/main/webapp/app/shared/auth/has-any-authority.directive.ts
@@ -3,7 +3,7 @@ import { AccountService } from 'app/core/auth/account.service';
 
 /**
  * @whatItDoes Conditionally includes an HTML element if current user has any
- * of the authorities passed as the `expression`.
+ * of the authorities in any course passed as the `expression`.
  *
  * @howToUse
  * ```

--- a/src/test/javascript/spec/component/competencies/competency.service.spec.ts
+++ b/src/test/javascript/spec/component/competencies/competency.service.spec.ts
@@ -7,6 +7,8 @@ import { take } from 'rxjs/operators';
 import { LectureUnit } from 'app/entities/lecture-unit/lectureUnit.model';
 import { CompetencyService } from 'app/course/competencies/competency.service';
 import { Competency, CompetencyProgress, CompetencyRelation, CourseCompetencyProgress } from 'app/entities/competency.model';
+import { AccountService } from 'app/core/auth/account.service';
+import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
 
 describe('CompetencyService', () => {
     let competencyService: CompetencyService;
@@ -30,6 +32,7 @@ describe('CompetencyService', () => {
                         return lectureUnits;
                     },
                 }),
+                { provide: AccountService, useClass: MockAccountService },
             ],
         });
         expectedResultCompetency = {} as HttpResponse<Competency>;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix #7467 and other similar problems related to `jhiHasAnyAuthority` leading to visible buttons that should not be visible.

### Description
<!-- Describe your changes in detail -->
`jhiHasAnyAuthority` only checks that the user has that authority in any course. So an instructor or tutor in one course could be a student in another but the directive would still show this html element to the user. Instead `isAtLeastTutor` and similar attributes of courses and exercises should be used in an `ngIf`.
If the whole route is already reserved for specific authorities, there is no use in checking them again inside the html.

The only visible change to the UI should be the button mentioned in the issue, the rest is removal and refactoring of redundant code.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor 
- 1 Student that is instructor in another course

1. Log in to Artemis
2. Create a competency as instructor
3. View the competency as the student that is instructor in another course
4. Check that there is no edit button on the right in the header

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2