### PR TITLE
`Development`: Improve localCi setup documentation for windows setups

### DIFF
--- a/docs/dev/setup/localci-localvc.rst
+++ b/docs/dev/setup/localci-localvc.rst
@@ -51,8 +51,8 @@ The values configured here are sufficient for a basic Artemis setup that allows 
 
 If you are running Artemis on Windows, you also need to add a property ``artemis.continuous-integration.docker-connection-uri``
 with the value ``tcp://localhost:2375`` as shown above.
-Make sure that Artemis can access docker by activating the "Expose daemon on tcp://localhost:2375 without TLS" option under Settings > General in Docker Desktop.
 If you are running Artemis inside of a docker container, use ``tcp://host.docker.internal:2375`` instead.
+Make sure that Artemis can access docker by activating the "Expose daemon on tcp://localhost:2375 without TLS" option under Settings > General in Docker Desktop.
 
 When you start Artemis for the first time, it will automatically create an admin user called "artemis_admin". If this does not work, refer to the guide for the :ref:`Jenkins and GitLab Setup` to manually create an admin user in the database.
 You can then use that admin user to create further users in Artemis' internal user management system.

--- a/docs/dev/setup/localci-localvc.rst
+++ b/docs/dev/setup/localci-localvc.rst
@@ -43,12 +43,16 @@ Create a file ``src/main/resources/config/application-local.yml`` with the follo
                use-external: false # if you do not wish to use Jira for user management
            version-control:
                url: http://localhost:8080
+           # Only necessary on Windows:
+           continuous-integration:
+               docker-connection-uri: tcp://localhost:2375
 
 The values configured here are sufficient for a basic Artemis setup that allows for running programming exercises with the local VC and local CI systems.
 
-.. HINT::
-   If you are running Artemis in Windows, you also need to add a property ``artemis.continuous-integration.docker-connection-uri`` with the value ``tcp://localhost:2375``.
-   The default value for this property is ``unix:///var/run/docker.sock`` which is defined in ``src/main/resources/config/application-localci.yml``. The ``application-local.yml`` file overrides the values set there. When using Windows, you will also need make sure to enable the Docker setting "Expose daemon on tcp://localhost:2375 without TLS". You can do this in Docker Desktop under Settings > General.
+If you are running Artemis on Windows, you also need to add a property ``artemis.continuous-integration.docker-connection-uri``
+with the value ``tcp://localhost:2375`` as shown above.
+Make sure that Artemis can access docker by activating the "Expose daemon on tcp://localhost:2375 without TLS" option under Settings > General in Docker Desktop.
+If you are running Artemis inside of a docker container, use ``tcp://host.docker.internal:2375`` instead.
 
 When you start Artemis for the first time, it will automatically create an admin user called "artemis_admin". If this does not work, refer to the guide for the :ref:`Jenkins and GitLab Setup` to manually create an admin user in the database.
 You can then use that admin user to create further users in Artemis' internal user management system.


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
I ran into some issues setting up Artemis with LocalCI on Windows. The necessary changes were already documented, but I overlooked them since they are part of a "hint".

### Description
I removed the hint and improved to wording to be clearer. This now also directly mentions how to set up the connection when running Artemis in its own container.

### Steps for Testing
Read the documentation at 

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2