### PR TITLE
`Development`: Fix IrisMessageIntegrationTest for MySQL

### DIFF
--- a/docs/dev/migration/structure.rst
+++ b/docs/dev/migration/structure.rst
@@ -66,6 +66,11 @@ Only in special cases where you cannot avoid different SQL statements depending 
         <!-- … -->
     </databaseChangelog>
 
+2.1.1. DATETIME
+===============
+The recommended default data type for storing values that involve date and time, such as creation dates and timestamps, is :code:`datetime(3)`.
+Liquibase will translate this to :code:`datetime(3)` for MySQL and :code:`timestamp(3)` for PostgreSQL.
+This choice ensures consistent support for milliseconds across both MySQL and PostgreSQL databases.
 
 3. Development
 ==============

--- a/src/main/resources/config/liquibase/changelog/20231121165300_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20231121165300_changelog.xml
@@ -1,0 +1,18 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+    <changeSet id="20231121165300-1" author="maximiliansoelch">
+        <!-- Introduced in 20230430235959_changelog.xml -->
+        <modifyDataType tableName="iris_message" columnName="sent_at" newDataType="datetime(3)"/>
+        <!-- Introduced in 20230705141500_changelog.xml -->
+        <modifyDataType tableName="iris_session" columnName="creation_date" newDataType="datetime(3)"/>
+        <!-- Introduced in 20230714012100_changelog.xml -->
+        <modifyDataType tableName="jhi_user" columnName="iris_accepted" newDataType="datetime(3)"/>
+
+        <!--
+        Due to mysql SQL limitations, modifyDataType will lose primary key/autoincrement/not null/comment settings explicitly redefined in the change.
+        Therefore, we have to explicitly set not null again for the affected columns!
+        -->
+        <addNotNullConstraint tableName="iris_session" columnName="creation_date" columnDataType="datetime(3)"/>
+
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -69,6 +69,7 @@
     <include file="classpath:config/liquibase/changelog/20230930160925_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20231023163427_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20231029162645_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20231121165300_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command 'date '+%Y%m%d%H%M%S'' to get the current date and time in the correct format -->


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

> [!WARNING]
> **This PR includes a migration! Do not deploy to a normal test server.**

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, `sendMessageRateLimitReached()` is flaky and fails when run against MySQL.
This can also cause the succeeding tests to fail because the rate limits are not reset properly.

### Description
<!-- Describe your changes in detail -->
This PR adds a migration to change `datetime` to `datetime(3)` in three tables to avoid issues with cut-off dates on MySQL (similar to #6046).

In addition, it adds an entry for the recommended type in the documentation: https://artemis-platform--7645.org.readthedocs.build/en/7645/dev/migration/structure.html#datetime

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
TBD

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
