### PR TITLE
`Integrated code lifecycle`: Fix issues in build queue when running on multiple nodes and remove cancellation of running build jobs

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobManagementService.java
@@ -56,10 +56,6 @@ public class LocalCIBuildJobManagementService {
     @Value("${artemis.continuous-integration.build-container-prefix:local-ci-}")
     private String buildContainerPrefix;
 
-    private final Map<Long, Future<LocalCIBuildResult>> runningBuildJobs = new ConcurrentHashMap<>();
-
-    private final Set<Long> cancelledBuildJobs = new HashSet<>();
-
     public LocalCIBuildJobManagementService(LocalCIBuildJobExecutionService localCIBuildJobExecutionService, ExecutorService localCIBuildExecutorService,
             ProgrammingMessagingService programmingMessagingService, LocalCIBuildPlanService localCIBuildPlanService, LocalCIContainerService localCIContainerService,
             LocalCIDockerService localCIDockerService, ProgrammingLanguageConfiguration programmingLanguageConfiguration) {
@@ -79,12 +75,11 @@ public class LocalCIBuildJobManagementService {
      * @param commitHash             The commit hash of the submission that led to this build. If it is "null", the latest commit of the repository will be used.
      * @param isRetry                Whether this build job is a retry of a previous build job.
      * @param isPushToTestRepository Defines if the build job is triggered by a push to a test repository.
-     * @param buildJobId             The id of the build job.
      * @return A future that will be completed with the build result.
      * @throws LocalCIException If the build job could not be submitted to the executor service.
      */
-    public CompletableFuture<LocalCIBuildResult> executeBuildJob(ProgrammingExerciseParticipation participation, String commitHash, boolean isRetry, boolean isPushToTestRepository,
-            long buildJobId) throws LocalCIException {
+    public CompletableFuture<LocalCIBuildResult> executeBuildJob(ProgrammingExerciseParticipation participation, String commitHash, boolean isRetry, boolean isPushToTestRepository)
+            throws LocalCIException {
 
         ProgrammingExercise programmingExercise = participation.getProgrammingExercise();
         ProgrammingLanguage programmingLanguage = programmingExercise.getProgrammingLanguage();
@@ -107,7 +102,6 @@ public class LocalCIBuildJobManagementService {
          * Usually, when using asynchronous build jobs, it will just resolve to "CompletableFuture.supplyAsync".
          */
         Future<LocalCIBuildResult> future = localCIBuildExecutorService.submit(buildJob);
-        runningBuildJobs.put(buildJobId, future);
 
         CompletableFuture<LocalCIBuildResult> futureResult = createCompletableFuture(() -> {
             try {
@@ -117,19 +111,13 @@ public class LocalCIBuildJobManagementService {
                 // RejectedExecutionException is thrown if the queue size limit (defined in "artemis.continuous-integration.queue-size-limit") is reached.
                 // Wrap the exception in a CompletionException so that the future is completed exceptionally and the thenAccept block is not run.
                 // This CompletionException will not resurface anywhere else as it is thrown in this completable future's separate thread.
-                if (cancelledBuildJobs.contains(buildJobId)) {
-                    finishCancelledBuildJob(participation, buildJobId, containerName);
-                    throw new CompletionException("Build job with id " + buildJobId + " was cancelled.", e);
-                }
-                else {
-                    finishBuildJobExceptionally(participation, commitHash, containerName, isRetry, e);
-                    throw new CompletionException(e);
-                }
+                finishBuildJobExceptionally(participation, commitHash, containerName, isRetry, e);
+                throw new CompletionException(e);
+
             }
         });
         // Update the build plan status to "QUEUED".
         localCIBuildPlanService.updateBuildPlanStatus(participation, ContinuousIntegrationService.BuildStatus.QUEUED);
-        futureResult.whenComplete(((result, throwable) -> runningBuildJobs.remove(buildJobId)));
 
         return futureResult;
     }
@@ -184,52 +172,5 @@ public class LocalCIBuildJobManagementService {
         localCIContainerService.deleteScriptFile(containerName);
 
         localCIContainerService.stopContainer(containerName);
-    }
-
-    /**
-     * Cancel the build job for the given buildJobId.
-     *
-     * @param buildJobId The id of the build job that should be cancelled.
-     */
-    public void cancelBuildJob(long buildJobId) {
-        Future<LocalCIBuildResult> future = runningBuildJobs.get(buildJobId);
-        if (future != null) {
-            try {
-                cancelledBuildJobs.add(buildJobId);
-                future.cancel(true); // Attempt to interrupt the build job
-            }
-            catch (CancellationException e) {
-                log.warn("Build job already cancelled or completed for id {}", buildJobId);
-            }
-        }
-        else {
-            log.warn("Attempted to cancel a non-existent build job for id {}", buildJobId);
-        }
-    }
-
-    /**
-     * Finish the build job if it was cancelled by the user.
-     *
-     * @param participation The participation of the repository for which the build job was executed.
-     * @param buildJobId    The id of the cancelled build job
-     * @param containerName The name of the Docker container that was used to execute the build job.
-     */
-    private void finishCancelledBuildJob(ProgrammingExerciseParticipation participation, long buildJobId, String containerName) {
-        log.debug("Build job with id {} in repository {} was cancelled", buildJobId, participation.getRepositoryUri());
-
-        // Set the build status to "INACTIVE" to indicate that the build is not running anymore.
-        localCIBuildPlanService.updateBuildPlanStatus(participation, ContinuousIntegrationService.BuildStatus.INACTIVE);
-
-        // Notify the user, that the build job produced an exception.
-        BuildTriggerWebsocketError error = new BuildTriggerWebsocketError("Build job was cancelled", participation.getId());
-        // This cast to Participation is safe as the participation is either a ProgrammingExerciseStudentParticipation, a TemplateProgrammingExerciseParticipation, or a
-        // SolutionProgrammingExerciseParticipation, which all extend Participation.
-        programmingMessagingService.notifyUserAboutSubmissionError((Participation) participation, error);
-
-        localCIContainerService.deleteScriptFile(containerName);
-
-        localCIContainerService.stopContainer(containerName);
-
-        cancelledBuildJobs.remove(buildJobId);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIQueueWebsocketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIQueueWebsocketService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import com.hazelcast.collection.IQueue;
 import com.hazelcast.collection.ItemEvent;
 import com.hazelcast.collection.ItemListener;
+import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.listener.EntryAddedListener;
@@ -58,6 +59,7 @@ public class LocalCIQueueWebsocketService {
         this.queue = this.hazelcastInstance.getQueue("buildJobQueue");
         this.processingJobs = this.hazelcastInstance.getMap("processingJobs");
         this.buildAgentInformation = this.hazelcastInstance.getMap("buildAgentInformation");
+        hazelcastInstance.getConfig().getMapConfig("processingJobs").addEntryListenerConfig(new EntryListenerConfig("ProcessingBuildJobItemListener", false, true));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIQueueWebsocketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIQueueWebsocketService.java
@@ -26,7 +26,7 @@ import de.tum.in.www1.artemis.web.websocket.localci.LocalCIWebsocketMessagingSer
  * same information multiple times and thus also avoids unnecessary load on the server.
  */
 @Service
-@Profile("localci & scheduling")
+@Profile("localci")
 public class LocalCIQueueWebsocketService {
 
     private static final Logger log = LoggerFactory.getLogger(LocalCIQueueWebsocketService.class);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIQueueWebsocketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIQueueWebsocketService.java
@@ -26,7 +26,7 @@ import de.tum.in.www1.artemis.web.websocket.localci.LocalCIWebsocketMessagingSer
  * same information multiple times and thus also avoids unnecessary load on the server.
  */
 @Service
-@Profile("localci")
+@Profile("localci & scheduling")
 public class LocalCIQueueWebsocketService {
 
     private static final Logger log = LoggerFactory.getLogger(LocalCIQueueWebsocketService.class);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIQueueWebsocketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIQueueWebsocketService.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import com.hazelcast.collection.IQueue;
 import com.hazelcast.collection.ItemEvent;
 import com.hazelcast.collection.ItemListener;
-import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import com.hazelcast.map.listener.EntryAddedListener;
@@ -59,7 +58,6 @@ public class LocalCIQueueWebsocketService {
         this.queue = this.hazelcastInstance.getQueue("buildJobQueue");
         this.processingJobs = this.hazelcastInstance.getMap("processingJobs");
         this.buildAgentInformation = this.hazelcastInstance.getMap("buildAgentInformation");
-        hazelcastInstance.getConfig().getMapConfig("processingJobs").addEntryListenerConfig(new EntryListenerConfig("ProcessingBuildJobItemListener", false, true));
     }
 
     /**
@@ -68,8 +66,8 @@ public class LocalCIQueueWebsocketService {
     @PostConstruct
     public void addListeners() {
         this.queue.addItemListener(new QueuedBuildJobItemListener(), true);
-        this.processingJobs.addLocalEntryListener(new ProcessingBuildJobItemListener());
-        this.buildAgentInformation.addLocalEntryListener(new BuildAgentListener());
+        this.processingJobs.addEntryListener(new ProcessingBuildJobItemListener(), true);
+        this.buildAgentInformation.addEntryListener(new BuildAgentListener(), true);
     }
 
     private void sendQueuedJobsOverWebsocket(long courseId) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCISharedBuildJobQueueService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCISharedBuildJobQueueService.java
@@ -119,15 +119,9 @@ public class LocalCISharedBuildJobQueueService {
      */
     public void addBuildJob(String name, long participationId, String repositoryTypeOrUsername, String commitHash, ZonedDateTime submissionDate, int priority, long courseId,
             boolean isPushToTestRepository) {
-        sharedLock.lock();
-        try {
-            LocalCIBuildJobQueueItem buildJobQueueItem = new LocalCIBuildJobQueueItem(Long.parseLong(String.valueOf(participationId) + submissionDate.toInstant().toEpochMilli()),
-                    name, null, participationId, repositoryTypeOrUsername, commitHash, submissionDate, 0, null, priority, courseId, isPushToTestRepository);
-            queue.add(buildJobQueueItem);
-        }
-        finally {
-            sharedLock.unlock();
-        }
+        LocalCIBuildJobQueueItem buildJobQueueItem = new LocalCIBuildJobQueueItem(Long.parseLong(String.valueOf(participationId) + submissionDate.toInstant().toEpochMilli()), name,
+                null, participationId, repositoryTypeOrUsername, commitHash, submissionDate, 0, null, priority, courseId, isPushToTestRepository);
+        queue.add(buildJobQueueItem);
     }
 
     public List<LocalCIBuildJobQueueItem> getQueuedJobs() {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCISharedBuildJobQueueService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCISharedBuildJobQueueService.java
@@ -124,7 +124,7 @@ public class LocalCISharedBuildJobQueueService {
     }
 
     public List<LocalCIBuildJobQueueItem> getProcessingJobs() {
-        return processingJobs.values().stream().toList();
+        return new ArrayList<>(this.processingJobs.values());
     }
 
     public List<LocalCIBuildJobQueueItem> getQueuedJobsForCourse(long courseId) {
@@ -132,13 +132,19 @@ public class LocalCISharedBuildJobQueueService {
     }
 
     public List<LocalCIBuildJobQueueItem> getProcessingJobsForCourse(long courseId) {
-        return processingJobs.values().stream().filter(job -> job.courseId() == courseId).toList();
+        List<LocalCIBuildJobQueueItem> processingJobsForCourse = new ArrayList<>();
+        for (LocalCIBuildJobQueueItem job : processingJobs.values()) {
+            if (job.courseId() == courseId) {
+                processingJobsForCourse.add(job);
+            }
+        }
+        return processingJobsForCourse;
     }
 
     public List<LocalCIBuildAgentInformation> getBuildAgentInformation() {
         // Remove build agent information of offline nodes
         removeOfflineNodes();
-        return buildAgentInformation.values().stream().toList();
+        return new ArrayList<>(buildAgentInformation.values());
     }
 
     /**
@@ -261,7 +267,13 @@ public class LocalCISharedBuildJobQueueService {
     }
 
     private List<LocalCIBuildJobQueueItem> getProcessingJobsOfNode(String memberAddress) {
-        return processingJobs.values().stream().filter(job -> Objects.equals(job.buildAgentAddress(), memberAddress)).toList();
+        List<LocalCIBuildJobQueueItem> processingJobsOfMember = new ArrayList<>();
+        for (LocalCIBuildJobQueueItem job : processingJobs.values()) {
+            if (Objects.equals(job.buildAgentAddress(), memberAddress)) {
+                processingJobsOfMember.add(job);
+            }
+        }
+        return processingJobsOfMember;
     }
 
     private void removeOfflineNodes() {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCISharedBuildJobQueueService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCISharedBuildJobQueueService.java
@@ -96,7 +96,7 @@ public class LocalCISharedBuildJobQueueService {
      * Add listener to the shared build job queue.
      */
     @PostConstruct
-    public void init() {
+    public void addListener() {
         this.queue.addItemListener(new QueuedBuildJobItemListener(), true);
     }
 
@@ -147,13 +147,19 @@ public class LocalCISharedBuildJobQueueService {
      * @param participationId id of the participation
      */
     public void removeQueuedJobsForParticipation(long participationId) {
-        List<LocalCIBuildJobQueueItem> toRemove = new ArrayList<>();
-        for (LocalCIBuildJobQueueItem job : queue) {
-            if (job.participationId() == participationId) {
-                toRemove.add(job);
+        sharedLock.lock();
+        try {
+            List<LocalCIBuildJobQueueItem> toRemove = new ArrayList<>();
+            for (LocalCIBuildJobQueueItem job : queue) {
+                if (job.participationId() == participationId) {
+                    toRemove.add(job);
+                }
             }
+            queue.removeAll(toRemove);
         }
-        queue.removeAll(toRemove);
+        finally {
+            sharedLock.unlock();
+        }
     }
 
     /**
@@ -417,22 +423,33 @@ public class LocalCISharedBuildJobQueueService {
      * @param buildJobId id of the build job to cancel
      */
     public void cancelBuildJob(String buildJobId) {
-        List<LocalCIBuildJobQueueItem> toRemove = new ArrayList<>();
-        for (LocalCIBuildJobQueueItem job : queue) {
-            log.error("Checking if job {} is the canceled job {}", job.id(), buildJobId);
-            if (Objects.equals(job.id(), buildJobId)) {
-                toRemove.add(job);
+        sharedLock.lock();
+        try {
+            List<LocalCIBuildJobQueueItem> toRemove = new ArrayList<>();
+            for (LocalCIBuildJobQueueItem job : queue) {
+                if (Objects.equals(job.id(), buildJobId)) {
+                    toRemove.add(job);
+                }
             }
+            queue.removeAll(toRemove);
         }
-        queue.removeAll(toRemove);
+        finally {
+            sharedLock.unlock();
+        }
     }
 
     /**
      * Cancel all queued build jobs.
      */
     public void cancelAllQueuedBuildJobs() {
-        log.debug("Cancelling all queued build jobs");
-        queue.clear();
+        sharedLock.lock();
+        try {
+            log.debug("Cancelling all queued build jobs");
+            queue.clear();
+        }
+        finally {
+            sharedLock.unlock();
+        }
     }
 
     /**
@@ -441,13 +458,19 @@ public class LocalCISharedBuildJobQueueService {
      * @param courseId id of the course
      */
     public void cancelAllQueuedBuildJobsForCourse(long courseId) {
-        List<LocalCIBuildJobQueueItem> toRemove = new ArrayList<>();
-        for (LocalCIBuildJobQueueItem job : queue) {
-            if (job.courseId() == courseId) {
-                toRemove.add(job);
+        sharedLock.lock();
+        try {
+            List<LocalCIBuildJobQueueItem> toRemove = new ArrayList<>();
+            for (LocalCIBuildJobQueueItem job : queue) {
+                if (job.courseId() == courseId) {
+                    toRemove.add(job);
+                }
             }
+            queue.removeAll(toRemove);
         }
-        queue.removeAll(toRemove);
+        finally {
+            sharedLock.unlock();
+        }
     }
 
     private class QueuedBuildJobItemListener implements ItemListener<LocalCIBuildJobQueueItem> {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCISharedBuildJobQueueService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCISharedBuildJobQueueService.java
@@ -241,6 +241,7 @@ public class LocalCISharedBuildJobQueueService {
                     buildJob.repositoryTypeOrUserName(), buildJob.commitHash(), buildJob.submissionDate(), buildJob.retryCount(), ZonedDateTime.now(), buildJob.priority(),
                     buildJob.courseId(), buildJob.isPushToTestRepository());
             processingJobs.put(processingJob.id(), processingJob);
+            processingJobs.flush();
             localProcessingJobs.incrementAndGet();
 
             updateLocalBuildAgentInformation();
@@ -256,6 +257,7 @@ public class LocalCISharedBuildJobQueueService {
         int maxNumberOfConcurrentBuilds = localCIBuildExecutorService.getMaximumPoolSize();
         LocalCIBuildAgentInformation info = new LocalCIBuildAgentInformation(memberAddress, maxNumberOfConcurrentBuilds, numberOfCurrentBuildJobs, processingJobsOfMember);
         buildAgentInformation.put(memberAddress, info);
+        buildAgentInformation.flush();
     }
 
     private List<LocalCIBuildJobQueueItem> getProcessingJobsOfNode(String memberAddress) {
@@ -267,6 +269,7 @@ public class LocalCISharedBuildJobQueueService {
         for (String key : buildAgentInformation.keySet()) {
             if (!memberAddresses.contains(key)) {
                 buildAgentInformation.remove(key);
+                buildAgentInformation.flush();
             }
         }
     }
@@ -297,6 +300,7 @@ public class LocalCISharedBuildJobQueueService {
         catch (IllegalStateException e) {
             log.error("Cannot process build job for participation with id {} because it could not be retrieved from the database.", buildJob.participationId());
             processingJobs.remove(buildJob.id());
+            processingJobs.flush();
             localProcessingJobs.decrementAndGet();
             updateLocalBuildAgentInformation();
             checkAvailabilityAndProcessNextBuild();
@@ -305,6 +309,7 @@ public class LocalCISharedBuildJobQueueService {
         catch (Exception e) {
             log.error("Cannot process build job for participation with id {} because of an unexpected error.", buildJob.participationId(), e);
             processingJobs.remove(buildJob.id());
+            processingJobs.flush();
             localProcessingJobs.decrementAndGet();
             updateLocalBuildAgentInformation();
             checkAvailabilityAndProcessNextBuild();
@@ -340,6 +345,7 @@ public class LocalCISharedBuildJobQueueService {
 
             // after processing a build job, remove it from the processing jobs
             processingJobs.remove(buildJob.id());
+            processingJobs.flush();
             localProcessingJobs.decrementAndGet();
             updateLocalBuildAgentInformation();
 
@@ -349,6 +355,7 @@ public class LocalCISharedBuildJobQueueService {
             log.error("Error while processing build job: {}", buildJob, ex);
 
             processingJobs.remove(buildJob.id());
+            processingJobs.flush();
             localProcessingJobs.decrementAndGet();
             updateLocalBuildAgentInformation();
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -1,14 +1,10 @@
 package de.tum.in.www1.artemis.service.connectors.localci;
 
-import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
-
-import com.hazelcast.core.HazelcastInstance;
 
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
@@ -24,11 +20,8 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
 
     private final LocalCISharedBuildJobQueueService localCISharedBuildJobQueueService;
 
-    private final HazelcastInstance hazelcastInstance;
-
-    public LocalCITriggerService(LocalCISharedBuildJobQueueService localCISharedBuildJobQueueService, HazelcastInstance hazelcastInstance) {
+    public LocalCITriggerService(LocalCISharedBuildJobQueueService localCISharedBuildJobQueueService) {
         this.localCISharedBuildJobQueueService = localCISharedBuildJobQueueService;
-        this.hazelcastInstance = hazelcastInstance;
     }
 
     /**
@@ -66,9 +59,7 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
         // Exam exercises have a higher priority than normal exercises
         int priority = programmingExercise.isExamExercise() ? 1 : 2;
 
-        ZonedDateTime currentDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(hazelcastInstance.getCluster().getClusterTime()), ZoneId.systemDefault());
-
-        localCISharedBuildJobQueueService.addBuildJob(participation.getBuildPlanId(), participation.getId(), repositoryTypeOrUserName, commitHash, currentDateTime, priority,
+        localCISharedBuildJobQueueService.addBuildJob(participation.getBuildPlanId(), participation.getId(), repositoryTypeOrUserName, commitHash, ZonedDateTime.now(), priority,
                 courseId, isPushToTestRepository);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.service.connectors.localci;
 
-import java.time.ZonedDateTime;
 import java.util.Objects;
 
 import org.springframework.context.annotation.Profile;
@@ -9,6 +8,7 @@ import org.springframework.stereotype.Service;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.exception.LocalCIException;
+import de.tum.in.www1.artemis.service.TimeService;
 import de.tum.in.www1.artemis.service.connectors.ci.ContinuousIntegrationTriggerService;
 
 /**
@@ -20,8 +20,11 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
 
     private final LocalCISharedBuildJobQueueService localCISharedBuildJobQueueService;
 
-    public LocalCITriggerService(LocalCISharedBuildJobQueueService localCISharedBuildJobQueueService) {
+    private final TimeService timeService;
+
+    public LocalCITriggerService(LocalCISharedBuildJobQueueService localCISharedBuildJobQueueService, TimeService timeService) {
         this.localCISharedBuildJobQueueService = localCISharedBuildJobQueueService;
+        this.timeService = timeService;
     }
 
     /**
@@ -59,7 +62,7 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
         // Exam exercises have a higher priority than normal exercises
         int priority = programmingExercise.isExamExercise() ? 1 : 2;
 
-        localCISharedBuildJobQueueService.addBuildJob(participation.getBuildPlanId(), participation.getId(), repositoryTypeOrUserName, commitHash, ZonedDateTime.now(), priority,
+        localCISharedBuildJobQueueService.addBuildJob(participation.getBuildPlanId(), participation.getId(), repositoryTypeOrUserName, commitHash, timeService.now(), priority,
                 courseId, isPushToTestRepository);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/LocalCIBuildJobQueueItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/LocalCIBuildJobQueueItem.java
@@ -4,7 +4,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 
-public record LocalCIBuildJobQueueItem(long id, String name, String buildAgentAddress, long participationId, String repositoryTypeOrUserName, String commitHash,
+public record LocalCIBuildJobQueueItem(String id, String name, String buildAgentAddress, long participationId, String repositoryTypeOrUserName, String commitHash,
         ZonedDateTime submissionDate, int retryCount, ZonedDateTime buildStartDate, int priority, long courseId, boolean isPushToTestRepository) implements Serializable {
 
     @Serial

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminBuildJobQueueResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminBuildJobQueueResource.java
@@ -76,7 +76,7 @@ public class AdminBuildJobQueueResource {
     public ResponseEntity<Void> cancelBuildJob(@PathVariable long buildJobId) {
         log.debug("REST request to cancel the build job with id {}", buildJobId);
         // Call the cancelBuildJob method in LocalCIBuildJobManagementService
-        localCIBuildJobQueueService.cancelBuildJob(buildJobId);
+        localCIBuildJobQueueService.triggerBuildJobCancellation(buildJobId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminBuildJobQueueResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminBuildJobQueueResource.java
@@ -95,19 +95,4 @@ public class AdminBuildJobQueueResource {
 
         return ResponseEntity.noContent().build();
     }
-
-    /**
-     * Cancels all running build jobs.
-     *
-     * @return the ResponseEntity with the result of the cancellation
-     */
-    @DeleteMapping("/cancel-all-running-jobs")
-    @EnforceAdmin
-    public ResponseEntity<Void> cancelAllRunningBuildJobs() {
-        log.debug("REST request to cancel all running build jobs");
-        // Call the cancelAllRunningBuildJobs method in LocalCIBuildJobManagementService
-        localCIBuildJobQueueService.cancelAllRunningBuildJobs();
-
-        return ResponseEntity.noContent().build();
-    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminBuildJobQueueResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminBuildJobQueueResource.java
@@ -73,10 +73,10 @@ public class AdminBuildJobQueueResource {
      */
     @DeleteMapping("/cancel-job/{buildJobId}")
     @EnforceAdmin
-    public ResponseEntity<Void> cancelBuildJob(@PathVariable long buildJobId) {
+    public ResponseEntity<Void> cancelBuildJob(@PathVariable String buildJobId) {
         log.debug("REST request to cancel the build job with id {}", buildJobId);
         // Call the cancelBuildJob method in LocalCIBuildJobManagementService
-        localCIBuildJobQueueService.triggerBuildJobCancellation(buildJobId);
+        localCIBuildJobQueueService.cancelBuildJob(buildJobId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/localci/BuildJobQueueResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/localci/BuildJobQueueResource.java
@@ -89,7 +89,7 @@ public class BuildJobQueueResource {
         }
 
         // Call the cancelBuildJob method in LocalCIBuildJobManagementService
-        localCIBuildJobQueueService.cancelBuildJob(buildJobId);
+        localCIBuildJobQueueService.triggerBuildJobCancellation(buildJobId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/localci/BuildJobQueueResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/localci/BuildJobQueueResource.java
@@ -81,7 +81,7 @@ public class BuildJobQueueResource {
      */
     @DeleteMapping("/courses/{courseId}/cancel-job/{buildJobId}")
     @EnforceAtLeastInstructor
-    public ResponseEntity<Void> cancelBuildJob(@PathVariable long courseId, @PathVariable long buildJobId) {
+    public ResponseEntity<Void> cancelBuildJob(@PathVariable long courseId, @PathVariable String buildJobId) {
         log.debug("REST request to cancel the build job for course {} and with id {}", courseId, buildJobId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         if (!authorizationCheckService.isAtLeastInstructorInCourse(course, null)) {
@@ -89,7 +89,7 @@ public class BuildJobQueueResource {
         }
 
         // Call the cancelBuildJob method in LocalCIBuildJobManagementService
-        localCIBuildJobQueueService.triggerBuildJobCancellation(buildJobId);
+        localCIBuildJobQueueService.cancelBuildJob(buildJobId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/localci/BuildJobQueueResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/localci/BuildJobQueueResource.java
@@ -114,24 +114,4 @@ public class BuildJobQueueResource {
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * Cancels all running build jobs for the given course.
-     *
-     * @param courseId the id of the course
-     * @return the ResponseEntity with the result of the cancellation
-     */
-    @DeleteMapping("/courses/{courseId}/cancel-all-running-jobs")
-    @EnforceAtLeastInstructor
-    public ResponseEntity<Void> cancelAllRunningBuildJobs(@PathVariable long courseId) {
-        log.debug("REST request to cancel all running build jobs for course {}", courseId);
-        Course course = courseRepository.findByIdElseThrow(courseId);
-        if (!authorizationCheckService.isAtLeastInstructorInCourse(course, null)) {
-            throw new AccessForbiddenException("You are not allowed to cancel the build job of this course!");
-        }
-        // Call the cancelAllRunningBuildJobs method in LocalCIBuildJobManagementService
-        localCIBuildJobQueueService.cancelAllRunningBuildJobsForCourse(courseId);
-
-        return ResponseEntity.noContent().build();
-    }
-
 }

--- a/src/main/webapp/app/entities/build-job.model.ts
+++ b/src/main/webapp/app/entities/build-job.model.ts
@@ -2,7 +2,7 @@ import { BaseEntity } from 'app/shared/model/base-entity';
 import dayjs from 'dayjs/esm';
 
 export class BuildJob implements BaseEntity {
-    public id?: number;
+    public id?: any;
     public name?: string;
     public participationId?: number;
     public repositoryTypeOrUserName?: string;

--- a/src/main/webapp/app/localci/build-queue/build-queue.component.html
+++ b/src/main/webapp/app/localci/build-queue/build-queue.component.html
@@ -103,23 +103,6 @@
                         <span>{{ value }}</span>
                     </ng-template>
                 </ngx-datatable-column>
-                <ngx-datatable-column prop="cancel" [minWidth]="150" [width]="100">
-                    <div class="d-flex justify-content-center align-items-center">
-                        <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper">
-                                <button class="btn btn-danger btn-sm" (click)="cancelAllRunningBuildJobs()">
-                                    <fa-icon [icon]="faTimes"></fa-icon>
-                                    <span jhiTranslate="artemisApp.buildQueue.cancelAll"> Cancel All </span>
-                                </button>
-                            </span>
-                        </ng-template>
-                        <ng-template ngx-datatable-cell-template let-row="row">
-                            <button class="btn btn-danger btn-sm" (click)="cancelBuildJob(row.id)">
-                                <fa-icon [icon]="faTimes"></fa-icon>
-                            </button>
-                        </ng-template>
-                    </div>
-                </ngx-datatable-column>
             </ngx-datatable>
         </ng-template>
     </jhi-data-table>

--- a/src/main/webapp/app/localci/build-queue/build-queue.component.ts
+++ b/src/main/webapp/app/localci/build-queue/build-queue.component.ts
@@ -132,18 +132,4 @@ export class BuildQueueComponent implements OnInit, OnDestroy {
             }
         });
     }
-
-    /**
-     * Cancel all running build jobs
-     */
-    cancelAllRunningBuildJobs() {
-        this.route.paramMap.pipe(take(1)).subscribe((params) => {
-            const courseId = Number(params.get('courseId'));
-            if (courseId) {
-                this.buildQueueService.cancelAllRunningBuildJobsInCourse(courseId).subscribe();
-            } else {
-                this.buildQueueService.cancelAllRunningBuildJobs().subscribe();
-            }
-        });
-    }
 }

--- a/src/main/webapp/app/localci/build-queue/build-queue.component.ts
+++ b/src/main/webapp/app/localci/build-queue/build-queue.component.ts
@@ -108,7 +108,7 @@ export class BuildQueueComponent implements OnInit, OnDestroy {
      * Cancel a specific build job associated with the build job id
      * @param buildJobId    the id of the build job to cancel
      */
-    cancelBuildJob(buildJobId: number) {
+    cancelBuildJob(buildJobId: string) {
         this.route.paramMap.pipe(take(1)).subscribe((params) => {
             const courseId = Number(params.get('courseId'));
             if (courseId) {

--- a/src/main/webapp/app/localci/build-queue/build-queue.service.ts
+++ b/src/main/webapp/app/localci/build-queue/build-queue.service.ts
@@ -47,7 +47,7 @@ export class BuildQueueService {
      * @param courseId the id of the course
      * @param buildJobId the id of the build job to cancel
      */
-    cancelBuildJobInCourse(courseId: number, buildJobId: number): Observable<void> {
+    cancelBuildJobInCourse(courseId: number, buildJobId: string): Observable<void> {
         return this.http.delete<void>(`${this.resourceUrl}/courses/${courseId}/cancel-job/${buildJobId}`).pipe(
             catchError((err) => {
                 return throwError(() => new Error(`Failed to cancel build job ${buildJobId} in course ${courseId}\n${err.message}`));
@@ -59,7 +59,7 @@ export class BuildQueueService {
      * Cancel a specific build job associated with the build job id
      * @param buildJobId the id of the build job to cancel
      */
-    cancelBuildJob(buildJobId: number): Observable<void> {
+    cancelBuildJob(buildJobId: string): Observable<void> {
         return this.http.delete<void>(`${this.adminResourceUrl}/cancel-job/${buildJobId}`).pipe(
             catchError((err) => {
                 return throwError(() => new Error(`Failed to cancel build job ${buildJobId}\n${err.message}`));

--- a/src/main/webapp/app/localci/build-queue/build-queue.service.ts
+++ b/src/main/webapp/app/localci/build-queue/build-queue.service.ts
@@ -68,28 +68,6 @@ export class BuildQueueService {
     }
 
     /**
-     * Cancel all running build jobs
-     */
-    cancelAllRunningBuildJobs(): Observable<void> {
-        return this.http.delete<void>(`${this.adminResourceUrl}/cancel-all-running-jobs`).pipe(
-            catchError((err) => {
-                return throwError(() => new Error(`Failed to cancel all running build jobs\n${err.message}`));
-            }),
-        );
-    }
-
-    /**
-     * Cancel all running build jobs associated with a course
-     */
-    cancelAllRunningBuildJobsInCourse(courseId: number): Observable<void> {
-        return this.http.delete<void>(`${this.resourceUrl}/courses/${courseId}/cancel-all-running-jobs`).pipe(
-            catchError((err) => {
-                return throwError(() => new Error(`Failed to cancel all running build jobs in course ${courseId}\n${err.message}`));
-            }),
-        );
-    }
-
-    /**
      * Cancel all queued build jobs
      */
     cancelAllQueuedBuildJobs(): Observable<void> {

--- a/src/test/javascript/spec/component/localci/build-queue.component.spec.ts
+++ b/src/test/javascript/spec/component/localci/build-queue.component.spec.ts
@@ -207,23 +207,6 @@ describe('BuildQueueComponent', () => {
         expect(mockBuildQueueService.cancelAllQueuedBuildJobsInCourse).toHaveBeenCalledWith(testCourseId);
     });
 
-    it('should cancel all running build jobs in a course', () => {
-        // Mock ActivatedRoute to return no course ID
-        mockActivatedRoute.paramMap = of(new Map([['courseId', testCourseId.toString()]]));
-
-        // Mock BuildQueueService to return a successful response for canceling all running build jobs
-        mockBuildQueueService.cancelAllRunningBuildJobsInCourse.mockReturnValue(of(null));
-
-        // Initialize the component
-        component.ngOnInit();
-
-        // Call the cancelAllRunningBuildJobs method
-        component.cancelAllRunningBuildJobs();
-
-        // Expectations: The service method for canceling all running build jobs is called with the correct parameter
-        expect(mockBuildQueueService.cancelAllRunningBuildJobsInCourse).toHaveBeenCalledWith(testCourseId);
-    });
-
     it('should cancel all queued build jobs', () => {
         // Mock ActivatedRoute to return no course ID
         mockActivatedRoute.paramMap = of(new Map([]));
@@ -239,22 +222,5 @@ describe('BuildQueueComponent', () => {
 
         // Expectations: The service method for canceling all running build jobs is called without a course ID
         expect(mockBuildQueueService.cancelAllQueuedBuildJobs).toHaveBeenCalled();
-    });
-
-    it('should cancel all running build jobs', () => {
-        // Mock ActivatedRoute to return no course ID
-        mockActivatedRoute.paramMap = of(new Map([]));
-
-        // Mock BuildQueueService to return a successful response for canceling all running build jobs
-        mockBuildQueueService.cancelAllRunningBuildJobs.mockReturnValue(of(null));
-
-        // Initialize the component
-        component.ngOnInit();
-
-        // Call the cancelAllRunningBuildJobs method
-        component.cancelAllRunningBuildJobs();
-
-        // Expectations: The service method for canceling all running build jobs is called without a course ID
-        expect(mockBuildQueueService.cancelAllRunningBuildJobs).toHaveBeenCalled();
     });
 });

--- a/src/test/javascript/spec/component/localci/build-queue.component.spec.ts
+++ b/src/test/javascript/spec/component/localci/build-queue.component.spec.ts
@@ -172,7 +172,7 @@ describe('BuildQueueComponent', () => {
     });
 
     it('should cancel a build job in a course', () => {
-        const buildJobId = 1;
+        const buildJobId = '1';
 
         // Mock ActivatedRoute to return a specific course ID
         mockActivatedRoute.paramMap = of(new Map([['courseId', testCourseId]]));

--- a/src/test/javascript/spec/component/localci/build-queue.service.spec.ts
+++ b/src/test/javascript/spec/component/localci/build-queue.service.spec.ts
@@ -95,7 +95,7 @@ describe('BuildQueueService', () => {
 
     it('should cancel a specific build job in a course', () => {
         const courseId = 1;
-        const buildJobId = 1;
+        const buildJobId = '1';
 
         service.cancelBuildJobInCourse(courseId, buildJobId).subscribe(() => {
             // Ensure that the cancellation was successful
@@ -108,7 +108,7 @@ describe('BuildQueueService', () => {
     });
 
     it('should cancel a specific build job', () => {
-        const buildJobId = 1;
+        const buildJobId = '1';
 
         service.cancelBuildJob(buildJobId).subscribe(() => {
             // Ensure that the cancellation was successful
@@ -145,7 +145,7 @@ describe('BuildQueueService', () => {
     });
 
     it('should handle errors when cancelling a specific build job', fakeAsync(() => {
-        const buildJobId = 1;
+        const buildJobId = '1';
 
         let errorOccurred = false;
 
@@ -179,7 +179,7 @@ describe('BuildQueueService', () => {
 
     it('should handle errors when cancelling a specific build job in a course', fakeAsync(() => {
         const courseId = 1;
-        const buildJobId = 1;
+        const buildJobId = '1';
 
         let errorOccurred = false;
 

--- a/src/test/javascript/spec/component/localci/build-queue.service.spec.ts
+++ b/src/test/javascript/spec/component/localci/build-queue.service.spec.ts
@@ -120,30 +120,6 @@ describe('BuildQueueService', () => {
         req.flush({}); // Flush an empty response to indicate success
     });
 
-    it('should cancel all running build jobs', () => {
-        service.cancelAllRunningBuildJobs().subscribe(() => {
-            // Ensure that the cancellation was successful
-            expect(true).toBeTrue();
-        });
-
-        const req = httpMock.expectOne(`${service.adminResourceUrl}/cancel-all-running-jobs`);
-        expect(req.request.method).toBe('DELETE');
-        req.flush({}); // Flush an empty response to indicate success
-    });
-
-    it('should cancel all running build jobs in a course', () => {
-        const courseId = 1;
-
-        service.cancelAllRunningBuildJobsInCourse(courseId).subscribe(() => {
-            // Ensure that the cancellation was successful
-            expect(true).toBeTrue();
-        });
-
-        const req = httpMock.expectOne(`${service.resourceUrl}/courses/${courseId}/cancel-all-running-jobs`);
-        expect(req.request.method).toBe('DELETE');
-        req.flush({}); // Flush an empty response to indicate success
-    });
-
     it('should cancel all queued build jobs', () => {
         service.cancelAllQueuedBuildJobs().subscribe(() => {
             // Ensure that the cancellation was successful
@@ -228,64 +204,6 @@ describe('BuildQueueService', () => {
         });
 
         const req = httpMock.expectOne(`${service.resourceUrl}/courses/${courseId}/cancel-job/${buildJobId}`);
-        expect(req.request.method).toBe('DELETE');
-
-        // Simulate an error response from the server
-        req.flush(null, { status: 500, statusText: 'Internal Server Error' });
-
-        tick();
-
-        // Verify that an error occurred during the subscription
-        expect(errorOccurred).toBeTrue();
-    }));
-
-    it('should handle errors when cancelling all running build jobs', fakeAsync(() => {
-        let errorOccurred = false;
-
-        service.cancelAllRunningBuildJobs().subscribe({
-            error: (err) => {
-                // Ensure that the error is handled properly
-                expect(err.message).toBe(
-                    'Failed to cancel all running build jobs' + '\nHttp failure response for ' + service.adminResourceUrl + '/cancel-all-running-jobs: 500 Internal Server Error',
-                );
-                errorOccurred = true;
-            },
-        });
-
-        const req = httpMock.expectOne(`${service.adminResourceUrl}/cancel-all-running-jobs`);
-        expect(req.request.method).toBe('DELETE');
-
-        // Simulate an error response from the server
-        req.flush(null, { status: 500, statusText: 'Internal Server Error' });
-
-        tick();
-
-        // Verify that an error occurred during the subscription
-        expect(errorOccurred).toBeTrue();
-    }));
-
-    it('should handle errors when cancelling all running build jobs in a course', fakeAsync(() => {
-        const courseId = 1;
-
-        let errorOccurred = false;
-
-        service.cancelAllRunningBuildJobsInCourse(courseId).subscribe({
-            error: (err) => {
-                // Ensure that the error is handled properly
-                expect(err.message).toBe(
-                    'Failed to cancel all running build jobs in course ' +
-                        courseId +
-                        '\nHttp failure response for ' +
-                        service.resourceUrl +
-                        '/courses/' +
-                        courseId +
-                        '/cancel-all-running-jobs: 500 Internal Server Error',
-                );
-                errorOccurred = true;
-            },
-        });
-
-        const req = httpMock.expectOne(`${service.resourceUrl}/courses/${courseId}/cancel-all-running-jobs`);
         expect(req.request.method).toBe('DELETE');
 
         // Simulate an error response from the server


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, we can observe the running and queued build jobs, but we can't cancel them deterministically on a multiple node system f.ex. TS3. It would be nice to fix this and be able to cancel these build jobs if they freeze or are irrelevant. For testing purposes, it would also be nice to cancel all.

### Description
<!-- Describe your changes in detail -->
The implementation on canceling running build jobs was removed as it wasn't working yet (This is tackled in the stacked PR https://github.com/ls1intum/Artemis/pull/7894). Issues that were causing the build queue to not be updated on ts3 were fixed by changing the EntryListeners from `LocalEntryListeners` to normal `EntryListeners` in `LocalCIQueueWebsocketService`. Also, there was a rounding issue between the Server and Client with the _Long_ `buildJobId`, which was used to update the queue, so it was turned into a _String_ now.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

**Only deploy on ts3, ts6 and ts11.** 


Prerequisites:
- 1 Instructor
- 1 Admin
- 1 Student/ Tutor

**Build Queue for Instructors/Admin on Course Level:** Course Management > _course xy_ > Build Queue
**Build Queue for Admins only:** Server Administration > Build Queue

Trigger some builds by submitting a few programming exercises. Navigate to the Build Queue and try to cancel some builds differently (individually or canceling all at once). Make sure that Students and Tutors can't access this functionality. Lastly, make sure that you also don't receive any feedback for the canceled build job, suggesting it got processed successfully. Make sure that it also works on ts3, which uses multiple nodes.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1422" alt="Screenshot 2024-01-16 at 13 09 38" src="https://github.com/ls1intum/Artemis/assets/120647937/477a7141-c8c4-49d7-a086-9a1de437c419">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new methods for canceling individual and all queued build jobs.

- **Improvements**
  - Enhanced build job management with simplified cancellation logic.

- **User Interface Changes**
  - Removed cancel buttons for running build jobs from the build queue interface.

- **Refactor**
  - Standardized build job identifiers to use strings instead of numbers across various components and services.

- **Bug Fixes**
  - Adjusted event listener registration to improve build job processing notifications.

- **Tests**
  - Updated tests to reflect changes in build job cancellation and identifier data types.

- **Removals**
  - Eliminated the functionality for canceling all running build jobs to streamline the build queue management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->