### PR TITLE
`Adaptive learning`: Enable learning paths per default

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/feature/FeatureToggleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/feature/FeatureToggleService.java
@@ -25,17 +25,10 @@ public class FeatureToggleService {
         features = hazelcastInstance.getMap("features");
 
         // Features that are neither enabled nor disabled should be enabled by default
-        // This ensures that all features (except learning paths) are enabled once the system starts up
+        // This ensures that all features are enabled once the system starts up
         for (Feature feature : Feature.values()) {
             if (!features.containsKey(feature)) {
-                if (feature == Feature.LearningPaths) {
-                    // disable learning paths per default
-                    // TODO: remove this once learning paths are deliverable
-                    features.put(feature, false);
-                }
-                else {
-                    features.put(feature, true);
-                }
+                features.put(feature, true);
             }
         }
     }

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LearningPathIntegrationTest.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,8 +32,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.CompetencyProgressService;
 import de.tum.in.www1.artemis.service.LectureUnitService;
-import de.tum.in.www1.artemis.service.feature.Feature;
-import de.tum.in.www1.artemis.service.feature.FeatureToggleService;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 import de.tum.in.www1.artemis.web.rest.LearningPathResource;
@@ -92,9 +89,6 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @Autowired
     private LearningPathUtilService learningPathUtilService;
 
-    @Autowired
-    private FeatureToggleService featureToggleService;
-
     private Course course;
 
     private Competency[] competencies;
@@ -110,16 +104,6 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     private static final String EDITOR_OF_COURSE = TEST_PREFIX + "editor1";
 
     private static final String INSTRUCTOR_OF_COURSE = TEST_PREFIX + "instructor1";
-
-    @BeforeEach
-    void enableLearningPathsFeatureToggle() {
-        featureToggleService.enableFeature(Feature.LearningPaths);
-    }
-
-    @AfterEach
-    void disableLearningPathsFeatureToggle() {
-        featureToggleService.disableFeature(Feature.LearningPaths);
-    }
 
     @BeforeEach
     void setupTestScenario() throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/service/FeatureToggleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FeatureToggleServiceTest.java
@@ -23,7 +23,7 @@ class FeatureToggleServiceTest extends AbstractSpringIntegrationIndependentTest 
         // Verify that the test has reset the state
         // Must be extended if additional features are added
         assertThat(featureToggleService.isFeatureEnabled(Feature.ProgrammingExercises)).isTrue();
-        assertThat(featureToggleService.isFeatureEnabled(Feature.LearningPaths)).isFalse();
+        assertThat(featureToggleService.isFeatureEnabled(Feature.LearningPaths)).isTrue();
     }
 
     @Test
@@ -60,22 +60,22 @@ class FeatureToggleServiceTest extends AbstractSpringIntegrationIndependentTest 
 
     @Test
     void testShouldNotEnableTwice() {
-        assertThat(featureToggleService.enabledFeatures().size()).isEqualTo(Feature.values().length - 1);
+        assertThat(featureToggleService.enabledFeatures()).hasSameSizeAs(Feature.values());
         featureToggleService.enableFeature(Feature.ProgrammingExercises);
 
         // Feature should not be added multiple times
-        assertThat(featureToggleService.enabledFeatures().size()).isEqualTo(Feature.values().length - 1);
+        assertThat(featureToggleService.enabledFeatures()).hasSameSizeAs(Feature.values());
     }
 
     @Test
     void testShouldNotDisableTwice() {
         featureToggleService.disableFeature(Feature.ProgrammingExercises);
 
-        assertThat(featureToggleService.disabledFeatures()).hasSize(2);
+        assertThat(featureToggleService.disabledFeatures()).hasSize(1);
         featureToggleService.disableFeature(Feature.ProgrammingExercises);
 
         // Feature should not be added multiple times
-        assertThat(featureToggleService.disabledFeatures()).hasSize(2);
+        assertThat(featureToggleService.disabledFeatures()).hasSize(1);
 
         // Reset
         featureToggleService.enableFeature(Feature.ProgrammingExercises);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With #7684 we add the documentation of learning paths in Artemis. Therefore, we can now enable the feature per default on server start-up.

### Description
<!-- Describe your changes in detail -->
Enables feature toggle for learning paths per default.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Admin

1. Log in to Artemis
2. Navigate to Server Administration > Feature toggles
3. Make sure the Learning Path feature toggle is enabled

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

unchanged
