### PR TITLE
`General`: Fix translation shown after successful password reset

### DIFF
--- a/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html
+++ b/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html
@@ -15,8 +15,8 @@
         </div>
 
         <div class="alert alert-success" *ngIf="success">
-            <span jhiTranslate="reset.finish.messages.success"><strong>Your password has been reset.</strong> Please </span>
-            <a class="alert-link" [routerLink]="['/']" jhiTranslate="global.messages.info.authenticated.link">sign in</a>.
+            <span jhiTranslate="reset.finish.messages.success">Your password has been reset.</span>
+            <a class="alert-link" [routerLink]="['/']" jhiTranslate="reset.finish.messages.success-part2">Please sign in.</a>
         </div>
 
         <div class="alert alert-danger" *ngIf="doNotMatch" jhiTranslate="global.messages.error.dontmatch">The password and its confirmation do not match!</div>

--- a/src/main/webapp/i18n/de/reset.json
+++ b/src/main/webapp/i18n/de/reset.json
@@ -27,7 +27,8 @@
             },
             "messages": {
                 "info": "Wähle ein neues Passwort",
-                "success": "<strong>Dein Passwort wurde zurückgesetzt.</strong> Bitte ",
+                "success": "Dein Passwort wurde zurückgesetzt.",
+                "success-part2": "Bitte melde dich an.",
                 "keymissing": "Der Reset-Schlüssel fehlt.",
                 "error": "Dein Passwort konnte nicht zurückgesetzt werden. Zur Erinnerung, deine Anfrage ist nur 24 Stunden gültig."
             }

--- a/src/main/webapp/i18n/en/reset.json
+++ b/src/main/webapp/i18n/en/reset.json
@@ -27,7 +27,8 @@
             },
             "messages": {
                 "info": "Choose a new password",
-                "success": "<strong>Your password has been reset.</strong> Please ",
+                "success": "Your password has been reset.",
+                "success-part2": "Please sign in.",
                 "keymissing": "The reset key is missing.",
                 "error": "Your password couldn't be reset. As a reminder, password reset requests are only valid for 24 hours."
             }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
The page previously showed in German: ‘Dein Password wurde zurückgesetzt. Bitte melde.’

### Description
Fixes the translation to show a complete sentence.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- Local test setup, password reset on test servers probably not working due to LDAP integration and/or should not be done since shared test accounts.

1. Use the password forgotten dialogue when logged out of Artemis.
2. In the console for the server you can find the password reset link since the local dev server does not send emails.
3. Navigate to that page and change your password.
4. See the success page as shown in the screenshots below.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
n/a

### Screenshots
![Screenshot 2023-12-09 at 15-47-22 Password](https://github.com/ls1intum/Artemis/assets/64250573/ab9b68ad-1ca1-4e02-a7f9-ea5f32930e64)
![Screenshot 2023-12-09 at 15-46-54 Passwort](https://github.com/ls1intum/Artemis/assets/64250573/809144fc-699e-4a7c-a1cc-b0d95d430887)
