### PR TITLE
`Development`: Add documentation describing password and secret handling in production setups

### DIFF
--- a/docs/admin/setup.rst
+++ b/docs/admin/setup.rst
@@ -12,6 +12,7 @@ For information on how to set up extension services to activate additional funct
    :includehidden:
    :maxdepth: 2
 
+   setup/security
    setup/programming-exercises
    setup/customization
    setup/legal-documents

--- a/docs/admin/setup/security.rst
+++ b/docs/admin/setup/security.rst
@@ -6,7 +6,7 @@ Passwords
 ---------
 
 The Artemis configuration files contain a few default passwords and secrets
-that have to be overriden in your own configuration files or via environment
+that have to be overridden in your own configuration files or via environment
 variables (`Spring relaxed binding <https://github.com/spring-projects/spring-boot/wiki/Relaxed-Binding-2.0>`_).
 
 .. code-block:: yaml

--- a/docs/admin/setup/security.rst
+++ b/docs/admin/setup/security.rst
@@ -1,0 +1,56 @@
+Security
+========
+
+
+Passwords
+---------
+
+The Artemis configuration files contain a few default passwords and secrets
+that have to be overriden in your own configuration files or via environment
+variables (`Spring relaxed binding <https://github.com/spring-projects/spring-boot/wiki/Relaxed-Binding-2.0>`_).
+
+.. code-block:: yaml
+
+    artemis:
+        user-management:
+            internal-admin:
+                username: "artemis-admin"
+                # can be changed later, Artemis will update the password in the database
+                # and connected systems on the next start
+                password: "artemis-admin"
+    jhipster:
+        security:
+            authentication:
+                jwt:
+                    # used to sign the JWT tokens for user authentication
+                    # can be changed later, will require all users to log in again
+                    #
+                    # encoded using Base64 (you can use `echo 'secret-key'|base64` on your command line)
+                    base64-secret: ""
+        registry:
+            password: "change-me"  # only for distributed setups with multiple Artemis instances
+
+    spring:
+        prometheus:
+            # if Prometheus monitoring is enabled: a comma-separated list of
+            # IPs that are allowed to access the metrics endpoint
+            monitoring-ip: "127.0.0.1"
+        websocket:
+            broker:
+                username: "guest"  # only for distributed setups
+                password: "guest"  # only for distributed setups
+
+
+.. note::
+
+    The usernames/passwords for external systems (Bamboo, Bitbucket, GitLab,
+    Jenkins, …) are not listed here since the general setup documentation
+    describes how to set up those systems.
+    Without replacing the default values the connection to them will not work.
+
+
+.. note::
+
+    Ensure restrictive access to the configuration files so that access is only
+    possible for the system account that runs Artemis and administrators.
+

--- a/docs/admin/setup/security.rst
+++ b/docs/admin/setup/security.rst
@@ -44,13 +44,13 @@ variables (`Spring relaxed binding <https://github.com/spring-projects/spring-bo
 .. note::
 
     The usernames/passwords for external systems (Bamboo, Bitbucket, GitLab,
-    Jenkins, …) are not listed here since the general setup documentation
+    Jenkins, …) are not listed here, since the general setup documentation
     describes how to set up those systems.
-    Without replacing the default values the connection to them will not work.
+    Without replacing the default values, the connection to them will not work.
 
 
 .. note::
 
-    Ensure restrictive access to the configuration files so that access is only
+    Ensure restrictive access to the configuration files, so that access is only
     possible for the system account that runs Artemis and administrators.
 

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -96,8 +96,8 @@ jhipster:
                 # As this is the PRODUCTION configuration, you MUST change the default key, and store it securely:
                 # - In the JHipster Registry (which includes a Spring Cloud Config server)
                 # - In a separate `application-prod.yml` file, in the same folder as your executable WAR file
-                # - In the `JHIPSTER_SECURITY_AUTHENTICATION_JWT_BASE64_SECRET` environment variable
-                base64-secret: bXktc2VjcmV0LWtleS13aGljaC1zaG91bGQtYmUtY2hhbmdlZC1pbi1wcm9kdWN0aW9uLWFuZC1iZS1iYXNlNjQtZW5jb2RlZAo=
+                # - In the `JHIPSTER_SECURITY_AUTHENTICATION_JWT_BASE64SECRET` environment variable
+                # base64-secret: ""
                 # Token is valid 24 hours
                 token-validity-in-seconds: 86400
                 token-validity-in-seconds-for-remember-me: 2592000


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
The Artemis configuration files contain a few secrets/passwords that should be changed before using Artemis in production instances.

### Description
Adds a documentation page for administrators to inform them which passwords and secrets have to be changed.

The name of the environment variable describing the JWT secret was incorrect. According to [Spring relaxed binding rules](https://github.com/spring-projects/spring-boot/wiki/Relaxed-Binding-2.0#environment-variables) `base64-secret` in the YAML has to be represented as `BASE64SECRET` since `_` are reserved for `.` in the YAML (i.e., the previous env-name would point to a value `base64.secret` instead).

Additional change:
Removes the default value for the JWT secret token since that *has* to be changed for a production setup to not accidentally allow insecure production instances.
Note: Technically, this is a breaking change for administrators that forgot to actively set a value here. This should be noted as part of the release notes.


### Steps for Testing
Look at https://artemis-platform--7688.org.readthedocs.build/en/7688/admin/setup/security.html and check for understandability, formatting, and typos.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
