### PR TITLE
`Development`: Fix e2e test 'Complaints about text exercises assessment'

### DIFF
--- a/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamAssessment.cy.ts
@@ -171,7 +171,7 @@ function prepareExam(course: Course, end: dayjs.Dayjs, exerciseType: ExerciseTyp
         startDate: dayjs(),
         endDate: end,
         numberOfCorrectionRoundsInExam: 1,
-        examStudentReviewStart: resultDate.add(10, 'seconds'),
+        examStudentReviewStart: resultDate,
         examStudentReviewEnd: resultDate.add(1, 'minute'),
         publishResultsDate: resultDate,
         gracePeriod: 10,


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
The test 'Complaints about text exercises assessment' used to fail every now and then. The reason was that sometimes cypress was too fast and opened exam results overview page before review period had started. That led to a problem, that "complain" button couldn't be found. The timeout of 20 seconds didn't have an effect, because cypress didn't reload the page. 

The solution is to make the start review date equal to the end date of the exam. This way we make sure, that every time the test opens exam results overview page, the "complain" button will be visible, without need to reload the page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the timing logic for the start of student exam review to ensure it begins at the correct moment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->