### PR TITLE
`Development`: Fixed flaky test assertion in conversation test

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/metis/ConversationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ConversationIntegrationTest.java
@@ -3,8 +3,10 @@ package de.tum.in.www1.artemis.metis;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -466,7 +468,9 @@ class ConversationIntegrationTest extends AbstractConversationTest {
         ConversationParticipant updatedParticipant = conversationParticipantRepository
                 .findConversationParticipantByConversationIdAndUserIdElseThrow(participant.getConversation().getId(), participant.getUser().getId());
         assertThat(updatedParticipant.getLastRead()).isNotNull();
-        assertThat(updatedParticipant.getLastRead()).isAfterOrEqualTo(participant.getLastRead());
+        // lenient assertion to prevent flaky behavior
+        assertThat(updatedParticipant.getLastRead()).satisfiesAnyOf(lastRead -> assertThat(lastRead).isCloseTo(participant.getLastRead(), Assertions.within(1, ChronoUnit.SECONDS)),
+                lastRead -> assertThat(lastRead).isAfter(participant.getLastRead()));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
During the work on another PR, this test failed for no apparent reason and succeeded on reruns. The cause was a failed equal assertion caused by deviating millisecond precision.

### Description
<!-- Describe your changes in detail -->
Instead of the equal/after I added a more lenient assertion to match either a lax equals value **or** after.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
