### PR TITLE
`Exam mode`: Hide supervisor comment on attendance check

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -232,7 +232,7 @@ public class StudentExamResource {
     }
 
     /**
-     * POST /courses/{courseId}/exams/{examId}/student-exams/{studentExamId}/attendance-check : Throw attandance Check Event in the student exam
+     * POST /courses/{courseId}/exams/{examId}/students/{studentLogin}/attendance-check : Throw attendance Check Event in the student exam
      *
      * @param courseId     the course to which the student exams belong to
      * @param examId       the exam to which the student exams belong to

--- a/src/main/webapp/app/exam/shared/events/exam-live-event.component.html
+++ b/src/main/webapp/app/exam/shared/events/exam-live-event.component.html
@@ -43,10 +43,6 @@
                         <th>{{ 'artemisApp.studentExamDetail.matriculationNumber' | artemisTranslate }}</th>
                         <td>{{ event.user?.visibleRegistrationNumber }}</td>
                     </tr>
-                    <tr *ngIf="examAttendanceCheckEvent.text && examAttendanceCheckEvent.text.length > 0">
-                        <th>{{ 'artemisApp.exam.events.messages.examAttendanceCheck.comment' | artemisTranslate }}</th>
-                        <td [innerHTML]="examAttendanceCheckEvent.text | htmlForMarkdown"></td>
-                    </tr>
                 </tbody>
             </table>
         </div>

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -185,8 +185,7 @@
                         "new": "Neue Bearbeitungszeit"
                     },
                     "examAttendanceCheck": {
-                        "description": "Eine Klausur-Aufsicht hat die Anwesenheitskontrolle für dich ausgelöst. Bitte folge den Anweisungen der Aufsicht.",
-                        "comment": "Kommentar der Aufsicht:"
+                        "description": "Eine Klausur-Aufsicht hat die Anwesenheitskontrolle für dich ausgelöst. Bitte folge den Anweisungen der Aufsicht."
                     }
                 }
             }

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -185,8 +185,7 @@
                         "new": "New working time"
                     },
                     "examAttendanceCheck": {
-                        "description": "An exam supervisor has triggered the attendance check for you. Please follow the instructions of the supervisor.",
-                        "comment": "Supervisor comment:"
+                        "description": "An exam supervisor has triggered the attendance check for you. Please follow the instructions of the supervisor."
                     }
                 }
             }

--- a/src/test/javascript/spec/component/exam/shared/events/exam-live-event.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/shared/events/exam-live-event.component.spec.ts
@@ -1,13 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ExamLiveEventComponent } from 'app/exam/shared/events/exam-live-event.component';
-import {
-    ExamAttendanceCheckEvent,
-    ExamLiveEvent,
-    ExamLiveEventType,
-    ExamWideAnnouncementEvent,
-    WorkingTimeUpdateEvent,
-} from 'app/exam/participate/exam-participation-live-events.service';
+import { ExamLiveEvent, ExamLiveEventType, ExamWideAnnouncementEvent, WorkingTimeUpdateEvent } from 'app/exam/participate/exam-participation-live-events.service';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
@@ -56,18 +50,6 @@ describe('ExamLiveEventComponent', () => {
 
         const typeElement = fixture.debugElement.query(By.css('.type')).nativeElement;
         expect(typeElement.textContent).toContain('artemisApp.exam.events.type.examAttendanceCheck');
-    });
-
-    it('should display the attendance check event text', () => {
-        component.event = {
-            eventType: ExamLiveEventType.EXAM_ATTENDANCE_CHECK,
-            text: 'Attendance',
-        } as ExamAttendanceCheckEvent;
-
-        fixture.detectChanges();
-
-        const contentElement = fixture.debugElement.query(By.css('.content > div')).nativeElement;
-        expect(contentElement.innerHTML).toContain('Attendance');
     });
 
     it('should display exam-wide announcement text when event is of type EXAM_WIDE_ANNOUNCEMENT', () => {


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Description

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Running exam with registered students

#### Testing with Postman
1. `instructor`: navigate to the student exams of a running exam and open one individual exam (e.g. https://artemis-test4.artemis.cit.tum.de/course-management/12/exams/14/student-exams/23)
2. `instructor`: Copy jwt token (Cookie) from the headers when loading the page to postman
3. `instructor`: send the request via postman, in this example it would be
https://artemis-test4.artemis.cit.tum.de/api/courses/12/exams/14/students/artemis_test_user_3/attendance-check
more general: {testServerUrl}/api/courses/{courseId}/exams/{examId}/students/{studentId}/attendance-check
4. `student`: See that the message is displayed as in the screenshot (and no `supervisor comment` in json format is visible) - _(in the student participation view of the exam) _

#### Testing with the Exam Checker iPad App
1. `instructor`: Verify the student attendance
2. `student`: See that `supervisor comment` is no longer displayed

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
#### Server

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [StudentExamResource.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5746/latest/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.web.rest/StudentExamResource.html) | 86% | ✅ |

 

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

#### new
How it should look like:
![image](https://github.com/ls1intum/Artemis/assets/63976129/a7bdf177-b61c-43dc-9e74-a00df9051bc7)

#### old
Previously the attribute `supervisor comment` was displayed under matriculation number (if you do not see JSON displayed this is not the case)
![image](https://github.com/ls1intum/Artemis/assets/63976129/a00bd00b-999d-4c70-9ea8-f6fce0bba9e2)

The issue seems to arise from the exam checker app, as simply the string is displayed