### PR TITLE
`General`: Fix broken color picker

### DIFF
--- a/src/main/webapp/app/shared/category-selector/category-selector.component.ts
+++ b/src/main/webapp/app/shared/category-selector/category-selector.component.ts
@@ -81,13 +81,6 @@ export class CategorySelectorComponent implements OnChanges {
      * @param {ExerciseCategory} tagItem
      */
     openColorSelector(event: MouseEvent, tagItem: ExerciseCategory) {
-        /**
-         * without {@link event#stopPropagation} the color picker would close immediately as the mouseEvent
-         * is triggered again for the child component {@link ColorSelectorComponent} which would interpret
-         * it as a click outside the colorpicker
-         */
-        event.stopPropagation();
-
         this.selectedCategory = tagItem;
         this.colorSelector.openColorSelector(event, undefined, this.colorSelectorHeight);
     }

--- a/src/main/webapp/app/shared/color-selector/color-selector.component.ts
+++ b/src/main/webapp/app/shared/color-selector/color-selector.component.ts
@@ -71,6 +71,13 @@ export class ColorSelectorComponent implements OnInit {
      * @param {number} height
      */
     openColorSelector(event: MouseEvent, marginTop?: number, height?: number) {
+        /**
+         * without {@link event#stopPropagation} the color picker would close immediately as the mouseEvent
+         * is triggered again for the child component {@link ColorSelectorComponent} which would interpret
+         * it as a click outside the colorpicker
+         */
+        event.stopPropagation();
+
         const parentElement = (event.target as Element).closest('.ng-trigger') as HTMLElement;
 
         this.colorSelectorPosition.left = parentElement ? parentElement.offsetLeft : 0;

--- a/src/test/javascript/spec/component/shared/category-selector.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/category-selector.component.spec.ts
@@ -92,14 +92,12 @@ describe('CategorySelectorComponent', () => {
             clientX: 1,
             clientY: 2,
         });
-        const stopPropagationSpy = jest.spyOn(mouseEvent, 'stopPropagation');
 
         const openColorSelectorSpy = jest.spyOn(comp.colorSelector, 'openColorSelector');
         comp.openColorSelector(mouseEvent, category5);
 
         expect(comp.selectedCategory).toEqual(category5);
         expect(openColorSelectorSpy).toHaveBeenCalledWith(mouseEvent, undefined, 150);
-        expect(stopPropagationSpy).toHaveBeenCalledOnce(); // otherwise the colorpicker will close immediately
     });
 
     it('should select color for category', () => {

--- a/src/test/javascript/spec/component/shared/color-selector.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/color-selector.component.spec.ts
@@ -47,6 +47,7 @@ describe('ColorSelectorComponent', () => {
         const target = document.createElement('div');
         const event = {
             target,
+            stopPropagation: jest.fn(),
         } as unknown as MouseEvent;
         component.ngOnInit();
 

--- a/src/test/javascript/spec/component/shared/color-selector.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/color-selector.component.spec.ts
@@ -34,6 +34,15 @@ describe('ColorSelectorComponent', () => {
         expect(addEventListenerSpy).toHaveBeenCalledOnce();
     });
 
+    it('should stop event propagation on openSelector', () => {
+        const event = { stopPropagation: jest.fn(), target: { closest: jest.fn() } };
+        const eventStopPropagationSpy = jest.spyOn(event, 'stopPropagation');
+        component.colorSelectorPosition = { left: 0, top: 0 };
+        component.openColorSelector(event as unknown as MouseEvent, 0, 0);
+
+        expect(eventStopPropagationSpy).toHaveBeenCalledOnce();
+    });
+
     it('should position the color selector after opening correctly', () => {
         const target = document.createElement('div');
         const event = {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
The color picker in the course update view did not open onClick.

### Description
This PR solves this by stopping the eventPropagation within the color picker, so that the functionality doesn't rely on who the parent component opens the picker.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course

1. Log in to Artemis
2. Navigate to Course Administration
3. Click on Edit
4. Click on the Color Picker and Verify that it opens
5. Save Course and verify that the color has been saved.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [category-selector.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5836/latest/artifact/shared/Coverage-Report-Client-Tests/app/shared/category-selector/category-selector.component.ts.html) | 97.14% | ✅ |
| [color-selector.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS5836/latest/artifact/shared/Coverage-Report-Client-Tests/app/shared/color-selector/color-selector.component.ts.html) | 100% | ✅ |



### Screenshots
![image](https://github.com/ls1intum/Artemis/assets/78978542/8be194af-d9f0-4139-b84e-7463e0d04c2c)
