### PR TITLE
`Development`: Fix race condition on the participation page

### DIFF
--- a/src/main/webapp/app/exercises/programming/participate/programming-submission.service.ts
+++ b/src/main/webapp/app/exercises/programming/participate/programming-submission.service.ts
@@ -397,6 +397,13 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
         if (!forceCacheOverride && subject) {
             return subject.asObservable().pipe(filter((stateObj) => stateObj !== undefined)) as Observable<ProgrammingSubmissionStateObj>;
         }
+        const exercisePreloadingSubject = this.exerciseBuildStateSubjects.get(exerciseId);
+        if (exercisePreloadingSubject) {
+            return exercisePreloadingSubject.asObservable().pipe(
+                filter((val: ExerciseSubmissionState | undefined) => val !== undefined),
+                map((val: ExerciseSubmissionState) => val[participationId]),
+            ) as Observable<ProgrammingSubmissionStateObj>;
+        }
         // The setup process is difficult, because it should not happen that multiple subscribers trigger the setup process at the same time.
         // There the subject is returned before the REST call is made, but will emit its result as soon as it returns.
         this.submissionSubjects[participationId] = new BehaviorSubject<ProgrammingSubmissionStateObj | undefined>(undefined);

--- a/src/main/webapp/app/exercises/programming/participate/programming-submission.service.ts
+++ b/src/main/webapp/app/exercises/programming/participate/programming-submission.service.ts
@@ -125,11 +125,11 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      *
      * @param participationId
      */
-    private fetchLatestPendingSubmissionByParticipationId = (participationId: number): Observable<ProgrammingSubmission | undefined> => {
+    private fetchLatestPendingSubmissionByParticipationId(participationId: number): Observable<ProgrammingSubmission | undefined> {
         return this.http
             .get<ProgrammingSubmission>('api/programming-exercise-participations/' + participationId + '/latest-pending-submission')
             .pipe(catchError(() => of(undefined)));
-    };
+    }
 
     /**
      * Fetch the latest pending submission for all participations of a given exercise.
@@ -140,11 +140,11 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      *
      * @param exerciseId of programming exercise.
      */
-    private fetchLatestPendingSubmissionsByExerciseId = (exerciseId: number): Observable<{ [participationId: number]: ProgrammingSubmission }> => {
+    private fetchLatestPendingSubmissionsByExerciseId(exerciseId: number): Observable<{ [participationId: number]: ProgrammingSubmission }> {
         return this.http
             .get<{ [participationId: number]: ProgrammingSubmission }>(`api/programming-exercises/${exerciseId}/latest-pending-submissions`)
             .pipe(catchError(() => of([])));
-    };
+    }
 
     /**
      * Start a timer after which the timer subject will notify the corresponding subject.
@@ -153,7 +153,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      * @param participationId
      * @param time
      */
-    private startResultWaitingTimer = (participationId: number, time = this.currentExpectedResultETA) => {
+    private startResultWaitingTimer(participationId: number, time = this.currentExpectedResultETA) {
         this.resetResultWaitingTimer(participationId);
         this.resultTimerSubscriptions[participationId] = timer(time)
             .pipe(
@@ -165,13 +165,13 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
                 }),
             )
             .subscribe();
-    };
+    }
 
-    private resetResultWaitingTimer = (participationId: number) => {
+    private resetResultWaitingTimer(participationId: number) {
         if (this.resultTimerSubscriptions[participationId]) {
             this.resultTimerSubscriptions[participationId].unsubscribe();
         }
-    };
+    }
 
     /**
      * Set up a submission subscription for the latest pending submission if not yet existing.
@@ -180,7 +180,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      * @param exerciseId that is connected to the participation.
      * @param personal whether the current user is a participant in the participation.
      */
-    private setupWebsocketSubscriptionForLatestPendingSubmission = (participationId: number, exerciseId: number, personal: boolean): void => {
+    private setupWebsocketSubscriptionForLatestPendingSubmission(participationId: number, exerciseId: number, personal: boolean): void {
         if (!this.submissionTopicsSubscribed.get(participationId)) {
             let newSubmissionTopic: string;
             if (personal) {
@@ -215,7 +215,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
             }
             this.submissionTopicsSubscribed.set(participationId, newSubmissionTopic);
         }
-    };
+    }
 
     /**
      * Waits for a new result to come in while a pending submission exists.
@@ -225,7 +225,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      * @param exerciseId that is connected to the participation.
      * @param personal whether the current user is a participant in the participation.
      */
-    private subscribeForNewResult = (participationId: number, exerciseId: number, personal: boolean) => {
+    private subscribeForNewResult(participationId: number, exerciseId: number, personal: boolean) {
         if (this.resultSubscriptions[participationId]) {
             return;
         }
@@ -268,27 +268,27 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
                 }),
             )
             .subscribe();
-    };
+    }
 
-    private isResultOfLatestSubmission = (result: Result | undefined, exerciseId: number, participationId: number): boolean => {
+    private isResultOfLatestSubmission(result: Result | undefined, exerciseId: number, participationId: number): boolean {
         if (!result || !result.submission) {
             return false;
         }
         const { submission } = this.exerciseBuildState[exerciseId][participationId];
         return !!submission && result.submission.id === submission.id;
-    };
+    }
 
-    private emitNoPendingSubmission = (participationId: number, exerciseId: number) => {
+    private emitNoPendingSubmission(participationId: number, exerciseId: number) {
         const newSubmissionState = { participationId, submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined };
         this.notifySubscribers(participationId, exerciseId, newSubmissionState);
-    };
+    }
 
-    private emitBuildingSubmission = (participationId: number, exerciseId: number, submission: ProgrammingSubmission) => {
+    private emitBuildingSubmission(participationId: number, exerciseId: number, submission: ProgrammingSubmission) {
         const newSubmissionState = { participationId, submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission };
         this.notifySubscribers(participationId, exerciseId, newSubmissionState);
-    };
+    }
 
-    private emitFailedSubmission = (participationId: number, exerciseId: number) => {
+    private emitFailedSubmission(participationId: number, exerciseId: number) {
         const submissionStateObj = this.exerciseBuildState[exerciseId] && this.exerciseBuildState[exerciseId][participationId];
         const newSubmissionState = {
             participationId,
@@ -296,7 +296,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
             submission: submissionStateObj ? submissionStateObj.submission : undefined,
         };
         this.notifySubscribers(participationId, exerciseId, newSubmissionState);
-    };
+    }
 
     /**
      * Notifies both the exercise and participation specific subscribers about a new SubmissionState.
@@ -305,7 +305,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      * @param exerciseId id of ProgrammingExercise
      * @param newSubmissionState to inform subscribers about.
      */
-    private notifySubscribers = (participationId: number, exerciseId: number, newSubmissionState: ProgrammingSubmissionStateObj) => {
+    private notifySubscribers(participationId: number, exerciseId: number, newSubmissionState: ProgrammingSubmissionStateObj) {
         // Inform participation subscribers.
         const submissionSubject = this.submissionSubjects[participationId];
         if (submissionSubject) {
@@ -317,7 +317,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
         if (exerciseBuildStateSubject) {
             exerciseBuildStateSubject.next(this.exerciseBuildState[exerciseId]);
         }
-    };
+    }
 
     /**
      * Check how much time is still left for the build.
@@ -325,9 +325,9 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      * @param submission for which to check the passed build time.
      * @return the expected rest time to wait for the build.
      */
-    private getExpectedRemainingTimeForBuild = (submission: ProgrammingSubmission): number => {
+    private getExpectedRemainingTimeForBuild(submission: ProgrammingSubmission): number {
         return this.currentExpectedResultETA - (Date.now() - Date.parse(submission.submissionDate as any));
-    };
+    }
 
     /**
      * Initialize the cache from outside the service.
@@ -392,7 +392,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      * @param forceCacheOverride whether the cache should definitely be overridden, default is false
      * @param fetchPending whether the latest pending submission should be fetched from the server
      */
-    public getLatestPendingSubmissionByParticipationId = (participationId: number, exerciseId: number, personal: boolean, forceCacheOverride = false, fetchPending = true) => {
+    public getLatestPendingSubmissionByParticipationId(participationId: number, exerciseId: number, personal: boolean, forceCacheOverride = false, fetchPending = true) {
         const subject = this.submissionSubjects[participationId];
         if (!forceCacheOverride && subject) {
             return subject.asObservable().pipe(filter((stateObj) => stateObj !== undefined)) as Observable<ProgrammingSubmissionStateObj>;
@@ -415,7 +415,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
             );
         }
         return this.loadLatestPendingSubmissionByParticipationId(participationId, exerciseId, personal, fetchPending);
-    };
+    }
 
     private loadLatestPendingSubmissionByParticipationId(participationId: number, exerciseId: number, personal: boolean, fetchPending: boolean) {
         // The setup process is difficult, because it should not happen that multiple subscribers trigger the setup process at the same time.
@@ -445,7 +445,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      *
      * @param exerciseId id of programming exercise for which to retrieve all pending submissions.
      */
-    public getSubmissionStateOfExercise = (exerciseId: number): Observable<ExerciseSubmissionState> => {
+    public getSubmissionStateOfExercise(exerciseId: number): Observable<ExerciseSubmissionState> {
         // We need to check if the submissions for the given exercise are already being fetched, otherwise the call would be done multiple times.
         const preloadingSubject = this.exerciseBuildStateSubjects.get(exerciseId);
         if (preloadingSubject) {
@@ -479,11 +479,11 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
             .get(exerciseId)!
             .asObservable()
             .pipe(filter((val) => val !== undefined)) as Observable<ExerciseSubmissionState>;
-    };
+    }
 
-    getResultEtaInMs = () => {
+    getResultEtaInMs() {
         return this.resultEtaSubject.asObservable().pipe(distinctUntilChanged());
-    };
+    }
 
     public triggerBuild(participationId: number, submissionType = SubmissionType.MANUAL) {
         return this.http.post(this.SUBMISSION_RESOURCE_URL + participationId + `/trigger-build?submissionType=${submissionType}`, {});
@@ -526,12 +526,12 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      * @param exerciseId of the given participationId.
      * @param personal whether the current user is a participant in the participation.
      */
-    private processPendingSubmission = (
+    private processPendingSubmission(
         submissionToBeProcessed: ProgrammingSubmission | undefined,
         participationId: number,
         exerciseId: number,
         personal: boolean,
-    ): Observable<ProgrammingSubmissionStateObj> => {
+    ): Observable<ProgrammingSubmissionStateObj> {
         return of(submissionToBeProcessed).pipe(
             // When a new submission comes in, make sure that a subscription is set up for new incoming submissions.
             // The new submission would then override the current latest pending submission.
@@ -561,19 +561,19 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
                 this.subscribeForNewResult(participationId, exerciseId, personal);
             }),
         );
-    };
+    }
 
-    private mapParticipationIdToNumber = (submissions: Array<[string, ProgrammingSubmission | undefined]>) => {
+    private mapParticipationIdToNumber(submissions: Array<[string, ProgrammingSubmission | undefined]>) {
         return submissions.map(([participationId, submission]) => [parseInt(participationId, 10), submission]);
-    };
+    }
 
-    private mapToExerciseBuildState = (acc: ExerciseSubmissionState, val: ProgrammingSubmissionStateObj) => {
+    private mapToExerciseBuildState(acc: ExerciseSubmissionState, val: ProgrammingSubmissionStateObj) {
         if (!Object.keys(val).length) {
             return {};
         }
         const { participationId, submission, submissionState } = val;
         return { ...acc, [participationId]: { participationId, submissionState, submission } };
-    };
+    }
 
     /**
      * Returns programming submissions for exercise from the server

--- a/src/main/webapp/app/exercises/programming/participate/programming-submission.service.ts
+++ b/src/main/webapp/app/exercises/programming/participate/programming-submission.service.ts
@@ -397,11 +397,13 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
         if (!forceCacheOverride && subject) {
             return subject.asObservable().pipe(filter((stateObj) => stateObj !== undefined)) as Observable<ProgrammingSubmissionStateObj>;
         }
+        // If all submission states for the exercise are currently loaded, don't send a new rest request.
+        // Instead, wait for the exercise request to finish and return this result
         const exercisePreloadingSubject = this.exerciseBuildStateSubjects.get(exerciseId);
         if (exercisePreloadingSubject) {
             return exercisePreloadingSubject.asObservable().pipe(
-                filter((val: ExerciseSubmissionState | undefined) => val !== undefined),
-                map((val: ExerciseSubmissionState) => val[participationId]),
+                map((val) => val && val[participationId]),
+                filter((val) => val !== undefined),
             ) as Observable<ProgrammingSubmissionStateObj>;
         }
         // The setup process is difficult, because it should not happen that multiple subscribers trigger the setup process at the same time.

--- a/src/main/webapp/app/exercises/shared/participation/participation.component.ts
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.ts
@@ -104,7 +104,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
      * Initialize component by calling loadAll and registerChangeInParticipation
      */
     ngOnInit() {
-        this.paramSub = this.route.params.subscribe((params) => this.loadExercise(params['exerciseId']));
+        this.paramSub = this.route.params.subscribe((params) => this.loadExercise(+params['exerciseId']));
         this.registerChangeInParticipations();
         this.isAdmin = this.accountService.isAdmin();
     }

--- a/src/test/javascript/spec/component/participation/participation.component.spec.ts
+++ b/src/test/javascript/spec/component/participation/participation.component.spec.ts
@@ -47,7 +47,7 @@ describe('ParticipationComponent', () => {
 
     const exercise: Exercise = { numberOfAssessmentsOfCorrectionRounds: [], studentAssignedTeamIdComputed: false, id: 1, secondCorrectionEnabled: true };
 
-    const route = { params: of({ exerciseId: 1 } as Params) } as ActivatedRoute;
+    const route = { params: of({ exerciseId: '1' } as Params) } as ActivatedRoute;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -89,6 +89,16 @@ describe('ParticipationComponent', () => {
 
     afterEach(() => {
         jest.restoreAllMocks();
+    });
+
+    it('should initialize with exerciseId from route', () => {
+        // @ts-ignore
+        component.exercise = undefined;
+        const exerciseFindStub = jest.spyOn(exerciseService, 'find').mockReturnValue(of(new HttpResponse({ body: exercise })));
+        component.ngOnInit();
+
+        expect(exerciseFindStub).toHaveBeenCalledExactlyOnceWith(exercise.id);
+        expect(component.exercise).toEqual(exercise);
     });
 
     it('should initialize for non programming exercise', fakeAsync(() => {


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
@krusche noticed a lot of REST-requests when opening the participation page. This PR removes these unnecessary requests.

### Description
The requests were caused by a race condition in the build trigger button. This component checks if the current build status got already retrived, and sends a REST request if this is not the case. Opening the participations page loads the submission state of all participations, but due to a race condition, the button might still find no available status.

We now check if the state of all submissions for the exercise currently gets loaded, and wait for this request if that is the case.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Programming Exercise 

1. Open the participations page (course management -> exercises -> participations)
2. Check that only one request to `latest-pending-submissions` (all submissions) is present, no requests to `latest-pending-submission`.
3. Interact with the page (e.g. open the submission for one participation and go back again) and check that still no request for a single participation is there (this step is needed since the issue is a race condition and might not happen every time)
4. Submit a solution as a student. Reload the participation page. Check that the spinner next to the participation is visible (showing that the participation is currently building)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
