### PR TITLE
`Development`: Fix checkstyle issues in server code documentation

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/plagiarism/ProgrammingPlagiarismDetectionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/plagiarism/ProgrammingPlagiarismDetectionService.java
@@ -94,6 +94,7 @@ public class ProgrammingPlagiarismDetectionService {
      * @param programmingExerciseId the id of the programming exercises which should be checked
      * @param similarityThreshold   ignore comparisons whose similarity is below this threshold (in % between 0 and 100)
      * @param minimumScore          consider only submissions whose score is greater or equal to this value
+     * @param minimumSize           consider only submissions whose number of lines in diff to template is greater or equal to this value
      * @return the text plagiarism result container with up to 500 comparisons with the highest similarity values
      * @throws ExitException is thrown if JPlag exits unexpectedly
      * @throws IOException   is thrown for file handling errors
@@ -145,6 +146,7 @@ public class ProgrammingPlagiarismDetectionService {
      * @param programmingExerciseId the id of the programming exercises which should be checked
      * @param similarityThreshold   ignore comparisons whose similarity is below this threshold (in % between 0 and 100)
      * @param minimumScore          consider only submissions whose score is greater or equal to this value
+     * @param minimumSize           consider only submissions whose number of lines in diff to template is greater or equal to this value
      * @return a zip file that can be returned to the client
      */
     public File checkPlagiarismWithJPlagReport(long programmingExerciseId, float similarityThreshold, int minimumScore, int minimumSize) {


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer **based on CI results**.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
There was a missing `@param` comment in ProgramingPlagiarismDetectionService`, which caused server style to fail.

### Description
This PR adds the missing comment.

### Steps for Testing
- code review

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
