### PR TITLE
`Development`: Improve JPQL style for complaint repositories

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ComplaintRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ComplaintRepository.java
@@ -259,6 +259,7 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     @EntityGraph(type = LOAD, attributePaths = { "result.participation", "result.submission", "result.assessor" })
     List<Complaint> getAllByResult_Assessor_IdAndResult_Participation_Exercise_Course_Id(Long assessorId, Long courseId);
 
+    // Valid JPQL syntax. Only SCA fails to properly detect the types.
     /**
      * Get the number of Complaints for all tutors of a course
      *
@@ -284,6 +285,7 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
             """)
     List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByCourseId(@Param("courseId") long courseId);
 
+    // Valid JPQL syntax. Only SCA fails to properly detect the types.
     /**
      * Get the number of Complaints for all tutors of an exercise
      *
@@ -309,6 +311,7 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
             """)
     List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByExerciseId(@Param("exerciseId") long exerciseId);
 
+    // Valid JPQL syntax. Only SCA fails to properly detect the types.
     /**
      * Get the number of Complaints for all tutors of an exam
      *
@@ -411,6 +414,7 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
             """)
     List<TutorLeaderboardComplaintResponses> findTutorLeaderboardComplaintResponsesByExamId(@Param("examId") long examId);
 
+    // Valid JPQL syntax. Only SCA fails to properly detect the types.
     /**
      * Get the number of Feedback Requests for all tutors assessments of a course
      *
@@ -435,6 +439,7 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
             """)
     List<TutorLeaderboardMoreFeedbackRequests> findTutorLeaderboardMoreFeedbackRequestsByCourseId(@Param("courseId") long courseId);
 
+    // Valid JPQL syntax. Only SCA fails to properly detect the types.
     /**
      * Get the number of Feedback Requests for all tutors assessments of an exercise
      *

--- a/src/main/java/de/tum/in/www1/artemis/repository/ComplaintRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ComplaintRepository.java
@@ -26,29 +26,32 @@ import de.tum.in.www1.artemis.domain.leaderboard.tutor.*;
 public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
 
     @Query("""
-            SELECT c FROM Complaint c
-            LEFT JOIN c.result r
-            LEFT JOIN r.submission s
-            WHERE s.id = :#{#submissionId}
+            SELECT c
+            FROM Complaint c
+                LEFT JOIN c.result r
+                LEFT JOIN r.submission s
+            WHERE s.id = :submissionId
             """)
     Optional<Complaint> findByResultSubmissionId(@Param("submissionId") Long submissionId);
 
     @Query("""
-                        SELECT c FROM Complaint c
-                            LEFT JOIN c.result r
-                            LEFT JOIN r.submission s
-                            LEFT JOIN FETCH c.complaintResponse
-                        WHERE s.id = :#{#submissionId}
+            SELECT c
+            FROM Complaint c
+                LEFT JOIN c.result r
+                LEFT JOIN r.submission s
+                LEFT JOIN FETCH c.complaintResponse
+            WHERE s.id = :submissionId
             """)
     Optional<Complaint> findWithEagerComplaintResponseByResultSubmissionId(@Param("submissionId") long submissionId);
 
     Optional<Complaint> findByResultId(Long resultId);
 
     @Query("""
-            SELECT c FROM Complaint c
-            LEFT JOIN FETCH c.result r
-            LEFT JOIN FETCH r.assessor
-            WHERE c.id = :#{#complaintId}
+            SELECT c
+            FROM Complaint c
+                LEFT JOIN FETCH c.result r
+                LEFT JOIN FETCH r.assessor
+            WHERE c.id = :complaintId
             """)
     Optional<Complaint> findByIdWithEagerAssessor(@Param("complaintId") Long complaintId);
 
@@ -71,13 +74,15 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     long countByResult_Participation_Exercise_ExerciseGroup_Exam_IdAndComplaintType(Long examId, ComplaintType complaintType);
 
     @Query("""
-            SELECT c FROM Complaint c
-            LEFT JOIN FETCH c.result r
-            LEFT JOIN FETCH r.assessor
-            LEFT JOIN FETCH r.participation p
-            LEFT JOIN FETCH p.exercise e
-            LEFT JOIN FETCH r.submission
-            WHERE e.id = :#{#exerciseId} AND c.complaintType = :#{#complaintType}
+            SELECT c
+            FROM Complaint c
+                LEFT JOIN FETCH c.result r
+                LEFT JOIN FETCH r.assessor
+                LEFT JOIN FETCH r.participation p
+                LEFT JOIN FETCH p.exercise e
+                LEFT JOIN FETCH r.submission
+            WHERE e.id = :exerciseId
+                AND c.complaintType = :complaintType
             """)
     List<Complaint> getAllComplaintsByExerciseIdAndComplaintType(@Param("exerciseId") Long exerciseId, @Param("complaintType") ComplaintType complaintType);
 
@@ -90,9 +95,12 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return the number of unaccepted complaints
      */
     @Query("""
-            SELECT COUNT(c) FROM Complaint c
-            WHERE c.complaintType = 'COMPLAINT' AND c.student.id = :#{#studentId}
-            AND c.result.participation.exercise.course.id = :#{#courseId} AND (c.accepted = false OR c.accepted is null)
+            SELECT COUNT(c)
+            FROM Complaint c
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.COMPLAINT
+                AND c.student.id = :studentId
+                AND c.result.participation.exercise.course.id = :courseId
+                AND (c.accepted IS FALSE OR c.accepted IS NULL)
             """)
     long countUnacceptedComplaintsByComplaintTypeStudentIdAndCourseId(@Param("studentId") Long studentId, @Param("courseId") Long courseId);
 
@@ -105,9 +113,12 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return the number of unaccepted complaints
      */
     @Query("""
-            SELECT COUNT(c) FROM Complaint c
-            WHERE c.complaintType = 'COMPLAINT' AND c.team.shortName = :#{#teamShortName}
-            AND c.result.participation.exercise.course.id = :#{#courseId} AND (c.accepted = false OR c.accepted is null)
+            SELECT COUNT(c)
+            FROM Complaint c
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.COMPLAINT
+                AND c.team.shortName = :teamShortName
+                AND c.result.participation.exercise.course.id = :courseId
+                AND (c.accepted IS FALSE OR c.accepted IS NULL)
             """)
     long countUnacceptedComplaintsByComplaintTypeTeamShortNameAndCourseId(@Param("teamShortName") String teamShortName, @Param("courseId") Long courseId);
 
@@ -119,8 +130,9 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return number of complaints associated to exercise exerciseId
      */
     @Query("""
-                SELECT COUNT(c) FROM Complaint c
-                WHERE c.result.participation.exercise.id = :exerciseId
+            SELECT COUNT(c)
+            FROM Complaint c
+            WHERE c.result.participation.exercise.id = :exerciseId
                 AND c.complaintType = :complaintType
             """)
     long countComplaintsByExerciseIdAndComplaintType(@Param("exerciseId") Long exerciseId, @Param("complaintType") ComplaintType complaintType);
@@ -133,15 +145,14 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return number of complaints associated to exercise exerciseId
      */
     @Query("""
-                SELECT
-                    new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
-                        c.result.participation.exercise.id,
-                        COUNT(DISTINCT c)
-                    )
-                FROM Complaint c
-                WHERE c.result.participation.exercise.id IN (:exerciseIds)
-                    AND c.complaintType = :complaintType
-                GROUP BY c.result.participation.exercise.id
+            SELECT new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
+                c.result.participation.exercise.id,
+                COUNT(DISTINCT c)
+            )
+            FROM Complaint c
+            WHERE c.result.participation.exercise.id IN :exerciseIds
+                AND c.complaintType = :complaintType
+            GROUP BY c.result.participation.exercise.id
             """)
     List<ExerciseMapEntry> countComplaintsByExerciseIdsAndComplaintType(@Param("exerciseIds") Set<Long> exerciseIds, @Param("complaintType") ComplaintType complaintType);
 
@@ -153,16 +164,15 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return number of complaints associated to exercise exerciseId
      */
     @Query("""
-                SELECT
-                    new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
-                        c.result.participation.exercise.id,
-                        count(DISTINCT c)
-                    )
-                FROM Complaint c
-                WHERE c.result.participation.exercise.id IN (:exerciseIds)
-                    AND c.complaintType = :complaintType
-                    AND c.result.participation.testRun = FALSE
-                GROUP BY c.result.participation.exercise.id
+            SELECT new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
+                c.result.participation.exercise.id,
+                COUNT(DISTINCT c)
+            )
+            FROM Complaint c
+            WHERE c.result.participation.exercise.id IN :exerciseIds
+                AND c.complaintType = :complaintType
+                AND c.result.participation.testRun IS FALSE
+            GROUP BY c.result.participation.exercise.id
             """)
     List<ExerciseMapEntry> countComplaintsByExerciseIdsAndComplaintTypeIgnoreTestRuns(@Param("exerciseIds") Set<Long> exerciseIds,
             @Param("complaintType") ComplaintType complaintType);
@@ -176,10 +186,11 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return number of complaints associated to exercise exerciseId without test runs
      */
     @Query("""
-            SELECT count(c) FROM Complaint c
-            WHERE c.complaintType = :#{#complaintType}
-            AND c.result.participation.testRun = false
-            AND c.result.participation.exercise.id = :#{#exerciseId}
+            SELECT COUNT(c)
+            FROM Complaint c
+            WHERE c.complaintType = :complaintType
+                AND c.result.participation.testRun IS FALSE
+                AND c.result.participation.exercise.id = :exerciseId
             """)
     long countByResultParticipationExerciseIdAndComplaintTypeIgnoreTestRuns(@Param("exerciseId") Long exerciseId, @Param("complaintType") ComplaintType complaintType);
 
@@ -255,20 +266,20 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return list of TutorLeaderboardComplaints
      */
     @Query("""
-            SELECT
-            new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaints(
+            SELECT new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaints(
                 r.assessor.id,
-                count(c),
-                sum( CASE WHEN (c.accepted = true) THEN 1L ELSE 0L END),
-                sum( CASE WHEN (c.accepted = true) THEN e.maxPoints ELSE 0.0 END)
+                COUNT(c),
+                SUM( CASE WHEN (c.accepted IS TRUE ) THEN 1L ELSE 0L END),
+                SUM( CASE WHEN (c.accepted IS TRUE) THEN e.maxPoints ELSE 0.0 END)
             )
-            FROM
-                Complaint c join c.result r join r.participation p join p.exercise e
-            WHERE
-                    c.complaintType = 'COMPLAINT'
-                and e.course.id = :courseId
-                and r.completionDate IS NOT NULL
-                and r.assessor.id IS NOT NULL
+            FROM Complaint c
+                JOIN c.result r
+                JOIN r.participation p
+                JOIN p.exercise e
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.COMPLAINT
+                AND e.course.id = :courseId
+                AND r.completionDate IS NOT NULL
+                AND r.assessor.id IS NOT NULL
             GROUP BY r.assessor.id
             """)
     List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByCourseId(@Param("courseId") long courseId);
@@ -280,20 +291,20 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return list of TutorLeaderboardComplaints
      */
     @Query("""
-            SELECT
-            new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaints(
+            SELECT new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaints(
                 r.assessor.id,
-                count(c),
-                sum( CASE WHEN (c.accepted = true ) THEN 1L ELSE 0L END),
-                sum( CASE WHEN (c.accepted = true) THEN e.maxPoints ELSE 0.0 END)
+                COUNT(c),
+                SUM( CASE WHEN (c.accepted IS TRUE ) THEN 1L ELSE 0L END),
+                SUM( CASE WHEN (c.accepted IS TRUE) THEN e.maxPoints ELSE 0.0 END)
             )
-            FROM
-                Complaint c join c.result r join r.participation p join p.exercise e
-            WHERE
-                    c.complaintType = 'COMPLAINT'
-                and e.id = :#{#exerciseId}
-                and r.completionDate IS NOT NULL
-                and r.assessor.id IS NOT NULL
+            FROM Complaint c
+                JOIN c.result r
+                JOIN r.participation p
+                JOIN p.exercise e
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.COMPLAINT
+                AND e.id = :exerciseId
+                AND r.completionDate IS NOT NULL
+                AND r.assessor.id IS NOT NULL
             GROUP BY r.assessor.id
             """)
     List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByExerciseId(@Param("exerciseId") long exerciseId);
@@ -305,20 +316,21 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return list of TutorLeaderboardComplaints
      */
     @Query("""
-            SELECT
-            new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaints(
+            SELECT new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaints(
                 r.assessor.id,
-                count(c),
-                sum( CASE WHEN (c.accepted = true ) THEN 1L ELSE 0L END),
-                sum( CASE WHEN (c.accepted = true) THEN e.maxPoints ELSE 0.0 END)
+                COUNT(c),
+                SUM( CASE WHEN (c.accepted IS TRUE ) THEN 1L ELSE 0L END),
+                SUM( CASE WHEN (c.accepted IS TRUE) THEN e.maxPoints ELSE 0.0 END)
             )
-            FROM
-                Complaint c join c.result r join r.participation p join p.exercise e join e.exerciseGroup eg
-            WHERE
-                    c.complaintType = 'COMPLAINT'
-                and eg.exam.id = :#{#examId}
-                and r.completionDate IS NOT NULL
-                and r.assessor.id IS NOT NULL
+            FROM Complaint c
+                JOIN c.result r
+                JOIN r.participation p
+                JOIN p.exercise e
+                JOIN e.exerciseGroup eg
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.COMPLAINT
+                AND eg.exam.id = :examId
+                AND r.completionDate IS NOT NULL
+                AND r.assessor.id IS NOT NULL
             GROUP BY r.assessor.id
             """)
     List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByExamId(@Param("examId") long examId);
@@ -330,19 +342,20 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return list of TutorLeaderboardComplaintResponses
      */
     @Query("""
-            SELECT
-            new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaintResponses(
+            SELECT new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaintResponses(
                 cr.reviewer.id,
-                count(c),
-                sum(e.maxPoints)
+                COUNT(c),
+                SUM(e.maxPoints)
             )
-            FROM
-                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e
-            WHERE
-                c.complaintType = 'COMPLAINT'
-                and e.course.id = :courseId
-                and r.completionDate IS NOT NULL
-                and c.accepted IS NOT NULL
+            FROM Complaint c
+                JOIN c.complaintResponse cr
+                JOIN c.result r
+                JOIN r.participation p
+                JOIN p.exercise e
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.COMPLAINT
+                AND e.course.id = :courseId
+                AND r.completionDate IS NOT NULL
+                AND c.accepted IS NOT NULL
             GROUP BY cr.reviewer.id
             """)
     List<TutorLeaderboardComplaintResponses> findTutorLeaderboardComplaintResponsesByCourseId(@Param("courseId") long courseId);
@@ -354,21 +367,22 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return list of TutorLeaderboardComplaintResponses
      */
     @Query("""
-            SELECT
-             new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaintResponses(
-                 cr.reviewer.id,
-                 count(c),
-                 sum(e.maxPoints)
-             )
-             FROM
-                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e
-             WHERE
-                 c.complaintType = 'COMPLAINT'
-                 and e.id = :exerciseId
-                 and r.completionDate IS NOT NULL
-                 and c.accepted IS NOT NULL
-             GROUP BY cr.reviewer.id
-             """)
+            SELECT new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaintResponses(
+                cr.reviewer.id,
+                COUNT(c),
+                SUM(e.maxPoints)
+            )
+            FROM Complaint c
+                JOIN c.complaintResponse cr
+                JOIN c.result r
+                JOIN r.participation p
+                JOIN p.exercise e
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.COMPLAINT
+                AND e.id = :exerciseId
+                AND r.completionDate IS NOT NULL
+                AND c.accepted IS NOT NULL
+            GROUP BY cr.reviewer.id
+            """)
     List<TutorLeaderboardComplaintResponses> findTutorLeaderboardComplaintResponsesByExerciseId(@Param("exerciseId") long exerciseId);
 
     /**
@@ -378,21 +392,23 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return list of TutorLeaderboardComplaintResponses
      */
     @Query("""
-            SELECT
-             new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaintResponses(
-                 cr.reviewer.id,
-                 count(c),
-                 sum(e.maxPoints)
-             )
-             FROM
-                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e join e.exerciseGroup eg
-             WHERE
-                 c.complaintType = 'COMPLAINT'
-                 and eg.exam.id = :examId
-                 and r.completionDate IS NOT NULL
-                 and c.accepted IS NOT NULL
-             GROUP BY cr.reviewer.id
-             """)
+            SELECT new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaintResponses(
+                cr.reviewer.id,
+                COUNT(c),
+                SUM(e.maxPoints)
+            )
+            FROM Complaint c
+                JOIN c.complaintResponse cr
+                JOIN c.result r
+                JOIN r.participation p
+                JOIN p.exercise e
+                JOIN e.exerciseGroup eg
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.COMPLAINT
+                AND eg.exam.id = :examId
+                AND r.completionDate IS NOT NULL
+                AND c.accepted IS NOT NULL
+            GROUP BY cr.reviewer.id
+            """)
     List<TutorLeaderboardComplaintResponses> findTutorLeaderboardComplaintResponsesByExamId(@Param("examId") long examId);
 
     /**
@@ -402,21 +418,21 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return list of TutorLeaderboardMoreFeedbackRequests
      */
     @Query("""
-            SELECT
-             new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardMoreFeedbackRequests(
-                 r.assessor.id,
-                 count(c),
-                 sum( CASE WHEN (c.accepted IS NULL) THEN 1L ELSE 0L END),
-                 sum( CASE WHEN (c.accepted IS NULL) THEN e.maxPoints ELSE 0.0 END)
-             )
-             FROM
-                Complaint c join c.result r join r.participation p join p.exercise e
-             WHERE
-                 c.complaintType = 'MORE_FEEDBACK'
-                 and e.course.id = :courseId
-                 and r.completionDate IS NOT NULL
-             GROUP BY r.assessor.id
-             """)
+            SELECT new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardMoreFeedbackRequests(
+                r.assessor.id,
+                COUNT(c),
+                SUM( CASE WHEN (c.accepted IS NULL) THEN 1L ELSE 0L END),
+                SUM( CASE WHEN (c.accepted IS NULL) THEN e.maxPoints ELSE 0.0 END)
+            )
+            FROM Complaint c
+                JOIN c.result r
+                JOIN r.participation p
+                JOIN p.exercise e
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.MORE_FEEDBACK
+                AND e.course.id = :courseId
+                AND r.completionDate IS NOT NULL
+            GROUP BY r.assessor.id
+            """)
     List<TutorLeaderboardMoreFeedbackRequests> findTutorLeaderboardMoreFeedbackRequestsByCourseId(@Param("courseId") long courseId);
 
     /**
@@ -426,19 +442,20 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return list of TutorLeaderboardMoreFeedbackRequests
      */
     @Query("""
-            SELECT
-            new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardMoreFeedbackRequests(
+            SELECT new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardMoreFeedbackRequests(
                 r.assessor.id,
-                count(c),
-                sum( CASE WHEN (c.accepted IS NULL) THEN 1L ELSE 0L END),
-                sum( CASE WHEN (c.accepted IS NULL) THEN e.maxPoints ELSE 0.0 END)
+                COUNT(c),
+                SUM( CASE WHEN (c.accepted IS NULL) THEN 1L ELSE 0L END),
+                SUM( CASE WHEN (c.accepted IS NULL) THEN e.maxPoints ELSE 0.0 END)
             )
-            FROM
-                Complaint c join c.result r join r.participation p join p.exercise e
+            FROM Complaint c
+                JOIN c.result r
+                JOIN r.participation p
+                JOIN p.exercise e
             WHERE
-                c.complaintType = 'MORE_FEEDBACK'
-                and e.id = :exerciseId
-                and r.completionDate IS NOT NULL
+                c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.MORE_FEEDBACK
+                AND e.id = :exerciseId
+                AND r.completionDate IS NOT NULL
             GROUP BY r.assessor.id
             """)
     List<TutorLeaderboardMoreFeedbackRequests> findTutorLeaderboardMoreFeedbackRequestsByExerciseId(@Param("exerciseId") long exerciseId);
@@ -450,19 +467,20 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return list of TutorLeaderboardAnsweredMoreFeedbackRequests
      */
     @Query("""
-            SELECT
-            new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardAnsweredMoreFeedbackRequests(
+            SELECT new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardAnsweredMoreFeedbackRequests(
                 cr.reviewer.id,
-                count(c),
-                sum(e.maxPoints)
+                COUNT(c),
+                SUM(e.maxPoints)
             )
-            FROM
-                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e
-            WHERE
-                c.complaintType = 'MORE_FEEDBACK'
-                and e.course.id = :courseId
-                and r.completionDate IS NOT NULL
-                and c.accepted = true
+            FROM Complaint c
+                JOIN c.complaintResponse cr
+                JOIN c.result r
+                JOIN r.participation p
+                JOIN p.exercise e
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.MORE_FEEDBACK
+                AND e.course.id = :courseId
+                AND r.completionDate IS NOT NULL
+                AND c.accepted IS TRUE
             GROUP BY cr.reviewer.id
             """)
     List<TutorLeaderboardAnsweredMoreFeedbackRequests> findTutorLeaderboardAnsweredMoreFeedbackRequestsByCourseId(@Param("courseId") long courseId);
@@ -474,19 +492,20 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
      * @return list of TutorLeaderboardAnsweredMoreFeedbackRequests
      */
     @Query("""
-            SELECT
-            new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardAnsweredMoreFeedbackRequests(
+            SELECT new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardAnsweredMoreFeedbackRequests(
                 cr.reviewer.id,
-                count(c),
-                sum(e.maxPoints)
-                )
-            FROM
-                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e
-            WHERE
-                c.complaintType = 'MORE_FEEDBACK'
-                and e.id = :exerciseId
-                and r.completionDate IS NOT NULL
-                and c.accepted = true
+                COUNT(c),
+                SUM(e.maxPoints)
+            )
+            FROM Complaint c
+                JOIN c.complaintResponse cr
+                JOIN c.result r
+                JOIN r.participation p
+                JOIN p.exercise e
+            WHERE c.complaintType = de.tum.in.www1.artemis.domain.enumeration.ComplaintType.MORE_FEEDBACK
+                AND e.id = :exerciseId
+                AND r.completionDate IS NOT NULL
+                AND c.accepted IS TRUE
             GROUP BY cr.reviewer.id
             """)
     List<TutorLeaderboardAnsweredMoreFeedbackRequests> findTutorLeaderboardAnsweredMoreFeedbackRequestsByExerciseId(@Param("exerciseId") long exerciseId);

--- a/src/main/java/de/tum/in/www1/artemis/repository/ComplaintRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ComplaintRepository.java
@@ -102,7 +102,7 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
                 AND c.result.participation.exercise.course.id = :courseId
                 AND (c.accepted IS FALSE OR c.accepted IS NULL)
             """)
-    long countUnacceptedComplaintsByComplaintTypeStudentIdAndCourseId(@Param("studentId") Long studentId, @Param("courseId") Long courseId);
+    long countUnacceptedComplaintsByStudentIdAndCourseId(@Param("studentId") Long studentId, @Param("courseId") Long courseId);
 
     /**
      * Count the number of unaccepted complaints of a team in a given course. Unaccepted means that they are either open/unhandled or rejected. We use this to limit the number

--- a/src/main/java/de/tum/in/www1/artemis/repository/ComplaintResponseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ComplaintResponseRepository.java
@@ -49,8 +49,9 @@ public interface ComplaintResponseRepository extends JpaRepository<ComplaintResp
      * @return number of complaints response associated to exercise exerciseId
      */
     @Query("""
-            SELECT COUNT (DISTINCT cr) FROM ComplaintResponse cr
-                WHERE cr.complaint.result.participation.exercise.id = :exerciseId
+            SELECT COUNT (DISTINCT cr)
+            FROM ComplaintResponse cr
+            WHERE cr.complaint.result.participation.exercise.id = :exerciseId
                 AND cr.complaint.complaintType = :complaintType
                 AND cr.submittedTime IS NOT NULL
             """)
@@ -64,17 +65,16 @@ public interface ComplaintResponseRepository extends JpaRepository<ComplaintResp
      * @return number of complaints associated to exercise exerciseId
      */
     @Query("""
-                SELECT
-                    new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
-                        cr.complaint.result.participation.exercise.id,
-                        count(DISTINCT cr)
-                    )
-                FROM ComplaintResponse cr
-                WHERE cr.complaint.result.participation.exercise.id IN (:exerciseIds)
-                    AND cr.submittedTime IS NOT NULL
-                    AND cr.complaint.complaintType = :complaintType
-                    AND cr.complaint.result.participation.testRun = FALSE
-                GROUP BY cr.complaint.result.participation.exercise.id
+            SELECT new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
+                cr.complaint.result.participation.exercise.id,
+                COUNT(DISTINCT cr)
+            )
+            FROM ComplaintResponse cr
+            WHERE cr.complaint.result.participation.exercise.id IN :exerciseIds
+                AND cr.submittedTime IS NOT NULL
+                AND cr.complaint.complaintType = :complaintType
+                AND cr.complaint.result.participation.testRun IS FALSE
+            GROUP BY cr.complaint.result.participation.exercise.id
             """)
     List<ExerciseMapEntry> countComplaintsByExerciseIdsAndComplaintComplaintTypeIgnoreTestRuns(@Param("exerciseIds") Set<Long> exerciseIds,
             @Param("complaintType") ComplaintType complaintType);
@@ -87,16 +87,15 @@ public interface ComplaintResponseRepository extends JpaRepository<ComplaintResp
      * @return number of complaints associated to exercise exerciseId
      */
     @Query("""
-                SELECT
-                    new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
-                        cr.complaint.result.participation.exercise.id,
-                        count(DISTINCT cr)
-                    )
-                FROM ComplaintResponse cr
-                WHERE cr.complaint.result.participation.exercise.id IN (:exerciseIds)
-                    AND cr.submittedTime IS NOT NULL
-                    AND cr.complaint.complaintType = :complaintType
-                GROUP BY cr.complaint.result.participation.exercise.id
+            SELECT new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
+                cr.complaint.result.participation.exercise.id,
+                COUNT(DISTINCT cr)
+            )
+            FROM ComplaintResponse cr
+            WHERE cr.complaint.result.participation.exercise.id IN :exerciseIds
+                AND cr.submittedTime IS NOT NULL
+                AND cr.complaint.complaintType = :complaintType
+            GROUP BY cr.complaint.result.participation.exercise.id
             """)
     List<ExerciseMapEntry> countComplaintsByExerciseIdsAndComplaintComplaintType(@Param("exerciseIds") Set<Long> exerciseIds, @Param("complaintType") ComplaintType complaintType);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ComplaintService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ComplaintService.java
@@ -132,7 +132,7 @@ public class ComplaintService {
      */
     public long countUnacceptedComplaintsByParticipantAndCourseId(Participant participant, long courseId) {
         if (participant instanceof User) {
-            return complaintRepository.countUnacceptedComplaintsByComplaintTypeStudentIdAndCourseId(participant.getId(), courseId);
+            return complaintRepository.countUnacceptedComplaintsByStudentIdAndCourseId(participant.getId(), courseId);
         }
         else if (participant instanceof Team) {
             return complaintRepository.countUnacceptedComplaintsByComplaintTypeTeamShortNameAndCourseId(participant.getParticipantIdentifier(), courseId);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I just fixed the style in one repository so I decided to go through some more repos to make the codebase more consistent and clean.

### Description
<!-- Describe your changes in detail -->
I enforced capitalisation (SELECT instead of select), simple variable declaration (:var instead of :#{#var}, explicit enum values, consistent newlines and indentations.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
No functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the readability and structure of database queries related to complaint management.
- **Bug Fixes**
	- Fixed query parameters to accurately filter complaint responses by type and ensure only non-null submission times are considered.
	- Corrected logical conditions in queries to distinguish between test runs and actual exercise submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->