### PR TITLE
 `General`: Fix text overlapping buttons in course management view

### DIFF
--- a/src/main/webapp/app/course/manage/overview/course-management-card.scss
+++ b/src/main/webapp/app/course/manage/overview/course-management-card.scss
@@ -102,7 +102,7 @@
 
     .section-card {
         min-width: 30%;
-        height: 300px;
+        height: 310px;
 
         .collapsed {
             margin-top: 2px;
@@ -122,12 +122,12 @@
 
     .section-content {
         overflow: auto;
-        height: 300px;
+        height: 310px;
     }
 
     .statistics-card {
         border-left: 1px solid rgba(0, 0, 0, 0.125);
-        height: 300px;
+        height: 310px;
 
         .statistics-chart {
             position: relative;

--- a/src/main/webapp/app/course/manage/overview/course-management-exercise-row.scss
+++ b/src/main/webapp/app/course/manage/overview/course-management-exercise-row.scss
@@ -5,7 +5,7 @@
     display: flex;
     align-items: center;
     align-content: center;
-    height: 60px;
+    height: 70px;
 
     .item-title-container {
         display: flex;
@@ -130,10 +130,6 @@
         display: flex;
         flex-direction: column;
         justify-content: center;
-
-        span {
-            white-space: nowrap;
-        }
     }
 
     .pointer-row {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Description
<!-- Describe your changes in detail -->
After an exercise has finished the course management overview page has a statistic per exercise on the average achieved points.
In the German translation this bar graph extends behind the buttons.

This PR resolves #7726 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Set the Artemis UI language to German.
Go to the course management.
Compare to screenshot below.
![287808944-5ebaeced-6c43-4ec3-997d-ec97206231a5](https://github.com/ls1intum/Artemis/assets/38523756/ed873175-8cdf-4328-aed9-e42dff799923)


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
After seeting the language to German average statistics should not overlap with button container in course overview page.
![Screenshot 2024-01-15 at 22 43 35](https://github.com/ls1intum/Artemis/assets/38523756/9072d4a9-883a-48fd-9267-23e081d4f977)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted layout dimensions for section and statistics cards.
	- Increased element height for better visual presentation.
	- Improved text wrapping for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->