### PR TITLE
`Development`: Add paper publications from 2023 to documentation

### DIFF
--- a/docs/research/publications.bib
+++ b/docs/research/publications.bib
@@ -1,7 +1,7 @@
 %%%
 % All entries in this file should be sorted chronologically.
 % Use BibTeX Tidy to keep this file sorted, formated, and organized.
-%q:
+%
 % https://flamingtempura.github.io/bibtex-tidy/index.html?opt=%7B%22curly%22%3Atrue%2C%22numeric%22%3Atrue%2C%22sort%22%3A%5B%22-year%22%2C%22-month%22%2C%22author%22%5D%2C%22omit%22%3A%5B%22timestamp%22%2C%22biburl%22%2C%22bibsource%22%2C%22editor%22%2C%22copyright%22%2C%22category%22%2C%22note%22%2C%22metadata%22%5D%2C%22space%22%3A2%2C%22tab%22%3Afalse%2C%22align%22%3A13%2C%22wrap%22%3A80%2C%22blankLines%22%3Afalse%2C%22duplicates%22%3A%5B%22key%22%2C%22doi%22%2C%22citation%22%5D%2C%22merge%22%3Afalse%2C%22enclosingBraces%22%3Afalse%2C%22stripEnclosingBraces%22%3Atrue%2C%22dropAllCaps%22%3Afalse%2C%22sortFields%22%3A%5B%22title%22%2C%22shorttitle%22%2C%22author%22%2C%22year%22%2C%22month%22%2C%22day%22%2C%22journal%22%2C%22booktitle%22%2C%22location%22%2C%22on%22%2C%22publisher%22%2C%22address%22%2C%22series%22%2C%22volume%22%2C%22number%22%2C%22pages%22%2C%22doi%22%2C%22isbn%22%2C%22issn%22%2C%22url%22%2C%22urldate%22%5D%2C%22stripComments%22%3Afalse%2C%22tidyComments%22%3Atrue%2C%22encodeUrls%22%3Afalse%2C%22escape%22%3Afalse%2C%22trailingCommas%22%3Atrue%2C%22removeEmptyFields%22%3Afalse%2C%22removeDuplicateFields%22%3Afalse%2C%22lowercase%22%3Atrue%2C%22generateKeys%22%3Atrue%7D
 %%%
 

--- a/docs/research/publications.bib
+++ b/docs/research/publications.bib
@@ -5,6 +5,94 @@
 % https://flamingtempura.github.io/bibtex-tidy/index.html?opt=%7B%22curly%22%3Atrue%2C%22numeric%22%3Atrue%2C%22sort%22%3A%5B%22-year%22%2C%22-month%22%2C%22author%22%5D%2C%22omit%22%3A%5B%22timestamp%22%2C%22biburl%22%2C%22bibsource%22%2C%22editor%22%2C%22copyright%22%2C%22category%22%2C%22note%22%2C%22metadata%22%5D%2C%22space%22%3A2%2C%22tab%22%3Afalse%2C%22align%22%3A13%2C%22wrap%22%3A80%2C%22blankLines%22%3Afalse%2C%22duplicates%22%3A%5B%22key%22%2C%22doi%22%2C%22citation%22%5D%2C%22merge%22%3Afalse%2C%22enclosingBraces%22%3Afalse%2C%22stripEnclosingBraces%22%3Atrue%2C%22dropAllCaps%22%3Afalse%2C%22sortFields%22%3A%5B%22title%22%2C%22shorttitle%22%2C%22author%22%2C%22year%22%2C%22month%22%2C%22day%22%2C%22journal%22%2C%22booktitle%22%2C%22location%22%2C%22on%22%2C%22publisher%22%2C%22address%22%2C%22series%22%2C%22volume%22%2C%22number%22%2C%22pages%22%2C%22doi%22%2C%22isbn%22%2C%22issn%22%2C%22url%22%2C%22urldate%22%5D%2C%22stripComments%22%3Afalse%2C%22tidyComments%22%3Atrue%2C%22encodeUrls%22%3Afalse%2C%22escape%22%3Afalse%2C%22trailingCommas%22%3Atrue%2C%22removeEmptyFields%22%3Afalse%2C%22removeDuplicateFields%22%3Afalse%2C%22lowercase%22%3Atrue%2C%22generateKeys%22%3Atrue%7D
 %%%
 
+@InProceedings{linhuber23koli,
+    author = {Linhuber, Matthias and Bernius, Jan Philip and Krusche, Stephan},
+    title = {Constructive Alignment in Modern Computing Education: An Open-Source Computer-Based Examination System},
+    booktitle = {23nd Koli Calling International Conference on Computing Education Research},
+    series = {{Koli} '23},
+    year = {2023},
+    month = nov,
+    location = {Koli, Finland},
+    doi = {10.35542/osf.io/nmpf6},
+}
+@inproceedings{BerrezuetaGuzmanK23,
+  author       = {Jonnathan Berrezueta{-}Guzman and
+                  Stephan Krusche},
+  title        = {Recommendations to Create Programming Exercises to Overcome ChatGPT},
+  booktitle    = {
+    35th International Conference on Software Engineering Education and Training
+  },
+  series       = {{CSEE{\&}T} '23},
+  location     = {Tokyo, Japan},
+  publisher    = {{IEEE}},
+  year         = {2023},
+  month        = aug,
+  pages        = {147--151},
+  doi          = {10.1109/CSEET58097.2023.00031},
+}
+@inproceedings{BerrezuetaGuzmanPK23,
+  author       = {Jonnathan Berrezueta{-}Guzman and
+                  Markus Paulsen and
+                  Stephan Krusche},
+  title        = {Plagiarism Detection and its Effect on the Learning Outcomes},
+  booktitle    = {
+    35th International Conference on Software Engineering Education and Training
+  },
+  series       = {{CSEE{\&}T} '23},
+  location     = {Tokyo, Japan},
+  publisher    = {{IEEE}},
+  year         = {2023},
+  month        = aug,
+  pages        = {99--108},
+  doi          = {10.1109/CSEET58097.2023.00021},
+}
+@inproceedings{KruscheB23,
+  author       = {Stephan Krusche and
+                  Jonnathan Berrezueta{-}Guzman},
+  title        = {Introduction to Programming using Interactive Learning},
+  booktitle    = {
+    35th International Conference on Software Engineering Education and Training
+  },
+  series       = {{CSEE{\&}T} '23},
+  location     = {Tokyo, Japan},
+  pages        = {178--182},
+  publisher    = {{IEEE}},
+  year         = {2023},
+  month        = aug,
+  doi          = {10.1109/CSEET58097.2023.00037},
+}
+@inproceedings{MangerSLWZK23,
+  author       = {Stefanie Manger and
+                  Maximilian S{\"{o}}lch and
+                  Matthias Linhuber and
+                  Christoph Weinhuber and
+                  Philipp Zagar and
+                  Stephan Krusche},
+  title        = {
+    Is Online Teaching Dead After COVID-19? Student Preferences for Programming Courses
+  },
+  booktitle    = {
+    35th International Conference on Software Engineering Education and Training
+  },
+  series       = {{CSEE{\&}T} '23},
+  location     = {Tokyo, Japan},
+  pages        = {89--98},
+  publisher    = {{IEEE}},
+  year         = {2023},
+  month        = aug,
+  doi          = {10.1109/CSEET58097.2023.00020},
+}
+@inproceedings{soelch2023lak,
+  author       = {Maximilian S{\"{o}}lch and
+                  Moritz Aberle and
+                  Stephan Krusche},
+  title        = {Integrating Competency-Based Education in Interactive Learning Systems},
+  booktitle    = {13th International Conference on Learning Analytics & Knowledge},
+  series       = {{LAK} '23},
+  year         = {2023},
+  month        = mar,
+  doi          = {10.48550/ARXIV.2309.12343},
+}
 @article{bernius2022machine,
   title        = {
     Machine Learning Based Feedback on Textual Student Answers in Large Courses

--- a/docs/research/publications.bib
+++ b/docs/research/publications.bib
@@ -1,96 +1,96 @@
 %%%
 % All entries in this file should be sorted chronologically.
 % Use BibTeX Tidy to keep this file sorted, formated, and organized.
-%
+%q:
 % https://flamingtempura.github.io/bibtex-tidy/index.html?opt=%7B%22curly%22%3Atrue%2C%22numeric%22%3Atrue%2C%22sort%22%3A%5B%22-year%22%2C%22-month%22%2C%22author%22%5D%2C%22omit%22%3A%5B%22timestamp%22%2C%22biburl%22%2C%22bibsource%22%2C%22editor%22%2C%22copyright%22%2C%22category%22%2C%22note%22%2C%22metadata%22%5D%2C%22space%22%3A2%2C%22tab%22%3Afalse%2C%22align%22%3A13%2C%22wrap%22%3A80%2C%22blankLines%22%3Afalse%2C%22duplicates%22%3A%5B%22key%22%2C%22doi%22%2C%22citation%22%5D%2C%22merge%22%3Afalse%2C%22enclosingBraces%22%3Afalse%2C%22stripEnclosingBraces%22%3Atrue%2C%22dropAllCaps%22%3Afalse%2C%22sortFields%22%3A%5B%22title%22%2C%22shorttitle%22%2C%22author%22%2C%22year%22%2C%22month%22%2C%22day%22%2C%22journal%22%2C%22booktitle%22%2C%22location%22%2C%22on%22%2C%22publisher%22%2C%22address%22%2C%22series%22%2C%22volume%22%2C%22number%22%2C%22pages%22%2C%22doi%22%2C%22isbn%22%2C%22issn%22%2C%22url%22%2C%22urldate%22%5D%2C%22stripComments%22%3Afalse%2C%22tidyComments%22%3Atrue%2C%22encodeUrls%22%3Afalse%2C%22escape%22%3Afalse%2C%22trailingCommas%22%3Atrue%2C%22removeEmptyFields%22%3Afalse%2C%22removeDuplicateFields%22%3Afalse%2C%22lowercase%22%3Atrue%2C%22generateKeys%22%3Atrue%7D
 %%%
 
-@InProceedings{linhuber23koli,
-    author = {Linhuber, Matthias and Bernius, Jan Philip and Krusche, Stephan},
-    title = {Constructive Alignment in Modern Computing Education: An Open-Source Computer-Based Examination System},
-    booktitle = {23nd Koli Calling International Conference on Computing Education Research},
-    series = {{Koli} '23},
-    year = {2023},
-    month = nov,
-    location = {Koli, Finland},
-    doi = {10.35542/osf.io/nmpf6},
-}
-@inproceedings{BerrezuetaGuzmanK23,
-  author       = {Jonnathan Berrezueta{-}Guzman and
-                  Stephan Krusche},
-  title        = {Recommendations to Create Programming Exercises to Overcome ChatGPT},
-  booktitle    = {
-    35th International Conference on Software Engineering Education and Training
+@inproceedings{linhuber2023constructive,
+  title        = {
+    Constructive Alignment in Modern Computing Education: An Open-Source
+    Computer-Based Examination System
   },
-  series       = {{CSEE{\&}T} '23},
-  location     = {Tokyo, Japan},
-  publisher    = {{IEEE}},
-  year         = {2023},
-  month        = aug,
-  pages        = {147--151},
-  doi          = {10.1109/CSEET58097.2023.00031},
+  author       = {Linhuber, Matthias and Bernius, Jan Philip and Krusche, Stephan},
+  year         = 2023,
+  month        = nov,
+  booktitle    = {23nd Koli Calling International Conference on Computing Education Research},
+  location     = {Koli, Finland},
+  series       = {{Koli} '23},
+  doi          = {10.35542/osf.io/nmpf6},
 }
-@inproceedings{BerrezuetaGuzmanPK23,
-  author       = {Jonnathan Berrezueta{-}Guzman and
-                  Markus Paulsen and
-                  Stephan Krusche},
+@inproceedings{manger2023is,
+  title        = {
+    Is Online Teaching Dead After COVID-19? Student Preferences for Programming
+    Courses
+  },
+  author       = {
+    Stefanie Manger and Maximilian S{\"{o}}lch and Matthias Linhuber and
+    Christoph Weinhuber and Philipp Zagar and Stephan Krusche
+  },
+  year         = 2023,
+  month        = aug,
+  booktitle    = {
+    35th International Conference on Software Engineering Education and
+    Training
+  },
+  location     = {Tokyo, Japan},
+  publisher    = {IEEE},
+  series       = {{CSEE{\&}T} '23},
+  pages        = {89--98},
+  doi          = {10.1109/CSEET58097.2023.00020},
+}
+@inproceedings{berrezueta_guzman2023plagiarism,
   title        = {Plagiarism Detection and its Effect on the Learning Outcomes},
-  booktitle    = {
-    35th International Conference on Software Engineering Education and Training
-  },
-  series       = {{CSEE{\&}T} '23},
-  location     = {Tokyo, Japan},
-  publisher    = {{IEEE}},
-  year         = {2023},
+  author       = {Jonnathan Berrezueta{-}Guzman and Markus Paulsen and Stephan Krusche},
+  year         = 2023,
   month        = aug,
+  booktitle    = {
+    35th International Conference on Software Engineering Education and
+    Training
+  },
+  location     = {Tokyo, Japan},
+  publisher    = {IEEE},
+  series       = {{CSEE{\&}T} '23},
   pages        = {99--108},
   doi          = {10.1109/CSEET58097.2023.00021},
 }
-@inproceedings{KruscheB23,
-  author       = {Stephan Krusche and
-                  Jonnathan Berrezueta{-}Guzman},
-  title        = {Introduction to Programming using Interactive Learning},
-  booktitle    = {
-    35th International Conference on Software Engineering Education and Training
-  },
-  series       = {{CSEE{\&}T} '23},
-  location     = {Tokyo, Japan},
-  pages        = {178--182},
-  publisher    = {{IEEE}},
-  year         = {2023},
+@inproceedings{berrezueta_guzman2023recommendations,
+  title        = {Recommendations to Create Programming Exercises to Overcome ChatGPT},
+  author       = {Jonnathan Berrezueta{-}Guzman and Stephan Krusche},
+  year         = 2023,
   month        = aug,
+  booktitle    = {
+    35th International Conference on Software Engineering Education and
+    Training
+  },
+  location     = {Tokyo, Japan},
+  publisher    = {IEEE},
+  series       = {{CSEE{\&}T} '23},
+  pages        = {147--151},
+  doi          = {10.1109/CSEET58097.2023.00031},
+}
+@inproceedings{krusche2023introduction,
+  title        = {Introduction to Programming using Interactive Learning},
+  author       = {Stephan Krusche and Jonnathan Berrezueta{-}Guzman},
+  year         = 2023,
+  month        = aug,
+  booktitle    = {
+    35th International Conference on Software Engineering Education and
+    Training
+  },
+  location     = {Tokyo, Japan},
+  publisher    = {IEEE},
+  series       = {{CSEE{\&}T} '23},
+  pages        = {178--182},
   doi          = {10.1109/CSEET58097.2023.00037},
 }
-@inproceedings{MangerSLWZK23,
-  author       = {Stefanie Manger and
-                  Maximilian S{\"{o}}lch and
-                  Matthias Linhuber and
-                  Christoph Weinhuber and
-                  Philipp Zagar and
-                  Stephan Krusche},
-  title        = {
-    Is Online Teaching Dead After COVID-19? Student Preferences for Programming Courses
-  },
-  booktitle    = {
-    35th International Conference on Software Engineering Education and Training
-  },
-  series       = {{CSEE{\&}T} '23},
-  location     = {Tokyo, Japan},
-  pages        = {89--98},
-  publisher    = {{IEEE}},
-  year         = {2023},
-  month        = aug,
-  doi          = {10.1109/CSEET58097.2023.00020},
-}
-@inproceedings{soelch2023lak,
-  author       = {Maximilian S{\"{o}}lch and
-                  Moritz Aberle and
-                  Stephan Krusche},
+@inproceedings{s_olch2023integrating,
   title        = {Integrating Competency-Based Education in Interactive Learning Systems},
+  author       = {Maximilian S{\"{o}}lch and Moritz Aberle and Stephan Krusche},
+  year         = 2023,
+  month        = mar,
   booktitle    = {13th International Conference on Learning Analytics & Knowledge},
   series       = {{LAK} '23},
-  year         = {2023},
-  month        = mar,
   doi          = {10.48550/ARXIV.2309.12343},
 }
 @article{bernius2022machine,


### PR DESCRIPTION
### Checklist
Documentation change. Checklists are not applicable.

### Description
Add missing publications to https://docs.artemis.cit.tum.de/research/publications.html page.

### Screenshots

<img width="1409" alt="image" src="https://github.com/ls1intum/Artemis/assets/6382716/d684b2c0-13fd-48dd-9cd3-d43f3f42e142">

https://artemis-platform--7482.org.readthedocs.build/en/7482/research/publications.html