### PR TITLE
`Development`: Fix failing client tests because of missing mock component

### DIFF
--- a/src/test/javascript/spec/component/exam/manage/suspicious-behavior/suspicious-behavior.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/suspicious-behavior/suspicious-behavior.component.spec.ts
@@ -17,6 +17,7 @@ import { Exercise } from 'app/entities/exercise.model';
 import { SuspiciousExamSessions, SuspiciousSessionReason } from 'app/entities/exam-session.model';
 import { MockRouter } from '../../../../helpers/mocks/mock-router';
 import { FormsModule } from '@angular/forms';
+import { DocumentationButtonComponent } from 'app/shared/components/documentation-button/documentation-button.component';
 
 describe('SuspiciousBehaviorComponent', () => {
     let component: SuspiciousBehaviorComponent;
@@ -72,7 +73,13 @@ describe('SuspiciousBehaviorComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, MockRouterLinkDirective, MockModule(FormsModule)],
-            declarations: [SuspiciousBehaviorComponent, MockPipe(ArtemisTranslatePipe), MockComponent(PlagiarismCasesOverviewComponent), MockComponent(ButtonComponent)],
+            declarations: [
+                SuspiciousBehaviorComponent,
+                MockPipe(ArtemisTranslatePipe),
+                MockComponent(PlagiarismCasesOverviewComponent),
+                MockComponent(ButtonComponent),
+                MockComponent(DocumentationButtonComponent),
+            ],
             providers: [
                 { provide: ActivatedRoute, useValue: route },
                 { provide: Router, useClass: MockRouter },


### PR DESCRIPTION

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the client tests fail on develop. #7462 introduced that.

### Description
<!-- Describe your changes in detail -->

Mock the `DocumentationButton` component in the `SuspiciousBehavior` component tests

### Steps for Testing
Make sure the client tests pass again

### Test Coverage
unchanged

