### PR TITLE
`Development`: Add Aeolus build plan templates for Ocaml for local continuous integration

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
@@ -355,7 +355,7 @@ public class LocalCIBuildJobExecutionService {
             case PYTHON -> {
                 return getPythonTestResultPaths();
             }
-            case ASSEMBLER, C, VHDL, HASKELL -> {
+            case ASSEMBLER, C, VHDL, HASKELL, OCAML -> {
                 return getCustomTestResultPaths(programmingExercise);
             }
             default -> throw new IllegalArgumentException("Programming language " + programmingExercise.getProgrammingLanguage() + " is not supported");

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIProgrammingLanguageFeatureService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIProgrammingLanguageFeatureService.java
@@ -29,8 +29,6 @@ public class LocalCIProgrammingLanguageFeatureService extends ProgrammingLanguag
         programmingLanguageFeatures.put(KOTLIN, new ProgrammingLanguageFeature(KOTLIN, true, false, true, true, false, List.of(), false, true, true));
         programmingLanguageFeatures.put(VHDL, new ProgrammingLanguageFeature(VHDL, false, false, false, false, false, List.of(), false, true, true));
         programmingLanguageFeatures.put(HASKELL, new ProgrammingLanguageFeature(HASKELL, true, false, false, false, true, List.of(), false, true, true));
-        // TODO LOCALVC_CI: Local CI is not supporting Haskell at the moment.
-        // TODO LOCALVC_CI: Local CI is not supporting Swift at the moment.
-        // TODO LOCALVC_CI: Local CI is not supporting OCAML at the moment.
+        programmingLanguageFeatures.put(OCAML, new ProgrammingLanguageFeature(OCAML, false, false, false, false, true, List.of(), false, true, true));
     }
 }

--- a/src/main/resources/templates/aeolus/ocaml/default.yaml
+++ b/src/main/resources/templates/aeolus/ocaml/default.yaml
@@ -1,0 +1,17 @@
+api: v0.0.1
+actions:
+  - name: build_and_test_the_code
+    script: |
+      # the build process is specified in `run.sh` in the test repository
+      chmod +x run.sh
+      ./run.sh -s
+    workdir: tests
+    runAlways: false
+  - name: junit
+    script: '#empty script action, just for the results'
+    runAlways: true
+    results:
+      - name: junit
+        path: test-reports/results.xml
+        type: junit
+        before: true

--- a/src/test/java/de/tum/in/www1/artemis/connectors/AeolusTemplateResourceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/connectors/AeolusTemplateResourceTest.java
@@ -53,6 +53,7 @@ class AeolusTemplateResourceTest extends AbstractSpringIntegrationLocalCILocalVC
         templatesWithExpectedScriptActions.put("VHDL", 4);
         templatesWithExpectedScriptActions.put("HASKELL", 2);
         templatesWithExpectedScriptActions.put("HASKELL?sequentialRuns=true", 3);
+        templatesWithExpectedScriptActions.put("OCAML", 2);
         for (Map.Entry<String, Integer> entry : templatesWithExpectedScriptActions.entrySet()) {
             String template = request.get("/api/aeolus/templates/" + entry.getKey(), HttpStatus.OK, String.class);
             assertThat(template).isNotEmpty();


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR adds the templates for build plans for the language C. 

### Description
<!-- Describe your changes in detail -->
I added the templates and added the `ProgrammingLanguageFeature` for LocalCI so one can now create custom build plans (starting with the help of the template) for Ocaml in LocalCI and Bamboo.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students
- Programming Exercise Setup with either LocalCI or Bamboo

1. Log in to Artemis
2. Create a new Ocaml exercise and enable custom build plans
3. Confirm that the build plan behaves the same as it does in Bamboo. meaning that base fails and solution hopefully passes

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Create an exam
3. Create a new Ocaml exercise and enable custom build plans
4. Confirm that the build plan behaves the same as it does in Bamboo. meaning that base fails and solution hopefully passes

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)
