### PR TITLE
`Programming exercises`: Use default programming language in course as fallback in exam exercises

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -404,7 +404,6 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
                     if (this.isImportFromFile) {
                         this.createProgrammingExerciseForImportFromFile();
                     }
-                    console.log(this.selectedProgrammingLanguage);
                     if (this.isImportFromExistingExercise) {
                         this.createProgrammingExerciseForImport(params);
                     } else {

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -404,6 +404,7 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
                     if (this.isImportFromFile) {
                         this.createProgrammingExerciseForImportFromFile();
                     }
+                    console.log(this.selectedProgrammingLanguage);
                     if (this.isImportFromExistingExercise) {
                         this.createProgrammingExerciseForImport(params);
                     } else {
@@ -411,6 +412,9 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
                             this.isExamMode = true;
                             this.exerciseGroupService.find(params['courseId'], params['examId'], params['exerciseGroupId']).subscribe((res) => {
                                 this.programmingExercise.exerciseGroup = res.body!;
+                                if (this.programmingExercise.exerciseGroup.exam?.course?.defaultProgrammingLanguage && !this.isImportFromFile) {
+                                    this.selectedProgrammingLanguage = this.programmingExercise.exerciseGroup.exam.course.defaultProgrammingLanguage;
+                                }
                             });
                             // we need the course id  to make the request to the server if it's an import from file
                             if (this.isImportFromFile) {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -239,7 +239,7 @@ describe('ProgrammingExerciseUpdateComponent', () => {
             comp.save();
 
             // THEN
-            expect(comp.isSaving).toBeFalsy();
+            expect(comp.isSaving).toBeFalse();
             expect(alertSpy).toHaveBeenCalledWith({ type: AlertType.DANGER, message: 'error-message', disableTranslation: true });
         });
     });
@@ -474,8 +474,8 @@ describe('ProgrammingExerciseUpdateComponent', () => {
             tick();
             expect(comp.programmingExercise.exerciseGroup).toBe(exerciseGroup);
             expect(comp.programmingExercise.course).toBeUndefined();
-            expect(comp.isImportFromExistingExercise).toBeTruthy();
-            expect(comp.isExamMode).toBeTruthy();
+            expect(comp.isImportFromExistingExercise).toBeTrue();
+            expect(comp.isExamMode).toBeTrue();
         }));
 
         it('should reset dates, id and project key', fakeAsync(() => {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -1,8 +1,8 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
-import { HttpResponse } from '@angular/common/http';
+import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { ActivatedRoute, UrlSegment } from '@angular/router';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import dayjs from 'dayjs/esm';
 import { MockNgbModalService } from '../../helpers/mocks/service/mock-ngb-modal.service';
 import { ArtemisTestModule } from '../../test.module';
@@ -65,6 +65,7 @@ import { ExerciseUpdateNotificationComponent } from 'app/exercises/shared/exerci
 import { ExerciseUpdatePlagiarismComponent } from 'app/exercises/shared/plagiarism/exercise-update-plagiarism/exercise-update-plagiarism.component';
 import * as Utils from 'app/exercises/shared/course-exercises/course-utils';
 import { AuxiliaryRepository } from 'app/entities/programming-exercise-auxiliary-repository-model';
+import { AlertService, AlertType } from 'app/core/util/alert.service';
 
 describe('ProgrammingExerciseUpdateComponent', () => {
     const courseId = 1;
@@ -77,6 +78,7 @@ describe('ProgrammingExerciseUpdateComponent', () => {
     let courseService: CourseManagementService;
     let exerciseGroupService: ExerciseGroupService;
     let programmingExerciseFeatureService: ProgrammingLanguageFeatureService;
+    let alertService: AlertService;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -129,6 +131,7 @@ describe('ProgrammingExerciseUpdateComponent', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: ActivatedRoute, useValue: new MockActivatedRoute({}) },
                 { provide: NgbModal, useClass: MockNgbModalService },
+                { provide: AlertService, useValue: { addAlert: () => {} } },
             ],
         })
             .compileComponents()
@@ -140,6 +143,7 @@ describe('ProgrammingExerciseUpdateComponent', () => {
                 courseService = debugElement.injector.get(CourseManagementService);
                 exerciseGroupService = debugElement.injector.get(ExerciseGroupService);
                 programmingExerciseFeatureService = debugElement.injector.get(ProgrammingLanguageFeatureService);
+                alertService = debugElement.injector.get(AlertService);
             });
     });
 
@@ -215,6 +219,29 @@ describe('ProgrammingExerciseUpdateComponent', () => {
             expect(programmingExerciseService.automaticSetup).toHaveBeenCalledWith(entity);
             expect(entity.title).toBe('My Exercise');
         }));
+
+        it('should fail on error', async () => {
+            // GIVEN
+            const entity = new ProgrammingExercise(undefined, undefined);
+            entity.id = 1;
+            jest.spyOn(programmingExerciseService, 'update').mockReturnValue(
+                throwError(
+                    new HttpResponse({
+                        headers: new HttpHeaders({ 'X-artemisApp-alert': 'error-message' }),
+                    }),
+                ),
+            );
+            const alertSpy = jest.spyOn(alertService, 'addAlert');
+            comp.programmingExercise = entity;
+            comp.backupExercise = {} as ProgrammingExercise;
+            comp.programmingExercise.course = course;
+            // WHEN
+            comp.save();
+
+            // THEN
+            expect(comp.isSaving).toBeFalsy();
+            expect(alertSpy).toHaveBeenCalledWith({ type: AlertType.DANGER, message: 'error-message', disableTranslation: true });
+        });
     });
 
     describe('exam mode', () => {
@@ -430,6 +457,26 @@ describe('ProgrammingExerciseUpdateComponent', () => {
             route.params = of({ courseId });
             route.url = of([{ path: 'import' } as UrlSegment]);
         });
+
+        it('should correctly import into an exam exercise', fakeAsync(() => {
+            const examId = 1;
+            const exerciseGroupId = 1;
+            const exerciseGroup = new ExerciseGroup();
+            exerciseGroup.id = exerciseGroupId;
+            exerciseGroup.exam = { id: examId, course };
+            const programmingExercise = new ProgrammingExercise(undefined, exerciseGroup);
+            jest.spyOn(exerciseGroupService, 'find').mockReturnValue(of(new HttpResponse({ body: exerciseGroup })));
+            route = TestBed.inject(ActivatedRoute);
+            route.params = of({ courseId, examId, exerciseGroupId });
+            route.data = of({ programmingExercise });
+
+            comp.ngOnInit();
+            tick();
+            expect(comp.programmingExercise.exerciseGroup).toBe(exerciseGroup);
+            expect(comp.programmingExercise.course).toBeUndefined();
+            expect(comp.isImportFromExistingExercise).toBeTruthy();
+            expect(comp.isExamMode).toBeTruthy();
+        }));
 
         it('should reset dates, id and project key', fakeAsync(() => {
             const programmingExercise = getProgrammingExerciseForImport();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
On Creation of a Course Programming Exercise, the course default programming language is used as default in the exercise.
But in an exam exercise the course programming exercise is not used as initial value.

### Description
This PR changes that :)

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 1 Exam Exercise Group in a Course with default Programming Language != JAVA

1. Log in to Artemis
2. Create New Programming Exercise in this Exercise Group
3. Verify that the course default programming language is set as initial value

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Exam Mode Test
- [x] Test 1
- [x] Test 2

### Test Coverage
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [programming-exercise-update.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5833/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/programming/manage/update/programming-exercise-update.component.ts.html) | 88.19% | ✅ |



### Screenshots
![image](https://github.com/ls1intum/Artemis/assets/78978542/e4b85c07-30dc-45c9-a931-77b749711a9e)

