### PR TITLE
`Programming exercises`: Fix build timeout in Jenkins pipeline script

### DIFF
--- a/src/main/resources/templates/jenkins/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/Jenkinsfile
@@ -53,7 +53,9 @@ node('docker') {
             timestamps {
                 sh "curl -o pipeline.groovy #buildPlanUrl"
                 ownStages = load 'pipeline.groovy'
-                ownStages.testRunner()
+                timeout(time: #jenkinsTimeout, unit: 'MINUTES') {
+                    ownStages.testRunner()
+                }
             }
         }
     } finally {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
Artemis allows to define a CI build timeout:
https://github.com/ls1intum/Artemis/blob/bd07c0fb5bc4441bca4b7a31f8dc68465b4db44e/src/main/resources/config/application-artemis.yml#L88
This setting was ignored by Jenkins since the timeout was not set as part the build plan template.

### Description
Adds the timeout to the build plan template.
The necessary replacements are already made in the code. It was just a case of the relevant timeout block missing from the template:

https://github.com/ls1intum/Artemis/blob/bd07c0fb5bc4441bca4b7a31f8dc68465b4db44e/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/build_plan/JenkinsBuildPlanCreator.java#L54
https://github.com/ls1intum/Artemis/blob/bd07c0fb5bc4441bca4b7a31f8dc68465b4db44e/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/build_plan/JenkinsBuildPlanCreator.java#L149

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- Test server connected to Jenkins

1. Create a new programming exercise.
2. The build for the solution should work.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

