### PR TITLE
`Development`: Improve JPQL style for exam repositories

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamLiveEventRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamLiveEventRepository.java
@@ -27,7 +27,8 @@ public interface ExamLiveEventRepository extends JpaRepository<ExamLiveEvent, Lo
     @Query("""
             SELECT DISTINCT event
             FROM ExamLiveEvent event
-            WHERE event.studentExamId = :studentExamId OR (event.studentExamId IS NULL AND event.examId = :examId)
+            WHERE event.studentExamId = :studentExamId
+                OR (event.studentExamId IS NULL AND event.examId = :examId)
             ORDER BY event.id DESC
             """)
     List<ExamLiveEvent> findAllByStudentExamIdOrGlobalByExamId(@Param("examId") Long examId, @Param("studentExamId") Long studentExamId);

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -348,7 +348,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
      * @return true if the user is registered for the exam
      */
     @Query("""
-            SELECT CASE WHEN COUNT(exam) > 0 THEN TRUE ELSE FALSE END
+            SELECT COUNT(exam) > 0
             FROM Exam exam
                 LEFT JOIN exam.examUsers examUsers
             WHERE exam.id = :examId

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -63,18 +63,19 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
                 LEFT JOIN e.examUsers registeredUsers
             WHERE e.course.id IN :courseIds
                 AND e.visibleDate <= :now
-                AND (registeredUsers.user.id = :userId
+                AND (
+                    registeredUsers.user.id = :userId
                     OR e.course.teachingAssistantGroupName IN :groupNames
                     OR e.course.editorGroupName IN :groupNames
                     OR e.course.instructorGroupName IN :groupNames
-                    OR e.testExam = true)
+                    OR e.testExam IS TRUE
+                )
             """)
     Set<Exam> findByCourseIdsForUser(@Param("courseIds") Set<Long> courseIds, @Param("userId") Long userId, @Param("groupNames") Set<String> groupNames,
             @Param("now") ZonedDateTime now);
 
     @Query("""
-            select
-            new de.tum.in.www1.artemis.web.rest.dto.CourseContentCount(
+            SELECT new de.tum.in.www1.artemis.web.rest.dto.CourseContentCount(
                 COUNT(e.id),
                 e.course.id
                 )
@@ -88,8 +89,8 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @Query("""
             SELECT exam
             FROM Exam exam
-            WHERE exam.course.testCourse = false
-                AND exam.endDate >= :#{#date}
+            WHERE exam.course.testCourse IS FALSE
+                AND exam.endDate >= :date
             ORDER BY exam.startDate asc
             """)
     List<Exam> findAllByEndDateGreaterThanEqual(@Param("date") ZonedDateTime date);
@@ -104,7 +105,8 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
      * @return Page with exams
      */
     @Query("""
-            SELECT e FROM Exam e
+            SELECT e
+            FROM Exam e
             WHERE e.course.instructorGroupName IN :groups
                 AND e.visibleDate >= :fromDate
                 AND e.visibleDate <= :toDate
@@ -122,8 +124,8 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
             SELECT COUNT(exam)
             FROM Exam exam
             WHERE exam.course.testCourse = false
-                AND exam.visibleDate >= :#{#now}
-                AND exam.endDate <= :#{#now}
+                AND exam.visibleDate >= :now
+                AND exam.endDate <= :now
             """)
     Integer countAllActiveExams(@Param("now") ZonedDateTime now);
 
@@ -137,9 +139,9 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @Query("""
             SELECT COUNT(exam)
             FROM Exam exam
-            WHERE exam.course.testCourse = false
-                AND exam.endDate >= :#{#minDate}
-                AND exam.endDate <= :#{#maxDate}
+            WHERE exam.course.testCourse IS FALSE
+                AND exam.endDate >= :minDate
+                AND exam.endDate <= :maxDate
             """)
     Integer countExamsWithEndDateBetween(@Param("minDate") ZonedDateTime minDate, @Param("maxDate") ZonedDateTime maxDate);
 
@@ -154,9 +156,9 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
             SELECT COUNT(DISTINCT examUsers.user.id)
             FROM Exam exam
             JOIN exam.examUsers examUsers
-            WHERE exam.course.testCourse = false
-                AND exam.endDate >= :#{#minDate}
-                AND exam.endDate <= :#{#maxDate}
+            WHERE exam.course.testCourse IS FALSE
+                AND exam.endDate >= :minDate
+                AND exam.endDate <= :maxDate
             """)
     Integer countExamUsersInExamsWithEndDateBetween(@Param("minDate") ZonedDateTime minDate, @Param("maxDate") ZonedDateTime maxDate);
 
@@ -170,9 +172,9 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @Query("""
             SELECT COUNT(exam)
             FROM Exam exam
-            WHERE exam.course.testCourse = false
-                AND exam.startDate >= :#{#minDate}
-                AND exam.startDate <= :#{#maxDate}
+            WHERE exam.course.testCourse IS FALSE
+                AND exam.startDate >= :minDate
+                AND exam.startDate <= :maxDate
             """)
     Integer countExamsWithStartDateBetween(@Param("minDate") ZonedDateTime minDate, @Param("maxDate") ZonedDateTime maxDate);
 
@@ -187,9 +189,9 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
             SELECT COUNT(DISTINCT examUsers.user.id)
             FROM Exam exam
             JOIN exam.examUsers examUsers
-            WHERE exam.course.testCourse = false
-                AND exam.startDate >= :#{#minDate}
-                AND exam.startDate <= :#{#maxDate}
+            WHERE exam.course.testCourse IS FALSE
+                AND exam.startDate >= :minDate
+                AND exam.startDate <= :maxDate
             """)
     Integer countExamUsersInExamsWithStartDateBetween(@Param("minDate") ZonedDateTime minDate, @Param("maxDate") ZonedDateTime maxDate);
 
@@ -213,18 +215,18 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     Optional<Exam> findWithStudentExamsExercisesById(long id);
 
     @Query("""
-                SELECT e
-                FROM Exam e
-                    LEFT JOIN FETCH e.exerciseGroups exg
-                    LEFT JOIN FETCH exg.exercises ex
-                    LEFT JOIN FETCH ex.quizQuestions
-                    LEFT JOIN FETCH ex.templateParticipation tp
-                    LEFT JOIN FETCH ex.solutionParticipation sp
-                    LEFT JOIN FETCH tp.results tpr
-                    LEFT JOIN FETCH sp.results spr
-                WHERE e.id = :examId
-                    AND (tpr.id = (SELECT MAX(re1.id) FROM tp.results re1) OR tpr.id IS NULL)
-                    AND (spr.id = (SELECT MAX(re2.id) FROM sp.results re2) OR spr.id IS NULL)
+            SELECT e
+            FROM Exam e
+                LEFT JOIN FETCH e.exerciseGroups exg
+                LEFT JOIN FETCH exg.exercises ex
+                LEFT JOIN FETCH ex.quizQuestions
+                LEFT JOIN FETCH ex.templateParticipation tp
+                LEFT JOIN FETCH ex.solutionParticipation sp
+                LEFT JOIN FETCH tp.results tpr
+                LEFT JOIN FETCH sp.results spr
+            WHERE e.id = :examId
+                AND (tpr.id = (SELECT MAX(re1.id) FROM tp.results re1) OR tpr.id IS NULL)
+                AND (spr.id = (SELECT MAX(re2.id) FROM sp.results re2) OR spr.id IS NULL)
             """)
     Optional<Exam> findWithExerciseGroupsAndExercisesAndDetailsById(@Param("examId") long examId);
 
@@ -232,9 +234,9 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
             SELECT DISTINCT e
             FROM Exam e
                 LEFT JOIN FETCH e.exerciseGroups eg
-                LEFT JOIN FETCH eg.exercises ex
-            WHERE e.course.instructorGroupName IN :#{#userGroups}
-                AND TYPE(ex) = QuizExercise
+                JOIN TREAT (eg.exercises AS QuizExercise) ex
+                JOIN FETCH ex
+            WHERE e.course.instructorGroupName IN :userGroups
             """)
     List<Exam> getExamsWithQuizExercisesForWhichUserHasInstructorAccess(@Param("userGroups") List<String> userGroups);
 
@@ -242,8 +244,8 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
             SELECT DISTINCT e
             FROM Exam e
                 LEFT JOIN FETCH e.exerciseGroups eg
-                LEFT JOIN FETCH eg.exercises ex
-            WHERE TYPE(ex) = QuizExercise
+                JOIN TREAT (eg.exercises AS QuizExercise) ex
+                JOIN FETCH ex
             """)
     List<Exam> findAllWithQuizExercisesWithEagerExerciseGroupsAndExercises();
 
@@ -256,9 +258,14 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
      * @return Page with search results
      */
     @Query("""
-            SELECT e FROM Exam e
+            SELECT e
+            FROM Exam e
             WHERE e.course.instructorGroupName IN :groups
-                AND (CONCAT(e.id, '') = :#{#searchTerm} OR e.title LIKE %:searchTerm% OR e.course.title LIKE %:searchTerm%)
+                AND (
+                    CONCAT(e.id, '') = :searchTerm
+                    OR e.title LIKE %:searchTerm%
+                    OR e.course.title LIKE %:searchTerm%
+                )
             """)
     Page<Exam> queryBySearchTermInCoursesWhereInstructor(@Param("searchTerm") String searchTerm, @Param("groups") Set<String> groups, Pageable pageable);
 
@@ -271,10 +278,15 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
      * @return Page with search results
      */
     @Query("""
-            SELECT e FROM Exam e
+            SELECT e
+            FROM Exam e
             WHERE e.course.instructorGroupName IN :groups
-                AND (CONCAT(e.id, '') = :#{#searchTerm} OR e.title LIKE %:searchTerm% OR e.course.title LIKE %:searchTerm%)
                 AND e.exerciseGroups IS NOT EMPTY
+                AND (
+                    CONCAT(e.id, '') = :searchTerm
+                    OR e.title LIKE %:searchTerm%
+                    OR e.course.title LIKE %:searchTerm%
+                )
             """)
     Page<Exam> queryNonEmptyBySearchTermInCoursesWhereInstructor(@Param("searchTerm") String searchTerm, @Param("groups") Set<String> groups, Pageable pageable);
 
@@ -288,7 +300,11 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @Query("""
             SELECT e
             FROM Exam e
-                WHERE (CONCAT(e.id, '') = :#{#searchTerm} OR e.title LIKE %:searchTerm% OR e.course.title LIKE %:searchTerm%)
+            WHERE (
+                CONCAT(e.id, '') = :searchTerm
+                OR e.title LIKE %:searchTerm%
+                OR e.course.title LIKE %:searchTerm%
+            )
             """)
     Page<Exam> queryBySearchTermInAllCourses(@Param("searchTerm") String searchTerm, Pageable pageable);
 
@@ -302,8 +318,12 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @Query("""
             SELECT e
             FROM Exam e
-            WHERE (CONCAT(e.id, '') = :#{#searchTerm} OR e.title LIKE %:searchTerm% OR e.course.title LIKE %:searchTerm%)
-                AND e.exerciseGroups IS NOT EMPTY
+            WHERE e.exerciseGroups IS NOT EMPTY
+                AND (
+                    CONCAT(e.id, '') = :searchTerm
+                    OR e.title LIKE %:searchTerm%
+                    OR e.course.title LIKE %:searchTerm%
+                )
             """)
     Page<Exam> queryNonEmptyBySearchTermInAllCourses(@Param("searchTerm") String searchTerm, Pageable pageable);
 
@@ -329,7 +349,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
      * @return true if the user is registered for the exam
      */
     @Query("""
-            SELECT CASE WHEN COUNT(exam) > 0 THEN true ELSE false END
+            SELECT CASE WHEN COUNT(exam) > 0 THEN TRUE ELSE FALSE END
             FROM Exam exam
                 LEFT JOIN exam.examUsers examUsers
             WHERE exam.id = :examId
@@ -338,7 +358,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     boolean isUserRegisteredForExam(@Param("examId") long examId, @Param("userId") long userId);
 
     @Query("""
-            SELECT exam.id, count(registeredUsers)
+            SELECT exam.id, COUNT(registeredUsers)
             FROM Exam exam
                 LEFT JOIN exam.examUsers registeredUsers
             WHERE exam.id in :examIds
@@ -347,9 +367,9 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     List<long[]> countExamUsersByExamIds(@Param("examIds") List<Long> examIds);
 
     @Query("""
-            SELECT count(studentExam)
+            SELECT COUNT(studentExam)
             FROM StudentExam studentExam
-            WHERE studentExam.testRun = FALSE
+            WHERE studentExam.testRun IS FALSE
                 AND studentExam.exam.id = :examId
             """)
     long countGeneratedStudentExamsByExamWithoutTestRuns(@Param("examId") long examId);
@@ -481,7 +501,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
             WHERE e.course.id IN :courseIds
                 AND e.visibleDate <= :visible
                 AND e.endDate >= :end
-                AND e.testExam = false
+                AND e.testExam IS FALSE
                 AND registeredUsers.user.id = :userId
             """)
     Set<Exam> findActiveExams(@Param("courseIds") Set<Long> courseIds, @Param("userId") Long userId, @Param("visible") ZonedDateTime visible, @Param("end") ZonedDateTime end);

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -78,7 +78,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
             SELECT new de.tum.in.www1.artemis.web.rest.dto.CourseContentCount(
                 COUNT(e.id),
                 e.course.id
-                )
+            )
             FROM Exam e
             WHERE e.course.id IN :courseIds
                 AND e.visibleDate <= :now
@@ -123,7 +123,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @Query("""
             SELECT COUNT(exam)
             FROM Exam exam
-            WHERE exam.course.testCourse = false
+            WHERE exam.course.testCourse IS FALSE
                 AND exam.visibleDate >= :now
                 AND exam.endDate <= :now
             """)
@@ -234,8 +234,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
             SELECT DISTINCT e
             FROM Exam e
                 LEFT JOIN FETCH e.exerciseGroups eg
-                JOIN TREAT (eg.exercises AS QuizExercise) ex
-                JOIN FETCH ex
+                LEFT JOIN FETCH eg.exercises ex
             WHERE e.course.instructorGroupName IN :userGroups
             """)
     List<Exam> getExamsWithQuizExercisesForWhichUserHasInstructorAccess(@Param("userGroups") List<String> userGroups);
@@ -244,8 +243,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
             SELECT DISTINCT e
             FROM Exam e
                 LEFT JOIN FETCH e.exerciseGroups eg
-                JOIN TREAT (eg.exercises AS QuizExercise) ex
-                JOIN FETCH ex
+                LEFT JOIN FETCH eg.exercises ex
             """)
     List<Exam> findAllWithQuizExercisesWithEagerExerciseGroupsAndExercises();
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -244,6 +244,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
             FROM Exam e
                 LEFT JOIN FETCH e.exerciseGroups eg
                 LEFT JOIN FETCH eg.exercises ex
+            WHERE TYPE(ex) = QuizExercise
             """)
     List<Exam> findAllWithQuizExercisesWithEagerExerciseGroupsAndExercises();
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -236,6 +236,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
                 LEFT JOIN FETCH e.exerciseGroups eg
                 LEFT JOIN FETCH eg.exercises ex
             WHERE e.course.instructorGroupName IN :userGroups
+                AND TYPE(ex) = QuizExercise
             """)
     List<Exam> getExamsWithQuizExercisesForWhichUserHasInstructorAccess(@Param("userGroups") List<String> userGroups);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamSessionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamSessionRepository.java
@@ -31,13 +31,13 @@ public interface ExamSessionRepository extends JpaRepository<ExamSession, Long> 
                 AND (:ipAddress IS NULL OR es.ipAddress = :ipAddress)
                 AND (:browserFingerprintHash IS NULL OR es.browserFingerprintHash = :browserFingerprintHash)
             """)
-    Set<ExamSession> findAllExamSessionsWithTheSameIpAddressAndBrowserFingerprintByExamIdAndExamSession(Long examId, Long sessionId, Long studentExamId, String ipAddress,
-            String browserFingerprintHash);
+    Set<ExamSession> findAllExamSessionsWithTheSameIpAddressAndBrowserFingerprintByExamIdAndExamSession(@Param("examId") Long examId, @Param("sessionId") Long sessionId,
+            @Param("studentExamId") Long studentExamId, @Param("ipAddress") String ipAddress, @Param("browserFingerprintHash") String browserFingerprintHash);
 
     @Query("""
                 SELECT es
                 FROM ExamSession es
                 WHERE es.studentExam.exam.id = :examId
             """)
-    Set<ExamSession> findAllExamSessionsByExamId(long examId);
+    Set<ExamSession> findAllExamSessionsByExamId(@Param("examId") long examId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamSessionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamSessionRepository.java
@@ -16,22 +16,23 @@ import de.tum.in.www1.artemis.domain.exam.ExamSession;
 public interface ExamSessionRepository extends JpaRepository<ExamSession, Long> {
 
     @Query("""
-                SELECT count(es.id)
-                FROM ExamSession es
-                WHERE es.studentExam.id = :#{#studentExamId}
+            SELECT COUNT(es.id)
+            FROM ExamSession es
+            WHERE es.studentExam.id = :studentExamId
             """)
     long findExamSessionCountByStudentExamId(@Param("studentExamId") Long studentExamId);
 
     @Query("""
-                SELECT es
-                FROM ExamSession es
-                WHERE es.studentExam.exam.id = :examId
-                    AND es.id <> :#{#examSession.id}
-                    AND es.studentExam.id <> :#{#examSession.studentExam.id}
-                    AND es.ipAddress = :#{#examSession.ipAddress}
-                    AND es.browserFingerprintHash = :#{#examSession.browserFingerprintHash}
+            SELECT es
+            FROM ExamSession es
+            WHERE es.studentExam.exam.id = :examId
+                AND es.id <> :sessionId
+                AND es.studentExam.id <> :studentExamId
+                AND (:ipAddress IS NULL OR es.ipAddress = :ipAddress)
+                AND (:browserFingerprintHash IS NULL OR es.browserFingerprintHash = :browserFingerprintHash)
             """)
-    Set<ExamSession> findAllExamSessionsWithTheSameIpAddressAndBrowserFingerprintByExamIdAndExamSession(long examId, @Param("examSession") ExamSession examSession);
+    Set<ExamSession> findAllExamSessionsWithTheSameIpAddressAndBrowserFingerprintByExamIdAndExamSession(Long examId, Long sessionId, Long studentExamId, String ipAddress,
+            String browserFingerprintHash);
 
     @Query("""
                 SELECT es
@@ -39,25 +40,4 @@ public interface ExamSessionRepository extends JpaRepository<ExamSession, Long> 
                 WHERE es.studentExam.exam.id = :examId
             """)
     Set<ExamSession> findAllExamSessionsByExamId(long examId);
-
-    @Query("""
-                SELECT es
-                FROM ExamSession es
-                WHERE es.studentExam.exam.id = :examId
-                    AND es.id <> :#{#examSession.id}
-                    AND es.studentExam.id <> :#{#examSession.studentExam.id}
-                    AND es.browserFingerprintHash = :#{#examSession.browserFingerprintHash}
-            """)
-    Set<ExamSession> findAllExamSessionsWithTheSameBrowserFingerprintByExamIdAndExamSession(long examId, @Param("examSession") ExamSession examSession);
-
-    @Query("""
-                SELECT es
-                FROM ExamSession es
-                WHERE es.studentExam.exam.id = :examId
-                    AND es.id <> :#{#examSession.id}
-                    AND es.studentExam.id <> :#{#examSession.studentExam.id}
-                    AND es.ipAddress = :#{#examSession.ipAddress}
-            """)
-    Set<ExamSession> findAllExamSessionsWithTheSameIpAddressByExamIdAndExamSession(long examId, @Param("examSession") ExamSession examSession);
-
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamUserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamUserRepository.java
@@ -32,20 +32,27 @@ public interface ExamUserRepository extends JpaRepository<ExamUser, Long> {
     List<ExamUser> findAllByExamId(long examId);
 
     @Query("""
-            SELECT new de.tum.in.www1.artemis.web.rest.dto.ExamUserAttendanceCheckDTO(examUser.id, examUser.studentImagePath, examUser.user.login,
-            examUser.user.registrationNumber, examUser.signingImagePath,
-            studentExams.started, studentExams.submitted)
+            SELECT new de.tum.in.www1.artemis.web.rest.dto.ExamUserAttendanceCheckDTO(
+                examUser.id,
+                examUser.studentImagePath,
+                examUser.user.login,
+                examUser.user.registrationNumber,
+                examUser.signingImagePath,
+                studentExams.started,
+                studentExams.submitted
+            )
             FROM ExamUser examUser
                 LEFT JOIN examUser.exam exam
                 LEFT JOIN exam.studentExams studentExams ON studentExams.user.id = examUser.user.id
             WHERE exam.id = :examId
-            AND studentExams.started = true
-            AND (examUser.signingImagePath IS NULL
-                OR examUser.signingImagePath = ''
-                OR examUser.didCheckImage = false
-                OR examUser.didCheckLogin = false
-                OR examUser.didCheckRegistrationNumber = false
-                OR examUser.didCheckName = false)
+                AND studentExams.started IS TRUE
+                AND (examUser.signingImagePath IS NULL
+                    OR examUser.signingImagePath = ''
+                    OR examUser.didCheckImage IS FALSE
+                    OR examUser.didCheckLogin IS FALSE
+                    OR examUser.didCheckRegistrationNumber IS FALSE
+                    OR examUser.didCheckName IS FALSE
+                )
             """)
     Set<ExamUserAttendanceCheckDTO> findAllExamUsersWhoDidNotSign(@Param("examId") long examId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -52,7 +52,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             SELECT DISTINCT se
             FROM StudentExam se
                 LEFT JOIN FETCH se.exercises e
-            WHERE se.testRun = FALSE
+            WHERE se.testRun IS FALSE
                 AND se.exam.id = :examId
                 AND se.user.id = :userId
             """)
@@ -73,7 +73,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             SELECT se
             FROM StudentExam se
             WHERE se.exam.id = :examId
-                AND se.testRun = FALSE
+                AND se.testRun IS FALSE
             """)
     Set<StudentExam> findByExamId(@Param("examId") long examId);
 
@@ -81,7 +81,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             SELECT COUNT(DISTINCT se)
             FROM StudentExam se
             WHERE se.exam.id = :examId
-                AND se.testRun = FALSE
+                AND se.testRun IS FALSE
             """)
     long countByExamId(@Param("examId") long examId);
 
@@ -90,7 +90,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             FROM StudentExam se
                 LEFT JOIN FETCH se.examSessions
             WHERE se.exam.id = :examId
-            	AND se.testRun = FALSE
+            	AND se.testRun IS FALSE
             """)
     Set<StudentExam> findByExamIdWithSessions(@Param("examId") long examId);
 
@@ -107,7 +107,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             FROM StudentExam se
                 LEFT JOIN FETCH se.exercises e
             WHERE se.exam.id = :examId
-            	AND se.testRun = FALSE
+            	AND se.testRun IS FALSE
             """)
     Set<StudentExam> findAllWithoutTestRunsWithExercisesByExamId(@Param("examId") long examId);
 
@@ -115,33 +115,33 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             SELECT se
             FROM StudentExam se
             WHERE se.exam.id = :examId
-            	AND se.testRun = TRUE
+            	AND se.testRun IS TRUE
             """)
     List<StudentExam> findAllTestRunsByExamId(@Param("examId") Long examId);
 
     @Query("""
-            SELECT count(se)
+            SELECT COUNT(se)
             FROM StudentExam se
             WHERE se.exam.id = :examId
-            	AND se.testRun = TRUE
+            	AND se.testRun IS TRUE
             """)
     long countTestRunsByExamId(@Param("examId") Long examId);
 
     @Query("""
-            SELECT count(se)
+            SELECT COUNT(se)
             FROM StudentExam se
             WHERE se.exam.id = :examId
-            	AND se.started = TRUE
-            	AND se.testRun = FALSE
+            	AND se.started IS TRUE
+            	AND se.testRun IS FALSE
             """)
     long countStudentExamsStartedByExamIdIgnoreTestRuns(@Param("examId") Long examId);
 
     @Query("""
-            SELECT count(se)
+            SELECT COUNT(se)
             FROM StudentExam se
             WHERE se.exam.id = :examId
-            	AND se.submitted = TRUE
-            	AND se.testRun = FALSE
+            	AND se.submitted IS TRUE
+            	AND se.testRun IS FALSE
             """)
     long countStudentExamsSubmittedByExamIdIgnoreTestRuns(@Param("examId") Long examId);
 
@@ -154,7 +154,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
                 LEFT JOIN FETCH s.results r
                 LEFT JOIN FETCH r.assessor a
             WHERE se.exam.id = :examId
-            	AND se.testRun = TRUE
+            	AND se.testRun IS TRUE
             	AND se.user.id = sp.student.id
             """)
     List<StudentExam> findAllTestRunsWithExercisesParticipationsSubmissionsResultsByExamId(@Param("examId") Long examId);
@@ -185,7 +185,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             FROM StudentExam se
                 LEFT JOIN FETCH se.exercises e
             WHERE se.exam.id = :examId
-            	AND se.testRun = TRUE
+            	AND se.testRun IS TRUE
             	AND se.user.id = :userId
             """)
     List<StudentExam> findAllTestRunsWithExercisesByExamIdForUser(@Param("examId") Long examId, @Param("userId") Long userId);
@@ -193,7 +193,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
     @Query("""
             SELECT DISTINCT se
             FROM StudentExam se
-            WHERE se.testRun = FALSE
+            WHERE se.testRun IS FALSE
             	AND se.exam.id = :examId
             	AND se.user.id = :userId
             """)
@@ -213,16 +213,16 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             SELECT DISTINCT se
             FROM StudentExam se
                 LEFT JOIN FETCH se.exercises e
-            WHERE se.testRun = FALSE
-            	AND e.id = :#{#exerciseId}
+            WHERE se.testRun IS FALSE
+            	AND e.id = :exerciseId
             	AND se.user.id = :userId
             """)
     Optional<StudentExam> findByExerciseIdAndUserId(@Param("exerciseId") Long exerciseId, @Param("userId") Long userId);
 
     @Query("""
-            SELECT max(se.workingTime)
+            SELECT MAX(se.workingTime)
             FROM StudentExam se
-            WHERE se.testRun = FALSE
+            WHERE se.testRun IS FALSE
             	AND se.exam.id = :examId
             """)
     Optional<Integer> findMaxWorkingTimeByExamId(@Param("examId") Long examId);
@@ -230,7 +230,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
     @Query("""
             SELECT DISTINCT se.workingTime
             FROM StudentExam se
-            WHERE se.testRun = FALSE
+            WHERE se.testRun IS FALSE
             	AND se.exam.id = :examId
             """)
     Set<Integer> findAllDistinctWorkingTimesByExamId(@Param("examId") Long examId);
@@ -239,7 +239,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             SELECT DISTINCT u
             FROM StudentExam se
                 LEFT JOIN se.user u
-            WHERE se.testRun = FALSE
+            WHERE se.testRun IS FALSE
             	AND se.exam.id = :examId
             """)
     Set<User> findUsersWithStudentExamsForExam(@Param("examId") Long examId);
@@ -249,8 +249,8 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             FROM StudentExam se
                 LEFT JOIN FETCH se.exercises
             WHERE se.exam.id = :examId
-            	AND se.submitted = FALSE
-            	AND se.testRun = FALSE
+            	AND se.submitted IS FALSE
+            	AND se.testRun IS FALSE
             """)
     Set<StudentExam> findAllUnsubmittedWithExercisesByExamId(Long examId);
 
@@ -260,9 +260,9 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             SELECT DISTINCT se
             FROM StudentExam se
             WHERE se.user.id = :userId
-                AND se.exam.course.id = :#{#courseId}
-                AND se.exam.testExam = TRUE
-                AND se.testRun = FALSE
+                AND se.exam.course.id = :courseId
+                AND se.exam.testExam IS TRUE
+                AND se.testRun IS FALSE
             """)
     List<StudentExam> findStudentExamForTestExamsByUserIdAndCourseId(@Param("userId") Long userId, @Param("courseId") Long courseId);
 
@@ -272,9 +272,9 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
                 LEFT JOIN FETCH se.exercises exercises
             WHERE se.exam.id = :examId
                 AND se.user.id = :userId
-                AND se.submitted = FALSE
-                AND se.testRun = FALSE
-                AND se.exam.testExam = TRUE
+                AND se.submitted IS FALSE
+                AND se.testRun IS FALSE
+                AND se.exam.testExam IS TRUE
             """)
     List<StudentExam> findUnsubmittedStudentExamsForTestExamsWithExercisesByExamIdAndUserId(@Param("examId") Long examId, @Param("userId") Long userId);
 
@@ -282,7 +282,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
     @Transactional // ok because of modifying query
     @Query("""
             UPDATE StudentExam s
-            SET s.submitted = true,
+            SET s.submitted = TRUE,
                 s.submissionDate = :submissionDate
             WHERE s.id = :studentExamId
             """)
@@ -292,7 +292,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
     @Transactional // ok because of modifying query
     @Query("""
             UPDATE StudentExam s
-            SET s.started = true,
+            SET s.started = TRUE,
                 s.startedDate = :startedDate
             WHERE s.id = :studentExamId
             """)

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -207,7 +207,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
      * @param userId   the id of the user (student) who may or may not have a StudentExam
      * @return True if the given user id has a matching StudentExam in the given exam and course, else false.
      */
-    boolean existsByExam_CourseIdAndExamIdAndUserId(@Param("courseId") long courseId, @Param("examId") long examId, @Param("userId") long userId);
+    boolean existsByExam_CourseIdAndExamIdAndUserId(long courseId, long examId, long userId);
 
     @Query("""
             SELECT DISTINCT se
@@ -252,9 +252,9 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             	AND se.submitted IS FALSE
             	AND se.testRun IS FALSE
             """)
-    Set<StudentExam> findAllUnsubmittedWithExercisesByExamId(Long examId);
+    Set<StudentExam> findAllUnsubmittedWithExercisesByExamId(@Param("examId") Long examId);
 
-    List<StudentExam> findAllByExamId_AndTestRunIsTrue(@Param("examId") Long examId);
+    List<StudentExam> findAllByExamId_AndTestRunIsTrue(Long examId);
 
     @Query("""
             SELECT DISTINCT se
@@ -485,7 +485,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
                 LEFT JOIN FETCH se.quizQuestions qq
             WHERE se.id IN :ids
             """)
-    List<StudentExam> findAllWithEagerQuizQuestionsById(List<Long> ids);
+    List<StudentExam> findAllWithEagerQuizQuestionsById(@Param("ids") List<Long> ids);
 
     /**
      * Get all student exams for the given exam id with exercises.
@@ -499,5 +499,5 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
                 LEFT JOIN FETCH se.exercises e
             WHERE se.id IN :ids
             """)
-    List<StudentExam> findAllWithEagerExercisesById(List<Long> ids);
+    List<StudentExam> findAllWithEagerExercisesById(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamSessionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamSessionService.java
@@ -30,9 +30,25 @@ public class ExamSessionService {
 
     private final StudentExamRepository studentExamRepository;
 
+    private final BiFunction<Long, ExamSession, Set<ExamSession>> filterSessionsForIpAndFingerprint;
+
+    private final BiFunction<Long, ExamSession, Set<ExamSession>> filterSessionsForIp;
+
+    private final BiFunction<Long, ExamSession, Set<ExamSession>> filterSessionsForFingerprint;
+
     public ExamSessionService(ExamSessionRepository examSessionRepository, StudentExamRepository studentExamRepository) {
         this.examSessionRepository = examSessionRepository;
         this.studentExamRepository = studentExamRepository;
+
+        this.filterSessionsForIpAndFingerprint = (Long internalExamId, ExamSession examSession) -> examSessionRepository
+                .findAllExamSessionsWithTheSameIpAddressAndBrowserFingerprintByExamIdAndExamSession(internalExamId, examSession.getId(), examSession.getStudentExam().getId(),
+                        examSession.getIpAddress(), examSession.getBrowserFingerprintHash());
+        this.filterSessionsForIp = (Long internalExamId, ExamSession examSession) -> examSessionRepository
+                .findAllExamSessionsWithTheSameIpAddressAndBrowserFingerprintByExamIdAndExamSession(internalExamId, examSession.getId(), examSession.getStudentExam().getId(),
+                        examSession.getIpAddress(), null);
+        this.filterSessionsForFingerprint = (Long internalExamId, ExamSession examSession) -> examSessionRepository
+                .findAllExamSessionsWithTheSameIpAddressAndBrowserFingerprintByExamIdAndExamSession(internalExamId, examSession.getId(), examSession.getStudentExam().getId(), null,
+                        examSession.getBrowserFingerprintHash());
     }
 
     /**
@@ -165,18 +181,15 @@ public class ExamSessionService {
             Set<ExamSession> filteredSessions) {
         if (analysisOptions.sameIpAddressDifferentStudentExams() && analysisOptions.sameBrowserFingerprintDifferentStudentExams()) {
             // first step find all sessions that have matching browser fingerprint and ip address
-            findSuspiciousSessionsForGivenCriteria(filteredSessions, examId,
-                    examSessionRepository::findAllExamSessionsWithTheSameIpAddressAndBrowserFingerprintByExamIdAndExamSession, suspiciousExamSessions, true, true);
+            findSuspiciousSessionsForGivenCriteria(filteredSessions, examId, filterSessionsForIpAndFingerprint, suspiciousExamSessions, true, true);
         }
         if (analysisOptions.sameBrowserFingerprintDifferentStudentExams()) {
             // second step find all sessions that have only matching browser fingerprint
-            findSuspiciousSessionsForGivenCriteria(filteredSessions, examId, examSessionRepository::findAllExamSessionsWithTheSameBrowserFingerprintByExamIdAndExamSession,
-                    suspiciousExamSessions, false, true);
+            findSuspiciousSessionsForGivenCriteria(filteredSessions, examId, filterSessionsForFingerprint, suspiciousExamSessions, false, true);
         }
         if (analysisOptions.sameIpAddressDifferentStudentExams()) {
             // third step find all sessions that have only matching ip address
-            findSuspiciousSessionsForGivenCriteria(filteredSessions, examId, examSessionRepository::findAllExamSessionsWithTheSameIpAddressByExamIdAndExamSession,
-                    suspiciousExamSessions, true, false);
+            findSuspiciousSessionsForGivenCriteria(filteredSessions, examId, filterSessionsForIp, suspiciousExamSessions, true, false);
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I just fixed the style in one repository so I decided to go through some more repos to make the codebase more consistent and clean.

### Description
<!-- Describe your changes in detail -->
I enforced capitalisation (SELECT instead of select), simple variable declaration (:var instead of :#{#var}, explicit enum values, consistent newlines and indentations.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
No functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Standardized boolean expressions in SQL queries for improved readability and consistency.

- **Bug Fixes**
	- Enhanced exam session identification with additional parameters for more accurate tracking.

- **New Features**
	- Improved filtering of exam sessions by IP address and browser fingerprint to ensure exam integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->