### PR TITLE
`Iris`: Fix iris health check taking too long

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/RestTemplateConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/RestTemplateConfiguration.java
@@ -156,8 +156,8 @@ public class RestTemplateConfiguration {
 
     @Bean
     @Profile("iris")
-    public RestTemplate shortTimeoutIrisRestTemplate() {
-        return createShortTimeoutRestTemplate();
+    public RestTemplate shortTimeoutIrisRestTemplate(IrisAuthorizationInterceptor irisAuthorizationInterceptor) {
+        return initializeRestTemplateWithInterceptors(irisAuthorizationInterceptor, createShortTimeoutRestTemplate());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/iris/IrisHealthIndicator.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/iris/IrisHealthIndicator.java
@@ -24,7 +24,7 @@ public class IrisHealthIndicator implements HealthIndicator {
     @Value("${artemis.iris.url}")
     private URI irisUrl;
 
-    public IrisHealthIndicator(@Qualifier("irisRestTemplate") RestTemplate restTemplate) {
+    public IrisHealthIndicator(@Qualifier("shortTimeoutIrisRestTemplate") RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/connector/IrisRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/IrisRequestMockProvider.java
@@ -34,7 +34,11 @@ public class IrisRequestMockProvider {
 
     private final RestTemplate restTemplate;
 
+    private final RestTemplate shortTimeoutRestTemplate;
+
     private MockRestServiceServer mockServer;
+
+    private MockRestServiceServer shortTimeoutMockServer;
 
     @Value("${artemis.iris.url}/api/v1/messages")
     private URL messagesApiV1URL;
@@ -53,12 +57,14 @@ public class IrisRequestMockProvider {
 
     private AutoCloseable closeable;
 
-    public IrisRequestMockProvider(@Qualifier("irisRestTemplate") RestTemplate restTemplate) {
+    public IrisRequestMockProvider(@Qualifier("irisRestTemplate") RestTemplate restTemplate, @Qualifier("shortTimeoutIrisRestTemplate") RestTemplate shortTimeoutRestTemplate) {
         this.restTemplate = restTemplate;
+        this.shortTimeoutRestTemplate = shortTimeoutRestTemplate;
     }
 
     public void enableMockingOfRequests() {
         mockServer = MockRestServiceServer.createServer(restTemplate);
+        shortTimeoutMockServer = MockRestServiceServer.createServer(shortTimeoutRestTemplate);
         closeable = MockitoAnnotations.openMocks(this);
     }
 
@@ -160,7 +166,7 @@ public class IrisRequestMockProvider {
         var irisStatusDTOArray = new IrisStatusDTO[] { new IrisStatusDTO("TEST_MODEL_UP", IrisStatusDTO.ModelStatus.UP),
                 new IrisStatusDTO("TEST_MODEL_DOWN", IrisStatusDTO.ModelStatus.DOWN), new IrisStatusDTO("TEST_MODEL_NA", IrisStatusDTO.ModelStatus.NOT_AVAILABLE) };
         // @formatter:off
-        mockServer.expect(ExpectedCount.once(), requestTo(healthApiURL.toString()))
+        shortTimeoutMockServer.expect(ExpectedCount.once(), requestTo(healthApiURL.toString()))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withSuccess(mapper.writeValueAsString(irisStatusDTOArray), MediaType.APPLICATION_JSON));
         // @formatter:on


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Sometimes the Pyris server takes a long time to respond to the health check, which causes the Artemis health check to break, as it did not use the short timeout rest template.

### Description
<!-- Describe your changes in detail -->
This PR fixes that.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Admin

1. Log in to Artemis
2. Go to the health admin page
3. Check that the Pyris health check is green

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
#### Manual Tests
- [ ] Test 1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the initialization process for REST template configurations to enhance communication with external services.
- **Chores**
	- Updated the constructor parameter annotation in the `IrisHealthIndicator` class to use a specific qualifier for the injected `RestTemplate` bean.
	- Modified the `IrisRequestMockProvider` class to support an additional `shortTimeoutRestTemplate` and its associated `shortTimeoutMockServer`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->