### PR TITLE
`General`: Use easier date format when sending emails

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/TimeService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TimeService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class TimeService {
 
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy - hh:mm");
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd - hh:mm");
 
     public ZonedDateTime now() {
         return ZonedDateTime.now();


### PR DESCRIPTION
MM/dd/yyyy is confusing - change is needed to keep the students happy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the date format for displayed times to "yyyy-MM-dd - hh:mm" for improved consistency and international standards compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->