### PR TITLE
`Development`: Add proxy config env variables for docker in local continuous integration

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
@@ -252,7 +252,7 @@ public class LocalCIBuildJobExecutionService {
         // Create the container from the "ls1tum/artemis-maven-template" image with the local paths to the Git repositories and the shell script bound to it. Also give the
         // container information about the branch and commit hash to be used.
         // This does not start the container yet.
-        CreateContainerResponse container = localCIContainerService.configureContainer(containerName, branch, commitHash, dockerImage);
+        CreateContainerResponse container = localCIContainerService.configureContainer(containerName, dockerImage);
 
         return runScriptAndParseResults(participation, containerName, container.getId(), branch, commitHash, assignmentRepositoryPath, testsRepositoryPath, solutionRepositoryPath,
                 auxiliaryRepositoriesPaths, auxiliaryRepositoryCheckoutDirectories, buildScriptPath, isPushToTestRepository);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
@@ -249,8 +249,7 @@ public class LocalCIBuildJobExecutionService {
             assignmentRepositoryPath = cloneAndCheckoutRepository(participation, commitHash);
         }
 
-        // Create the container from the "ls1tum/artemis-maven-template" image with the local paths to the Git repositories and the shell script bound to it. Also give the
-        // container information about the branch and commit hash to be used.
+        // Create the container from the "ls1tum/artemis-maven-template" image with the local paths to the Git repositories and the shell script bound to it.
         // This does not start the container yet.
         CreateContainerResponse container = localCIContainerService.configureContainer(containerName, dockerImage);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -70,13 +70,13 @@ public class LocalCIContainerService {
     @Value("${artemis.continuous-integration.proxies.use-system-proxy:false}")
     boolean useSystemProxy;
 
-    @Value("${artemis.continuous-integration.proxies.default.http-proxy}")
+    @Value("${artemis.continuous-integration.proxies.default.http-proxy:}")
     String httpProxy;
 
-    @Value("${artemis.continuous-integration.proxies.default.https-proxy}")
+    @Value("${artemis.continuous-integration.proxies.default.https-proxy:}")
     String httpsProxy;
 
-    @Value("${artemis.continuous-integration.proxies.default.no-proxy}")
+    @Value("${artemis.continuous-integration.proxies.default.no-proxy:}")
     String noProxy;
 
     AeolusTemplateService aeolusTemplateService;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -61,23 +61,20 @@ public class LocalCIContainerService {
 
     public static final String WORKING_DIRECTORY = "/var/tmp";
 
-    @Value("${artemis.continuous-integration.build.images.java.default}")
-    String dockerImage;
-
     @Value("${artemis.continuous-integration.local-cis-build-scripts-path}")
-    String localCIBuildScriptBasePath;
+    private String localCIBuildScriptBasePath;
 
     @Value("${artemis.continuous-integration.proxies.use-system-proxy:false}")
-    boolean useSystemProxy;
+    private boolean useSystemProxy;
 
     @Value("${artemis.continuous-integration.proxies.default.http-proxy:}")
-    String httpProxy;
+    private String httpProxy;
 
     @Value("${artemis.continuous-integration.proxies.default.https-proxy:}")
-    String httpsProxy;
+    private String httpsProxy;
 
     @Value("${artemis.continuous-integration.proxies.default.no-proxy:}")
-    String noProxy;
+    private String noProxy;
 
     AeolusTemplateService aeolusTemplateService;
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -88,7 +88,7 @@ public class LocalCIContainerService {
     }
 
     /**
-     * Configure a container with the Docker image, the container name, the binds, and the branch to checkout, and set the command that runs when the container starts.
+     * Configure a container with the Docker image, the container name, optional proxy config variables, and set the command that runs when the container starts.
      *
      * @param containerName the name of the container to be created
      * @param image         the Docker image to use for the container

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -67,6 +67,18 @@ public class LocalCIContainerService {
     @Value("${artemis.continuous-integration.local-cis-build-scripts-path}")
     String localCIBuildScriptBasePath;
 
+    @Value("${artemis.continuous-integration.proxies.use-system-proxy:false}")
+    boolean useSystemProxy;
+
+    @Value("${artemis.continuous-integration.proxies.default.http-proxy}")
+    String httpProxy;
+
+    @Value("${artemis.continuous-integration.proxies.default.https-proxy}")
+    String httpsProxy;
+
+    @Value("${artemis.continuous-integration.proxies.default.no-proxy}")
+    String noProxy;
+
     AeolusTemplateService aeolusTemplateService;
 
     public LocalCIContainerService(DockerClient dockerClient, HostConfig hostConfig, AeolusTemplateService aeolusTemplateService) {
@@ -79,14 +91,17 @@ public class LocalCIContainerService {
      * Configure a container with the Docker image, the container name, the binds, and the branch to checkout, and set the command that runs when the container starts.
      *
      * @param containerName the name of the container to be created
-     * @param branch        the branch to checkout
-     * @param commitHash    the commit hash to checkout. If it is null, the latest commit of the branch will be checked out.
      * @param image         the Docker image to use for the container
      * @return {@link CreateContainerResponse} that can be used to start the container
      */
-    public CreateContainerResponse configureContainer(String containerName, String branch, String commitHash, String image) {
-        return dockerClient.createContainerCmd(image).withName(containerName).withHostConfig(hostConfig)
-                .withEnv("ARTEMIS_BUILD_TOOL=gradle", "ARTEMIS_DEFAULT_BRANCH=" + branch, "ARTEMIS_ASSIGNMENT_REPOSITORY_COMMIT_HASH=" + (commitHash != null ? commitHash : ""))
+    public CreateContainerResponse configureContainer(String containerName, String image) {
+        List<String> envVars = new ArrayList<>();
+        if (useSystemProxy) {
+            envVars.add("HTTP_PROXY=" + httpProxy);
+            envVars.add("HTTPS_PROXY=" + httpsProxy);
+            envVars.add("NO_PROXY=" + noProxy);
+        }
+        return dockerClient.createContainerCmd(image).withName(containerName).withHostConfig(hostConfig).withEnv(envVars)
                 // Command to run when the container starts. This is the command that will be executed in the container's main process, which runs in the foreground and blocks the
                 // container from exiting until it finishes.
                 // It waits until the script that is running the tests (see below execCreateCmdResponse) is completed, and until the result files are extracted which is indicated

--- a/src/main/resources/config/application-localci.yml
+++ b/src/main/resources/config/application-localci.yml
@@ -19,3 +19,12 @@ artemis:
         queue-size-limit: 100
         # The path to the local CI build scripts. This path is relative to the Artemis root directory.
         local-cis-build-scripts-path: local-ci-scripts
+        proxies:
+            use-system-proxy: false
+            default:
+                http-proxy: http://proxyserver:port
+                https-proxy: http://proxyserver:port
+                no-proxy: localhost,127.0.0.1
+
+
+

--- a/src/main/resources/config/application-localci.yml
+++ b/src/main/resources/config/application-localci.yml
@@ -19,6 +19,7 @@ artemis:
         queue-size-limit: 100
         # The path to the local CI build scripts. This path is relative to the Artemis root directory.
         local-cis-build-scripts-path: local-ci-scripts
+        # In case you need to use a proxy to access the internet from the Docker container (e.g., due to firewall constraints), set use-system-proxy to true and configure the proxy settings below.
         proxies:
             use-system-proxy: false
             default:

--- a/src/main/resources/config/application-localci.yml
+++ b/src/main/resources/config/application-localci.yml
@@ -26,6 +26,3 @@ artemis:
                 http-proxy: http://proxyserver:port
                 https-proxy: http://proxyserver:port
                 no-proxy: localhost,127.0.0.1
-
-
-

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCITestConfiguration.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCITestConfiguration.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.localvcci;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -62,7 +63,7 @@ public class LocalCITestConfiguration {
         doReturn(createContainerCmd).when(dockerClient).createContainerCmd(anyString());
         doReturn(createContainerCmd).when(createContainerCmd).withName(anyString());
         doReturn(createContainerCmd).when(createContainerCmd).withHostConfig(any());
-        doReturn(createContainerCmd).when(createContainerCmd).withEnv(anyString(), anyString(), anyString());
+        doReturn(createContainerCmd).when(createContainerCmd).withEnv(anyList());
         doReturn(createContainerCmd).when(createContainerCmd).withUser(anyString());
         doReturn(createContainerCmd).when(createContainerCmd).withCmd(anyString(), anyString(), anyString());
         doReturn(createContainerResponse).when(createContainerCmd).exec();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In the case that Docker containers in local CI cannot directly access the internet due to firewall restrictions, it should be able to use an HTTP(s)-Proxy.

### Description
<!-- Describe your changes in detail -->
This PR sets optional proxy config env variables when configuring the build job docker containers in local CI.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
**Test locally, contains config change**
Prerequisites:
- 1 Student
- 1 Programming Exercise

1. Trigger a submission to the programming exercise
2. Verify that you receive a build result after some time


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2