### PR TITLE
`Development`: Only load AthenaModuleUrlHelper with respective Spring Profile

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaModuleUrlHelper.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaModuleUrlHelper.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.service.connectors.athena;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.enumeration.ExerciseType;
@@ -9,6 +10,7 @@ import de.tum.in.www1.artemis.domain.enumeration.ExerciseType;
  * Service to get the URL for an Athena module, depending on the type of exercise.
  */
 @Service
+@Profile("athena")
 public class AthenaModuleUrlHelper {
 
     @Value("${artemis.athena.url}")


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The PR #7136 introduced a new Bean that the application tried to load it, even without the correct profile. If the configuration is not there, Artemis can't start.

### Description
<!-- Describe your changes in detail -->
I added the Spring annotation 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- Test server/Local setup

1. Deploy Artemis on develop or a PR rebased on develop today (shamelessly plugging my PR #7642) and observe that it can't start due to the missing URL [logs here](https://grafana.gchq.ase.in.tum.de/d/uBBKO8qnk/nodes-detailed-view?orgId=1&refresh=1m&var-DS_PROMETHEUS=default&var-job=artemis_test&var-name=artemis-test1.artemis.cit.tum.de&var-node=artemis-test1.artemis.cit.tum.de&var-port=9100&from=now-1h&to=now)
2. Deploy/start artemis somewhere where `${artemis.athena.url}` (TS1 for example) is not specified and check if Artemis starts.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2