### PR TITLE
`Development`: Fix flaky element order in PlagiarismCaseIntegrationTest

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
@@ -209,7 +209,7 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
         Exam exam = examTextExercise.getExerciseGroup().getExam();
         var plagiarismCasesResponse = request.getList("/api/courses/" + examCourse.getId() + "/exams/" + exam.getId() + "/plagiarism-cases/for-instructor", HttpStatus.OK,
                 PlagiarismCase.class);
-        assertThat(plagiarismCasesResponse).as("should get exam plagiarism cases for instructor").isEqualTo(examPlagiarismCases);
+        assertThat(plagiarismCasesResponse).as("should get exam plagiarism cases for instructor").containsExactlyInAnyOrderElementsOf(examPlagiarismCases);
         for (var submission : plagiarismCasesResponse.get(0).getPlagiarismSubmissions()) {
             assertThat(submission.getPlagiarismComparison().getPlagiarismResult().getExercise()).as("should remove unneeded elements from the response").isNull();
             assertThat(submission.getPlagiarismComparison().getSubmissionA()).as("should filter out submission A").isNull();


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer **on CI server**.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
`PlagiarismCaseIntegrationTest` was flaky due to an assertion failing when the order of list elements in REST response was not matching the given one. In case of this test the order is not important as the list field was behaving as a set here. 

### Description
This PR changes the test implementation so that it asserts presence in the list not  order elements from a REST response (which may be different on different databases/computers).

Note: I've verified the change by running this test 100 times locally and it always passed ✅ 

### Steps for Testing
- verify if tests are green on CI or run it locally few times

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2