### PR TITLE
`Development`: Fix PushNotificationResourceTest for MySQL

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/notification/PushNotificationResourceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/PushNotificationResourceTest.java
@@ -36,7 +36,7 @@ class PushNotificationResourceTest extends AbstractSpringIntegrationIndependentT
     @Autowired
     private UserUtilService userUtilService;
 
-    private static final String FAKE_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9BRE1JTiIsImV4cCI6MjU5MzY5ODYwODg0MH0.52mSTsxFbIxqx0OmRJuy1lohq41GAKtUBO1bAY4Y_RKNW0exsmopaV_0J7iIQpfYySCNS5-37LIG_HX1tVuvxA";
+    private static final String FAKE_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ4eDQ0eHh4IiwiYXV0aCI6IlJPTEVfVEEsUk9MRV9JTlNUUlVDVE9SLFJPTEVfVVNFUiIsImV4cCI6MjUzNDAyMjU3NjAwfQ.mm9sUblgWLp97xC5ML2z6KZ0rQucKOyP7zmmI_bINlfu_axQ1dmw7A60gzOH7kzArWtx7ZmHYQZN3RMwlKHRIA";
 
     private static final String USER_LOGIN = "test-user";
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I noticed that two tests in PushNotificationResourceTest constantly fail when run against MySQL.
The reason for that was that in 8ec8f03d the used JWT token was changed to an expiration date in the year `84161`.
However, MySQL can only store dates up until the year `9999`. Therefore the two mentioned tests fail with the following log output:
```21:23:22.723 |  19 nPool-1-worker-1 | ERROR | o.h.e.j.batch.internal.BatchingBatch : HHH000315: Exception executing batch [java.sql.BatchUpdateException: Data truncation: Incorrect datetime value: '84161-01-13 19:47:20' for column 'expiration_date' at row 1], SQL: insert into push_notification_device_configuration (expiration_date, secret_key, device_type, user_id, token) values (?, ?, ?, ?, ?)
    21:23:22.724 |  19 nPool-1-worker-1 | WARN  | o.h.e.jdbc.spi.SqlExceptionHelper    : SQL Error: 1292, SQLState: 22001
    21:23:22.724 |  19 nPool-1-worker-1 | ERROR | o.h.e.jdbc.spi.SqlExceptionHelper    : Data truncation: Incorrect datetime value: '84161-01-13 19:47:20' for column 'expiration_date' at row 1
    21:23:22.738 |  19 nPool-1-worker-1 | ERROR | o.z.p.spring.common.AdviceTraits     : Internal Server Error
```

### Description
<!-- Describe your changes in detail -->
This PR exchanges the JWT token with a token that has an earlier expiration date.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. On develop, run `PushNotificationResourceTest` against MySQL
2. There should be two failed tests (`testRegister()` and `testUnregister()`)
3. Check out this PR, and run the test again
4. All tests should succeed now.
5. Also run the tests against H2 and Postgres and make sure they succeed there as well

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
