### PR TITLE
`Exam mode`: Fix navigation to exams list and add no-exam hint

### DIFF
--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -31,7 +31,7 @@
                             <span>Exams: {{ examCount }}</span>
                         }
                         @if (examCount > 0) {
-                            <a [routerLink]="['/courses', course.id!, 'exams']">Exams: {{ examCount }}</a>
+                            <a (click)="navigateToExams($event)">Exams: {{ examCount }}</a>
                         }
                     </div>
                 </div>

--- a/src/main/webapp/app/overview/course-card.component.ts
+++ b/src/main/webapp/app/overview/course-card.component.ts
@@ -101,6 +101,16 @@ export class CourseCardComponent implements OnChanges {
         this.router.navigate(['courses', this.course.id]);
     }
 
+    /**
+     * Navigates to the exam page of the course.
+     * We stop the propagation of the click event to avoid navigating to the exercise page.
+     * @param event the click event
+     */
+    navigateToExams(event: Event) {
+        event.stopPropagation();
+        this.router.navigate(['courses', this.course.id, 'exams']);
+    }
+
     private updateNextDueDate() {
         let nextExerciseDueDate = undefined;
         if (this.nextRelevantExercise) {

--- a/src/main/webapp/app/overview/course-exams/course-exams.component.html
+++ b/src/main/webapp/app/overview/course-exams/course-exams.component.html
@@ -1,3 +1,15 @@
+<!-- Section for no exams. Should only be displayed if no real and test exams exist -->
+@if (realExamsOfCourse.length === 0 && testExamsOfCourse.length === 0) {
+    <div class="d-flex flex-column align-items-center justify-content-center mt-3">
+        <h3 jhiTranslate="artemisApp.exam.overview.noExams">No exams present</h3>
+        <button [routerLink]="['/courses', this.course?.id, 'exercises']" class="btn btn-primary">
+            <fa-icon [icon]="faListAlt" class="pe-1"></fa-icon>
+            {{ 'artemisApp.exam.overview.goToExercises' | artemisTranslate }}
+        </button>
+    </div>
+}
+
+<!-- Section for real exams. Should not be displayed if no real exams exist -->
 @if (realExamsOfCourse.length > 0) {
     <h2 class="my-2" jhiTranslate="artemisApp.exam.overview.realExamsHeading">Exams</h2>
     <div class="row d-flex align-items-start">
@@ -12,7 +24,7 @@
     </div>
     <hr />
 }
-<!-- Section test exams. Should not be displayed, if no test exams exist -->
+<!-- Section test exams. Should not be displayed if no test exams exist -->
 @if (testExamsOfCourse.length > 0) {
     <h2 jhiTranslate="artemisApp.exam.overview.testExamsHeading">Test Exams</h2>
     <div class="row">

--- a/src/main/webapp/app/overview/course-exams/course-exams.component.ts
+++ b/src/main/webapp/app/overview/course-exams/course-exams.component.ts
@@ -7,7 +7,7 @@ import dayjs from 'dayjs/esm';
 import { ArtemisServerDateService } from 'app/shared/server-date.service';
 import { StudentExam } from 'app/entities/student-exam.model';
 import { ExamParticipationService } from 'app/exam/participate/exam-participation.service';
-import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
+import { faAngleDown, faAngleUp, faListAlt } from '@fortawesome/free-solid-svg-icons';
 import { CourseStorageService } from 'app/course/manage/course-storage.service';
 
 @Component({
@@ -29,6 +29,7 @@ export class CourseExamsComponent implements OnInit, OnDestroy {
     // Icons
     faAngleUp = faAngleUp;
     faAngleDown = faAngleDown;
+    faListAlt = faListAlt;
 
     constructor(
         private route: ActivatedRoute,

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -42,6 +42,8 @@
                 "reviewExplanation": "Die Einsicht findet statt bis ",
                 "realExamsHeading": "Klausuren",
                 "testExamsHeading": "Testklausuren",
+                "noExams": "Keine Klausuren vorhanden",
+                "goToExercises": "Gehe zu Aufgaben",
                 "testExam": {
                     "upcoming": "Demnächst stattfindende Testklausur",
                     "imminent": "Die Testklausur beginnt in ",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -42,6 +42,8 @@
                 "reviewExplanation": "You can review the assessment until ",
                 "realExamsHeading": "Exams",
                 "testExamsHeading": "Test Exams",
+                "noExams": "No exams present",
+                "goToExercises": "Go to exercises",
                 "testExam": {
                     "upcoming": "Upcoming Test Exam",
                     "imminent": "The Test Exam will start ",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR addresses two primary issues in the Artemis platform. First, there was a navigation problem in the course card component, particularly when trying to access the exams list. This bug was significant as it hindered efficient and intuitive navigation within the platform. Secondly, due to recent changes (PR #7826), users could navigate to the exam list even when no exams were present, which could lead to confusion. This PR aims to resolve these issues, thereby improving the user experience.

### Description
<!-- Describe your changes in detail -->
The PR introduces a change in the navigation method from the course card to the exams list by replacing the nested router link with imperative navigation. This approach resolves the navigation issue. Additionally, a new UI element is added to the exams page, which displays a helpful message and a navigation button when no exams are available. This feature enhances user understanding and navigation in scenarios where the exam list is empty.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 User with access to courses with exams

Steps:
1. Navigate to the courses overview.
2. In the course card, click on the 'Exams' link.
3. Ensure you are redirected to the exams view of the course.
4. In cases where no exams are present, verify that a message is shown indicating no available exams, along with a button to navigate to the exercise list.
5. Click on the button provided and confirm that it redirects to the exercise list of the course.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/ls1intum/Artemis/assets/23171488/580e47ec-60b2-4098-af9c-0380ef4785c2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the "Exams" link behavior to ensure proper navigation without unintended redirects.

- **New Features**
  - Enhanced the course card with a direct navigation method to the exam page.

- **Style**
  - Integrated new iconography for a more intuitive visual representation of exams sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->