### PR TITLE
`General`: Align exercise statistics correctly

### DIFF
--- a/src/main/webapp/app/exercises/shared/statistics/doughnut-chart.component.html
+++ b/src/main/webapp/app/exercises/shared/statistics/doughnut-chart.component.html
@@ -1,4 +1,4 @@
-<div class="mx-2">
+<div class="mx-2 d-flex flex-column justify-content-between h-100">
     <a *ngIf="titleLink" [routerLink]="titleLink">
         <h4 class="text-center">{{ 'exercise-statistics.' + doughnutChartTitle | artemisTranslate }}</h4>
     </a>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
closes #7714 

### Description
align the pie chart to the bottom of the container so that headlines and pie charts always start on the same height.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 exercise with statistics shown

1. Log in to Artemis
2. Navigate to Exercise Detail Page
3. Change Language to German
4. Verify that the statistics are correctly aligned

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Test Coverage
|File | Coverage | Assertion |
|---|---|---|
|[doughnut-chart.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5826-1/artifact/shared/Coverage-Report-Client-Tests/app/exercises/shared/statistics/doughnut-chart.component.ts.html)| 90%| ✅|

### Screenshots
Before:
![image](https://github.com/ls1intum/Artemis/assets/78978542/96eab827-a52b-489a-978e-11f17514e262)

After:
![image](https://github.com/ls1intum/Artemis/assets/78978542/f6c49eea-74a7-4f70-a9bb-6f69a40f32ec)
