### PR TITLE
`Exercices`: Set the maximum length of characters in the categories section at 25

### DIFF
--- a/src/main/webapp/app/shared/category-selector/category-selector.component.html
+++ b/src/main/webapp/app/shared/category-selector/category-selector.component.html
@@ -21,6 +21,7 @@
             [matChipInputFor]="chipList"
             [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
             (matChipInputTokenEnd)="onItemAdd($event)"
+            maxlength="25"
         />
     </mat-chip-grid>
     <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onItemSelect($event)">


### PR DESCRIPTION
#### General
- [x] This is a small issue that I tested locally.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The category field (by creating a new exercise) doesn't support very long names. The tipped name goes over the text field layout (see screenshot below).
### Description
Made the maximum length of characters equals 25. 
### Steps for Testing
Prerequisites:
- 1 Instructor
- Try to create an exercise and define a category with more than 25 characters. 

![image](https://github.com/ls1intum/Artemis/assets/74144843/2cbf4ffe-a3aa-4a2c-a103-27bab5e1b399)

