### PR TITLE
`Development`: Improve persistent storage of competency relations

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Course.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Course.java
@@ -242,7 +242,7 @@ public class Course extends DomainObject {
     private Set<Organization> organizations = new HashSet<>();
 
     @ManyToMany
-    @JoinTable(name = "learning_goal_course", joinColumns = @JoinColumn(name = "course_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "learning_goal_id", referencedColumnName = "id"))
+    @JoinTable(name = "competency_course", joinColumns = @JoinColumn(name = "course_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "competency_id", referencedColumnName = "id"))
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties("consecutiveCourses")
     private Set<Competency> prerequisites = new HashSet<>();

--- a/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
@@ -72,7 +72,7 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
     private String gradingInstructions;
 
     @ManyToMany
-    @JoinTable(name = "learning_goal_exercise", joinColumns = @JoinColumn(name = "exercise_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "learning_goal_id", referencedColumnName = "id"))
+    @JoinTable(name = "competency_exercise", joinColumns = @JoinColumn(name = "exercise_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "competency_id", referencedColumnName = "id"))
     @JsonIgnoreProperties({ "exercises", "course" })
     @JsonView(QuizView.Before.class)
     private Set<Competency> competencies = new HashSet<>();

--- a/src/main/java/de/tum/in/www1/artemis/domain/competency/Competency.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/competency/Competency.java
@@ -19,7 +19,7 @@ import de.tum.in.www1.artemis.domain.lecture.ExerciseUnit;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 
 @Entity
-@Table(name = "learning_goal")
+@Table(name = "competency")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class Competency extends DomainObject {
 
@@ -65,12 +65,12 @@ public class Competency extends DomainObject {
      * A set of courses for which this competency is a prerequisite for.
      */
     @ManyToMany
-    @JoinTable(name = "learning_goal_course", joinColumns = @JoinColumn(name = "learning_goal_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "course_id", referencedColumnName = "id"))
+    @JoinTable(name = "competency_course", joinColumns = @JoinColumn(name = "competency_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "course_id", referencedColumnName = "id"))
     @JsonIgnoreProperties({ "competencies", "prerequisites" })
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<Course> consecutiveCourses = new HashSet<>();
 
-    @OneToMany(mappedBy = "learningGoal", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "competency", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     @JsonIgnoreProperties({ "user", "competency" })
     private Set<CompetencyProgress> userProgress = new HashSet<>();
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/competency/CompetencyProgress.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/competency/CompetencyProgress.java
@@ -39,7 +39,6 @@ public class CompetencyProgress implements Serializable {
     @JsonIgnore
     private User user;
 
-    // TODO: rename to competency
     @ManyToOne
     @MapsId("competencyId")
     @JsonIgnore

--- a/src/main/java/de/tum/in/www1/artemis/domain/competency/CompetencyProgress.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/competency/CompetencyProgress.java
@@ -22,7 +22,7 @@ import de.tum.in.www1.artemis.domain.User;
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-@Table(name = "learning_goal_user")
+@Table(name = "competency_user")
 @EntityListeners(AuditingEntityListener.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class CompetencyProgress implements Serializable {
@@ -39,10 +39,11 @@ public class CompetencyProgress implements Serializable {
     @JsonIgnore
     private User user;
 
+    // TODO: rename to competency
     @ManyToOne
-    @MapsId("learningGoalId")
+    @MapsId("competencyId")
     @JsonIgnore
-    private Competency learningGoal;
+    private Competency competency;
 
     @Column(name = "progress")
     private Double progress;
@@ -68,11 +69,11 @@ public class CompetencyProgress implements Serializable {
     }
 
     public Competency getCompetency() {
-        return learningGoal;
+        return competency;
     }
 
     public void setCompetency(Competency competency) {
-        this.learningGoal = competency;
+        this.competency = competency;
     }
 
     public Double getProgress() {
@@ -114,15 +115,14 @@ public class CompetencyProgress implements Serializable {
 
     @Override
     public String toString() {
-        return "CompetencyProgress{" + "id=" + id + ", user=" + user + ", competency=" + learningGoal + ", progress=" + progress + ", confidence=" + confidence + '}';
+        return "CompetencyProgress{" + "id=" + id + ", user=" + user + ", competency=" + competency + ", progress=" + progress + ", confidence=" + confidence + '}';
     }
 
     /**
-     * This class is used to create a composite primary key (user_id, learning_goal_id).
+     * This class is used to create a composite primary key (user_id, competency_id).
      * See also https://www.baeldung.com/spring-jpa-embedded-method-parameters
      */
     @Embeddable
-    @SuppressWarnings("unused")
     public static class CompetencyUserId implements Serializable {
 
         @Serial
@@ -130,15 +130,15 @@ public class CompetencyProgress implements Serializable {
 
         private Long userId;
 
-        private Long learningGoalId;
+        private Long competencyId;
 
         public CompetencyUserId() {
             // Empty constructor for Spring
         }
 
-        public CompetencyUserId(Long userId, Long learningGoalId) {
+        public CompetencyUserId(Long userId, Long competencyId) {
             this.userId = userId;
-            this.learningGoalId = learningGoalId;
+            this.competencyId = competencyId;
         }
 
         @Override
@@ -153,12 +153,12 @@ public class CompetencyProgress implements Serializable {
             if (userId == null || that.userId == null) {
                 return false;
             }
-            return userId.equals(that.userId) && learningGoalId.equals(that.learningGoalId);
+            return userId.equals(that.userId) && competencyId.equals(that.competencyId);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(userId, learningGoalId);
+            return Objects.hash(userId, competencyId);
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/competency/CompetencyRelation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/competency/CompetencyRelation.java
@@ -9,19 +9,19 @@ import de.tum.in.www1.artemis.domain.DomainObject;
  * Because we want to keep this very generic (using the type attribute), this can not be modeled as a simple JPA relationship.
  */
 @Entity
-@Table(name = "learning_goal_relation")
+@Table(name = "competency_relation")
 public class CompetencyRelation extends DomainObject {
 
     @ManyToOne
-    @JoinColumn(name = "tail_learning_goal_id")
+    @JoinColumn(name = "tail_competency_id", nullable = false)
     private Competency tailCompetency;
 
     @ManyToOne
-    @JoinColumn(name = "head_learning_goal_id")
+    @JoinColumn(name = "head_competency_id", nullable = false)
     private Competency headCompetency;
 
-    @Column(name = "type")
-    @Convert(converter = RelationTypeConverter.class)
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.ORDINAL)
     private RelationType type;
 
     public Competency getTailCompetency() {
@@ -65,38 +65,5 @@ public class CompetencyRelation extends DomainObject {
          * The tail competency matches the head competency (e.g., a duplicate).
          */
         MATCHES
-    }
-
-    @Converter
-    public static class RelationTypeConverter implements AttributeConverter<RelationType, String> {
-
-        @Override
-        public String convertToDatabaseColumn(RelationType type) {
-            if (type == null) {
-                return null;
-            }
-
-            return switch (type) {
-                case RELATES -> "R";
-                case ASSUMES -> "A";
-                case EXTENDS -> "E";
-                case MATCHES -> "M";
-            };
-        }
-
-        @Override
-        public RelationType convertToEntityAttribute(String value) {
-            if (value == null) {
-                return null;
-            }
-
-            return switch (value) {
-                case "R" -> RelationType.RELATES;
-                case "A" -> RelationType.ASSUMES;
-                case "E" -> RelationType.EXTENDS;
-                case "M" -> RelationType.MATCHES;
-                default -> throw new IllegalArgumentException("Unknown RelationType: " + value);
-            };
-        }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/competency/CompetencyRelation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/competency/CompetencyRelation.java
@@ -48,22 +48,4 @@ public class CompetencyRelation extends DomainObject {
         this.type = type;
     }
 
-    public enum RelationType {
-        /**
-         * A generic relation between two competencies.
-         */
-        RELATES,
-        /**
-         * The tail competency assumes that the student already achieved the head competency.
-         */
-        ASSUMES,
-        /**
-         * The tail competency extends the head competency on the same topic in more detail.
-         */
-        EXTENDS,
-        /**
-         * The tail competency matches the head competency (e.g., a duplicate).
-         */
-        MATCHES
-    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/competency/RelationType.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/competency/RelationType.java
@@ -1,0 +1,20 @@
+package de.tum.in.www1.artemis.domain.competency;
+
+public enum RelationType {
+    /**
+     * A generic relation between two competencies.
+     */
+    RELATES,
+    /**
+     * The tail competency assumes that the student already achieved the head competency.
+     */
+    ASSUMES,
+    /**
+     * The tail competency extends the head competency on the same topic in more detail.
+     */
+    EXTENDS,
+    /**
+     * The tail competency matches the head competency (e.g., a duplicate).
+     */
+    MATCHES
+}

--- a/src/main/java/de/tum/in/www1/artemis/domain/lecture/LectureUnit.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/lecture/LectureUnit.java
@@ -44,7 +44,7 @@ public abstract class LectureUnit extends DomainObject implements LearningObject
     private Lecture lecture;
 
     @ManyToMany
-    @JoinTable(name = "learning_goal_lecture_unit", joinColumns = @JoinColumn(name = "lecture_unit_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "learning_goal_id", referencedColumnName = "id"))
+    @JoinTable(name = "competency_lecture_unit", joinColumns = @JoinColumn(name = "lecture_unit_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "competency_id", referencedColumnName = "id"))
     @OrderBy("title")
     @JsonIgnoreProperties({ "lectureUnits", "course" })
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)

--- a/src/main/java/de/tum/in/www1/artemis/repository/CompetencyProgressRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/CompetencyProgressRepository.java
@@ -17,8 +17,8 @@ public interface CompetencyProgressRepository extends JpaRepository<CompetencyPr
 
     @Transactional // ok because of delete
     @Modifying
-    @Query("DELETE FROM CompetencyProgress cp WHERE cp.learningGoal.id = :learningGoalId")
-    void deleteAllByCompetencyId(Long learningGoalId);
+    @Query("DELETE FROM CompetencyProgress cp WHERE cp.competency.id = :competencyId")
+    void deleteAllByCompetencyId(Long competencyId);
 
     @Transactional // ok because of delete
     @Modifying
@@ -27,14 +27,14 @@ public interface CompetencyProgressRepository extends JpaRepository<CompetencyPr
     @Query("""
             SELECT cp
             FROM CompetencyProgress cp
-            WHERE cp.learningGoal.id = :competencyId
+            WHERE cp.competency.id = :competencyId
             """)
     List<CompetencyProgress> findAllByCompetencyId(@Param("competencyId") Long competencyId);
 
     @Query("""
             SELECT cp
             FROM CompetencyProgress cp
-            WHERE cp.learningGoal.id = :competencyId
+            WHERE cp.competency.id = :competencyId
                 AND cp.user.id = :userId
             """)
     Optional<CompetencyProgress> findByCompetencyIdAndUserId(@Param("competencyId") Long competencyId, @Param("userId") Long userId);
@@ -42,8 +42,8 @@ public interface CompetencyProgressRepository extends JpaRepository<CompetencyPr
     @Query("""
             SELECT cp
             FROM CompetencyProgress cp
-                LEFT JOIN cp.learningGoal
-            WHERE cp.learningGoal in :competencies
+                LEFT JOIN cp.competency
+            WHERE cp.competency in :competencies
                 AND cp.user.id = :userId
             """)
     Set<CompetencyProgress> findByCompetenciesAndUser(@Param("competencies") Collection<Competency> competencies, @Param("userId") Long userId);
@@ -52,8 +52,8 @@ public interface CompetencyProgressRepository extends JpaRepository<CompetencyPr
             SELECT cp
             FROM CompetencyProgress cp
                 LEFT JOIN FETCH cp.user
-                LEFT JOIN FETCH cp.learningGoal
-            WHERE cp.learningGoal.id = :competencyId
+                LEFT JOIN FETCH cp.competency
+            WHERE cp.competency.id = :competencyId
                 AND cp.user.id = :userId
             """)
     Optional<CompetencyProgress> findEagerByCompetencyIdAndUserId(@Param("competencyId") Long competencyId, @Param("userId") Long userId);
@@ -61,7 +61,7 @@ public interface CompetencyProgressRepository extends JpaRepository<CompetencyPr
     @Query("""
             SELECT cp
             FROM CompetencyProgress cp
-            WHERE cp.learningGoal.id IN :competencyIds
+            WHERE cp.competency.id IN :competencyIds
                 AND cp.user.id = :userId
             """)
     Set<CompetencyProgress> findAllByCompetencyIdsAndUserId(@Param("competencyIds") Set<Long> competencyIds, @Param("userId") long userId);
@@ -69,21 +69,21 @@ public interface CompetencyProgressRepository extends JpaRepository<CompetencyPr
     @Query("""
             SELECT AVG(cp.confidence)
             FROM CompetencyProgress cp
-            WHERE cp.learningGoal.id = :competencyId
+            WHERE cp.competency.id = :competencyId
             """)
     Optional<Double> findAverageConfidenceByCompetencyId(@Param("competencyId") Long competencyId);
 
     @Query("""
             SELECT count(cp)
             FROM CompetencyProgress cp
-            WHERE cp.learningGoal.id = :competencyId
+            WHERE cp.competency.id = :competencyId
             """)
     Long countByCompetency(@Param("competencyId") Long competencyId);
 
     @Query("""
             SELECT count(cp)
             FROM CompetencyProgress cp
-            WHERE cp.learningGoal.id = :competencyId
+            WHERE cp.competency.id = :competencyId
                 AND cp.progress >= :progress
                 AND cp.confidence >= :confidence
             """)

--- a/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRelationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRelationRepository.java
@@ -85,15 +85,15 @@ public interface CompetencyRelationRepository extends JpaRepository<CompetencyRe
     @Query(value = """
                     WITH RECURSIVE transitive_closure(id) AS
                     (
-                        (SELECT competency.id FROM learning_goal as competency WHERE competency.id = :competencyId)
+                        (SELECT competency.id FROM competency WHERE competency.id = :competencyId)
                         UNION
                         (
                             SELECT CASE
-                                WHEN relation.tail_learning_goal_id = tc.id THEN relation.head_learning_goal_id
-                                WHEN relation.head_learning_goal_id = tc.id THEN relation.tail_learning_goal_id
+                                WHEN relation.tail_competency_id = tc.id THEN relation.head_competency_id
+                                WHEN relation.head_competency_id = tc.id THEN relation.tail_competency_id
                                 END
-                            FROM learning_goal_relation as relation
-                            JOIN transitive_closure AS tc ON relation.tail_learning_goal_id = tc.id OR relation.head_learning_goal_id = tc.id
+                            FROM competency_relation as relation
+                            JOIN transitive_closure AS tc ON relation.tail_competency_id = tc.id OR relation.head_competency_id = tc.id
                             WHERE relation.type = 'M'
                         )
                     )

--- a/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRelationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRelationRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.in.www1.artemis.domain.competency.CompetencyRelation;
+import de.tum.in.www1.artemis.domain.competency.RelationType;
 
 /**
  * Spring Data JPA repository for the Competency Relation entity.
@@ -58,7 +59,7 @@ public interface CompetencyRelationRepository extends JpaRepository<CompetencyRe
                 LEFT JOIN relation.headCompetency
                 LEFT JOIN relation.tailCompetency
             WHERE relation.tailCompetency.id IN :competencyIds
-                AND relation.type != 3
+                AND relation.type != de.tum.in.www1.artemis.domain.competency.RelationType.MATCHES
             """)
     Set<Long> getPriorCompetenciesByCompetencyIds(@Param("competencyIds") Set<Long> competencyIds);
 
@@ -71,13 +72,14 @@ public interface CompetencyRelationRepository extends JpaRepository<CompetencyRe
                 AND relation.headCompetency.id IN :competencyHeadIds
                 AND relation.type = :type
             """)
-    long countRelationsOfTypeBetweenCompetencyGroups(@Param("competencyTailIds") Set<Long> competencyTailIds, @Param("type") CompetencyRelation.RelationType type,
+    long countRelationsOfTypeBetweenCompetencyGroups(@Param("competencyTailIds") Set<Long> competencyTailIds, @Param("type") RelationType type,
             @Param("competencyHeadIds") Set<Long> competencyHeadIds);
 
     /**
      * Gets set of all competency ids that are (transitively) connected via a matching relation to the given competency id.
      * <p>
-     * Important: this query is native since JPARepositories don't support recursive queries of this form
+     * Important: this query is native since JPARepositories don't support recursive queries of this form.
+     * type = 3 is the ordinal of the enum {@link RelationType#MATCHES}.
      *
      * @param competencyId the id of the competency
      * @return set of all competency ids that are (transitively) connected via a matching relation

--- a/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRelationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRelationRepository.java
@@ -23,7 +23,7 @@ public interface CompetencyRelationRepository extends JpaRepository<CompetencyRe
             WHERE relation.headCompetency.id = :competencyId
                 OR relation.tailCompetency.id = :competencyId
             """)
-    Set<CompetencyRelation> findAllByCompetencyId(@Param("competencyId") Long competencyId);
+    Set<CompetencyRelation> findAllByCompetencyId(@Param("competencyId") long competencyId);
 
     @Transactional
     @Modifying
@@ -42,7 +42,7 @@ public interface CompetencyRelationRepository extends JpaRepository<CompetencyRe
             WHERE relation.headCompetency.course.id = :courseId
                 AND relation.tailCompetency.course.id = :courseId
             """)
-    Set<CompetencyRelation> findAllWithHeadAndTailByCourseId(@Param("courseId") Long courseId);
+    Set<CompetencyRelation> findAllWithHeadAndTailByCourseId(@Param("courseId") long courseId);
 
     @Query("""
             SELECT count(cr)
@@ -58,7 +58,7 @@ public interface CompetencyRelationRepository extends JpaRepository<CompetencyRe
                 LEFT JOIN relation.headCompetency
                 LEFT JOIN relation.tailCompetency
             WHERE relation.tailCompetency.id IN :competencyIds
-                AND relation.type <> 'MATCHES'
+                AND relation.type != 3
             """)
     Set<Long> getPriorCompetenciesByCompetencyIds(@Param("competencyIds") Set<Long> competencyIds);
 
@@ -94,7 +94,7 @@ public interface CompetencyRelationRepository extends JpaRepository<CompetencyRe
                                 END
                             FROM competency_relation as relation
                             JOIN transitive_closure AS tc ON relation.tail_competency_id = tc.id OR relation.head_competency_id = tc.id
-                            WHERE relation.type = 'M'
+                            WHERE relation.type = 3
                         )
                     )
                     SELECT * FROM transitive_closure

--- a/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRelationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRelationRepository.java
@@ -79,7 +79,6 @@ public interface CompetencyRelationRepository extends JpaRepository<CompetencyRe
      * Gets set of all competency ids that are (transitively) connected via a matching relation to the given competency id.
      * <p>
      * Important: this query is native since JPARepositories don't support recursive queries of this form.
-     * type = 3 is the ordinal of the enum {@link RelationType#MATCHES}.
      *
      * @param competencyId the id of the competency
      * @return set of all competency ids that are (transitively) connected via a matching relation
@@ -96,7 +95,7 @@ public interface CompetencyRelationRepository extends JpaRepository<CompetencyRe
                                 END
                             FROM competency_relation as relation
                             JOIN transitive_closure AS tc ON relation.tail_competency_id = tc.id OR relation.head_competency_id = tc.id
-                            WHERE relation.type = 3
+                            WHERE relation.type = :#{T(de.tum.in.www1.artemis.domain.competency.RelationType).MATCHES.ordinal()}
                         )
                     )
                     SELECT * FROM transitive_closure

--- a/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRepository.java
@@ -61,7 +61,7 @@ public interface CompetencyRepository extends JpaRepository<Competency, Long> {
             SELECT competency
             FROM Competency competency
                 LEFT JOIN competency.userProgress progress
-                    ON competency.id = progress.learningGoal.id AND progress.user.id = :userId
+                    ON competency.id = progress.competency.id AND progress.user.id = :userId
                 LEFT JOIN FETCH competency.exercises
                 LEFT JOIN FETCH competency.lectureUnits lectureUnits
                 LEFT JOIN lectureUnits.completedUsers completedUsers

--- a/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/CompetencyRepository.java
@@ -29,16 +29,7 @@ public interface CompetencyRepository extends JpaRepository<Competency, Long> {
             FROM Competency c
             WHERE c.course.id = :courseId
             """)
-    Set<Competency> findAllForCourse(@Param("courseId") Long courseId);
-
-    @Query("""
-            SELECT c
-            FROM Competency c
-                LEFT JOIN FETCH c.userProgress progress
-            WHERE c.course.id = :courseId
-                AND (progress IS NULL OR progress.user.id = :userId)
-            """)
-    Set<Competency> findAllForCourseWithProgressForUser(@Param("courseId") Long courseId, @Param("userId") Long userId);
+    Set<Competency> findAllForCourse(@Param("courseId") long courseId);
 
     @Query("""
             SELECT c
@@ -79,7 +70,7 @@ public interface CompetencyRepository extends JpaRepository<Competency, Long> {
                 LEFT JOIN FETCH lu.completedUsers
             WHERE c.id = :competencyId
             """)
-    Optional<Competency> findByIdWithLectureUnitsAndCompletions(@Param("competencyId") Long competencyId);
+    Optional<Competency> findByIdWithLectureUnitsAndCompletions(@Param("competencyId") long competencyId);
 
     @Query("""
             SELECT c
@@ -89,7 +80,7 @@ public interface CompetencyRepository extends JpaRepository<Competency, Long> {
                 LEFT JOIN FETCH lu.completedUsers
             WHERE c.id = :competencyId
             """)
-    Optional<Competency> findByIdWithExercisesAndLectureUnitsAndCompletions(@Param("competencyId") Long competencyId);
+    Optional<Competency> findByIdWithExercisesAndLectureUnitsAndCompletions(@Param("competencyId") long competencyId);
 
     @Query("""
             SELECT c
@@ -100,7 +91,7 @@ public interface CompetencyRepository extends JpaRepository<Competency, Long> {
                 LEFT JOIN FETCH lu.competencies
             WHERE c.id = :competencyId
             """)
-    Optional<Competency> findByIdWithExercisesAndLectureUnitsBidirectional(@Param("competencyId") Long competencyId);
+    Optional<Competency> findByIdWithExercisesAndLectureUnitsBidirectional(@Param("competencyId") long competencyId);
 
     @Query("""
             SELECT c
@@ -108,7 +99,7 @@ public interface CompetencyRepository extends JpaRepository<Competency, Long> {
                 LEFT JOIN FETCH c.consecutiveCourses
             WHERE c.id = :competencyId
             """)
-    Optional<Competency> findByIdWithConsecutiveCourses(@Param("competencyId") Long competencyId);
+    Optional<Competency> findByIdWithConsecutiveCourses(@Param("competencyId") long competencyId);
 
     @Query("""
             SELECT pr
@@ -117,7 +108,7 @@ public interface CompetencyRepository extends JpaRepository<Competency, Long> {
             WHERE c.id = :courseId
             ORDER BY pr.title
             """)
-    Set<Competency> findPrerequisitesByCourseId(@Param("courseId") Long courseId);
+    Set<Competency> findPrerequisitesByCourseId(@Param("courseId") long courseId);
 
     @Query("""
             SELECT COUNT(*)
@@ -125,7 +116,7 @@ public interface CompetencyRepository extends JpaRepository<Competency, Long> {
                 LEFT JOIN pr.consecutiveCourses c
             WHERE c.id = :courseId
             """)
-    Long countPrerequisitesByCourseId(@Param("courseId") Long courseId);
+    Long countPrerequisitesByCourseId(@Param("courseId") long courseId);
 
     /**
      * Query which fetches all competencies for which the user is editor or instructor in the course and
@@ -158,7 +149,7 @@ public interface CompetencyRepository extends JpaRepository<Competency, Long> {
             WHERE c.id = :competencyId
             """)
     @Cacheable(cacheNames = "competencyTitle", key = "#competencyId", unless = "#result == null")
-    String getCompetencyTitle(@Param("competencyId") Long competencyId);
+    String getCompetencyTitle(@Param("competencyId") long competencyId);
 
     @SuppressWarnings("PMD.MethodNamingConventions")
     Page<Competency> findByTitleIgnoreCaseContainingOrCourse_TitleIgnoreCaseContaining(String partialTitle, String partialCourseTitle, Pageable pageable);
@@ -175,11 +166,11 @@ public interface CompetencyRepository extends JpaRepository<Competency, Long> {
         return findByIdWithConsecutiveCourses(competencyId).orElseThrow(() -> new EntityNotFoundException("Competency", competencyId));
     }
 
-    default Competency findByIdElseThrow(Long competencyId) {
+    default Competency findByIdElseThrow(long competencyId) {
         return findById(competencyId).orElseThrow(() -> new EntityNotFoundException("Competency", competencyId));
     }
 
-    default Competency findByIdWithLectureUnitsElseThrow(Long competencyId) {
+    default Competency findByIdWithLectureUnitsElseThrow(long competencyId) {
         return findByIdWithLectureUnits(competencyId).orElseThrow(() -> new EntityNotFoundException("Competency", competencyId));
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/LearningPathRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/LearningPathRepository.java
@@ -74,7 +74,7 @@ public interface LearningPathRepository extends JpaRepository<LearningPath, Long
             FROM LearningPath learningPath
                 LEFT JOIN FETCH learningPath.competencies competencies
                 LEFT JOIN competencies.userProgress progress
-                    ON competencies.id = progress.learningGoal.id AND progress.user.id = learningPath.user.id
+                    ON competencies.id = progress.competency.id AND progress.user.id = learningPath.user.id
                 LEFT JOIN FETCH competencies.lectureUnits lectureUnits
                 LEFT JOIN lectureUnits.completedUsers completedUsers
                     ON lectureUnits.id = completedUsers.lectureUnit.id AND completedUsers.user.id = learningPath.user.id

--- a/src/main/java/de/tum/in/www1/artemis/service/CompetencyService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CompetencyService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.competency.Competency;
 import de.tum.in.www1.artemis.domain.competency.CompetencyRelation;
+import de.tum.in.www1.artemis.domain.competency.RelationType;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.web.rest.dto.*;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
@@ -171,7 +172,7 @@ public class CompetencyService {
         }
         // combine vertices that are connected through MATCHES
         for (CompetencyRelation relation : relations) {
-            if (relation.getType() == CompetencyRelation.RelationType.MATCHES) {
+            if (relation.getType() == RelationType.MATCHES) {
                 var headVertex = graph.vertices.stream().filter(vertex -> vertex.label.equals(relation.getHeadCompetency().getTitle())).findFirst().orElseThrow();
                 var tailVertex = graph.vertices.stream().filter(vertex -> vertex.label.equals(relation.getTailCompetency().getTitle())).findFirst().orElseThrow();
                 if (headVertex.adjacencyList.contains(tailVertex) || tailVertex.adjacencyList.contains(headVertex)) {

--- a/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathNgxService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathNgxService.java
@@ -16,6 +16,7 @@ import de.tum.in.www1.artemis.domain.LearningObject;
 import de.tum.in.www1.artemis.domain.competency.Competency;
 import de.tum.in.www1.artemis.domain.competency.CompetencyRelation;
 import de.tum.in.www1.artemis.domain.competency.LearningPath;
+import de.tum.in.www1.artemis.domain.competency.RelationType;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.repository.CompetencyRelationRepository;
 import de.tum.in.www1.artemis.web.rest.dto.competency.NgxLearningPathDTO;
@@ -130,16 +131,16 @@ public class LearningPathNgxService {
 
         // compute match clusters
         Map<Long, Integer> competencyToMatchCluster = new HashMap<>();
-        final var competenciesInMatchRelation = relations.stream().filter(relation -> relation.getType().equals(CompetencyRelation.RelationType.MATCHES))
+        final var competenciesInMatchRelation = relations.stream().filter(relation -> relation.getType().equals(RelationType.MATCHES))
                 .flatMap(relation -> Stream.of(relation.getHeadCompetency().getId(), relation.getTailCompetency().getId())).collect(Collectors.toSet());
         if (!competenciesInMatchRelation.isEmpty()) {
             UnionFind<Long> matchClusters = new UnionFind<>(competenciesInMatchRelation);
-            relations.stream().filter(relation -> relation.getType().equals(CompetencyRelation.RelationType.MATCHES))
+            relations.stream().filter(relation -> relation.getType().equals(RelationType.MATCHES))
                     .forEach(relation -> matchClusters.union(relation.getHeadCompetency().getId(), relation.getTailCompetency().getId()));
 
             // generate map between competencies and cluster node
             AtomicInteger matchClusterId = new AtomicInteger();
-            relations.stream().filter(relation -> relation.getType().equals(CompetencyRelation.RelationType.MATCHES))
+            relations.stream().filter(relation -> relation.getType().equals(RelationType.MATCHES))
                     .flatMapToLong(relation -> LongStream.of(relation.getHeadCompetency().getId(), relation.getTailCompetency().getId())).distinct().forEach(competencyId -> {
                         var parentId = matchClusters.find(competencyId);
                         var clusterId = competencyToMatchCluster.computeIfAbsent(parentId, (key) -> matchClusterId.getAndIncrement());
@@ -161,7 +162,7 @@ public class LearningPathNgxService {
 
         // generate edges for remaining relations
         final Set<String> createdRelations = new HashSet<>();
-        relations.stream().filter(relation -> !relation.getType().equals(CompetencyRelation.RelationType.MATCHES))
+        relations.stream().filter(relation -> !relation.getType().equals(RelationType.MATCHES))
                 .forEach(relation -> generateNgxGraphRepresentationForRelation(relation, competencyToMatchCluster, createdRelations, edges));
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathRecommendationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathRecommendationService.java
@@ -13,8 +13,8 @@ import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.LearningObject;
 import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.competency.Competency;
-import de.tum.in.www1.artemis.domain.competency.CompetencyRelation;
 import de.tum.in.www1.artemis.domain.competency.LearningPath;
+import de.tum.in.www1.artemis.domain.competency.RelationType;
 import de.tum.in.www1.artemis.domain.enumeration.DifficultyLevel;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.repository.CompetencyRelationRepository;
@@ -175,7 +175,7 @@ public class LearningPathRecommendationService {
      * @return map to retrieve the number of competencies a competency extends
      */
     private Map<Long, Long> getExtendsCompetencyMapping(Set<Competency> competencies, Map<Long, Set<Long>> matchingClusters, Map<Long, Set<Long>> priorCompetencies) {
-        return getRelationsOfTypeCompetencyMapping(competencies, matchingClusters, priorCompetencies, CompetencyRelation.RelationType.EXTENDS);
+        return getRelationsOfTypeCompetencyMapping(competencies, matchingClusters, priorCompetencies, RelationType.EXTENDS);
     }
 
     /**
@@ -187,7 +187,7 @@ public class LearningPathRecommendationService {
      * @return map to retrieve the number of competencies a competency assumes
      */
     private Map<Long, Long> getAssumesCompetencyMapping(Set<Competency> competencies, Map<Long, Set<Long>> matchingClusters, Map<Long, Set<Long>> priorCompetencies) {
-        return getRelationsOfTypeCompetencyMapping(competencies, matchingClusters, priorCompetencies, CompetencyRelation.RelationType.ASSUMES);
+        return getRelationsOfTypeCompetencyMapping(competencies, matchingClusters, priorCompetencies, RelationType.ASSUMES);
     }
 
     /**
@@ -200,7 +200,7 @@ public class LearningPathRecommendationService {
      * @return map to retrieve the number of competencies a competency extends
      */
     private Map<Long, Long> getRelationsOfTypeCompetencyMapping(Set<Competency> competencies, Map<Long, Set<Long>> matchingClusters, Map<Long, Set<Long>> priorCompetencies,
-            CompetencyRelation.RelationType type) {
+            RelationType type) {
         Map<Long, Long> map = new HashMap<>();
         for (var competency : competencies) {
             if (!map.containsKey(competency.getId())) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CompetencyResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CompetencyResource.java
@@ -15,9 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.competency.Competency;
-import de.tum.in.www1.artemis.domain.competency.CompetencyProgress;
-import de.tum.in.www1.artemis.domain.competency.CompetencyRelation;
+import de.tum.in.www1.artemis.domain.competency.*;
 import de.tum.in.www1.artemis.domain.lecture.ExerciseUnit;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.repository.*;
@@ -406,7 +404,7 @@ public class CompetencyResource {
         checkAuthorizationForCompetency(Role.INSTRUCTOR, course, headCompetency);
 
         try {
-            var relationType = CompetencyRelation.RelationType.valueOf(type);
+            var relationType = RelationType.valueOf(type);
 
             var relation = new CompetencyRelation();
             relation.setTailCompetency(tailCompetency);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/competency/CompetencyRelationDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/competency/CompetencyRelationDTO.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.artemis.web.rest.dto.competency;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.in.www1.artemis.domain.competency.CompetencyRelation;
+import de.tum.in.www1.artemis.domain.competency.RelationType;
 
 /**
  * DTO containing {@link CompetencyRelation} data. It only contains ids of the linked competencies to reduce data sent.
@@ -12,7 +13,7 @@ import de.tum.in.www1.artemis.domain.competency.CompetencyRelation;
  * @param relationType     the relation type
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record CompetencyRelationDTO(long id, long tailCompetencyId, long headCompetencyId, CompetencyRelation.RelationType relationType) {
+public record CompetencyRelationDTO(long id, long tailCompetencyId, long headCompetencyId, RelationType relationType) {
 
     public CompetencyRelationDTO(CompetencyRelation competencyRelation) {
         this(competencyRelation.getId(), competencyRelation.getTailCompetency().getId(), competencyRelation.getHeadCompetency().getId(), competencyRelation.getType());

--- a/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
@@ -47,20 +47,23 @@
 
         <dropColumn tableName="competency_relation" columnName="type_old"/>
 
-        <createIndex indexName="UQymvhyta1mtg5mmu2n2fjmjc4m2y0mtniymy4odjh" tableName="competency_relation" unique="true">
+        <createIndex indexName="idx_head_tail_type" tableName="competency_relation" unique="true">
             <column name="head_competency_id"/>
             <column name="tail_competency_id"/>
             <column name="type"/>
         </createIndex>
 
-        <createIndex indexName="FKd84cd79d225d13687cfe9c1395fb1cc69e09f553" tableName="competency_relation">
+        <createIndex indexName="idx_head_competency_id" tableName="competency_relation">
+            <column name="head_competency_id"/>
+        </createIndex>
+        <createIndex indexName="idx_tail_competency_id" tableName="competency_relation">
             <column name="tail_competency_id"/>
         </createIndex>
 
-        <addForeignKeyConstraint baseColumnNames="head_competency_id" baseTableName="competency_relation" constraintName="FKbeaa051892e67ac2783f413bbf882a547db27e60"
+        <addForeignKeyConstraint baseColumnNames="head_competency_id" baseTableName="competency_relation" constraintName="FK_head_competency_id"
                                  deferrable="false" initiallyDeferred="false" onDelete="RESTRICT" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="competency"
                                  validate="true"/>
-        <addForeignKeyConstraint baseColumnNames="tail_competency_id" baseTableName="competency_relation" constraintName="FKd84cd79d225d13687cfe9c1395fb1cc69e09f553"
+        <addForeignKeyConstraint baseColumnNames="tail_competency_id" baseTableName="competency_relation" constraintName="FK_tail_competency_id"
                                  deferrable="false" initiallyDeferred="false" onDelete="RESTRICT" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="competency"
                                  validate="true"/>
     </changeSet>

--- a/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
@@ -30,7 +30,7 @@
         <!-- migrate competency relation type-column -->
         <renameColumn tableName="competency_relation" oldColumnName="type" newColumnName="type_old" columnDataType="varchar(31)" />
         <addColumn tableName="competency_relation">
-            <column name="type" type="tinyint">
+            <column name="type" type="tinyint" defaultValueNumeric="0">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="20240122000000" author="anzinger">
+        <!-- rename tables from learning goal to competency -->
+        <renameTable oldTableName="learning_goal" newTableName="competency"/>
+        <renameTable oldTableName="learning_goal_relation" newTableName="competency_relation"/>
+        <renameTable oldTableName="learning_goal_course" newTableName="competency_course"/>
+        <renameTable oldTableName="learning_goal_exercise" newTableName="competency_exercise"/>
+        <renameTable oldTableName="learning_goal_lecture_unit" newTableName="competency_lecture_unit"/>
+        <renameTable oldTableName="learning_goal_user" newTableName="competency_user"/>
+
+        <!-- rename columns from learning goal to competency -->
+        <renameColumn tableName="competency_relation" oldColumnName="tail_learning_goal_id" newColumnName="tail_competency_id" columnDataType="bigint" />
+        <renameColumn tableName="competency_relation" oldColumnName="head_learning_goal_id" newColumnName="head_competency_id" columnDataType="bigint" />
+        <renameColumn tableName="competency_course" oldColumnName="learning_goal_id" newColumnName="competency_id" columnDataType="bigint" />
+        <renameColumn tableName="competency_exercise" oldColumnName="learning_goal_id" newColumnName="competency_id" columnDataType="bigint" />
+        <renameColumn tableName="competency_lecture_unit" oldColumnName="learning_goal_id" newColumnName="competency_id" columnDataType="bigint" />
+
+        <!-- migrate competency relation type-column -->
+        <renameColumn tableName="competency_relation" oldColumnName="type" newColumnName="type_old" columnDataType="varchar(31)" />
+        <addColumn tableName="competency_relation">
+            <column name="type" type="tinyint">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <sql>
+            UPDATE competency_relation r
+            SET type = CASE
+                    WHEN r.type_old = 'A' THEN 1
+                    WHEN r.type_old = 'E' THEN 2
+                    WHEN r.type_old = 'M' THEN 3
+                    ELSE 0
+                END
+        </sql>
+
+        <dropColumn tableName="competency_relation" columnName="type_old"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
@@ -29,11 +29,11 @@
         </addColumn>
 
         <sql>
-            UPDATE competency_relation r
+            UPDATE competency_relation
             SET type = CASE
-                    WHEN r.type_old = 'A' THEN 1
-                    WHEN r.type_old = 'E' THEN 2
-                    WHEN r.type_old = 'M' THEN 3
+                    WHEN type_old = 'A' THEN 1
+                    WHEN type_old = 'E' THEN 2
+                    WHEN type_old = 'M' THEN 3
                     ELSE 0
                 END
         </sql>

--- a/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
@@ -4,6 +4,9 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <changeSet id="20240122000000" author="anzinger">
+
+        <dropIndex tableName="learning_goal_relation" indexName="UQymvhyta1mtg5mmu2n2fjmjc4m2y0mtniymy4odjh"/>
+
         <!-- rename tables from learning goal to competency -->
         <renameTable oldTableName="learning_goal" newTableName="competency"/>
         <renameTable oldTableName="learning_goal_relation" newTableName="competency_relation"/>
@@ -39,5 +42,11 @@
         </sql>
 
         <dropColumn tableName="competency_relation" columnName="type_old"/>
+
+        <createIndex indexName="UQymvhyta1mtg5mmu2n2fjmjc4m2y0mtniymy4odjh" tableName="competency_relation" unique="true">
+            <column name="head_competency_id"/>
+            <column name="tail_competency_id"/>
+            <column name="type"/>
+        </createIndex>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
@@ -18,6 +18,7 @@
         <renameColumn tableName="competency_course" oldColumnName="learning_goal_id" newColumnName="competency_id" columnDataType="bigint" />
         <renameColumn tableName="competency_exercise" oldColumnName="learning_goal_id" newColumnName="competency_id" columnDataType="bigint" />
         <renameColumn tableName="competency_lecture_unit" oldColumnName="learning_goal_id" newColumnName="competency_id" columnDataType="bigint" />
+        <renameColumn tableName="competency_user" oldColumnName="learning_goal_id" newColumnName="competency_id" columnDataType="bigint" />
 
         <!-- migrate competency relation type-column -->
         <renameColumn tableName="competency_relation" oldColumnName="type" newColumnName="type_old" columnDataType="varchar(31)" />

--- a/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20240122000000_changelog.xml
@@ -5,7 +5,11 @@
 
     <changeSet id="20240122000000" author="anzinger">
 
+        <dropForeignKeyConstraint baseTableName="learning_goal_relation" constraintName="FKbeaa051892e67ac2783f413bbf882a547db27e60" />
+        <dropForeignKeyConstraint baseTableName="learning_goal_relation" constraintName="FKd84cd79d225d13687cfe9c1395fb1cc69e09f553" />
+
         <dropIndex tableName="learning_goal_relation" indexName="UQymvhyta1mtg5mmu2n2fjmjc4m2y0mtniymy4odjh"/>
+        <dropIndex tableName="learning_goal_relation" indexName="FKd84cd79d225d13687cfe9c1395fb1cc69e09f553"/>
 
         <!-- rename tables from learning goal to competency -->
         <renameTable oldTableName="learning_goal" newTableName="competency"/>
@@ -48,5 +52,16 @@
             <column name="tail_competency_id"/>
             <column name="type"/>
         </createIndex>
+
+        <createIndex indexName="FKd84cd79d225d13687cfe9c1395fb1cc69e09f553" tableName="competency_relation">
+            <column name="tail_competency_id"/>
+        </createIndex>
+
+        <addForeignKeyConstraint baseColumnNames="head_competency_id" baseTableName="competency_relation" constraintName="FKbeaa051892e67ac2783f413bbf882a547db27e60"
+                                 deferrable="false" initiallyDeferred="false" onDelete="RESTRICT" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="competency"
+                                 validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="tail_competency_id" baseTableName="competency_relation" constraintName="FKd84cd79d225d13687cfe9c1395fb1cc69e09f553"
+                                 deferrable="false" initiallyDeferred="false" onDelete="RESTRICT" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="competency"
+                                 validate="true"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -80,6 +80,7 @@
     <include file="classpath:config/liquibase/changelog/20231028105016_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20231127155308_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20240113131313_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20240122000000_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command 'date '+%Y%m%d%H%M%S'' to get the current date and time in the correct format -->

--- a/src/test/java/de/tum/in/www1/artemis/competency/CompetencyUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/CompetencyUtilService.java
@@ -11,6 +11,7 @@ import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.competency.Competency;
 import de.tum.in.www1.artemis.domain.competency.CompetencyRelation;
+import de.tum.in.www1.artemis.domain.competency.RelationType;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.repository.CompetencyRelationRepository;
 import de.tum.in.www1.artemis.repository.CompetencyRepository;
@@ -148,7 +149,7 @@ public class CompetencyUtilService {
      * @param type The type of the relation
      * @param head The Competency that the tail Competency relates to
      */
-    public void addRelation(Competency tail, CompetencyRelation.RelationType type, Competency head) {
+    public void addRelation(Competency tail, RelationType type, Competency head) {
         CompetencyRelation relation = new CompetencyRelation();
         relation.setTailCompetency(tail);
         relation.setHeadCompetency(head);

--- a/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
@@ -1,4 +1,4 @@
-package de.tum.in.www1.artemis.lecture;
+package de.tum.in.www1.artemis.competency;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,8 +19,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.competency.CompetencyUtilService;
-import de.tum.in.www1.artemis.competency.LearningPathUtilService;
 import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.competency.Competency;
@@ -28,6 +26,7 @@ import de.tum.in.www1.artemis.domain.competency.LearningPath;
 import de.tum.in.www1.artemis.domain.lecture.TextUnit;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.textexercise.TextExerciseUtilService;
+import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.CompetencyProgressService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
@@ -159,7 +159,7 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
         return competency;
     }
 
-    CompetencyRelation createRelation(Competency head, Competency tail, CompetencyRelation.RelationType type) {
+    CompetencyRelation createRelation(Competency head, Competency tail, RelationType type) {
         CompetencyRelation relation = new CompetencyRelation();
         relation.setHeadCompetency(head);
         relation.setTailCompetency(tail);
@@ -775,7 +775,7 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
 
         Competency head = createCompetency(course2);
         Competency tail = createCompetency(course2);
-        createRelation(head, tail, CompetencyRelation.RelationType.RELATES);
+        createRelation(head, tail, RelationType.RELATES);
 
         competencyDTOList = request.postListWithResponseBody("/api/courses/" + course.getId() + "/competencies/import-all/" + course2.getId() + "?importRelations=true", null,
                 CompetencyWithTailRelationDTO.class, HttpStatus.CREATED);

--- a/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
@@ -24,10 +24,7 @@ import de.tum.in.www1.artemis.competency.CompetencyProgressUtilService;
 import de.tum.in.www1.artemis.competency.CompetencyUtilService;
 import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.competency.Competency;
-import de.tum.in.www1.artemis.domain.competency.CompetencyProgress;
-import de.tum.in.www1.artemis.domain.competency.CompetencyRelation;
-import de.tum.in.www1.artemis.domain.competency.CompetencyTaxonomy;
+import de.tum.in.www1.artemis.domain.competency.*;
 import de.tum.in.www1.artemis.domain.enumeration.ExerciseMode;
 import de.tum.in.www1.artemis.domain.enumeration.IncludedInOverallScore;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
@@ -393,7 +390,7 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
         var relation = new CompetencyRelation();
         relation.setTailCompetency(competency);
         relation.setHeadCompetency(competency1);
-        relation.setType(CompetencyRelation.RelationType.EXTENDS);
+        relation.setType(RelationType.EXTENDS);
         competencyRelationRepository.save(relation);
 
         request.delete("/api/courses/" + course.getId() + "/competencies/" + competency.getId(), HttpStatus.OK);
@@ -419,12 +416,13 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
     void createCompetencyRelation() throws Exception {
         Long idOfOtherCompetency = competencyUtilService.createCompetency(course).getId();
 
-        request.postWithoutResponseBody("/api/courses/" + course.getId() + "/competencies/" + competency.getId() + "/relations/" + idOfOtherCompetency + "?type="
-                + CompetencyRelation.RelationType.EXTENDS.name(), HttpStatus.OK, new LinkedMultiValueMap<>());
+        request.postWithoutResponseBody(
+                "/api/courses/" + course.getId() + "/competencies/" + competency.getId() + "/relations/" + idOfOtherCompetency + "?type=" + RelationType.EXTENDS.name(),
+                HttpStatus.OK, new LinkedMultiValueMap<>());
 
         var relations = competencyRelationRepository.findAllByCompetencyId(competency.getId());
         assertThat(relations).hasSize(1);
-        assertThat(relations.stream().findFirst().get().getType()).isEqualTo(CompetencyRelation.RelationType.EXTENDS);
+        assertThat(relations.stream().findFirst().get().getType()).isEqualTo(RelationType.EXTENDS);
     }
 
     @Test
@@ -447,17 +445,17 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
         var relation1 = new CompetencyRelation();
         relation1.setTailCompetency(competency);
         relation1.setHeadCompetency(otherCompetency1);
-        relation1.setType(CompetencyRelation.RelationType.EXTENDS);
+        relation1.setType(RelationType.EXTENDS);
         competencyRelationRepository.save(relation1);
 
         var relation2 = new CompetencyRelation();
         relation2.setTailCompetency(otherCompetency1);
         relation2.setHeadCompetency(otherCompetency2);
-        relation2.setType(CompetencyRelation.RelationType.MATCHES);
+        relation2.setType(RelationType.MATCHES);
         competencyRelationRepository.save(relation2);
 
-        request.post("/api/courses/" + course.getId() + "/competencies/" + idOfOtherCompetency2 + "/relations/" + competency.getId() + "?type="
-                + CompetencyRelation.RelationType.ASSUMES.name(), null, HttpStatus.BAD_REQUEST);
+        request.post("/api/courses/" + course.getId() + "/competencies/" + idOfOtherCompetency2 + "/relations/" + competency.getId() + "?type=" + RelationType.ASSUMES.name(), null,
+                HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -465,8 +463,8 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
     void createCompetencyRelation_shouldReturnForbidden() throws Exception {
         Long idOfOtherCompetency = competencyUtilService.createCompetency(course).getId();
 
-        request.post("/api/courses/" + course.getId() + "/competencies/" + competency.getId() + "/relations/" + idOfOtherCompetency + "?type="
-                + CompetencyRelation.RelationType.EXTENDS.name(), null, HttpStatus.FORBIDDEN);
+        request.post("/api/courses/" + course.getId() + "/competencies/" + competency.getId() + "/relations/" + idOfOtherCompetency + "?type=" + RelationType.EXTENDS.name(), null,
+                HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -477,7 +475,7 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
         var relation = new CompetencyRelation();
         relation.setTailCompetency(competency);
         relation.setHeadCompetency(otherCompetency);
-        relation.setType(CompetencyRelation.RelationType.EXTENDS);
+        relation.setType(RelationType.EXTENDS);
         relation = competencyRelationRepository.save(relation);
 
         var relations = request.getList("/api/courses/" + course.getId() + "/competencies/" + competency.getId() + "/relations", HttpStatus.OK, CompetencyRelation.class);
@@ -494,7 +492,7 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
         var relation = new CompetencyRelation();
         relation.setTailCompetency(competency);
         relation.setHeadCompetency(otherCompetency);
-        relation.setType(CompetencyRelation.RelationType.EXTENDS);
+        relation.setType(RelationType.EXTENDS);
         relation = competencyRelationRepository.save(relation);
 
         request.delete("/api/courses/" + course.getId() + "/competencies/" + competency.getId() + "/relations/" + relation.getId(), HttpStatus.OK);
@@ -511,7 +509,7 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
         var relation = new CompetencyRelation();
         relation.setTailCompetency(otherCompetency); // invalid
         relation.setHeadCompetency(competency);
-        relation.setType(CompetencyRelation.RelationType.EXTENDS);
+        relation.setType(RelationType.EXTENDS);
         relation = competencyRelationRepository.save(relation);
 
         request.delete("/api/courses/" + course.getId() + "/competencies/" + competency.getId() + "/relations/" + relation.getId(), HttpStatus.BAD_REQUEST);

--- a/src/test/java/de/tum/in/www1/artemis/service/LearningPathServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/LearningPathServiceTest.java
@@ -21,9 +21,7 @@ import de.tum.in.www1.artemis.competency.LearningPathUtilService;
 import de.tum.in.www1.artemis.course.CourseFactory;
 import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.competency.Competency;
-import de.tum.in.www1.artemis.domain.competency.CompetencyRelation;
-import de.tum.in.www1.artemis.domain.competency.LearningPath;
+import de.tum.in.www1.artemis.domain.competency.*;
 import de.tum.in.www1.artemis.domain.enumeration.DifficultyLevel;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.exercise.programmingexercise.ProgrammingExerciseUtilService;
@@ -117,7 +115,7 @@ class LearningPathServiceTest extends AbstractSpringIntegrationIndependentTest {
         void testHealthStatusOK() {
             final var competency1 = competencyUtilService.createCompetency(course);
             final var competency2 = competencyUtilService.createCompetency(course);
-            competencyUtilService.addRelation(competency1, CompetencyRelation.RelationType.MATCHES, competency2);
+            competencyUtilService.addRelation(competency1, RelationType.MATCHES, competency2);
             course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
             var healthStatus = learningPathService.getHealthStatusForCourse(course);
             assertThat(healthStatus.status()).containsExactly(LearningPathHealthDTO.HealthStatus.OK);
@@ -128,7 +126,7 @@ class LearningPathServiceTest extends AbstractSpringIntegrationIndependentTest {
         void testHealthStatusMissing() {
             final var competency1 = competencyUtilService.createCompetency(course);
             final var competency2 = competencyUtilService.createCompetency(course);
-            competencyUtilService.addRelation(competency1, CompetencyRelation.RelationType.MATCHES, competency2);
+            competencyUtilService.addRelation(competency1, RelationType.MATCHES, competency2);
             course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
             userUtilService.addStudent(TEST_PREFIX + "tumuser", TEST_PREFIX + "student1337");
             var healthStatus = learningPathService.getHealthStatusForCourse(course);
@@ -239,7 +237,7 @@ class LearningPathServiceTest extends AbstractSpringIntegrationIndependentTest {
             addExpectedComponentsForEmptyCompetencies(expectedNodes, expectedEdges, competency1, competency2);
         }
 
-        void testSimpleRelation(CompetencyRelation.RelationType type) {
+        void testSimpleRelation(RelationType type) {
             competencyUtilService.addRelation(competency1, type, competency2);
             final var sourceNodeId = LearningPathNgxService.getCompetencyEndNodeId(competency2.getId());
             final var targetNodeId = LearningPathNgxService.getCompetencyStartNodeId(competency1.getId());
@@ -250,22 +248,22 @@ class LearningPathServiceTest extends AbstractSpringIntegrationIndependentTest {
 
         @Test
         void testSingleRelates() {
-            testSimpleRelation(CompetencyRelation.RelationType.RELATES);
+            testSimpleRelation(RelationType.RELATES);
         }
 
         @Test
         void testSingleAssumes() {
-            testSimpleRelation(CompetencyRelation.RelationType.ASSUMES);
+            testSimpleRelation(RelationType.ASSUMES);
         }
 
         @Test
         void testSingleExtends() {
-            testSimpleRelation(CompetencyRelation.RelationType.EXTENDS);
+            testSimpleRelation(RelationType.EXTENDS);
         }
 
         @Test
         void testSingleMatches() {
-            competencyUtilService.addRelation(competency1, CompetencyRelation.RelationType.MATCHES, competency2);
+            competencyUtilService.addRelation(competency1, RelationType.MATCHES, competency2);
             expectedNodes.add(new NgxLearningPathDTO.Node(LearningPathNgxService.getMatchingClusterStartNodeId(0), NgxLearningPathDTO.NodeType.MATCH_START, null, ""));
             expectedNodes.add(new NgxLearningPathDTO.Node(LearningPathNgxService.getMatchingClusterEndNodeId(0), NgxLearningPathDTO.NodeType.MATCH_END, null, ""));
             expectedEdges.add(new NgxLearningPathDTO.Edge(LearningPathNgxService.getInEdgeId(competency1.getId()), LearningPathNgxService.getMatchingClusterStartNodeId(0),
@@ -285,8 +283,8 @@ class LearningPathServiceTest extends AbstractSpringIntegrationIndependentTest {
             var competency3 = competencyUtilService.createCompetency(course);
             addExpectedComponentsForEmptyCompetencies(expectedNodes, expectedEdges, competency3);
 
-            competencyUtilService.addRelation(competency1, CompetencyRelation.RelationType.MATCHES, competency2);
-            competencyUtilService.addRelation(competency2, CompetencyRelation.RelationType.MATCHES, competency3);
+            competencyUtilService.addRelation(competency1, RelationType.MATCHES, competency2);
+            competencyUtilService.addRelation(competency2, RelationType.MATCHES, competency3);
             expectedNodes.add(new NgxLearningPathDTO.Node(LearningPathNgxService.getMatchingClusterStartNodeId(0), NgxLearningPathDTO.NodeType.MATCH_START, null, ""));
             expectedNodes.add(new NgxLearningPathDTO.Node(LearningPathNgxService.getMatchingClusterEndNodeId(0), NgxLearningPathDTO.NodeType.MATCH_END, null, ""));
             expectedEdges.add(new NgxLearningPathDTO.Edge(LearningPathNgxService.getInEdgeId(competency1.getId()), LearningPathNgxService.getMatchingClusterStartNodeId(0),
@@ -411,10 +409,10 @@ class LearningPathServiceTest extends AbstractSpringIntegrationIndependentTest {
             Competency[] priors2 = competencyUtilService.createCompetencies(course, future(111), future(113), future(115));
             ;
             for (var competency : priors1) {
-                competencyUtilService.addRelation(competency1, CompetencyRelation.RelationType.RELATES, competency);
+                competencyUtilService.addRelation(competency1, RelationType.RELATES, competency);
             }
             for (var competency : priors2) {
-                competencyUtilService.addRelation(competency2, CompetencyRelation.RelationType.RELATES, competency);
+                competencyUtilService.addRelation(competency2, RelationType.RELATES, competency);
             }
             masterCompetencies(priors1);
             masterCompetencies(priors2[0]);
@@ -439,12 +437,12 @@ class LearningPathServiceTest extends AbstractSpringIntegrationIndependentTest {
             Competency[] priors1 = competencyUtilService.createCompetencies(course, future(110), future(112), future(114));
             Competency[] priors2 = competencyUtilService.createCompetencies(course, future(111), future(113), future(115));
             ;
-            competencyUtilService.addRelation(competency1, CompetencyRelation.RelationType.EXTENDS, priors1[0]);
-            competencyUtilService.addRelation(competency1, CompetencyRelation.RelationType.EXTENDS, priors1[1]);
-            competencyUtilService.addRelation(competency1, CompetencyRelation.RelationType.ASSUMES, priors1[2]);
-            competencyUtilService.addRelation(competency2, CompetencyRelation.RelationType.EXTENDS, priors2[0]);
-            competencyUtilService.addRelation(competency2, CompetencyRelation.RelationType.ASSUMES, priors2[1]);
-            competencyUtilService.addRelation(competency2, CompetencyRelation.RelationType.ASSUMES, priors2[2]);
+            competencyUtilService.addRelation(competency1, RelationType.EXTENDS, priors1[0]);
+            competencyUtilService.addRelation(competency1, RelationType.EXTENDS, priors1[1]);
+            competencyUtilService.addRelation(competency1, RelationType.ASSUMES, priors1[2]);
+            competencyUtilService.addRelation(competency2, RelationType.EXTENDS, priors2[0]);
+            competencyUtilService.addRelation(competency2, RelationType.ASSUMES, priors2[1]);
+            competencyUtilService.addRelation(competency2, RelationType.ASSUMES, priors2[2]);
 
             Competency[] expectedOrder = new Competency[] { priors1[0], priors2[0], priors1[1], priors2[1], priors1[2], priors2[2], competency1, competency2 };
             for (int i = 0; i < expectedOrder.length - 1; i++) {


### PR DESCRIPTION
> [!WARNING]
> **This PR includes a migration! Do only deploy to test-server 4.**

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the `type` of a `CompetencyRelation` is stored as a string. This takes up unnecessary space and limits the performance of queries. Additionally, we've many inconsistencies in the database that still reference competencies by the old description "Learning Goal".

### Description
<!-- Describe your changes in detail -->
This PR
- reduces storage and improves performance by migrating from a string representation to integers for `CometencyRelation.RelationTypes`
- resolves inconsistencies regarding the renaming from "Learning Goal" to "Competency"
- improves code style in competency and learning path related repositories

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students
- Course with 5 Competencies with configured relations (each relation type at least once), Learning Paths enabled

Before Migration:
Make sure you've a course with competencies and the relations (see above).

Test Migration:
1. Start the server
2. Make sure the migration runs without any failure

Test Post Migration:
1. Login as Instructor
2. Navigate to the Course>Competencies and check that all competencies and the relations are unchanged
3. Navigate to Course>Learning Paths
4. View a student's learning path and make sure everything looks normal / there are no errors
5. Login as Student
6. Navigate to Course>Learning Path and view your Learning Path Graph
7. make sure everything looks normal / there are no errors

Try anything else Competency / CompetencyRelation related to break the PR 👍 

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Competency` framework, replacing the previous `Learning Goal` system to better reflect skill development.
	- Added a `RelationType` enum to categorize different types of competency relationships.

- **Refactor**
	- Renamed database tables and columns to align with the new `Competency` terminology.
	- Updated service and repository layers to reflect changes in the competency data model.

- **Tests**
	- Adjusted test cases to accommodate the new `Competency` framework and `RelationType` usage.

- **Documentation**
	- Consolidated import statements in various classes for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->