### PR TITLE
`Development`: Fix marking of suggestions as "adapted"

### DIFF
--- a/src/main/webapp/app/assessment/unreferenced-feedback-detail/unreferenced-feedback-detail.component.ts
+++ b/src/main/webapp/app/assessment/unreferenced-feedback-detail/unreferenced-feedback-detail.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { faCheck, faExclamation, faExclamationTriangle, faQuestionCircle, faTrash, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
-import { FEEDBACK_SUGGESTION_ACCEPTED_IDENTIFIER, FEEDBACK_SUGGESTION_ADAPTED_IDENTIFIER, Feedback, FeedbackType } from 'app/entities/feedback.model';
+import { Feedback, FeedbackType } from 'app/entities/feedback.model';
 import { StructuredGradingCriterionService } from 'app/exercises/shared/structured-grading-criterion/structured-grading-criterion.service';
 import { ButtonSize } from 'app/shared/components/button.component';
 import { Subject } from 'rxjs';
@@ -46,13 +46,7 @@ export class UnreferencedFeedbackDetailComponent {
         if (this.feedback.type === FeedbackType.AUTOMATIC) {
             this.feedback.type = FeedbackType.AUTOMATIC_ADAPTED;
         }
-        if (Feedback.isFeedbackSuggestion(this.feedback)) {
-            // Change feedback suggestion type to adapted
-            this.feedback.text = (this.feedback.text ?? FEEDBACK_SUGGESTION_ACCEPTED_IDENTIFIER).replace(
-                FEEDBACK_SUGGESTION_ACCEPTED_IDENTIFIER,
-                FEEDBACK_SUGGESTION_ADAPTED_IDENTIFIER,
-            );
-        }
+        Feedback.updateFeedbackTypeOnChange(this.feedback);
         this.onFeedbackChange.emit(this.feedback);
     }
 

--- a/src/main/webapp/app/entities/feedback.model.ts
+++ b/src/main/webapp/app/entities/feedback.model.ts
@@ -250,8 +250,9 @@ export class Feedback implements BaseEntity {
     }
 
     public static updateFeedbackTypeOnChange(feedback: Feedback) {
-        if (feedback.type === FeedbackType.AUTOMATIC) {
-            feedback.type = FeedbackType.AUTOMATIC_ADAPTED;
+        if (Feedback.isFeedbackSuggestion(feedback)) {
+            // Mark as adapted feedback suggestion
+            feedback.text = (feedback.text ?? FEEDBACK_SUGGESTION_ACCEPTED_IDENTIFIER).replace(FEEDBACK_SUGGESTION_ACCEPTED_IDENTIFIER, FEEDBACK_SUGGESTION_ADAPTED_IDENTIFIER);
         }
     }
 }

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { FEEDBACK_SUGGESTION_ACCEPTED_IDENTIFIER, FEEDBACK_SUGGESTION_ADAPTED_IDENTIFIER, Feedback, FeedbackType, buildFeedbackTextForReview } from 'app/entities/feedback.model';
+import { Feedback, FeedbackType, buildFeedbackTextForReview } from 'app/entities/feedback.model';
 import { ButtonSize } from 'app/shared/components/button.component';
 import { cloneDeep } from 'lodash-es';
 import { TranslateService } from '@ngx-translate/core';
@@ -81,11 +81,7 @@ export class CodeEditorTutorAssessmentInlineFeedbackComponent {
         this.feedback.type = this.MANUAL;
         this.feedback.reference = `file:${this.selectedFile}_line:${this.codeLine}`;
         if (Feedback.isFeedbackSuggestion(this.feedback)) {
-            // Mark as modified feedback suggestion
-            this.feedback.text = (this.feedback.text ?? FEEDBACK_SUGGESTION_ACCEPTED_IDENTIFIER).replace(
-                FEEDBACK_SUGGESTION_ACCEPTED_IDENTIFIER,
-                FEEDBACK_SUGGESTION_ADAPTED_IDENTIFIER,
-            );
+            Feedback.updateFeedbackTypeOnChange(this.feedback);
         } else {
             this.feedback.text = `File ${this.selectedFile} at line ${this.codeLine + 1}`;
         }

--- a/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.ts
@@ -134,11 +134,11 @@ export class TextblockFeedbackEditorComponent implements AfterViewInit {
      * Hook to indicate changes in the feedback editor
      */
     didChange(): void {
-        const feedbackTypeBefore = this.feedback.type;
+        const feedbackTextBefore = this.feedback.text;
         Feedback.updateFeedbackTypeOnChange(this.feedback);
         this.feedbackChange.emit(this.feedback);
-        // send event to analytics if the feedback type changed
-        if (feedbackTypeBefore !== this.feedback.type) {
+        // send event to analytics if the feedback was adapted (=> title text changes to have prefix with "adapted" in it)
+        if (feedbackTextBefore !== this.feedback.text) {
             this.textAssessmentAnalytics.sendAssessmentEvent(TextAssessmentEventType.EDIT_AUTOMATIC_FEEDBACK, this.feedback.type, this.textBlock.type);
         }
     }

--- a/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-editor.component.spec.ts
@@ -179,7 +179,7 @@ describe('TextblockFeedbackEditorComponent', () => {
     });
 
     it('should send assessment event if feedback type changed', () => {
-        component.feedback.type = FeedbackType.AUTOMATIC;
+        component.feedback.text = 'FeedbackSuggestion:accepted:Test';
         const typeSpy = jest.spyOn(component.textAssessmentAnalytics, 'sendAssessmentEvent');
         component.didChange();
         expect(typeSpy).toHaveBeenCalledOnce();


### PR DESCRIPTION
> **Note**
> Stacked on #7136

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [X] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There is a small bug in #7136 where inline feedback suggestions are not marked as "adapted" when changing them.

### Description
<!-- Describe your changes in detail -->
Fix: Mark a suggestion as "adapted" when the tutor edits feedback.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
> **Warning**
> Test this on [ma-schwind.ase.cit.tum.de](https://ma-schwind.ase.cit.tum.de/)

Prerequisites:
- 1 Tutor
- 1 Programming Exercise with an existing submission
- 1 Text Exercise with an existing submission

1. Navigate to the assessment dashboard
2. Start a new assessment
3. See the feedback suggestions from Athena (requirement: Test Data PR is deployed on Athena server)
4. Edit a feedback suggestion (general or inline)
5. The suggestion badge text should now say "adapted" to note that it was edited.

### Testserver States
Do not apply. Use [ma-schwind.ase.cit.tum.de](https://ma-schwind.ase.cit.tum.de/).

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
