### PR TITLE
`Development`: Bump bamboo spec version to 9.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,7 +251,7 @@ dependencies {
     }
     implementation "org.jasypt:jasypt:1.9.3"
     implementation "me.xdrop:fuzzywuzzy:1.4.0"
-    implementation "com.atlassian.bamboo:bamboo-specs:9.3.5"
+    implementation "com.atlassian.bamboo:bamboo-specs:9.4.2"
     implementation ("org.yaml:snakeyaml") {
         version {
             strictly "2.2" // needed for Bamboo-specs and to reduce the number of vulnerabilities, also see https://mvnrepository.com/artifact/org.yaml/snakeyaml

--- a/docker/atlassian.yml
+++ b/docker/atlassian.yml
@@ -24,7 +24,7 @@ services:
         hostname: bitbucket
         extra_hosts:
             - "host.docker.internal:host-gateway"
-        image: ghcr.io/ls1intum/artemis-bitbucket:8.15.1
+        image: ghcr.io/ls1intum/artemis-bitbucket:8.16.2
         pull_policy: if_not_present
         volumes:
             - artemis-bitbucket-data:/var/atlassian/application-data/bitbucket
@@ -44,7 +44,7 @@ services:
         hostname: bamboo
         extra_hosts:
             - "host.docker.internal:host-gateway"
-        image: ghcr.io/ls1intum/artemis-bamboo:9.3.5
+        image: ghcr.io/ls1intum/artemis-bamboo:9.4.2
         pull_policy: if_not_present
         volumes:
             - artemis-bamboo-data:/var/atlassian/application-data/bamboo

--- a/docker/atlassian.yml
+++ b/docker/atlassian.yml
@@ -69,7 +69,7 @@ services:
         hostname: bamboo-build-agent
         extra_hosts:
             - "host.docker.internal:host-gateway"
-        image: ghcr.io/ls1intum/artemis-bamboo-build-agent:9.3.5
+        image: ghcr.io/ls1intum/artemis-bamboo-build-agent:9.4.2
         pull_policy: if_not_present
         volumes:
             # The following path needs to be the same absolute path on the host because of the docker socket:


### PR DESCRIPTION
## Motivation and Context
Updated Bamboo from 8.2.5 to 9.4.2 due to infrastructure changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Atlassian Bamboo specs dependency to version 9.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->