### PR TITLE
`General`: Improve the user interface of course management exercises overview

### DIFF
--- a/src/main/webapp/app/course/manage/course-management-exercises.component.html
+++ b/src/main/webapp/app/course/manage/course-management-exercises.component.html
@@ -20,7 +20,7 @@
     </div>
 
     <jhi-course-management-exercises-search *ngIf="showSearch" (exerciseFilter)="exerciseFilter = $event"></jhi-course-management-exercises-search>
-    <div *ngIf="showSearch && getFilteredExerciseCount() == 0 && !exerciseFilter.isEmpty()" class="alert alert-secondary" role="alert">
+    <div *ngIf="showSearch && getFilteredExerciseCount() === 0 && !exerciseFilter.isEmpty()" class="alert alert-secondary" role="alert">
         {{ 'artemisApp.course.exercise.search.noResults' | artemisTranslate }}
     </div>
 

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
@@ -3,7 +3,7 @@
         <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" (sortChange)="sortRows()">
                 <th *ngIf="course.isAtLeastInstructor" class="d-md-table-cell">
-                    <input class="form-check-input" type="checkbox" (change)="toggleMultipleExercises(fileUploadExercises)" />
+                    <input class="form-check-input" type="checkbox" (change)="toggleMultipleExercises(fileUploadExercises)" [ngModel]="allChecked" />
                 </th>
                 <th jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span>&nbsp;<fa-icon [icon]="faSort"></fa-icon></th>
                 <th jhiSortBy="title"><span jhiTranslate="artemisApp.exercise.title">Title</span>&nbsp;<fa-icon [icon]="faSort"></fa-icon></th>
@@ -27,13 +27,13 @@
                     <input class="form-check-input" type="checkbox" (change)="toggleExercise(fileUploadExercise)" [ngModel]="isExerciseSelected(fileUploadExercise)" />
                 </td>
                 <td>
-                    <a *ngIf="fileUploadExercise.isAtLeastEditor; else showId" [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]">
+                    <a *ngIf="fileUploadExercise.isAtLeastTutor; else showId" [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]">
                         {{ fileUploadExercise.id }}
                     </a>
                     <ng-template #showId>{{ fileUploadExercise.id }}</ng-template>
                 </td>
                 <td>
-                    <a *ngIf="fileUploadExercise.isAtLeastEditor; else showTitle" [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]">
+                    <a *ngIf="fileUploadExercise.isAtLeastTutor; else showTitle" [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]">
                         {{ fileUploadExercise.title }}
                     </a>
                     <ng-template #showTitle>{{ fileUploadExercise.title }}</ng-template>

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.ts
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.ts
@@ -36,6 +36,10 @@ export class FileUploadExerciseComponent extends ExerciseComponent {
     faTable = faTable;
     farListAlt = faListAlt;
 
+    protected get exercises() {
+        return this.fileUploadExercises;
+    }
+
     constructor(
         public exerciseService: ExerciseService,
         public fileUploadExerciseService: FileUploadExerciseService,

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
@@ -3,7 +3,7 @@
         <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" (sortChange)="sortRows()">
                 <th *ngIf="course.isAtLeastInstructor" class="d-md-table-cell">
-                    <input class="form-check-input" type="checkbox" (change)="toggleMultipleExercises(modelingExercises)" />
+                    <input class="form-check-input" type="checkbox" (change)="toggleMultipleExercises(modelingExercises)" [ngModel]="allChecked" />
                 </th>
                 <th jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span>&nbsp;<fa-icon [icon]="faSort"></fa-icon></th>
                 <th jhiSortBy="title"><span jhiTranslate="artemisApp.exercise.title">Title</span>&nbsp;<fa-icon [icon]="faSort"></fa-icon></th>
@@ -28,7 +28,7 @@
                 </td>
                 <td>
                     <a
-                        *ngIf="modelingExercise.isAtLeastEditor; else showId"
+                        *ngIf="modelingExercise.isAtLeastTutor; else showId"
                         [routerLink]="['/course-management', modelingExercise.course?.id, 'modeling-exercises', modelingExercise.id]"
                     >
                         {{ modelingExercise.id }}
@@ -37,7 +37,7 @@
                 </td>
                 <td id="modeling-exercise-{{ modelingExercise.id }}-title">
                     <a
-                        *ngIf="modelingExercise.isAtLeastEditor; else showTitle"
+                        *ngIf="modelingExercise.isAtLeastTutor; else showTitle"
                         [routerLink]="['/course-management', modelingExercise.course?.id, 'modeling-exercises', modelingExercise.id]"
                     >
                         {{ modelingExercise.title }}

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.ts
@@ -34,6 +34,10 @@ export class ModelingExerciseComponent extends ExerciseComponent {
     faWrench = faWrench;
     faTimes = faTimes;
 
+    protected get exercises() {
+        return this.modelingExercises;
+    }
+
     constructor(
         public exerciseService: ExerciseService,
         public modelingExerciseService: ModelingExerciseService,

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -3,7 +3,7 @@
         <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" (sortChange)="sortRows()">
                 <th *ngIf="course.isAtLeastEditor" class="d-md-table-cell">
-                    <input class="form-check-input" type="checkbox" (change)="toggleMultipleExercises(programmingExercises)" />
+                    <input class="form-check-input" type="checkbox" (change)="toggleMultipleExercises(programmingExercises)" [ngModel]="allChecked" />
                 </th>
                 <th class="d-md-table-cell" jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span>&nbsp;<fa-icon [icon]="faSort"></fa-icon></th>
                 <th jhiSortBy="title"><span jhiTranslate="artemisApp.exercise.title">Title</span>&nbsp;<fa-icon [icon]="faSort"></fa-icon></th>
@@ -32,13 +32,13 @@
                     <input class="form-check-input" type="checkbox" (change)="toggleExercise(programmingExercise)" [ngModel]="isExerciseSelected(programmingExercise)" />
                 </td>
                 <td class="d-md-table-cell">
-                    <a *ngIf="programmingExercise.isAtLeastEditor; else showId" [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id]">
+                    <a *ngIf="programmingExercise.isAtLeastTutor; else showId" [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id]">
                         {{ programmingExercise.id }}
                     </a>
                     <ng-template #showId>{{ programmingExercise.id }}</ng-template>
                 </td>
                 <td>
-                    <a *ngIf="programmingExercise.isAtLeastEditor; else showTitle" [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id]">
+                    <a *ngIf="programmingExercise.isAtLeastTutor; else showTitle" [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id]">
                         {{ programmingExercise.title }}
                     </a>
                     <ng-template #showTitle>{{ programmingExercise.title }}</ng-template>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.ts
@@ -74,6 +74,10 @@ export class ProgrammingExerciseComponent extends ExerciseComponent implements O
     faPencilAlt = faPencilAlt;
     faFileSignature = faFileSignature;
 
+    protected get exercises() {
+        return this.programmingExercises;
+    }
+
     constructor(
         private programmingExerciseService: ProgrammingExerciseService,
         private courseExerciseService: CourseExerciseService,

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
@@ -3,7 +3,7 @@
         <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" (sortChange)="sortRows()">
                 <th *ngIf="course.isAtLeastInstructor" class="d-md-table-cell">
-                    <input class="form-check-input" type="checkbox" (change)="toggleMultipleExercises(quizExercises)" />
+                    <input class="form-check-input" type="checkbox" (change)="toggleMultipleExercises(quizExercises)" [ngModel]="allChecked" />
                 </th>
                 <th jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span>&nbsp;<fa-icon [icon]="faSort"></fa-icon></th>
                 <th jhiSortBy="title"><span jhiTranslate="artemisApp.exercise.title">Title</span>&nbsp;<fa-icon [icon]="faSort"></fa-icon></th>
@@ -82,7 +82,7 @@
                             <span class="d-none d-md-inline" jhiTranslate="artemisApp.quizExercise.startQuiz">Start Quiz</span>
                         </button>
                         <ng-container
-                            *ngIf="(quizExercise.status === QuizStatus.VISIBLE || quizExercise.status === QuizStatus.ACTIVE) && quizExercise.quizMode == QuizMode.BATCHED"
+                            *ngIf="(quizExercise.status === QuizStatus.VISIBLE || quizExercise.status === QuizStatus.ACTIVE) && quizExercise.quizMode === QuizMode.BATCHED"
                         >
                             <div *ngFor="let batch of quizExercise.quizBatches">
                                 ID: {{ batch.id }}

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.ts
@@ -40,6 +40,10 @@ export class QuizExerciseComponent extends ExerciseComponent {
     faPlayCircle = faPlayCircle;
     faStopCircle = faStopCircle;
 
+    protected get exercises() {
+        return this.quizExercises;
+    }
+
     constructor(
         public quizExerciseService: QuizExerciseService,
         private accountService: AccountService,

--- a/src/main/webapp/app/exercises/shared/exercise/exercise.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise.component.ts
@@ -33,6 +33,8 @@ export abstract class ExerciseComponent implements OnInit, OnDestroy {
     protected dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
 
+    protected abstract get exercises(): Exercise[];
+
     protected constructor(
         private courseService: CourseManagementService,
         protected translateService: TranslateService,
@@ -141,6 +143,7 @@ export abstract class ExerciseComponent implements OnInit, OnDestroy {
         } else {
             this.selectedExercises.push(exercise);
         }
+        this.allChecked = this.selectedExercises.length === this.exercises.length;
     }
 
     toggleMultipleExercises(exercises: Exercise[]) {
@@ -148,7 +151,7 @@ export abstract class ExerciseComponent implements OnInit, OnDestroy {
         if (!this.allChecked) {
             this.selectedExercises = this.selectedExercises.concat(exercises);
         }
-        this.allChecked = !this.allChecked;
+        this.allChecked = this.selectedExercises.length === this.exercises.length;
     }
 
     isExerciseSelected(exercise: Exercise) {

--- a/src/main/webapp/app/exercises/shared/exercise/exercise.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise.component.ts
@@ -86,18 +86,6 @@ export abstract class ExerciseComponent implements OnInit, OnDestroy {
         });
     }
 
-    /**
-     * Returns the number of exercises given as a string
-     * @param exercises Exercises which to count
-     */
-    public getAmountOfExercisesString<T>(exercises: Array<T>): string {
-        if (exercises.length === 0) {
-            return this.translateService.instant('artemisApp.createExercise.noExercises');
-        } else {
-            return exercises.length.toString();
-        }
-    }
-
     protected abstract loadExercises(): void;
 
     protected abstract applyFilter(): void;
@@ -120,7 +108,6 @@ export abstract class ExerciseComponent implements OnInit, OnDestroy {
      * Deletes all the given exercises (does not work for programming exercises)
      * @param exercisesToDelete the exercise objects which are to be deleted
      * @param exerciseService service that is used to delete the exercise
-     * @param event contains additional checks which are performed for all these exercises
      */
     deleteMultipleExercises(exercisesToDelete: Exercise[], exerciseService: DeletionServiceInterface) {
         const deletionObservables = exercisesToDelete.map((exercise) => exerciseService.delete(exercise.id!));

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.html
@@ -3,7 +3,7 @@
         <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" (sortChange)="sortRows()">
                 <th *ngIf="course.isAtLeastInstructor" class="d-md-table-cell">
-                    <input class="form-check-input" type="checkbox" (change)="toggleMultipleExercises(textExercises)" />
+                    <input class="form-check-input" type="checkbox" (change)="toggleMultipleExercises(textExercises)" [ngModel]="allChecked" />
                 </th>
                 <th jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span>&nbsp;<fa-icon [icon]="faSort"></fa-icon></th>
                 <th jhiSortBy="title"><span jhiTranslate="artemisApp.exercise.title">Title</span>&nbsp;<fa-icon [icon]="faSort"></fa-icon></th>
@@ -26,13 +26,13 @@
                     <input class="form-check-input" type="checkbox" (change)="toggleExercise(textExercise)" [ngModel]="isExerciseSelected(textExercise)" />
                 </td>
                 <td>
-                    <a *ngIf="textExercise.isAtLeastEditor; else showId" [routerLink]="['/course-management', course.id, 'text-exercises', textExercise.id]">{{
+                    <a *ngIf="textExercise.isAtLeastTutor; else showId" [routerLink]="['/course-management', course.id, 'text-exercises', textExercise.id]">{{
                         textExercise.id
                     }}</a>
                     <ng-template #showId>{{ textExercise.id }}</ng-template>
                 </td>
                 <td>
-                    <a *ngIf="textExercise.isAtLeastEditor; else showTitle" [routerLink]="['/course-management', course.id, 'text-exercises', textExercise.id]">{{
+                    <a *ngIf="textExercise.isAtLeastTutor; else showTitle" [routerLink]="['/course-management', course.id, 'text-exercises', textExercise.id]">{{
                         textExercise.title
                     }}</a>
                     <ng-template #showTitle>{{ textExercise.title }}</ng-template>

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.ts
@@ -31,6 +31,10 @@ export class TextExerciseComponent extends ExerciseComponent {
     faPlus = faPlus;
     faTimes = faTimes;
 
+    protected get exercises() {
+        return this.textExercises;
+    }
+
     constructor(
         public exerciseService: ExerciseService,
         public textExerciseService: TextExerciseService,

--- a/src/main/webapp/i18n/de/createExercise.json
+++ b/src/main/webapp/i18n/de/createExercise.json
@@ -1,7 +1,0 @@
-{
-    "artemisApp": {
-        "createExercise": {
-            "noExercises": "Keine"
-        }
-    }
-}

--- a/src/main/webapp/i18n/en/createExercise.json
+++ b/src/main/webapp/i18n/en/createExercise.json
@@ -1,7 +1,0 @@
-{
-    "artemisApp": {
-        "createExercise": {
-            "noExercises": "No"
-        }
-    }
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
This PR fixes 2 different issues on this page:
- Tutors are able to navigate to the Exercise Management Detail Page through the Student Exercise Detail view, but not through the course management like it is possible for editors & instructions -> makes no sense, only more difficult to navigate for tutors
- the "All Checked" checkbox for exercise was not updated, e.g. if you clicked "All checked" and then removed on specific checkbox of one exercise, the "All Checked" stayed checked, even though not all exercises are checked.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Tutor
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis as instructor
2. Navigate to Course Administration > Exercises
3. Verify that the selection of all exercises interfered with the selection of a specific exercise always gets rendered correctly
4. Log in as tutor
5. Navigate to Course Administration > Exercises
6. Confirm that it is possible to navigate to the Exercise Detail Page from here (by clicking on exercise ID or Exercise title)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [file-upload-exercise.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5680/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/file-upload/manage/file-upload-exercise.component.ts.html) | 91.37% | ✅ |
| [modeling-exercise.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5680/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/modeling/manage/modeling-exercise.component.ts.html) | 92.72% | ✅ |
| [programming-exercise.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5680/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/programming/manage/programming-exercise.component.ts.html) | 88% | ✅ |
| [quiz-exercise.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5680/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/quiz/manage/quiz-exercise.component.ts.html) | 88.49% | ✅ |
| [exercise.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5680/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/shared/exercise/exercise.component.ts.html) | 89.28% | ✅ |
| [text-exercise.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5680/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/text/manage/text-exercise/text-exercise.component.ts.html) | 90.38% | ✅ |


### Screenshots
![image](https://github.com/ls1intum/Artemis/assets/78978542/c5401bea-6701-4da2-91a5-7fb822b99c15)