### PR TITLE
`Development`: Fix missing commit hash for build jobs in local continuous integration

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/ci/ContinuousIntegrationTriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/ci/ContinuousIntegrationTriggerService.java
@@ -15,4 +15,15 @@ public interface ContinuousIntegrationTriggerService {
      * @throws ContinuousIntegrationException if the request to the CI failed.
      */
     void triggerBuild(ProgrammingExerciseParticipation participation) throws ContinuousIntegrationException;
+
+    /**
+     * Triggers a build for the build plan in the given participation with an optional commit hash.
+     *
+     * @param participation the participation with the id of the build plan that should be triggered
+     * @param commitHash    the commit hash to be used for the build trigger
+     * @throws ContinuousIntegrationException if the request to the CI failed.
+     */
+    default void triggerBuild(ProgrammingExerciseParticipation participation, String commitHash) throws ContinuousIntegrationException {
+        triggerBuild(participation);
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -232,7 +232,7 @@ public class LocalCIContainerService {
     }
 
     private void convertDosFilesToUnix(String path, String containerId) {
-        executeDockerCommand(containerId, false, false, "sh", "-c", "find " + path + " -type f -exec sed -i 's/\\r$//' {} \\;");
+        executeDockerCommand(containerId, false, false, "sh", "-c", "find " + path + " -type f ! -path '*/.git/*' -exec sed -i 's/\\r$//' {} \\;");
     }
 
     private void copyToContainer(String sourcePath, String containerId) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -9,6 +9,7 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 import de.tum.in.www1.artemis.domain.enumeration.ProjectType;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.exception.ContinuousIntegrationException;
 import de.tum.in.www1.artemis.exception.LocalCIException;
 import de.tum.in.www1.artemis.service.connectors.ci.ContinuousIntegrationTriggerService;
 
@@ -36,7 +37,7 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
      * @throws LocalCIException if the build job could not be added to the queue.
      */
     @Override
-    public void triggerBuild(ProgrammingExerciseParticipation participation) {
+    public void triggerBuild(ProgrammingExerciseParticipation participation) throws ContinuousIntegrationException {
         triggerBuild(participation, null);
     }
 
@@ -47,6 +48,7 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
      * @param commitHash    the commit hash of the commit that triggers the build. If it is null, the latest commit of the default branch will be built.
      * @throws LocalCIException if the build job could not be added to the queue.
      */
+    @Override
     public void triggerBuild(ProgrammingExerciseParticipation participation, String commitHash) {
 
         ProgrammingExercise programmingExercise = participation.getProgrammingExercise();

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
@@ -155,7 +155,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
 
         // TODO: there might be cases in which Artemis should NOT trigger the build
         try {
-            continuousIntegrationTriggerService.orElseThrow().triggerBuild(participation);
+            continuousIntegrationTriggerService.orElseThrow().triggerBuild(participation, commit.getCommitHash());
         }
         catch (ContinuousIntegrationException ex) {
             // TODO: This case is currently not handled. The correct handling would be creating the submission and informing the user that the build trigger failed.


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [ ] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [ ] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I documented the Java code using JavaDoc style.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Due to some previous changes in the server code, the commit hash is not transfered to the local CI trigger service when a new push to a repository is processed.

### Description
<!-- Describe your changes in detail -->
This PR adds a default method to `ContinuousIntegrationTriggerService.java` so that we can trigger builds with the participation id and the commit hash in local CI, using the CI Trigger Service interface.

This PR also piggybacks a tiny fix so that repositories do not get corrupted when copying to the build job container.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Programming exercise
- Postman (authenticated as admin user)

1. Make a submission for the programming exercise
2. Use postman to GET /api/admin/build-job-queue/running. You should see a commit hash in the return body


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/ls1intum/Artemis/assets/38919977/734d3f25-84a8-4cef-9cfb-97b717076432)

