### PR TITLE
`Development`: Prevent direct calls to git.commit()

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -23,6 +24,7 @@ import com.tngtech.archunit.lang.*;
 import com.tngtech.archunit.library.GeneralCodingRules;
 
 import de.tum.in.www1.artemis.service.WebsocketMessagingService;
+import de.tum.in.www1.artemis.service.connectors.GitService;
 
 class ArchitectureTest extends AbstractArchitectureTest {
 
@@ -141,5 +143,13 @@ class ArchitectureTest extends AbstractArchitectureTest {
                 }
             }
         };
+    }
+
+    @Test
+    void testNoDirectGitCommitCalls() {
+        ArchRule usage = noClasses().should().callMethod(Git.class, "commit").because("You should use GitService.commit() instead");
+        var classesWithoutGitService = allClasses.that(not(assignableTo(GitService.class)));
+        usage.check(classesWithoutGitService);
+        usage.check(testClasses);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -154,6 +154,5 @@ class ArchitectureTest extends AbstractArchitectureTest {
         ArchRule usage = noClasses().should().callMethod(Git.class, "commit").because("You should use GitService.commit() instead");
         var classesWithoutGitService = allClasses.that(not(assignableTo(GitService.class)));
         usage.check(classesWithoutGitService);
-        usage.check(testClasses);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -145,6 +145,10 @@ class ArchitectureTest extends AbstractArchitectureTest {
         };
     }
 
+    /**
+     * Checks that no class directly calls Git.commit(), but instead uses GitService.commit()
+     * This is necessary to ensure that committing is identical for all setups, with and without commit signing
+     */
     @Test
     void testNoDirectGitCommitCalls() {
         ArchRule usage = noClasses().should().callMethod(Git.class, "commit").because("You should use GitService.commit() instead");

--- a/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
@@ -210,7 +210,7 @@ public class HestiaUtilTestService {
             FileUtils.write(filePath.toFile(), content, Charset.defaultCharset());
         }
         participationRepo.localGit.add().addFilepattern(".").call();
-        participationRepo.localGit.commit().setMessage("commit").call();
+        GitService.commit(participationRepo.localGit).setMessage("commit").call();
         var commits = participationRepo.localGit.log().call();
         var commitsList = StreamSupport.stream(commits.spliterator(), false).toList();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Some Hestia tests were failing on my system due to my setup having GPG signing enabled. I originally moved all calls to a more system-independent in #7028, with a new Architecture test I now force the usage of `GitService.commit`
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Run tests and check that all pass


