### PR TITLE
`Development`: Simplify tutorial group channel name generation

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/ChannelRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/ChannelRepository.java
@@ -17,7 +17,7 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
     @Query("""
              SELECT DISTINCT channel
              FROM Channel channel
-             WHERE channel.course.id = :#{#courseId}
+             WHERE channel.course.id = :courseId
              ORDER BY channel.name
             """)
     List<Channel> findChannelsByCourseId(@Param("courseId") Long courseId);
@@ -65,18 +65,20 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
     @Query("""
              SELECT DISTINCT channel
              FROM Channel channel
-             WHERE channel.course.id = :#{#courseId}
-             AND channel.name = :#{#name}
+             WHERE channel.course.id = :courseId
+                 AND channel.name = :name
              ORDER BY channel.name
             """)
     Set<Channel> findChannelByCourseIdAndName(@Param("courseId") Long courseId, @Param("name") String name);
 
+    boolean existsChannelByNameAndCourseId(String name, Long courseId);
+
     @Query("""
              SELECT DISTINCT channel
              FROM Channel channel
-             WHERE channel.course.id = :#{#courseId}
-             AND channel.name = :#{#name}
-             AND channel.id <> :#{#channelId}
+             WHERE channel.course.id = :courseId
+                 AND channel.name = :name
+                 AND channel.id <> :channelId
              ORDER BY channel.name
             """)
     Set<Channel> findChannelByCourseIdAndNameAndIdNot(@Param("courseId") Long courseId, @Param("name") String name, @Param("channelId") Long channelId);

--- a/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupChannelManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupChannelManagementService.java
@@ -5,7 +5,6 @@ import static javax.persistence.Persistence.getPersistenceUtil;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -247,24 +246,24 @@ public class TutorialGroupChannelManagementService {
      * @throws IllegalStateException if a unique channel name could not be determined
      */
     private String determineUniqueTutorialGroupChannelName(TutorialGroup tutorialGroup) {
-        Function<TutorialGroup, String> determineInitialTutorialGroupChannelName = (TutorialGroup tg) -> {
-            var cleanedTitle = tg.getTitle().replaceAll("\\s", "-").toLowerCase();
-            return "tutorgroup-" + cleanedTitle.substring(0, Math.min(cleanedTitle.length(), 18));
-        };
+        Course course = tutorialGroup.getCourse();
+        String cleanedGroupTitle = tutorialGroup.getTitle().replaceAll("\\s", "-").toLowerCase();
+        String channelName = "tutorgroup-" + cleanedGroupTitle.substring(0, Math.min(cleanedGroupTitle.length(), 18));
 
-        var channelName = determineInitialTutorialGroupChannelName.apply(tutorialGroup);
-        if (channelRepository.findChannelByCourseIdAndName(tutorialGroup.getCourse().getId(), channelName).isEmpty()) {
+        if (!channelRepository.existsChannelByNameAndCourseId(channelName, course.getId())) {
+            // No channel with this name exists in the course yet, so it can be used.
             return channelName;
         }
 
         // try to make it unique by adding a random number to the end of the channel name
         // if already max length remove the last 3 characters to get some space to try to make it unique
-        if (channelName.length() == 30) {
+        if (channelName.length() >= 30) {
             channelName = channelName.substring(0, 27);
         }
-        while (!channelRepository.findChannelByCourseIdAndName(tutorialGroup.getCourse().getId(), channelName).isEmpty() && channelName.length() <= 30) {
+        do {
             channelName += ThreadLocalRandom.current().nextInt(0, 10);
         }
+        while (channelRepository.existsChannelByNameAndCourseId(channelName, course.getId()) && channelName.length() <= 30);
 
         if (channelName.length() > 30) {
             // very unlikely to happen


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
This PR makes the generation of unique tutorial group channel names more readable by applying the following:

- Inlined a lambda function that was called directly afterwards.
- Removed the double negation (`!...isEmpty()`) by a direct exists-database-check.

### Steps for Testing
code review

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2