### PR TITLE
`Programming exercises`: Fix visible testid if the task name is also a test name

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseTaskService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseTaskService.java
@@ -435,13 +435,14 @@ public class ProgrammingExerciseTaskService {
             // matchResult is fa full task, e.g., [task][Bubble Sort](testBubbleSort,testClass[BubbleSort])
             String fullMatch = matchResult.group();
             // group 1: task name, group 2: test names, e.g, testBubbleSort,testClass[BubbleSort]
+            String taskName = matchResult.group(1);
             String testNames = matchResult.group(2);
 
             // converted testids, e.g., <testid>10</testid>,<testid>12</testid>
             String testIds = replacer.apply(testNames, testCases);
 
-            // replace the names with their ids
-            return fullMatch.replace(testNames, testIds);
+            // construct a new task using the testids
+            return "[task][%s](%s)".formatted(taskName, testIds);
         });
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseTaskServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseTaskServiceTest.java
@@ -381,8 +381,28 @@ class ProgrammingExerciseTaskServiceTest extends AbstractSpringIntegrationIndepe
         programmingExerciseTaskService.replaceTestNamesWithIds(programmingExercise);
         String problemStatement = programmingExercise.getProblemStatement();
 
-        assertThat(problemStatement).contains("[task][Taskname](<testid>%s</testid>,<testid>%s</testid>".formatted(test1.getId(), test2.getId()))
+        assertThat(problemStatement).contains("[task][Taskname](<testid>%s</testid>,<testid>%s</testid>)".formatted(test1.getId(), test2.getId()))
                 .contains("This description contains the words test and taskTest, which should not be replaced.");
+    }
+
+    @Test
+    void testNameReplacementTaskNameSameAsTestName() {
+        var sort = programmingExerciseUtilService.addTestCaseToProgrammingExercise(programmingExercise, "sort");
+
+        updateProblemStatement("""
+                [task][sort](sort)
+                Sort using the method sort.
+                @startuml
+                class LinkedList<T> {
+                    <color:testsColor(sort)>+ sort()</color>
+                }
+                @enduml""");
+
+        programmingExerciseTaskService.replaceTestNamesWithIds(programmingExercise);
+        String problemStatement = programmingExercise.getProblemStatement();
+
+        assertThat(problemStatement).contains("[task][sort](<testid>%s</testid>)".formatted(sort.getId())).contains("Sort using the method sort.")
+                .contains("<color:testsColor(<testid>%s</testid>)>+ sort</color>".formatted(sort.getId()));
     }
 
     @Test


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Fixes #7698

### Description
We use the full task match (the whole string `[task][name](tests)`) to apply the testid-replacement, which could lead to also replacing the task name if it is the same as the test name. This is fixed by now re-construction the tasks using the previously grouped task name.

### Steps for Testing
Try to replicate the bug descibed in the issue.

1. Create a task with the same name as a test, e.g. `[task][sort](sort)`. 
2. Check that the task name gets preserved when saving the problem statement
3. Check that the task is correctly visible to students.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
new test added, no coverage changed (was already covered)
