### PR TITLE
`Programming exercises`: Fix display of empty git diffs

### DIFF
--- a/src/main/webapp/app/entities/hestia/programming-exercise-git-diff-report.model.ts
+++ b/src/main/webapp/app/entities/hestia/programming-exercise-git-diff-report.model.ts
@@ -8,7 +8,7 @@ export class ProgrammingExerciseGitDiffReport implements BaseEntity {
     public programmingExercise: ProgrammingExercise;
     public leftCommitHash?: string;
     public rightCommitHash?: string;
-    public entries: ProgrammingExerciseGitDiffEntry[];
+    public entries?: ProgrammingExerciseGitDiffEntry[];
     public participationIdForLeftCommit?: number;
     public participationIdForRightCommit?: number;
 

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-line-stat.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-line-stat.component.ts
@@ -17,8 +17,8 @@ export class GitDiffLineStatComponent implements OnInit {
 
     ngOnInit(): void {
         if (!this.addedLineCount && !this.removedSquareCount) {
-            this.addedSquareCount = 5;
-            this.removedSquareCount = 5;
+            this.addedSquareCount = 1;
+            this.removedSquareCount = 1;
         } else if (this.addedLineCount === 0) {
             this.addedSquareCount = 0;
             this.removedSquareCount = 5;

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-line-stat.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-line-stat.component.ts
@@ -16,7 +16,10 @@ export class GitDiffLineStatComponent implements OnInit {
     constructor() {}
 
     ngOnInit(): void {
-        if (this.addedLineCount === 0) {
+        if (!this.addedLineCount && !this.removedSquareCount) {
+            this.addedSquareCount = 5;
+            this.removedSquareCount = 5;
+        } else if (this.addedLineCount === 0) {
             this.addedSquareCount = 0;
             this.removedSquareCount = 5;
         } else if (this.removedLineCount === 0) {

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-line-stat.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-line-stat.component.ts
@@ -16,7 +16,7 @@ export class GitDiffLineStatComponent implements OnInit {
     constructor() {}
 
     ngOnInit(): void {
-        if (!this.addedLineCount && !this.removedSquareCount) {
+        if (!this.addedLineCount && !this.removedLineCount) {
             this.addedSquareCount = 1;
             this.removedSquareCount = 1;
         } else if (this.addedLineCount === 0) {

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.ts
@@ -28,17 +28,18 @@ export class GitDiffReportComponent implements OnInit {
 
     ngOnInit(): void {
         // Sort the diff entries by file path and start lines
-        this.entries = this.report.entries.sort((a, b) => {
-            const filePathA = a.filePath ?? a.previousFilePath ?? '';
-            const filePathB = b.filePath ?? b.previousFilePath ?? '';
-            if (filePathA < filePathB) {
-                return -1;
-            }
-            if (filePathA > filePathB) {
-                return 1;
-            }
-            return (a.startLine ?? a.previousStartLine ?? 0) - (b.startLine ?? b.previousStartLine ?? 0);
-        });
+        this.entries =
+            this.report.entries?.sort((a, b) => {
+                const filePathA = a.filePath ?? a.previousFilePath ?? '';
+                const filePathB = b.filePath ?? b.previousFilePath ?? '';
+                if (filePathA < filePathB) {
+                    return -1;
+                }
+                if (filePathA > filePathB) {
+                    return 1;
+                }
+                return (a.startLine ?? a.previousStartLine ?? 0) - (b.startLine ?? b.previousStartLine ?? 0);
+            }) ?? [];
 
         this.addedLineCount = this.entries
             .flatMap((entry) => {

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -526,6 +526,7 @@
                                 ngbTooltip="{{ 'artemisApp.programmingExercise.diffReport.lineStatTooltipDetailPage' | artemisTranslate }}"
                             ></jhi-git-diff-line-stat>
                             <jhi-button
+                                *ngIf="addedLineCount > 0 || removedLineCount > 0"
                                 [featureToggle]="FeatureToggle.ProgrammingExercises"
                                 [isLoading]="isLoadingDiffReport"
                                 [btnSize]="ButtonSize.SMALL"

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -396,16 +396,18 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
             if (gitDiffReport) {
                 this.programmingExercise.gitDiffReport = gitDiffReport;
                 gitDiffReport.programmingExercise = this.programmingExercise;
-                this.addedLineCount = gitDiffReport.entries
-                    .map((entry) => entry.lineCount)
-                    .filter((lineCount) => lineCount)
-                    .map((lineCount) => lineCount!)
-                    .reduce((lineCount1, lineCount2) => lineCount1 + lineCount2, 0);
-                this.removedLineCount = gitDiffReport.entries
-                    .map((entry) => entry.previousLineCount)
-                    .filter((lineCount) => lineCount)
-                    .map((lineCount) => lineCount!)
-                    .reduce((lineCount1, lineCount2) => lineCount1 + lineCount2, 0);
+                this.addedLineCount =
+                    gitDiffReport.entries
+                        ?.map((entry) => entry.lineCount)
+                        .filter((lineCount) => lineCount)
+                        .map((lineCount) => lineCount!)
+                        .reduce((lineCount1, lineCount2) => lineCount1 + lineCount2, 0) ?? 0;
+                this.removedLineCount =
+                    gitDiffReport.entries
+                        ?.map((entry) => entry.previousLineCount)
+                        .filter((lineCount) => lineCount)
+                        .map((lineCount) => lineCount!)
+                        .reduce((lineCount1, lineCount2) => lineCount1 + lineCount2, 0) ?? 0;
             }
         });
     }

--- a/src/test/javascript/spec/component/hestia/git-diff-report/git-diff-line-stat.component.spec.ts
+++ b/src/test/javascript/spec/component/hestia/git-diff-report/git-diff-line-stat.component.spec.ts
@@ -25,6 +25,7 @@ describe('Git-Diff line-stat Component', () => {
         [2, 3, 4, 6],
         [1, 4, 2, 8],
         [0, 5, 0, 100],
+        [1, 1, 0, 0],
     ];
 
     it.each(boxesTestTable)('Should show %s-%s boxes', (expectedAddedSquareCount, expectedRemovedSquareCount, addedLineCount, removedLineCount) => {


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
If the template and solution repositories contain the same contents, the diff-view did not work correctly.

### Description
We now handle the case if the server does not return any diff entries in the client. We show +-0 and 2 squares, opening the diff view will lead to an empty window.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Setup the exercise in such a way that template and solution repositories contain the same code
2. Navigate to the exercise detail view
3. Check that +-0 is displayed as the diff and the the page still works correctly.
4. Verify that no errors are in the console.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Screenshots
old:

![grafik](https://github.com/ls1intum/Artemis/assets/26540346/b5c745d2-83d5-475f-b996-084a0a137065)

now: 
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/1a40c67b-9341-430f-8355-42c7c461009c)
