### PR TITLE
`Development`: Add Aeolus build plan templates for C programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/RestTemplateConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/RestTemplateConfiguration.java
@@ -166,7 +166,7 @@ public class RestTemplateConfiguration {
      * @return a RestTemplate with short timeouts
      */
     @Bean
-    @Profile("aeolus")
+    @Profile("localci")
     public RestTemplate shortTimeoutAeolusRestTemplate() {
         return createShortTimeoutRestTemplate();
     }

--- a/src/main/java/de/tum/in/www1/artemis/config/RestTemplateConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/RestTemplateConfiguration.java
@@ -166,7 +166,7 @@ public class RestTemplateConfiguration {
      * @return a RestTemplate with short timeouts
      */
     @Bean
-    @Profile("localci")
+    @Profile("aeolus | localci")
     public RestTemplate shortTimeoutAeolusRestTemplate() {
         return createShortTimeoutRestTemplate();
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/AeolusTemplateService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/AeolusTemplateService.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import de.tum.in.www1.artemis.config.ProgrammingLanguageConfiguration;
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 import de.tum.in.www1.artemis.domain.enumeration.ProjectType;
 import de.tum.in.www1.artemis.service.ResourceLoaderService;
@@ -95,6 +96,23 @@ public class AeolusTemplateService {
         Windfile windfile = readWindfile(yaml);
         this.addInstanceVariablesToWindfile(windfile, programmingLanguage, projectType);
         return windfile;
+    }
+
+    /**
+     * Returns the file content of the template file for the given exercise
+     *
+     * @param exercise the exercise for which the template file should be returned
+     * @return the requested template as a {@link Windfile} object
+     */
+    public Windfile getDefaultWindfileFor(ProgrammingExercise exercise) {
+        try {
+            return getWindfileFor(exercise.getProgrammingLanguage(), Optional.ofNullable(exercise.getProjectType()), exercise.isStaticCodeAnalysisEnabled(),
+                    exercise.hasSequentialTestRuns(), exercise.isTestwiseCoverageEnabled());
+        }
+        catch (IOException e) {
+            LOGGER.info("No windfile for the settings of exercise {}", exercise.getId(), e);
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/AeolusTemplateService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/AeolusTemplateService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -38,7 +39,7 @@ public class AeolusTemplateService {
 
     private final ResourceLoaderService resourceLoaderService;
 
-    private final HashMap<String, Windfile> templateCache = new HashMap<>();
+    private final ConcurrentHashMap<String, Windfile> templateCache = new ConcurrentHashMap<>();
 
     public AeolusTemplateService(ProgrammingLanguageConfiguration programmingLanguageConfiguration, ResourceLoaderService resourceLoaderService) {
         this.programmingLanguageConfiguration = programmingLanguageConfiguration;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
@@ -86,7 +86,7 @@ public class LocalCIBuildJobExecutionService {
     @Value("${artemis.version-control.default-branch:main}")
     private String defaultBranch;
 
-    private AeolusTemplateService aeolusTemplateService;
+    private final AeolusTemplateService aeolusTemplateService;
 
     public LocalCIBuildJobExecutionService(LocalCIBuildPlanService localCIBuildPlanService, Optional<VersionControlService> versionControlService,
             LocalCIContainerService localCIContainerService, AuxiliaryRepositoryRepository auxiliaryRepositoryRepository, XMLInputFactory localCIXMLInputFactory,

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
@@ -40,6 +40,7 @@ import de.tum.in.www1.artemis.exception.localvc.LocalVCInternalException;
 import de.tum.in.www1.artemis.repository.AuxiliaryRepositoryRepository;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.service.connectors.GitService;
+import de.tum.in.www1.artemis.service.connectors.aeolus.AeolusResult;
 import de.tum.in.www1.artemis.service.connectors.ci.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.connectors.localci.dto.LocalCIBuildResult;
 import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCRepositoryUrl;
@@ -320,6 +321,9 @@ public class LocalCIBuildJobExecutionService {
             case PYTHON -> {
                 return getPythonTestResultPaths();
             }
+            case C -> {
+                return getCTestResultPaths(programmingExercise);
+            }
             default -> throw new IllegalArgumentException("Programming language " + programmingExercise.getProgrammingLanguage() + " is not supported");
         }
     }
@@ -350,6 +354,15 @@ public class LocalCIBuildJobExecutionService {
     private List<String> getPythonTestResultPaths() {
         List<String> testResultPaths = new ArrayList<>();
         testResultPaths.add("/testing-dir/test-reports");
+        return testResultPaths;
+    }
+
+    private List<String> getCTestResultPaths(ProgrammingExercise programmingExercise) {
+        List<String> testResultPaths = new ArrayList<>();
+        for (AeolusResult testResultPath : programmingExercise.getWindfile().getResults()) {
+            testResultPaths.add("/repositories/test-repository" + testResultPath.getPath());
+            System.out.println("/repositories/test-repository" + testResultPath.getPath());
+        }
         return testResultPaths;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
@@ -332,20 +332,20 @@ public class LocalCIBuildJobExecutionService {
         List<String> testResultPaths = new ArrayList<>();
         if (ProjectType.isMavenProject(programmingExercise.getProjectType())) {
             if (programmingExercise.hasSequentialTestRuns()) {
-                testResultPaths.add("/testing-dir/structural/target/surefire-reports");
-                testResultPaths.add("/testing-dir/behavior/target/surefire-reports");
+                testResultPaths.add(LocalCIContainerService.WORKING_DIRECTORY + "/testing-dir/structural/target/surefire-reports");
+                testResultPaths.add(LocalCIContainerService.WORKING_DIRECTORY + "/testing-dir/behavior/target/surefire-reports");
             }
             else {
-                testResultPaths.add("/testing-dir/target/surefire-reports");
+                testResultPaths.add(LocalCIContainerService.WORKING_DIRECTORY + "/testing-dir/target/surefire-reports");
             }
         }
         else {
             if (programmingExercise.hasSequentialTestRuns()) {
-                testResultPaths.add("/testing-dir/build/test-results/behaviorTests");
-                testResultPaths.add("/testing-dir/build/test-results/structuralTests");
+                testResultPaths.add(LocalCIContainerService.WORKING_DIRECTORY + "/testing-dir/build/test-results/behaviorTests");
+                testResultPaths.add(LocalCIContainerService.WORKING_DIRECTORY + "/testing-dir/build/test-results/structuralTests");
             }
             else {
-                testResultPaths.add("/testing-dir/build/test-results/test");
+                testResultPaths.add(LocalCIContainerService.WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
             }
         }
         return testResultPaths;
@@ -353,15 +353,14 @@ public class LocalCIBuildJobExecutionService {
 
     private List<String> getPythonTestResultPaths() {
         List<String> testResultPaths = new ArrayList<>();
-        testResultPaths.add("/testing-dir/test-reports");
+        testResultPaths.add(LocalCIContainerService.WORKING_DIRECTORY + "/testing-dir/test-reports");
         return testResultPaths;
     }
 
     private List<String> getCTestResultPaths(ProgrammingExercise programmingExercise) {
         List<String> testResultPaths = new ArrayList<>();
         for (AeolusResult testResultPath : programmingExercise.getWindfile().getResults()) {
-            testResultPaths.add("/repositories/test-repository" + testResultPath.getPath());
-            System.out.println("/repositories/test-repository" + testResultPath.getPath());
+            testResultPaths.add(LocalCIContainerService.WORKING_DIRECTORY + "/testing-dir/" + testResultPath.getPath());
         }
         return testResultPaths;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
@@ -321,8 +321,8 @@ public class LocalCIBuildJobExecutionService {
             case PYTHON -> {
                 return getPythonTestResultPaths();
             }
-            case C -> {
-                return getCTestResultPaths(programmingExercise);
+            case ASSEMBLER, C -> {
+                return getCustomTestResultPaths(programmingExercise);
             }
             default -> throw new IllegalArgumentException("Programming language " + programmingExercise.getProgrammingLanguage() + " is not supported");
         }
@@ -357,7 +357,7 @@ public class LocalCIBuildJobExecutionService {
         return testResultPaths;
     }
 
-    private List<String> getCTestResultPaths(ProgrammingExercise programmingExercise) {
+    private List<String> getCustomTestResultPaths(ProgrammingExercise programmingExercise) {
         List<String> testResultPaths = new ArrayList<>();
         for (AeolusResult testResultPath : programmingExercise.getWindfile().getResults()) {
             testResultPaths.add(LocalCIContainerService.WORKING_DIRECTORY + "/testing-dir/" + testResultPath.getPath());

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -201,7 +201,7 @@ public class LocalCIContainerService {
         // Create a file "stop_container.txt" in the root directory of the container to indicate that the test results have been extracted or that the container should be stopped
         // for some other reason.
         // The container's main process is waiting for this file to appear and then stops the main process, thus stopping and removing the container.
-        executeDockerCommandWithoutAwaitingResponse(containerId, "touch", "stop_container.txt");
+        executeDockerCommandWithoutAwaitingResponse(containerId, "touch", WORKING_DIRECTORY + "/stop_container.txt");
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -84,8 +84,8 @@ public class LocalCIContainerService {
                 // container from exiting until it finishes.
                 // It waits until the script that is running the tests (see below execCreateCmdResponse) is completed, and until the result files are extracted which is indicated
                 // by the creation of a file "stop_container.txt" in the container's root directory.
-                .withCmd("sh", "-c", "while [ ! -f /stop_container.txt ]; do sleep 0.5; done")
-                // .withCmd("tail", "-f", "/dev/null") // Activate for debugging purposes instead of the above command to get a running container that you can peek into using
+                // .withCmd("sh", "-c", "while [ ! -f /stop_container.txt ]; do sleep 0.5; done")
+                .withCmd("tail", "-f", "/dev/null") // Activate for debugging purposes instead of the above command to get a running container that you can peek into using
                 // "docker exec -it <container-id> /bin/bash".
                 .exec();
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -314,7 +314,8 @@ public class LocalCIContainerService {
     private List<BuildLogEntry> executeDockerCommand(String containerId, boolean attachStdout, boolean attachStderr, String... command) {
         boolean detach = !attachStdout && !attachStderr;
 
-        ExecCreateCmdResponse execCreateCmdResponse = dockerClient.execCreateCmd(containerId).withAttachStdout(attachStdout).withAttachStderr(attachStderr).withUser("root").withCmd(command).exec();
+        ExecCreateCmdResponse execCreateCmdResponse = dockerClient.execCreateCmd(containerId).withAttachStdout(attachStdout).withAttachStderr(attachStderr).withUser("root")
+                .withCmd(command).exec();
         List<BuildLogEntry> buildLogEntries = new ArrayList<>();
         final CountDownLatch latch = new CountDownLatch(1);
         dockerClient.execStartCmd(execCreateCmdResponse.getId()).withDetach(detach).exec(new ResultCallback.Adapter<>() {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIProgrammingLanguageFeatureService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIProgrammingLanguageFeatureService.java
@@ -24,6 +24,7 @@ public class LocalCIProgrammingLanguageFeatureService extends ProgrammingLanguag
         programmingLanguageFeatures.put(JAVA,
                 new ProgrammingLanguageFeature(JAVA, true, false, true, true, false, List.of(PLAIN_GRADLE, GRADLE_GRADLE, PLAIN_MAVEN, MAVEN_MAVEN), false, false, true));
         programmingLanguageFeatures.put(PYTHON, new ProgrammingLanguageFeature(PYTHON, false, false, true, false, false, List.of(), false, false, true));
+        programmingLanguageFeatures.put(C, new ProgrammingLanguageFeature(C, false, true, true, false, false, List.of(FACT, GCC), false, false, true));
         // TODO LOCALVC_CI: Local CI is not supporting C at the moment.
         // TODO LOCALVC_CI: Local CI is not supporting Haskell at the moment.
         // TODO LOCALVC_CI: Local CI is not supporting Kotlin at the moment.

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIProgrammingLanguageFeatureService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIProgrammingLanguageFeatureService.java
@@ -24,7 +24,7 @@ public class LocalCIProgrammingLanguageFeatureService extends ProgrammingLanguag
         programmingLanguageFeatures.put(JAVA,
                 new ProgrammingLanguageFeature(JAVA, true, false, true, true, false, List.of(PLAIN_GRADLE, GRADLE_GRADLE, PLAIN_MAVEN, MAVEN_MAVEN), false, false, true));
         programmingLanguageFeatures.put(PYTHON, new ProgrammingLanguageFeature(PYTHON, false, false, true, false, false, List.of(), false, false, true));
-        programmingLanguageFeatures.put(C, new ProgrammingLanguageFeature(C, false, true, true, false, false, List.of(FACT, GCC), false, false, true));
+        programmingLanguageFeatures.put(C, new ProgrammingLanguageFeature(C, false, true, true, false, false, List.of(FACT, GCC), false, true, true));
         // TODO LOCALVC_CI: Local CI is not supporting C at the moment.
         // TODO LOCALVC_CI: Local CI is not supporting Haskell at the moment.
         // TODO LOCALVC_CI: Local CI is not supporting Kotlin at the moment.

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIProgrammingLanguageFeatureService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIProgrammingLanguageFeatureService.java
@@ -25,11 +25,10 @@ public class LocalCIProgrammingLanguageFeatureService extends ProgrammingLanguag
                 new ProgrammingLanguageFeature(JAVA, true, false, true, true, false, List.of(PLAIN_GRADLE, GRADLE_GRADLE, PLAIN_MAVEN, MAVEN_MAVEN), false, false, true));
         programmingLanguageFeatures.put(PYTHON, new ProgrammingLanguageFeature(PYTHON, false, false, true, false, false, List.of(), false, false, true));
         programmingLanguageFeatures.put(C, new ProgrammingLanguageFeature(C, false, true, true, false, false, List.of(FACT, GCC), false, true, true));
-        // TODO LOCALVC_CI: Local CI is not supporting C at the moment.
+        programmingLanguageFeatures.put(ASSEMBLER, new ProgrammingLanguageFeature(ASSEMBLER, false, false, false, false, false, List.of(), false, true, true));
         // TODO LOCALVC_CI: Local CI is not supporting Haskell at the moment.
         // TODO LOCALVC_CI: Local CI is not supporting Kotlin at the moment.
         // TODO LOCALVC_CI: Local CI is not supporting VHDL at the moment.
-        // TODO LOCALVC_CI: Local CI is not supporting Assembler at the moment.
         // TODO LOCALVC_CI: Local CI is not supporting Swift at the moment.
         // TODO LOCALVC_CI: Local CI is not supporting OCAML at the moment.
     }

--- a/src/main/resources/templates/aeolus/assembler/default.yaml
+++ b/src/main/resources/templates/aeolus/assembler/default.yaml
@@ -36,7 +36,8 @@ actions:
       cp result.xml ../assignment/result.xml
     runAlways: false
   - name: junit
-    script: '#empty script action, just for the results'
+    script: |
+        chmod -R 777 .
     runAlways: true
     results:
       - name: junit_result.xml

--- a/src/main/resources/templates/aeolus/c/fact.yaml
+++ b/src/main/resources/templates/aeolus/c/fact.yaml
@@ -32,7 +32,8 @@ actions:
       runAlways: false
     - name: cleanup
       script: |-
-          sudo rm -rf tests assignment test-reports || true
+          sudo rm -rf tests/ assignment/ test-reports/ || true
+          chmod -R 777 .
       runAlways: true
       results:
           - name: junit_test-reports/tests-results.xml

--- a/src/main/resources/templates/aeolus/c/fact.yaml
+++ b/src/main/resources/templates/aeolus/c/fact.yaml
@@ -8,10 +8,10 @@ actions:
           # Build and run all tests
           # ------------------------------
           # Updating assignment and test-reports ownership...
-          chown artemis_user:artemis_user assignment/ -R
-          rm -rf test-reports
-          mkdir test-reports
-          chown artemis_user:artemis_user test-reports/ -R
+          sudo chown artemis_user:artemis_user assignment/ -R || true
+          sudo rm -rf test-reports
+          sudo mkdir test-reports
+          sudo chown artemis_user:artemis_user test-reports/ -R || true
       runAlways: false
     - name: build_and_run_all_tests
       script: |
@@ -28,13 +28,11 @@ actions:
           cd tests
           python3 Tests.py
           rm Tests.py
-          rm -rf ./tests
+          rm -rf ./tests || true
       runAlways: false
     - name: cleanup
       script: |-
-          sudo rm -rf tests/
-          sudo rm -rf assignment/
-          rm -rf test-reports/
+          sudo rm -rf tests assignment test-reports || true
       runAlways: true
       results:
           - name: junit_test-reports/tests-results.xml

--- a/src/main/resources/templates/aeolus/c/fact.yaml
+++ b/src/main/resources/templates/aeolus/c/fact.yaml
@@ -8,10 +8,10 @@ actions:
           # Build and run all tests
           # ------------------------------
           # Updating assignment and test-reports ownership...
-          sudo chown artemis_user:artemis_user assignment/ -R
-          sudo rm -rf test-reports
-          sudo mkdir test-reports
-          sudo chown artemis_user:artemis_user test-reports/ -R
+          chown artemis_user:artemis_user assignment/ -R
+          rm -rf test-reports
+          mkdir test-reports
+          chown artemis_user:artemis_user test-reports/ -R
       runAlways: false
     - name: build_and_run_all_tests
       script: |
@@ -34,11 +34,11 @@ actions:
       script: |-
           sudo rm -rf tests/
           sudo rm -rf assignment/
-          sudo rm -rf test-reports/
+           rm -rf test-reports/
       runAlways: true
       results:
-          - name: junit_test-reports/*results.xml
-            path: test-reports/*results.xml
+          - name: junit_test-reports/tests-results.xml
+            path: test-reports/tests-results.xml
             type: junit
             before: true
 

--- a/src/main/resources/templates/aeolus/c/fact.yaml
+++ b/src/main/resources/templates/aeolus/c/fact.yaml
@@ -34,7 +34,7 @@ actions:
       script: |-
           sudo rm -rf tests/
           sudo rm -rf assignment/
-           rm -rf test-reports/
+          rm -rf test-reports/
       runAlways: true
       results:
           - name: junit_test-reports/tests-results.xml

--- a/src/main/resources/templates/aeolus/c/fact.yaml
+++ b/src/main/resources/templates/aeolus/c/fact.yaml
@@ -34,6 +34,7 @@ actions:
       script: |-
           sudo rm -rf tests/
           sudo rm -rf assignment/
+          sudo rm -rf test-reports/
       runAlways: true
       results:
           - name: junit_test-reports/*results.xml

--- a/src/main/resources/templates/aeolus/c/fact.yaml
+++ b/src/main/resources/templates/aeolus/c/fact.yaml
@@ -34,10 +34,10 @@ actions:
       script: |-
           sudo rm -rf tests/
           sudo rm -rf assignment/
-          sudo rm -rf test-reports/
       runAlways: true
       results:
           - name: junit_test-reports/*results.xml
             path: test-reports/*results.xml
             type: junit
+            before: true
 

--- a/src/main/resources/templates/aeolus/c/fact.yaml
+++ b/src/main/resources/templates/aeolus/c/fact.yaml
@@ -1,0 +1,43 @@
+api: v0.0.1
+actions:
+    - name: setup_the_build_environment
+      script: |
+          #!/usr/bin/env bash
+          # ------------------------------
+          # Task Description:
+          # Build and run all tests
+          # ------------------------------
+          # Updating assignment and test-reports ownership...
+          sudo chown artemis_user:artemis_user assignment/ -R
+          sudo rm -rf test-reports
+          sudo mkdir test-reports
+          sudo chown artemis_user:artemis_user test-reports/ -R
+      runAlways: false
+    - name: build_and_run_all_tests
+      script: |
+          #!/usr/bin/env bash
+          # ------------------------------
+          # Task Description:
+          # Build and run all tests
+          # ------------------------------
+
+          rm -f assignment/GNUmakefile
+          rm -f assignment/Makefile
+          cp -f tests/Makefile assignment/Makefile || exit 2
+
+          cd tests
+          python3 Tests.py
+          rm Tests.py
+          rm -rf ./tests
+      runAlways: false
+    - name: cleanup
+      script: |-
+          sudo rm -rf tests/
+          sudo rm -rf assignment/
+          sudo rm -rf test-reports/
+      runAlways: true
+      results:
+          - name: junit_test-reports/*results.xml
+            path: test-reports/*results.xml
+            type: junit
+

--- a/src/main/resources/templates/aeolus/c/gcc.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc.yaml
@@ -55,8 +55,8 @@ actions:
           # Task Description:
           # Build and run all tests if the compilation succeeds
           # ------------------------------
-
-          sudo gcc -c -Wall assignment/*.c || error=true
+          sudo chown artemis_user:artemis_user .
+          gcc -c -Wall assignment/*.c || error=true
           if [ ! $error ]
           then
               cd tests || exit 0
@@ -65,9 +65,10 @@ actions:
       runAlways: false
     - name: cleanup
       script: |-
-          sudo rm -rf tests/
-          sudo rm -rf assignment/
-          sudo rm -rf test-reports/
+          sudo rm -rf *.o
+          rm -rf tests/
+          rm -rf assignment/
+          rm -rf test-reports/
       runAlways: true
       results:
           - name: junit_test-reports/tests-results.xml

--- a/src/main/resources/templates/aeolus/c/gcc.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc.yaml
@@ -1,0 +1,79 @@
+api: v0.0.1
+actions:
+    - name: setup_the_build_environment
+      script: |
+          #!/usr/bin/env bash
+
+          # ------------------------------
+          # Task Description:
+          # Build and run all tests
+          # ------------------------------
+
+          # Updating assignment and test-reports ownership...
+          sudo chown artemis_user:artemis_user assignment/ -R
+          sudo rm -rf test-reports
+          sudo mkdir test-reports
+          sudo chown artemis_user:artemis_user test-reports/ -R
+
+          # assignment
+          cd tests
+          REQ_FILE=requirements.txt
+          if [ -f "$REQ_FILE" ]; then
+              pip3 install --user -r requirements.txt
+          else
+              echo "$REQ_FILE does not exist"
+          fi
+          exit 0
+      runAlways: false
+    - name: setup_makefile
+      script: |-
+          #!/usr/bin/env bash
+
+          # ------------------------------
+          # Task Description:
+          # Setup makefile
+          # ------------------------------
+
+          shadowFilePath="../tests/testUtils/c/shadow_exec.c"
+
+          foundIncludeDirs=`grep -m 1 'INCLUDEDIRS\s*=' assignment/Makefile`
+
+          foundSource=`grep -m 1 'SOURCE\s*=' assignment/Makefile`
+          foundSource="$foundSource $shadowFilePath"
+
+          rm -f assignment/GNUmakefile
+          rm -f assignment/makefile
+
+          cp -f tests/Makefile assignment/Makefile || exit 2
+          sed -i "s~\bINCLUDEDIRS\s*=.*~${foundIncludeDirs}~; s~\bSOURCE\s*=.*~${foundSource}~" assignment/Makefile
+      runAlways: false
+    - name: build_and_run_all_tests
+      script: |
+          #!/usr/bin/env bash
+
+          # ------------------------------
+          # Task Description:
+          # Build and run all tests if the compilation succeeds
+          # ------------------------------
+
+          sudo gcc -c -Wall assignment/*.c || error=true
+          if [ ! $error ]
+          then
+              cd tests || exit 0
+              python3 Tests.py
+              exit 0
+          else
+              exit 1
+          fi
+      runAlways: false
+    - name: cleanup
+      script: |-
+          sudo rm -rf tests/
+          sudo rm -rf assignment/
+          sudo rm -rf test-reports/
+      runAlways: true
+      results:
+          - name: junit_test-reports/*results.xml
+            path: test-reports/*results.xml
+            type: junit
+

--- a/src/main/resources/templates/aeolus/c/gcc.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc.yaml
@@ -12,8 +12,8 @@ actions:
           # Updating assignment and test-reports ownership...
           sudo chown artemis_user:artemis_user assignment/ -R
           sudo rm -rf test-reports
-          sudo mkdir test-reports
-          sudo chown artemis_user:artemis_user test-reports/ -R
+          mkdir test-reports
+          chown artemis_user:artemis_user test-reports/ -R
 
           # assignment
           cd tests
@@ -65,14 +65,11 @@ actions:
       runAlways: false
     - name: cleanup
       script: |-
-          sudo rm -rf *.o
-          rm -rf tests/
-          rm -rf assignment/
-          rm -rf test-reports/
+        sudo rm -rf tests/ assignment/ test-reports/ || true
+        chmod -R 777 .
       runAlways: true
       results:
           - name: junit_test-reports/tests-results.xml
             path: test-reports/tests-results.xml
             type: junit
             before: true
-

--- a/src/main/resources/templates/aeolus/c/gcc.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc.yaml
@@ -19,7 +19,7 @@ actions:
           cd tests
           REQ_FILE=requirements.txt
           if [ -f "$REQ_FILE" ]; then
-              pip3 install --user -r requirements.txt
+              pip3 install --user -r requirements.txt || true
           else
               echo "$REQ_FILE does not exist"
           fi
@@ -60,19 +60,18 @@ actions:
           if [ ! $error ]
           then
               cd tests || exit 0
-              python3 Tests.py
-              exit 0
-          else
-              exit 1
+              python3 Tests.py || true
           fi
       runAlways: false
     - name: cleanup
       script: |-
           sudo rm -rf tests/
           sudo rm -rf assignment/
+          sudo rm -rf test-reports/
       runAlways: true
       results:
           - name: junit_test-reports/*results.xml
             path: test-reports/*results.xml
             type: junit
+            before: true
 

--- a/src/main/resources/templates/aeolus/c/gcc.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc.yaml
@@ -10,10 +10,10 @@ actions:
           # ------------------------------
 
           # Updating assignment and test-reports ownership...
-          sudo chown artemis_user:artemis_user assignment/ -R
-          sudo rm -rf test-reports
-          sudo mkdir test-reports
-          sudo chown artemis_user:artemis_user test-reports/ -R
+          chown artemis_user:artemis_user assignment/ -R
+          rm -rf test-reports
+          mkdir test-reports
+          chown artemis_user:artemis_user test-reports/ -R
 
           # assignment
           cd tests
@@ -23,7 +23,7 @@ actions:
           else
               echo "$REQ_FILE does not exist"
           fi
-          exit 0
+          cd ..
       runAlways: false
     - name: setup_makefile
       script: |-
@@ -56,7 +56,7 @@ actions:
           # Build and run all tests if the compilation succeeds
           # ------------------------------
 
-          sudo gcc -c -Wall assignment/*.c || error=true
+          gcc -c -Wall assignment/*.c || error=true
           if [ ! $error ]
           then
               cd tests || exit 0
@@ -70,8 +70,8 @@ actions:
           sudo rm -rf test-reports/
       runAlways: true
       results:
-          - name: junit_test-reports/*results.xml
-            path: test-reports/*results.xml
+          - name: junit_test-reports/tests-results.xml
+            path: test-reports/tests-results.xml
             type: junit
             before: true
 

--- a/src/main/resources/templates/aeolus/c/gcc.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc.yaml
@@ -10,10 +10,10 @@ actions:
           # ------------------------------
 
           # Updating assignment and test-reports ownership...
-          chown artemis_user:artemis_user assignment/ -R
-          rm -rf test-reports
-          mkdir test-reports
-          chown artemis_user:artemis_user test-reports/ -R
+          sudo chown artemis_user:artemis_user assignment/ -R
+          sudo rm -rf test-reports
+          sudo mkdir test-reports
+          sudo chown artemis_user:artemis_user test-reports/ -R
 
           # assignment
           cd tests
@@ -56,7 +56,7 @@ actions:
           # Build and run all tests if the compilation succeeds
           # ------------------------------
 
-          gcc -c -Wall assignment/*.c || error=true
+          sudo gcc -c -Wall assignment/*.c || error=true
           if [ ! $error ]
           then
               cd tests || exit 0

--- a/src/main/resources/templates/aeolus/c/gcc.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc.yaml
@@ -70,7 +70,6 @@ actions:
       script: |-
           sudo rm -rf tests/
           sudo rm -rf assignment/
-          sudo rm -rf test-reports/
       runAlways: true
       results:
           - name: junit_test-reports/*results.xml

--- a/src/main/resources/templates/aeolus/c/gcc_static.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc_static.yaml
@@ -19,7 +19,7 @@ actions:
           cd tests
           REQ_FILE=requirements.txt
           if [ -f "$REQ_FILE" ]; then
-              pip3 install --user -r requirements.txt
+              pip3 install --user -r requirements.txt || true
           else
               echo "$REQ_FILE does not exist"
           fi
@@ -59,7 +59,7 @@ actions:
           if [ ! $error ]
           then
               cd tests || exit 0
-              python3 Tests.py
+              python3 Tests.py || true
           else
               exit 1
           fi
@@ -68,6 +68,7 @@ actions:
       script: |-
           sudo rm -rf tests/
           sudo rm -rf assignment/
+          sudo rm -rf test-reports/
       runAlways: true
       results:
           - name: gcc
@@ -75,3 +76,4 @@ actions:
           - name: junit_test-reports/*results.xml
             path: test-reports/*results.xml
             type: junit
+            before: true

--- a/src/main/resources/templates/aeolus/c/gcc_static.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc_static.yaml
@@ -1,0 +1,78 @@
+api: v0.0.1
+actions:
+    - name: setup_the_build_environment
+      script: |
+          #!/usr/bin/env bash
+
+          # ------------------------------
+          # Task Description:
+          # Build and run all tests
+          # ------------------------------
+
+          # Updating assignment and test-reports ownership...
+          sudo chown artemis_user:artemis_user assignment/ -R
+          sudo rm -rf test-reports
+          sudo mkdir test-reports
+          sudo chown artemis_user:artemis_user test-reports/ -R
+
+          # assignment
+          cd tests
+          REQ_FILE=requirements.txt
+          if [ -f "$REQ_FILE" ]; then
+              pip3 install --user -r requirements.txt
+          else
+              echo "$REQ_FILE does not exist"
+          fi
+      runAlways: false
+    - name: setup_makefile
+      script: |-
+          #!/usr/bin/env bash
+
+          # ------------------------------
+          # Task Description:
+          # Setup makefile
+          # ------------------------------
+
+          shadowFilePath="../tests/testUtils/c/shadow_exec.c"
+
+          foundIncludeDirs=`grep -m 1 'INCLUDEDIRS\s*=' assignment/Makefile`
+
+          foundSource=`grep -m 1 'SOURCE\s*=' assignment/Makefile`
+          foundSource="$foundSource $shadowFilePath"
+
+          rm -f assignment/GNUmakefile
+          rm -f assignment/makefile
+
+          cp -f tests/Makefile assignment/Makefile || exit 2
+          sed -i "s~\bINCLUDEDIRS\s*=.*~${foundIncludeDirs}~; s~\bSOURCE\s*=.*~${foundSource}~" assignment/Makefile
+      runAlways: false
+    - name: build_and_run_all_tests
+      script: |
+          #!/usr/bin/env bash
+
+          # ------------------------------
+          # Task Description:
+          # Build and run all tests if the compilation succeeds
+          # ------------------------------
+
+          sudo gcc -c -Wall assignment/*.c || error=true
+          if [ ! $error ]
+          then
+              cd tests || exit 0
+              python3 Tests.py
+          else
+              exit 1
+          fi
+      runAlways: false
+    - name: cleanup
+      script: |-
+          sudo rm -rf tests/
+          sudo rm -rf assignment/
+          sudo rm -rf test-reports/
+      runAlways: true
+      results:
+          - name: gcc
+            path: target/gcc.xml
+          - name: junit_test-reports/*results.xml
+            path: test-reports/*results.xml
+            type: junit

--- a/src/main/resources/templates/aeolus/c/gcc_static.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc_static.yaml
@@ -12,8 +12,8 @@ actions:
           # Updating assignment and test-reports ownership...
           sudo chown artemis_user:artemis_user assignment/ -R
           sudo rm -rf test-reports
-          sudo mkdir test-reports
-          sudo chown artemis_user:artemis_user test-reports/ -R
+          mkdir test-reports
+          chown artemis_user:artemis_user test-reports/ -R
 
           # assignment
           cd tests
@@ -55,8 +55,8 @@ actions:
           # Task Description:
           # Build and run all tests if the compilation succeeds
           # ------------------------------
-
-          sudo gcc -c -Wall assignment/*.c || error=true
+          sudo chown artemis_user:artemis_user .
+          gcc -c -Wall assignment/*.c || error=true
           if [ ! $error ]
           then
               cd tests || exit 0
@@ -67,6 +67,7 @@ actions:
       runAlways: false
     - name: cleanup
       script: |-
+          sudo rm -rf *.o
           sudo rm -rf tests/
           sudo rm -rf assignment/
           sudo rm -rf test-reports/

--- a/src/main/resources/templates/aeolus/c/gcc_static.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc_static.yaml
@@ -10,10 +10,10 @@ actions:
           # ------------------------------
 
           # Updating assignment and test-reports ownership...
-          sudo chown artemis_user:artemis_user assignment/ -R
-          sudo rm -rf test-reports
-          sudo mkdir test-reports
-          sudo chown artemis_user:artemis_user test-reports/ -R
+          chown artemis_user:artemis_user assignment/ -R
+          rm -rf test-reports
+          mkdir test-reports
+          chown artemis_user:artemis_user test-reports/ -R
 
           # assignment
           cd tests
@@ -23,6 +23,7 @@ actions:
           else
               echo "$REQ_FILE does not exist"
           fi
+          cd ..
       runAlways: false
     - name: setup_makefile
       script: |-
@@ -55,7 +56,7 @@ actions:
           # Build and run all tests if the compilation succeeds
           # ------------------------------
 
-          sudo gcc -c -Wall assignment/*.c || error=true
+          gcc -c -Wall assignment/*.c || error=true
           if [ ! $error ]
           then
               cd tests || exit 0
@@ -73,7 +74,7 @@ actions:
       results:
           - name: gcc
             path: target/gcc.xml
-          - name: junit_test-reports/*results.xml
-            path: test-reports/*results.xml
+          - name: junit_test-reports/tests-results.xml
+            path: test-reports/tests-results.xml
             type: junit
             before: true

--- a/src/main/resources/templates/aeolus/c/gcc_static.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc_static.yaml
@@ -10,10 +10,10 @@ actions:
           # ------------------------------
 
           # Updating assignment and test-reports ownership...
-          chown artemis_user:artemis_user assignment/ -R
-          rm -rf test-reports
-          mkdir test-reports
-          chown artemis_user:artemis_user test-reports/ -R
+          sudo chown artemis_user:artemis_user assignment/ -R
+          sudo rm -rf test-reports
+          sudo mkdir test-reports
+          sudo chown artemis_user:artemis_user test-reports/ -R
 
           # assignment
           cd tests
@@ -56,7 +56,7 @@ actions:
           # Build and run all tests if the compilation succeeds
           # ------------------------------
 
-          gcc -c -Wall assignment/*.c || error=true
+          sudo gcc -c -Wall assignment/*.c || error=true
           if [ ! $error ]
           then
               cd tests || exit 0

--- a/src/main/resources/templates/aeolus/c/gcc_static.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc_static.yaml
@@ -67,10 +67,8 @@ actions:
       runAlways: false
     - name: cleanup
       script: |-
-          sudo rm -rf *.o
-          sudo rm -rf tests/
-          sudo rm -rf assignment/
-          sudo rm -rf test-reports/
+          sudo rm -rf tests/ assignment/ test-reports/ || true
+          chmod -R 777 .
       runAlways: true
       results:
           - name: gcc

--- a/src/main/resources/templates/aeolus/c/gcc_static.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc_static.yaml
@@ -68,7 +68,6 @@ actions:
       script: |-
           sudo rm -rf tests/
           sudo rm -rf assignment/
-          sudo rm -rf test-reports/
       runAlways: true
       results:
           - name: gcc

--- a/src/main/webapp/app/entities/programming-exercise.model.ts
+++ b/src/main/webapp/app/entities/programming-exercise.model.ts
@@ -23,6 +23,7 @@ export class AeolusResult {
     path: string;
     ignore: string;
     type?: string;
+    before?: boolean;
 }
 
 export class ScriptAction extends BuildAction {

--- a/src/main/webapp/app/entities/programming-exercise.model.ts
+++ b/src/main/webapp/app/entities/programming-exercise.model.ts
@@ -13,19 +13,24 @@ import { BuildLogStatisticsDTO } from 'app/exercises/programming/manage/build-lo
 export class BuildAction {
     name: string;
     runAlways: boolean;
-    class: string;
     workdir: string;
+    results?: AeolusResult[];
+    parameters: Map<string, string | boolean | number>;
+}
+
+export class AeolusResult {
+    name: string;
+    path: string;
+    ignore: string;
+    type?: string;
 }
 
 export class ScriptAction extends BuildAction {
     script: string;
-    class: string = 'script-action';
 }
 
 export class PlatformAction extends BuildAction {
     type: string;
-    class: string = 'platform-action';
-    parameters: Map<string, string | boolean | number>;
     kind: string;
 }
 

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
@@ -11,10 +11,7 @@ import static tech.jhipster.config.JHipsterConstants.SPRING_PROFILE_TEST;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
@@ -11,7 +11,10 @@ import static tech.jhipster.config.JHipsterConstants.SPRING_PROFILE_TEST;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/de/tum/in/www1/artemis/connectors/AeolusTemplateResourceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/connectors/AeolusTemplateResourceTest.java
@@ -44,6 +44,9 @@ class AeolusTemplateResourceTest extends AbstractSpringIntegrationLocalCILocalVC
         templatesWithExpectedScriptActions.put("JAVA/PLAIN_MAVEN", 1);
         templatesWithExpectedScriptActions.put("JAVA/PLAIN_MAVEN?sequentialRuns=true", 1);
         templatesWithExpectedScriptActions.put("ASSEMBLER", 4);
+        templatesWithExpectedScriptActions.put("C/FACT", 3);
+        templatesWithExpectedScriptActions.put("C/GCC", 4);
+        templatesWithExpectedScriptActions.put("C/GCC?staticAnalysis=true", 4);
         for (Map.Entry<String, Integer> entry : templatesWithExpectedScriptActions.entrySet()) {
             String template = request.get("/api/aeolus/templates/" + entry.getKey(), HttpStatus.OK, String.class);
             assertThat(template).isNotEmpty();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.artemis.exercise.programmingexercise;
 
+import static de.tum.in.www1.artemis.service.connectors.localci.LocalCIContainerService.WORKING_DIRECTORY;
 import static de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResourceEndpoints.IMPORT;
 import static de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResourceEndpoints.PROGRAMMING_EXERCISES;
 import static de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResourceEndpoints.ROOT;
@@ -124,16 +125,17 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractSpringInt
         // participation).
         // Usually, specifying one doReturn() is enough to make the stub return the same object on every subsequent call.
         // However, in this case we have it return an InputStream, which will be consumed after returning it the first time, so we need to create two separate ones.
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/assignment/.git/refs/heads/[^/]+",
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
                 Map.of("assignmentCommitHash", DUMMY_COMMIT_HASH), Map.of("assignmentCommitHash", DUMMY_COMMIT_HASH));
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/.git/refs/heads/[^/]+", Map.of("testsCommitHash", DUMMY_COMMIT_HASH),
-                Map.of("testsCommitHash", DUMMY_COMMIT_HASH));
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/.git/refs/heads/[^/]+",
+                Map.of("testsCommitHash", DUMMY_COMMIT_HASH), Map.of("testsCommitHash", DUMMY_COMMIT_HASH));
 
         // Mock dockerClient.copyArchiveFromContainerCmd() such that it returns the XMLs containing the test results.
         // Mock the results for the template repository build and for the solution repository build that will both be triggered as a result of creating the exercise.
         Map<String, String> templateBuildTestResults = localVCLocalCITestService.createMapFromTestResultsFolder(ALL_FAIL_TEST_RESULTS_PATH);
         Map<String, String> solutionBuildTestResults = localVCLocalCITestService.createMapFromTestResultsFolder(ALL_SUCCEED_TEST_RESULTS_PATH);
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/build/test-results/test", templateBuildTestResults, solutionBuildTestResults);
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/build/test-results/test", templateBuildTestResults,
+                solutionBuildTestResults);
         newExercise.setChannelName("testchannelname-pe");
         ProgrammingExercise createdExercise = request.postWithResponseBody(ROOT + SETUP, newExercise, ProgrammingExercise.class, HttpStatus.CREATED);
 
@@ -195,16 +197,17 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractSpringInt
         // participation).
         // Usually, specifying one doReturn() is enough to make the stub return the same object on every subsequent call.
         // However, in this case we have it return an InputStream, which will be consumed after returning it the first time, so we need to create two separate ones.
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/assignment/.git/refs/heads/[^/]+",
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
                 Map.of("assignmentComitHash", DUMMY_COMMIT_HASH), Map.of("assignmentComitHash", DUMMY_COMMIT_HASH));
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/.git/refs/heads/[^/]+", Map.of("testsCommitHash", DUMMY_COMMIT_HASH),
-                Map.of("testsCommitHash", DUMMY_COMMIT_HASH));
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/.git/refs/heads/[^/]+",
+                Map.of("testsCommitHash", DUMMY_COMMIT_HASH), Map.of("testsCommitHash", DUMMY_COMMIT_HASH));
 
         // Mock dockerClient.copyArchiveFromContainerCmd() such that it returns the XMLs containing the test results.
         // Mock the results for the template repository build and for the solution repository build that will both be triggered as a result of creating the exercise.
         Map<String, String> templateBuildTestResults = localVCLocalCITestService.createMapFromTestResultsFolder(ALL_FAIL_TEST_RESULTS_PATH);
         Map<String, String> solutionBuildTestResults = localVCLocalCITestService.createMapFromTestResultsFolder(ALL_SUCCEED_TEST_RESULTS_PATH);
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/build/test-results/test", templateBuildTestResults, solutionBuildTestResults);
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/build/test-results/test", templateBuildTestResults,
+                solutionBuildTestResults);
 
         ProgrammingExercise exerciseToBeImported = ProgrammingExerciseFactory.generateToBeImportedProgrammingExercise("ImportTitle", "imported", programmingExercise,
                 courseUtilService.addEmptyCourse());

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCIIntegrationTest.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.artemis.localvcci;
 
+import static de.tum.in.www1.artemis.service.connectors.localci.LocalCIContainerService.WORKING_DIRECTORY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
@@ -50,13 +51,13 @@ class LocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
         commitHash = localVCLocalCITestService.commitFile(studentAssignmentRepository.localRepoFile.toPath(), studentAssignmentRepository.localGit);
         studentAssignmentRepository.localGit.push().call();
         // Mock dockerClient.copyArchiveFromContainerCmd() such that it returns the XMLs containing the test results.
-        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, "/testing-dir/build/test-results/test");
-        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, "/testing-dir/target/surefire-reports");
+        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
+        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, WORKING_DIRECTORY + "/testing-dir/target/surefire-reports");
         // Mock dockerClient.copyArchiveFromContainerCmd() such that it returns a dummy commit hash for the tests repository.
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/.git/refs/heads/[^/]+", Map.of("testCommitHash", DUMMY_COMMIT_HASH),
-                Map.of("testCommitHash", DUMMY_COMMIT_HASH));
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/assignment/.git/refs/heads/[^/]+", Map.of("commitHash", commitHash),
-                Map.of("commitHash", commitHash));
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/.git/refs/heads/[^/]+",
+                Map.of("testCommitHash", DUMMY_COMMIT_HASH), Map.of("testCommitHash", DUMMY_COMMIT_HASH));
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
+                Map.of("commitHash", commitHash), Map.of("commitHash", commitHash));
     }
 
     @AfterEach
@@ -194,7 +195,7 @@ class LocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
 
         // Return an InputStream from dockerClient.copyArchiveFromContainerCmd().exec() such that repositoryTarInputStream.getNextTarEntry() throws an IOException.
         CopyArchiveFromContainerCmd copyArchiveFromContainerCmd = mock(CopyArchiveFromContainerCmd.class);
-        ArgumentMatcher<String> expectedPathMatcher = path -> path.matches("/testing-dir/.git/refs/heads/[^/]+");
+        ArgumentMatcher<String> expectedPathMatcher = path -> path.matches(WORKING_DIRECTORY + "/testing-dir/.git/refs/heads/[^/]+");
         doReturn(copyArchiveFromContainerCmd).when(dockerClient).copyArchiveFromContainerCmd(anyString(), argThat(expectedPathMatcher));
         when(copyArchiveFromContainerCmd.exec()).thenReturn(new InputStream() {
 
@@ -216,7 +217,7 @@ class LocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
 
         // Should return a build result that indicates that the build failed.
         CopyArchiveFromContainerCmd copyArchiveFromContainerCmd = mock(CopyArchiveFromContainerCmd.class);
-        ArgumentMatcher<String> expectedPathMatcher = path -> path.matches("/testing-dir/build/test-results/test");
+        ArgumentMatcher<String> expectedPathMatcher = path -> path.matches(WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
         doReturn(copyArchiveFromContainerCmd).when(dockerClient).copyArchiveFromContainerCmd(anyString(), argThat(expectedPathMatcher));
         when(copyArchiveFromContainerCmd.exec()).thenThrow(new NotFoundException("Cannot find results"));
 
@@ -232,7 +233,7 @@ class LocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
 
         // Return an InputStream from dockerClient.copyArchiveFromContainerCmd().exec() such that repositoryTarInputStream.getNextTarEntry() throws an IOException.
         CopyArchiveFromContainerCmd copyArchiveFromContainerCmd = mock(CopyArchiveFromContainerCmd.class);
-        ArgumentMatcher<String> expectedPathMatcher = path -> path.matches("/testing-dir/build/test-results/test");
+        ArgumentMatcher<String> expectedPathMatcher = path -> path.matches(WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
         doReturn(copyArchiveFromContainerCmd).when(dockerClient).copyArchiveFromContainerCmd(anyString(), argThat(expectedPathMatcher));
         when(copyArchiveFromContainerCmd.exec()).thenReturn(new InputStream() {
 
@@ -255,7 +256,7 @@ class LocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
     void testFaultyResultFiles() throws IOException {
         ProgrammingExerciseStudentParticipation studentParticipation = localVCLocalCITestService.createParticipation(programmingExercise, student1Login);
 
-        localVCLocalCITestService.mockTestResults(dockerClient, FAULTY_FILES_TEST_RESULTS_PATH, "/testing-dir/build/test-results/test");
+        localVCLocalCITestService.mockTestResults(dockerClient, FAULTY_FILES_TEST_RESULTS_PATH, WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
         localCIConnectorService.processNewPush(commitHash, studentAssignmentRepository.originGit.getRepository());
 
         await().untilAsserted(() -> verify(programmingMessagingService).notifyUserAboutSubmissionError(Mockito.eq(studentParticipation), any()));

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCITestConfiguration.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCITestConfiguration.java
@@ -63,6 +63,7 @@ public class LocalCITestConfiguration {
         doReturn(createContainerCmd).when(createContainerCmd).withName(anyString());
         doReturn(createContainerCmd).when(createContainerCmd).withHostConfig(any());
         doReturn(createContainerCmd).when(createContainerCmd).withEnv(anyString(), anyString(), anyString());
+        doReturn(createContainerCmd).when(createContainerCmd).withUser(anyString());
         doReturn(createContainerCmd).when(createContainerCmd).withCmd(anyString(), anyString(), anyString());
         doReturn(createContainerResponse).when(createContainerCmd).exec();
 
@@ -82,6 +83,7 @@ public class LocalCITestConfiguration {
         ExecCreateCmdResponse execCreateCmdResponse = mock(ExecCreateCmdResponse.class);
         doReturn(execCreateCmd).when(dockerClient).execCreateCmd(anyString());
         doReturn(execCreateCmd).when(execCreateCmd).withCmd(any(String[].class));
+        doReturn(execCreateCmd).when(execCreateCmd).withUser(anyString());
         doReturn(execCreateCmd).when(execCreateCmd).withAttachStdout(anyBoolean());
         doReturn(execCreateCmd).when(execCreateCmd).withAttachStderr(anyBoolean());
         doReturn(execCreateCmd).when(execCreateCmd).withCmd(anyString(), anyString());

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCIIntegrationTest.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.artemis.localvcci;
 
+import static de.tum.in.www1.artemis.service.connectors.localci.LocalCIContainerService.WORKING_DIRECTORY;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -78,8 +79,8 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
         assignmentRepository = localVCLocalCITestService.createAndConfigureLocalRepository(projectKey1, assignmentRepositorySlug);
 
         // Mock dockerClient.copyArchiveFromContainerCmd() such that it returns a dummy commit hash for the tests repository.
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/.git/refs/heads/[^/]+", Map.of("testCommitHash", DUMMY_COMMIT_HASH),
-                Map.of("testCommitHash", DUMMY_COMMIT_HASH));
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/.git/refs/heads/[^/]+",
+                Map.of("testCommitHash", DUMMY_COMMIT_HASH), Map.of("testCommitHash", DUMMY_COMMIT_HASH));
 
         teamShortName = "team1";
         teamRepositorySlug = projectKey1.toLowerCase() + "-" + teamShortName;
@@ -134,14 +135,15 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
         // Mock dockerClient.copyArchiveFromContainerCmd() such that it returns the commitHash of the tests repository for both the solution and the template repository.
         // Note: The stub needs to receive the same object twice. Usually, specifying one doReturn() is enough to make the stub return the same object on every subsequent call.
         // However, in this case we have it return an InputStream, which will be consumed after returning it the first time, so we need to create two separate ones.
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/.git/refs/heads/[^/]+", Map.of("testCommitHash", commitHash),
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/.git/refs/heads/[^/]+", Map.of("testCommitHash", commitHash),
                 Map.of("testCommitHash", commitHash));
 
         // Mock dockerClient.copyArchiveFromContainerCmd() such that it returns the XMLs containing the test results.
         // Mock the results for the solution repository build and for the template repository build that will both be triggered as a result of updating the tests.
         Map<String, String> solutionBuildTestResults = localVCLocalCITestService.createMapFromTestResultsFolder(ALL_SUCCEED_TEST_RESULTS_PATH);
         Map<String, String> templateBuildTestResults = localVCLocalCITestService.createMapFromTestResultsFolder(ALL_FAIL_TEST_RESULTS_PATH);
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/build/test-results/test", solutionBuildTestResults, templateBuildTestResults);
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/build/test-results/test", solutionBuildTestResults,
+                templateBuildTestResults);
 
         localVCLocalCITestService.testPushSuccessful(testsRepository.localGit, instructor1Login, projectKey1, testsRepositorySlug);
 
@@ -165,9 +167,9 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
         localVCLocalCITestService.testFetchSuccessful(solutionRepository.localGit, instructor1Login, projectKey1, solutionRepositorySlug);
 
         String commitHash = localVCLocalCITestService.commitFile(solutionRepository.localRepoFile.toPath(), solutionRepository.localGit);
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/assignment/.git/refs/heads/[^/]+", Map.of("commitHash", commitHash),
-                Map.of("commitHash", commitHash));
-        localVCLocalCITestService.mockTestResults(dockerClient, ALL_SUCCEED_TEST_RESULTS_PATH, "/testing-dir/build/test-results/test");
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
+                Map.of("commitHash", commitHash), Map.of("commitHash", commitHash));
+        localVCLocalCITestService.mockTestResults(dockerClient, ALL_SUCCEED_TEST_RESULTS_PATH, WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
         doReturn(gitService.getExistingCheckedOutRepositoryByLocalPath(solutionRepository.localRepoFile.toPath(), null)).when(gitService)
                 .getOrCheckoutRepository(solutionParticipation);
 
@@ -191,9 +193,9 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
         localVCLocalCITestService.testFetchSuccessful(templateRepository.localGit, instructor1Login, projectKey1, templateRepositorySlug);
 
         String commitHash = localVCLocalCITestService.commitFile(templateRepository.localRepoFile.toPath(), templateRepository.localGit);
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/assignment/.git/refs/heads/[^/]+", Map.of("commitHash", commitHash),
-                Map.of("commitHash", commitHash));
-        localVCLocalCITestService.mockTestResults(dockerClient, ALL_FAIL_TEST_RESULTS_PATH, "/testing-dir/build/test-results/test");
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
+                Map.of("commitHash", commitHash), Map.of("commitHash", commitHash));
+        localVCLocalCITestService.mockTestResults(dockerClient, ALL_FAIL_TEST_RESULTS_PATH, WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
         doReturn(gitService.getExistingCheckedOutRepositoryByLocalPath(templateRepository.localRepoFile.toPath(), null)).when(gitService)
                 .getOrCheckoutRepository(templateParticipation);
 
@@ -215,10 +217,10 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
         // Student1
         localVCLocalCITestService.testFetchSuccessful(assignmentRepository.localGit, student1Login, projectKey1, assignmentRepositorySlug);
         String commitHash = localVCLocalCITestService.commitFile(assignmentRepository.localRepoFile.toPath(), assignmentRepository.localGit);
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/assignment/.git/refs/heads/[^/]+", Map.of("commitHash", commitHash),
-                Map.of("commitHash", commitHash));
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
+                Map.of("commitHash", commitHash), Map.of("commitHash", commitHash));
         // Mock dockerClient.copyArchiveFromContainerCmd() such that it returns the XMLs containing the test results.
-        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, "/testing-dir/build/test-results/test");
+        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
         localVCLocalCITestService.testPushSuccessful(assignmentRepository.localGit, student1Login, projectKey1, assignmentRepositorySlug);
         localVCLocalCITestService.testLatestSubmission(studentParticipation.getId(), commitHash, 1, false);
 
@@ -292,9 +294,9 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
 
         // First push should go through.
         String commit = localVCLocalCITestService.commitFile(assignmentRepository.localRepoFile.toPath(), assignmentRepository.localGit);
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/assignment/.git/refs/heads/[^/]+", Map.of("commitHash", commit),
-                Map.of("commitHash", commit));
-        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, "/testing-dir/build/test-results/test");
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
+                Map.of("commitHash", commit), Map.of("commitHash", commit));
+        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
         localVCLocalCITestService.testPushSuccessful(assignmentRepository.localGit, student1Login, projectKey1, assignmentRepositorySlug);
 
         await().until(() -> resultRepository.findFirstByParticipationIdOrderByCompletionDateDesc(participation.getId()).isPresent());
@@ -536,9 +538,9 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
         // student1 should be able to fetch and push.
         localVCLocalCITestService.testFetchSuccessful(assignmentRepository.localGit, student1Login, projectKey1, assignmentRepositorySlug);
         String commitHash = localVCLocalCITestService.commitFile(assignmentRepository.localRepoFile.toPath(), assignmentRepository.localGit);
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/assignment/.git/refs/heads/[^/]+", Map.of("commitHash", commitHash),
-                Map.of("commitHash", commitHash));
-        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, "/testing-dir/build/test-results/test");
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
+                Map.of("commitHash", commitHash), Map.of("commitHash", commitHash));
+        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
         localVCLocalCITestService.testPushSuccessful(assignmentRepository.localGit, student1Login, projectKey1, assignmentRepositorySlug);
         localVCLocalCITestService.testLatestSubmission(studentParticipation.getId(), commitHash, 1, false);
         // tutor1 should be able to fetch but not push.
@@ -601,9 +603,9 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
         // Instructor should be able to fetch and push.
         localVCLocalCITestService.testFetchSuccessful(instructorExamTestRunRepository.localGit, instructor1Login, projectKey1, repositorySlug);
         String commitHash = localVCLocalCITestService.commitFile(instructorExamTestRunRepository.localRepoFile.toPath(), instructorExamTestRunRepository.localGit);
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/assignment/.git/refs/heads/[^/]+", Map.of("commitHash", commitHash),
-                Map.of("commitHash", commitHash));
-        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, "/testing-dir/build/test-results/test");
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
+                Map.of("commitHash", commitHash), Map.of("commitHash", commitHash));
+        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
         localVCLocalCITestService.testPushSuccessful(instructorExamTestRunRepository.localGit, instructor1Login, projectKey1, repositorySlug);
         localVCLocalCITestService.testLatestSubmission(instructorTestRunParticipation.getId(), commitHash, 1, false);
 
@@ -662,9 +664,9 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
         // Student1
         localVCLocalCITestService.testFetchSuccessful(practiceRepository.localGit, student1Login, projectKey1, practiceRepositorySlug);
         String commitHash = localVCLocalCITestService.commitFile(practiceRepository.localRepoFile.toPath(), practiceRepository.localGit);
-        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, "/testing-dir/assignment/.git/refs/heads/[^/]+", Map.of("commitHash", commitHash),
-                Map.of("commitHash", commitHash));
-        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, "/testing-dir/build/test-results/test");
+        localVCLocalCITestService.mockInputStreamReturnedFromContainer(dockerClient, WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
+                Map.of("commitHash", commitHash), Map.of("commitHash", commitHash));
+        localVCLocalCITestService.mockTestResults(dockerClient, PARTLY_SUCCESSFUL_TEST_RESULTS_PATH, WORKING_DIRECTORY + "/testing-dir/build/test-results/test");
         localVCLocalCITestService.testPushSuccessful(practiceRepository.localGit, student1Login, projectKey1, practiceRepositorySlug);
         localVCLocalCITestService.testLatestSubmission(practiceParticipation.getId(), commitHash, 1, false);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR adds the templates for build plans for the language C. 

### Description
<!-- Describe your changes in detail -->
I added the templates and added the `ProgrammingLanguageFeature` for LocalCI so one can now create custom build plans (starting with the help of the template) for C in LocalCI and Bamboo.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students
- Programming Exercise Setup with either LocalCI or Bamboo

1. Log in to Artemis
2. Create a new C exercise and enable custom build plans
3. Confirm that the build plan behaves the same as it does in Bamboo. meaning that base fails and solution hopefully passes

#### Exam Mode Testing (should behave exactly the same, same code is used)
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Create an exam
3. Create a new C exercise and enable custom build plans
4. Confirm that the build plan behaves the same as it does in Bamboo. meaning that base fails and solution hopefully passes

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

