### PR TITLE
`Programming exercises`: Fix missing plagiarism detection config in import

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -426,6 +426,9 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
             """)
     List<ProgrammingExercise> findAllProgrammingExercisesInCourseOrInExamsOfCourse(@Param("course") Course course);
 
+    @EntityGraph(type = LOAD, attributePaths = { "plagiarismDetectionConfig" })
+    Optional<ProgrammingExercise> findWithPlagiarismDetectionConfigById(Long exerciseId);
+
     long countByShortNameAndCourse(String shortName, Course course);
 
     long countByTitleAndCourse(String shortName, Course course);
@@ -443,6 +446,18 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
     @NotNull
     default ProgrammingExercise findByIdElseThrow(Long programmingExerciseId) throws EntityNotFoundException {
         return findById(programmingExerciseId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
+    }
+
+    /**
+     * Find a programming exercise by its id and fetch related plagiarism detection config.
+     * Throws an EntityNotFoundException if the exercise cannot be found.
+     *
+     * @param programmingExerciseId of the programming exercise.
+     * @return The programming exercise related to the given id
+     */
+    @NotNull
+    default ProgrammingExercise findByIdWithPlagiarismDetectionConfigElseThrow(Long programmingExerciseId) throws EntityNotFoundException {
+        return findWithPlagiarismDetectionConfigById(programmingExerciseId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/export/ExerciseWithSubmissionsExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/export/ExerciseWithSubmissionsExportService.java
@@ -212,6 +212,8 @@ public abstract class ExerciseWithSubmissionsExportService {
         // do not include duplicate information
         exercise.getCourseViaExerciseGroupOrCourseMember().setExercises(null);
         exercise.getCourseViaExerciseGroupOrCourseMember().setExams(null);
+        // do not include related entities ids
+        Optional.ofNullable(exercise.getPlagiarismDetectionConfig()).ifPresent(it -> it.setId(null));
         pathsToBeZipped.add(fileService.writeObjectToJsonFile(exercise, this.objectMapper, exerciseDetailsExportPath));
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -218,6 +218,9 @@ public class ProgrammingExerciseService {
         programmingExerciseRepositoryService.setupExerciseTemplate(programmingExercise, exerciseCreator);
         programmingSubmissionService.createInitialSubmissions(programmingExercise);
 
+        // make sure that plagiarism detection config does not use existing id
+        Optional.ofNullable(programmingExercise.getPlagiarismDetectionConfig()).ifPresent(it -> it.setId(null));
+
         // Save programming exercise to prevent transient exception
         ProgrammingExercise savedProgrammingExercise = programmingExerciseRepository.save(programmingExercise);
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseExportImportResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseExportImportResource.java
@@ -262,7 +262,7 @@ public class ProgrammingExerciseExportImportResource {
     @EnforceAtLeastInstructor
     @FeatureToggle({ Feature.ProgrammingExercises, Feature.Exports })
     public ResponseEntity<Resource> exportInstructorExercise(@PathVariable long exerciseId) throws IOException {
-        var programmingExercise = programmingExerciseRepository.findByIdElseThrow(exerciseId);
+        var programmingExercise = programmingExerciseRepository.findByIdWithPlagiarismDetectionConfigElseThrow(exerciseId);
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, programmingExercise, null);
 
         long start = System.nanoTime();


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
After introducing continuous plagiarism control (CPC) its config was not added to the exported programming exercise file, which caused issue when trying to import this exercises.

### Description
This PR adds missing `PlagiarismDetectionConfig` to the export json and makes sure the imported config does not override existing one.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Export programming exercise to file.
2. Import that programming exercise.
3. Verify that new exercise was created correctly.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
