### PR TITLE
`Notifications`: Add version to push notifications

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -312,6 +312,9 @@ public final class Constants {
      */
     public static final String STUDENT_WORKING_TIME_CHANGE_DURING_CONDUCTION_TOPIC = "/topic/studentExams/%s/working-time-change-during-conduction";
 
+    /**
+     * The value of the version field we send with each push notification to the native clients (Android & iOS).
+     */
     public static final int PUSH_NOTIFICATION_VERSION = 1;
 
     private Constants() {

--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -312,6 +312,8 @@ public final class Constants {
      */
     public static final String STUDENT_WORKING_TIME_CHANGE_DURING_CONDUCTION_TOPIC = "/topic/studentExams/%s/working-time-change-during-conduction";
 
+    public static final int PUSH_NOTIFICATION_VERSION = 1;
+
     private Constants() {
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/push_notifications/PushNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/push_notifications/PushNotificationService.java
@@ -142,7 +142,8 @@ public abstract class PushNotificationService implements InstantNotificationServ
         }
 
         final String date = Instant.now().toString();
-        final String payload = gson.toJson(new PushNotificationData(notification.getTransientPlaceholderValuesAsArray(), notification.getTarget(), type.name(), date, Constants.PUSH_NOTIFICATION_VERSION));
+        final String payload = gson.toJson(
+                new PushNotificationData(notification.getTransientPlaceholderValuesAsArray(), notification.getTarget(), type.name(), date, Constants.PUSH_NOTIFICATION_VERSION));
 
         final byte[] initializationVector = new byte[16];
 

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/push_notifications/PushNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/push_notifications/PushNotificationService.java
@@ -142,7 +142,7 @@ public abstract class PushNotificationService implements InstantNotificationServ
         }
 
         final String date = Instant.now().toString();
-        final String payload = gson.toJson(new PushNotificationData(notification.getTransientPlaceholderValuesAsArray(), notification.getTarget(), type.name(), date));
+        final String payload = gson.toJson(new PushNotificationData(notification.getTransientPlaceholderValuesAsArray(), notification.getTarget(), type.name(), date, Constants.PUSH_NOTIFICATION_VERSION));
 
         final byte[] initializationVector = new byte[16];
 
@@ -170,7 +170,7 @@ public abstract class PushNotificationService implements InstantNotificationServ
 
     abstract void sendSpecificNotificationRequestsToEndpoint(List<RelayNotificationRequest> requests, String relayServerBaseUrl);
 
-    record PushNotificationData(String[] notificationPlaceholders, String target, String type, String date) {
+    record PushNotificationData(String[] notificationPlaceholders, String target, String type, String date, int version) {
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Currently, we do not send a notification-version to the native clients in push notifications. If we ever want to change the data structure of push notifications, the native clients not using the latest versions may start having issues because they cannot understand that they are receiving a new format and may be interpreting it wrong. This would make it harder to update the format in the future. 

### Description
With this small change, we simply add a version field to push notifications, such that we can, in the future, simply increment it on the server and be sure that native clients that do not support the updated push notifications can safely discard them.

### Steps for Testing
No testing required

#### Exam Mode Testing
not affected

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

#### Code Review
- [x] Code Review 1
- [x] Code Review 2