### PR TITLE
`Development`: Add CPC screencast to the documentation

### DIFF
--- a/docs/user/plagiarism-check.rst
+++ b/docs/user/plagiarism-check.rst
@@ -199,7 +199,12 @@ The following activity diagram depicts the CPC flow described above.
 |cpc-activity-diagram|
 
 
-This video below shows the full CPC process, including creation of a new exercise with the CPC enabled, viewing checks results and post due date steps:
+The video below shows the full CPC process from student's and instructor's perspective. It includes:
+
+#. Creating a new exercise with the CPC enabled.
+#. Reviewing check's results by a student and by an instructor.
+#. Fixing submissions marked as a significant similarity.
+#. Responding to a significant similarity plagiarism case that persisted after the exercise due date.
 
 .. raw:: html
 

--- a/docs/user/plagiarism-check.rst
+++ b/docs/user/plagiarism-check.rst
@@ -198,6 +198,15 @@ The following activity diagram depicts the CPC flow described above.
 
 |cpc-activity-diagram|
 
+
+This video below shows the full CPC process, including creation of a new exercise with the CPC enabled, viewing checks results and post due date steps:
+
+.. raw:: html
+
+    <iframe src="https://live.rbg.tum.de/w/artemisintro/42026?video_only=1&t=0" allowfullscreen="1" frameborder="0" width="600" height="350">
+        Watch this video on TUM-Live.
+    </iframe>
+
 Instructors
 ^^^^^^^^^^^
 

--- a/docs/user/plagiarism-check.rst
+++ b/docs/user/plagiarism-check.rst
@@ -205,6 +205,7 @@ The video below shows the full CPC process from student's and instructor's persp
 #. Reviewing check's results by a student and by an instructor.
 #. Fixing submissions marked as a significant similarity.
 #. Responding to a significant similarity plagiarism case that persisted after the exercise due date.
+#. Adding a verdict to a significant similarity plagiarism case that persisted after the exercise due date.
 
 .. raw:: html
 


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer ~~on a test server~~.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
The flow of the CPC is complex and new to Artemis users. There already exists a detailed documentation explaining it, but presenting the user story on a video improves understanding of this feature by instructors interested in utilising it.

### Description
Added a screencast showing the full flow of the CPC:
1. Creating a new exercise with the CPC enabled.
2. Reviewing check's results by a student and by an instructor.
3. Fixing submissions marked as a significant similarity.
4. Responding to a significant similarity plagiarism case that persisted after the exercise due date.
5. Adding a verdict to a significant similarity plagiarism case that persisted after the exercise due date.

### Steps for Testing
Watch the video: https://live.rbg.tum.de/w/artemisintro/42026

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

@coderabbitai ignore