### PR TITLE
`Programming exercises`: Fix reset of settings in import

### DIFF
--- a/src/main/webapp/app/entities/exercise.model.ts
+++ b/src/main/webapp/app/entities/exercise.model.ts
@@ -270,4 +270,8 @@ export function resetDates(exercise: Exercise) {
     exercise.dueDate = undefined;
     exercise.assessmentDueDate = undefined;
     exercise.exampleSolutionPublicationDate = undefined;
+
+    // without dates set, they can only be false
+    exercise.allowComplaintsForAutomaticAssessments = false;
+    exercise.allowManualFeedbackRequests = false;
 }

--- a/src/main/webapp/app/entities/programming-exercise.model.ts
+++ b/src/main/webapp/app/entities/programming-exercise.model.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs/esm';
 import { SolutionProgrammingExerciseParticipation } from 'app/entities/participation/solution-programming-exercise-participation.model';
 import { TemplateProgrammingExerciseParticipation } from 'app/entities/participation/template-programming-exercise-participation.model';
-import { Exercise, ExerciseType } from 'app/entities/exercise.model';
+import { Exercise, ExerciseType, resetDates } from 'app/entities/exercise.model';
 import { Course } from 'app/entities/course.model';
 import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import { AuxiliaryRepository } from 'app/entities/programming-exercise-auxiliary-repository-model';
@@ -95,4 +95,12 @@ export class ProgrammingExercise extends Exercise {
         this.showTestNamesToStudents = false; // default value
         this.testwiseCoverageEnabled = false; // default value
     }
+}
+
+export function resetProgrammingDates(exercise: ProgrammingExercise) {
+    resetDates(exercise);
+
+    // without dates set, they have to be reset as well
+    exercise.releaseTestsWithExampleSolution = false;
+    exercise.buildAndTestStudentSubmissionsAfterDueDate = undefined;
 }

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -4,7 +4,7 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { AlertService, AlertType } from 'app/core/util/alert.service';
 import { Observable, Subject } from 'rxjs';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
-import { ProgrammingExercise, ProgrammingLanguage, ProjectType } from 'app/entities/programming-exercise.model';
+import { ProgrammingExercise, ProgrammingLanguage, ProjectType, resetProgrammingDates } from 'app/entities/programming-exercise.model';
 import { ProgrammingExerciseService } from '../services/programming-exercise.service';
 import { FileService } from 'app/shared/http/file.service';
 import { TranslateService } from '@ngx-translate/core';
@@ -12,7 +12,7 @@ import { switchMap, tap } from 'rxjs/operators';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { AssessmentType } from 'app/entities/assessment-type.model';
-import { Exercise, IncludedInOverallScore, ValidationReason, resetDates } from 'app/entities/exercise.model';
+import { Exercise, IncludedInOverallScore, ValidationReason } from 'app/entities/exercise.model';
 import { EditorMode } from 'app/shared/markdown-editor/markdown-editor.component';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { ExerciseGroupService } from 'app/exam/manage/exercise-groups/exercise-group.service';
@@ -522,10 +522,9 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
             });
             this.isExamMode = false;
         }
-        resetDates(this.programmingExercise);
+        resetProgrammingDates(this.programmingExercise);
 
         this.programmingExercise.projectKey = undefined;
-        this.programmingExercise.buildAndTestStudentSubmissionsAfterDueDate = undefined;
         this.programmingExercise.shortName = undefined;
         this.programmingExercise.title = undefined;
         if (this.programmingExercise.submissionPolicy) {
@@ -1015,14 +1014,9 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
         this.programmingExercise.exerciseGroup = undefined;
         this.programmingExercise.course = undefined;
         this.programmingExercise.projectKey = undefined;
-        this.programmingExercise.dueDate = undefined;
-        this.programmingExercise.assessmentDueDate = undefined;
-        this.programmingExercise.releaseDate = undefined;
-        this.programmingExercise.startDate = undefined;
-        this.programmingExercise.exampleSolutionPublicationDate = undefined;
-        //without dates set, they can only be false
-        this.programmingExercise.allowComplaintsForAutomaticAssessments = false;
-        this.programmingExercise.allowManualFeedbackRequests = false;
+
+        resetProgrammingDates(this.programmingExercise);
+
         this.selectedProgrammingLanguage = this.programmingExercise.programmingLanguage!;
         // we need to get it from the history object as setting the programming language
         // sets the project type of the programming exercise to the default value for the programming language.

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -403,7 +403,7 @@ describe('ProgrammingExercise Management Update Component', () => {
             route.url = of([{ path: 'import' } as UrlSegment]);
         });
 
-        it('should reset dates, id, project key and store zipFile', fakeAsync(() => {
+        it('should reset dates, id and project key', fakeAsync(() => {
             const programmingExercise = getProgrammingExerciseForImport();
 
             route.data = of({ programmingExercise });

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -403,6 +403,25 @@ describe('ProgrammingExercise Management Update Component', () => {
             route.url = of([{ path: 'import' } as UrlSegment]);
         });
 
+        it('should reset dates, id, project key and store zipFile', fakeAsync(() => {
+            const programmingExercise = getProgrammingExerciseForImport();
+
+            route.data = of({ programmingExercise });
+            const getFeaturesStub = jest.spyOn(programmingExerciseFeatureService, 'getProgrammingLanguageFeature');
+            getFeaturesStub.mockImplementation((language: ProgrammingLanguage) => getProgrammingLanguageFeature(language));
+            comp.ngOnInit();
+            fixture.detectChanges();
+            tick();
+            expect(comp.isImportFromFile).toBeFalse();
+            expect(comp.isImportFromExistingExercise).toBeTrue();
+
+            verifyImport();
+
+            // name and short name should not be imported
+            expect(comp.programmingExercise.title).toBeUndefined();
+            expect(comp.programmingExercise.shortName).toBeUndefined();
+        }));
+
         it.each([
             [true, 80, ProjectType.PLAIN_MAVEN],
             [false, undefined, ProjectType.PLAIN_GRADLE],
@@ -462,6 +481,7 @@ describe('ProgrammingExercise Management Update Component', () => {
             }),
         );
     });
+
     describe('import from file', () => {
         let route: ActivatedRoute;
 
@@ -471,28 +491,9 @@ describe('ProgrammingExercise Management Update Component', () => {
 
             route.url = of([{ path: 'import-from-file' } as UrlSegment]);
         });
-        it('should reset dates, id, project key and store zipFile', fakeAsync(() => {
-            const programmingExercise = new ProgrammingExercise(undefined, undefined);
-            programmingExercise.programmingLanguage = ProgrammingLanguage.JAVA;
-            programmingExercise.projectType = ProjectType.PLAIN_MAVEN;
-            programmingExercise.dueDate = dayjs();
-            programmingExercise.releaseDate = dayjs();
-            programmingExercise.startDate = dayjs();
-            programmingExercise.projectKey = 'projectKey';
 
-            programmingExercise.assessmentDueDate = dayjs();
-            programmingExercise.exampleSolutionPublicationDate = dayjs();
-            programmingExercise.programmingLanguage = ProgrammingLanguage.JAVA;
-            programmingExercise.zipFileForImport = new File([''], 'test.zip');
-            programmingExercise.allowOfflineIde = true;
-            programmingExercise.allowOnlineEditor = true;
-            programmingExercise.publishBuildPlanUrl = true;
-            programmingExercise.allowComplaintsForAutomaticAssessments = true;
-            programmingExercise.allowManualFeedbackRequests = true;
-            programmingExercise.publishBuildPlanUrl = false;
-            history.pushState({ programmingExerciseForImportFromFile: programmingExercise }, '');
-            programmingExercise.shortName = 'shortName';
-            programmingExercise.title = 'title';
+        it('should reset dates, id, project key and store zipFile', fakeAsync(() => {
+            const programmingExercise = getProgrammingExerciseForImport();
 
             route.data = of({ programmingExercise });
             const getFeaturesStub = jest.spyOn(programmingExerciseFeatureService, 'getProgrammingLanguageFeature');
@@ -501,28 +502,15 @@ describe('ProgrammingExercise Management Update Component', () => {
             fixture.detectChanges();
             tick();
             expect(comp.isImportFromFile).toBeTrue();
-            expect(comp.programmingExercise.projectKey).toBeUndefined();
-            expect(comp.programmingExercise.id).toBeUndefined();
-            expect(comp.programmingExercise.dueDate).toBeUndefined();
-            expect(comp.programmingExercise.releaseDate).toBeUndefined();
-            expect(comp.programmingExercise.startDate).toBeUndefined();
-            expect(comp.programmingExercise.assessmentDueDate).toBeUndefined();
-            expect(comp.programmingExercise.exampleSolutionPublicationDate).toBeUndefined();
-            expect(comp.programmingExercise.zipFileForImport?.name).toBe('test.zip');
-            expect(comp.programmingExercise.allowComplaintsForAutomaticAssessments).toBeFalse();
-            expect(comp.programmingExercise.allowManualFeedbackRequests).toBeFalse();
-            expect(comp.programmingExercise.allowOfflineIde).toBeTrue();
-            expect(comp.programmingExercise.allowOnlineEditor).toBeTrue();
-            expect(comp.programmingExercise.publishBuildPlanUrl).toBeFalse();
-            expect(comp.programmingExercise.programmingLanguage).toBe(ProgrammingLanguage.JAVA);
-            expect(comp.programmingExercise.projectType).toBe(ProjectType.PLAIN_MAVEN);
-            // allow manual feedback requests and complaints for automatic assessments should be set to false because we reset all dates and hence they can only be false
-            expect(comp.programmingExercise.allowManualFeedbackRequests).toBeFalse();
-            expect(comp.programmingExercise.allowComplaintsForAutomaticAssessments).toBeFalse();
+            expect(comp.isImportFromExistingExercise).toBeFalse();
+
+            verifyImport();
+
             // name and short name should be imported
             expect(comp.programmingExercise.title).toBe('title');
             expect(comp.programmingExercise.shortName).toBe('shortName');
         }));
+
         it('should call import-from-file from service on import for entity from file', fakeAsync(() => {
             // GIVEN
             const entity = new ProgrammingExercise(undefined, undefined);
@@ -924,7 +912,56 @@ describe('ProgrammingExercise Management Update Component', () => {
         comp.updateCategories(categories);
         expect(comp.exerciseCategories).toBe(categories);
     }));
+
+    function verifyImport() {
+        expect(comp.programmingExercise.projectKey).toBeUndefined();
+        expect(comp.programmingExercise.id).toBeUndefined();
+        expect(comp.programmingExercise.dueDate).toBeUndefined();
+        expect(comp.programmingExercise.releaseDate).toBeUndefined();
+        expect(comp.programmingExercise.startDate).toBeUndefined();
+        expect(comp.programmingExercise.assessmentDueDate).toBeUndefined();
+        expect(comp.programmingExercise.exampleSolutionPublicationDate).toBeUndefined();
+        expect(comp.programmingExercise.zipFileForImport?.name).toBe('test.zip');
+        expect(comp.programmingExercise.allowComplaintsForAutomaticAssessments).toBeFalse();
+        expect(comp.programmingExercise.allowManualFeedbackRequests).toBeFalse();
+        expect(comp.programmingExercise.allowOfflineIde).toBeTrue();
+        expect(comp.programmingExercise.allowOnlineEditor).toBeTrue();
+        expect(comp.programmingExercise.publishBuildPlanUrl).toBeFalse();
+        expect(comp.programmingExercise.programmingLanguage).toBe(ProgrammingLanguage.JAVA);
+        expect(comp.programmingExercise.projectType).toBe(ProjectType.PLAIN_MAVEN);
+        // allow manual feedback requests and complaints for automatic assessments should be set to false because we reset all dates and hence they can only be false
+        expect(comp.programmingExercise.allowManualFeedbackRequests).toBeFalse();
+        expect(comp.programmingExercise.allowComplaintsForAutomaticAssessments).toBeFalse();
+    }
 });
+
+const getProgrammingExerciseForImport = () => {
+    const programmingExercise = new ProgrammingExercise(undefined, undefined);
+    programmingExercise.programmingLanguage = ProgrammingLanguage.JAVA;
+    programmingExercise.projectType = ProjectType.PLAIN_MAVEN;
+    programmingExercise.dueDate = dayjs();
+    programmingExercise.releaseDate = dayjs();
+    programmingExercise.startDate = dayjs();
+    programmingExercise.projectKey = 'projectKey';
+
+    programmingExercise.assessmentDueDate = dayjs();
+    programmingExercise.exampleSolutionPublicationDate = dayjs();
+    programmingExercise.programmingLanguage = ProgrammingLanguage.JAVA;
+    programmingExercise.zipFileForImport = new File([''], 'test.zip');
+    programmingExercise.allowOfflineIde = true;
+    programmingExercise.allowOnlineEditor = true;
+    programmingExercise.publishBuildPlanUrl = true;
+    programmingExercise.allowComplaintsForAutomaticAssessments = true;
+    programmingExercise.allowManualFeedbackRequests = true;
+    programmingExercise.publishBuildPlanUrl = false;
+
+    history.pushState({ programmingExerciseForImportFromFile: programmingExercise }, '');
+
+    programmingExercise.shortName = 'shortName';
+    programmingExercise.title = 'title';
+
+    return programmingExercise;
+};
 
 const getProgrammingLanguageFeature = (programmingLanguage: ProgrammingLanguage) => {
     switch (programmingLanguage) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix a bug where complaints after the due date are enabled in the import of the programming exercise, even though there was no due date.

### Description
<!-- Describe your changes in detail -->
The import component did not correctly reset some boolean flags when clearing all dates during the import of a programming exercise. This is now fixed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with Complaints on automatic assessment enabled

1. Log in to Artemis
2. Import the programming exercise again and check that complaints on automatic assessment are not activated for the new exercise. This is visible during the import directly below the timeline of the exercise
3. ...

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [exercise.model.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5679/latest/artifact/shared/Coverage-Report-Client-Tests/app/entities/exercise.model.ts.html) | 93.75% | ✅ |
| [programming-exercise.model.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5679/latest/artifact/shared/Coverage-Report-Client-Tests/app/entities/programming-exercise.model.ts.html) | 100% | ✅ |
| [programming-exercise-update.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5679/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/programming/manage/update/programming-exercise-update.component.ts.html) | 80.8% | ✅ |