### PR TITLE
`Development`: Untangle quiz dependencies and improve code formatting

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
@@ -35,7 +35,7 @@ public class Attachment extends DomainObject implements Serializable {
     private final transient FileService fileService = new FileService();
 
     @Transient
-    private final transient EntityFileService entityFileService = new EntityFileService(fileService, filePathService);
+    private final transient EntityFileService entityFileService = new EntityFileService(fileService);
 
     @Transient
     private String prevLink;

--- a/src/main/java/de/tum/in/www1/artemis/domain/Course.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Course.java
@@ -53,7 +53,7 @@ public class Course extends DomainObject {
     private final transient FileService fileService = new FileService();
 
     @Transient
-    private final transient EntityFileService entityFileService = new EntityFileService(fileService, filePathService);
+    private final transient EntityFileService entityFileService = new EntityFileService(fileService);
 
     @Transient
     private String prevCourseIcon;

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/ExamUser.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/ExamUser.java
@@ -36,7 +36,7 @@ public class ExamUser extends AbstractAuditingEntity {
     private final transient FileService fileService = new FileService();
 
     @Transient
-    private final transient EntityFileService entityFileService = new EntityFileService(fileService, filePathService);
+    private final transient EntityFileService entityFileService = new EntityFileService(fileService);
 
     @Transient
     private String prevSigningImagePath;

--- a/src/main/java/de/tum/in/www1/artemis/domain/hestia/ExerciseHint.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/hestia/ExerciseHint.java
@@ -25,7 +25,12 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 @DiscriminatorValue("T")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({ @JsonSubTypes.Type(value = ExerciseHint.class, name = "text"), @JsonSubTypes.Type(value = CodeHint.class, name = "code") })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ExerciseHint.class, name = "text"),
+    @JsonSubTypes.Type(value = CodeHint.class, name = "code")
+})
+// @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ExerciseHint extends DomainObject {
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/iris/session/IrisSession.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/iris/session/IrisSession.java
@@ -25,9 +25,11 @@ import de.tum.in.www1.artemis.domain.iris.message.IrisMessage;
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "discriminator", discriminatorType = DiscriminatorType.STRING)
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+// @formatter:on
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({ @JsonSubTypes.Type(value = IrisChatSession.class, name = "chat"), @JsonSubTypes.Type(value = IrisHestiaSession.class, name = "hestia"),
         @JsonSubTypes.Type(value = IrisCodeEditorSession.class, name = "codeEditor") })
+// @formatter:off
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class IrisSession extends DomainObject {
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/iris/session/IrisSession.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/iris/session/IrisSession.java
@@ -25,11 +25,14 @@ import de.tum.in.www1.artemis.domain.iris.message.IrisMessage;
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "discriminator", discriminatorType = DiscriminatorType.STRING)
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-// @formatter:on
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({ @JsonSubTypes.Type(value = IrisChatSession.class, name = "chat"), @JsonSubTypes.Type(value = IrisHestiaSession.class, name = "hestia"),
-        @JsonSubTypes.Type(value = IrisCodeEditorSession.class, name = "codeEditor") })
 // @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = IrisChatSession.class, name = "chat"),
+    @JsonSubTypes.Type(value = IrisHestiaSession.class, name = "hestia"),
+    @JsonSubTypes.Type(value = IrisCodeEditorSession.class, name = "codeEditor")
+})
+// @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class IrisSession extends DomainObject {
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/iris/settings/IrisSettings.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/iris/settings/IrisSettings.java
@@ -26,8 +26,13 @@ import de.tum.in.www1.artemis.domain.DomainObject;
 @DiscriminatorColumn(name = "discriminator", discriminatorType = DiscriminatorType.STRING)
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({ @JsonSubTypes.Type(value = IrisGlobalSettings.class, name = "global"), @JsonSubTypes.Type(value = IrisCourseSettings.class, name = "course"),
-        @JsonSubTypes.Type(value = IrisExerciseSettings.class, name = "exercise") })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = IrisGlobalSettings.class, name = "global"),
+    @JsonSubTypes.Type(value = IrisCourseSettings.class, name = "course"),
+    @JsonSubTypes.Type(value = IrisExerciseSettings.class, name = "exercise")
+})
+// @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class IrisSettings extends DomainObject {
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/iris/settings/IrisSubSettings.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/iris/settings/IrisSubSettings.java
@@ -30,8 +30,13 @@ import de.tum.in.www1.artemis.domain.DomainObject;
 @DiscriminatorColumn(name = "discriminator", discriminatorType = DiscriminatorType.STRING)
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({ @JsonSubTypes.Type(value = IrisChatSubSettings.class, name = "chat"), @JsonSubTypes.Type(value = IrisHestiaSubSettings.class, name = "hestia"),
-        @JsonSubTypes.Type(value = IrisCodeEditorSubSettings.class, name = "code-editor") })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = IrisChatSubSettings.class, name = "chat"),
+    @JsonSubTypes.Type(value = IrisHestiaSubSettings.class, name = "hestia"),
+    @JsonSubTypes.Type(value = IrisCodeEditorSubSettings.class, name = "code-editor")
+})
+// @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class IrisSubSettings extends DomainObject {
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/lecture/LectureUnit.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/lecture/LectureUnit.java
@@ -24,9 +24,15 @@ import de.tum.in.www1.artemis.domain.competency.Competency;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 // Annotation necessary to distinguish between concrete implementations of lecture-content when deserializing from JSON
-@JsonSubTypes({ @JsonSubTypes.Type(value = AttachmentUnit.class, name = "attachment"), @JsonSubTypes.Type(value = ExerciseUnit.class, name = "exercise"),
-        @JsonSubTypes.Type(value = TextUnit.class, name = "text"), @JsonSubTypes.Type(value = VideoUnit.class, name = "video"),
-        @JsonSubTypes.Type(value = OnlineUnit.class, name = "online") })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = AttachmentUnit.class, name = "attachment"),
+    @JsonSubTypes.Type(value = ExerciseUnit.class, name = "exercise"),
+    @JsonSubTypes.Type(value = TextUnit.class, name = "text"),
+    @JsonSubTypes.Type(value = VideoUnit.class, name = "video"),
+    @JsonSubTypes.Type(value = OnlineUnit.class, name = "online")
+})
+// @formatter:on
 public abstract class LectureUnit extends DomainObject implements LearningObject {
 
     @Transient

--- a/src/main/java/de/tum/in/www1/artemis/domain/lecture/Slide.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/lecture/Slide.java
@@ -34,7 +34,7 @@ public class Slide extends DomainObject {
     private final transient FileService fileService = new FileService();
 
     @Transient
-    private final transient EntityFileService entityFileService = new EntityFileService(fileService, filePathService);
+    private final transient EntityFileService entityFileService = new EntityFileService(fileService);
 
     @Transient
     private String prevSlideImagePath;

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Conversation.java
@@ -26,8 +26,13 @@ import de.tum.in.www1.artemis.domain.metis.Post;
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({ @JsonSubTypes.Type(value = OneToOneChat.class, name = "oneToOneChat"), @JsonSubTypes.Type(value = GroupChat.class, name = "groupChat"),
-        @JsonSubTypes.Type(value = Channel.class, name = "channel"), })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = OneToOneChat.class, name = "oneToOneChat"),
+    @JsonSubTypes.Type(value = GroupChat.class, name = "groupChat"),
+    @JsonSubTypes.Type(value = Channel.class, name = "channel"),
+})
+// @formatter:on
 public abstract class Conversation extends DomainObject {
 
     @ManyToOne

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/Notification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/Notification.java
@@ -31,8 +31,14 @@ import de.tum.in.www1.artemis.domain.enumeration.NotificationPriority;
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "notificationType")
 // Annotation necessary to distinguish between concrete implementations of Notification when deserializing from JSON
-@JsonSubTypes({ @JsonSubTypes.Type(value = GroupNotification.class, name = "group"), @JsonSubTypes.Type(value = SingleUserNotification.class, name = "single"),
-        @JsonSubTypes.Type(value = SystemNotification.class, name = "system"), @JsonSubTypes.Type(value = ConversationNotification.class, name = "conversation") })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = GroupNotification.class, name = "group"),
+    @JsonSubTypes.Type(value = SingleUserNotification.class, name = "single"),
+    @JsonSubTypes.Type(value = SystemNotification.class, name = "system"),
+    @JsonSubTypes.Type(value = ConversationNotification.class, name = "conversation")
+})
+// @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class Notification extends DomainObject {
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/Participation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/Participation.java
@@ -29,10 +29,14 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 // Annotation necessary to distinguish between concrete implementations of Exercise when deserializing from JSON
-@JsonSubTypes({ @JsonSubTypes.Type(value = StudentParticipation.class, name = "student"),
-        @JsonSubTypes.Type(value = ProgrammingExerciseStudentParticipation.class, name = "programming"),
-        @JsonSubTypes.Type(value = TemplateProgrammingExerciseParticipation.class, name = "template"),
-        @JsonSubTypes.Type(value = SolutionProgrammingExerciseParticipation.class, name = "solution"), })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = StudentParticipation.class, name = "student"),
+    @JsonSubTypes.Type(value = ProgrammingExerciseStudentParticipation.class, name = "programming"),
+    @JsonSubTypes.Type(value = TemplateProgrammingExerciseParticipation.class, name = "template"),
+    @JsonSubTypes.Type(value = SolutionProgrammingExerciseParticipation.class, name = "solution"),
+})
+// @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class Participation extends DomainObject implements ParticipationInterface {
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/plagiarism/PlagiarismResult.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/plagiarism/PlagiarismResult.java
@@ -26,7 +26,12 @@ import de.tum.in.www1.artemis.domain.plagiarism.text.TextPlagiarismResult;
 @Table(name = "plagiarism_result")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 // Annotation necessary to distinguish between concrete implementations of PlagiarismResults when deserializing from JSON
-@JsonSubTypes({ @JsonSubTypes.Type(value = ModelingPlagiarismResult.class, name = "modeling"), @JsonSubTypes.Type(value = TextPlagiarismResult.class, name = "text") })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ModelingPlagiarismResult.class, name = "modeling"),
+    @JsonSubTypes.Type(value = TextPlagiarismResult.class, name = "text")
+})
+// @formatter:on
 public abstract class PlagiarismResult<E extends PlagiarismSubmissionElement> extends AbstractAuditingEntity {
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerOption.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerOption.java
@@ -42,7 +42,6 @@ public class AnswerOption extends DomainObject implements QuizQuestionComponent<
     private Boolean invalid = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
     @JsonIgnore
     private MultipleChoiceQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerOption.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerOption.java
@@ -41,7 +41,7 @@ public class AnswerOption extends DomainObject implements QuizQuestionComponent<
     @JsonView(QuizView.Before.class)
     private Boolean invalid = false;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private MultipleChoiceQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerOption.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerOption.java
@@ -42,6 +42,7 @@ public class AnswerOption extends DomainObject implements QuizQuestionComponent<
     private Boolean invalid = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
     @JsonIgnore
     private MultipleChoiceQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropMapping.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropMapping.java
@@ -42,12 +42,10 @@ public class DragAndDropMapping extends DomainObject implements QuizQuestionComp
     private DropLocation dropLocation;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "submitted_answer_id")
     @JsonIgnore
     private DragAndDropSubmittedAnswer submittedAnswer;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
     @JsonIgnore
     private DragAndDropQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropMapping.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropMapping.java
@@ -42,10 +42,12 @@ public class DragAndDropMapping extends DomainObject implements QuizQuestionComp
     private DropLocation dropLocation;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "submitted_answer_id")
     @JsonIgnore
     private DragAndDropSubmittedAnswer submittedAnswer;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
     @JsonIgnore
     private DragAndDropQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
@@ -39,7 +39,7 @@ public class DragAndDropQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private String backgroundFilePath;
 
-    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
     // after 6.x upgrade
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
@@ -48,7 +48,7 @@ public class DragAndDropQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private List<DropLocation> dropLocations = new ArrayList<>();
 
-    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
     // after 6.x upgrade
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
@@ -57,7 +57,7 @@ public class DragAndDropQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private List<DragItem> dragItems = new ArrayList<>();
 
-    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
     // after 6.x upgrade
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
@@ -45,7 +45,10 @@ public class DragAndDropQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private List<DropLocation> dropLocations = new ArrayList<>();
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // after 6.x upgrade
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "question_id")
     @OrderColumn
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
@@ -39,9 +39,8 @@ public class DragAndDropQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private String backgroundFilePath;
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderColumn
-    @JoinColumn(name = "question_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
     private List<DropLocation> dropLocations = new ArrayList<>();

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
@@ -45,16 +45,14 @@ public class DragAndDropQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private List<DropLocation> dropLocations = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderColumn
-    @JoinColumn(name = "question_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
     private List<DragItem> dragItems = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderColumn
-    @JoinColumn(name = "question_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.After.class)
     private List<DragAndDropMapping> correctMappings = new ArrayList<>();

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
@@ -39,7 +39,10 @@ public class DragAndDropQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private String backgroundFilePath;
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // after 6.x upgrade
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "question_id")
     @OrderColumn
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
@@ -54,7 +57,10 @@ public class DragAndDropQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private List<DragItem> dragItems = new ArrayList<>();
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // after 6.x upgrade
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "question_id")
     @OrderColumn
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.After.class)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
@@ -30,11 +30,7 @@ import de.tum.in.www1.artemis.service.FileService;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DragAndDropQuestion extends QuizQuestion {
 
-    @Transient
-    private static final transient Logger log = LoggerFactory.getLogger(DragAndDropQuestion.class);
-
-    @Transient
-    private final transient FilePathService filePathService = new FilePathService();
+    private static final Logger log = LoggerFactory.getLogger(DragAndDropQuestion.class);
 
     @Transient
     private final transient FileService fileService = new FileService();
@@ -172,7 +168,7 @@ public class DragAndDropQuestion extends QuizQuestion {
         // delete old file if necessary
         try {
             if (backgroundFilePath != null) {
-                fileService.schedulePathForDeletion(filePathService.actualPathForPublicPathOrThrow(URI.create(backgroundFilePath)), 0);
+                fileService.schedulePathForDeletion(FilePathService.actualPathForPublicPathOrThrow(URI.create(backgroundFilePath)), 0);
             }
         }
         catch (FilePathParsingException e) {

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropSubmittedAnswer.java
@@ -23,7 +23,8 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DragAndDropSubmittedAnswer extends SubmittedAnswer {
 
-    @OneToMany(mappedBy = "submittedAnswer", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "submitted_answer_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
     private Set<DragAndDropMapping> mappings = new HashSet<>();

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropSubmittedAnswer.java
@@ -23,8 +23,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DragAndDropSubmittedAnswer extends SubmittedAnswer {
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
-    @JoinColumn(name = "submitted_answer_id")
+    @OneToMany(mappedBy = "submittedAnswer", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
     private Set<DragAndDropMapping> mappings = new HashSet<>();

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropSubmittedAnswer.java
@@ -23,6 +23,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DragAndDropSubmittedAnswer extends SubmittedAnswer {
 
+    // NOTE: this relation cannot be bidirectional, because it would otherwise be ManyToMany
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "submitted_answer_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
@@ -52,7 +52,7 @@ public class DragItem extends TempIdObject implements QuizQuestionComponent<Drag
     @JsonView(QuizView.Before.class)
     private Boolean invalid = false;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private DragAndDropQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
@@ -1,6 +1,8 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
 import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.persistence.*;
 
@@ -49,6 +51,12 @@ public class DragItem extends TempIdObject implements QuizQuestionComponent<Drag
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private DragAndDropQuestion question;
+
+    // NOTE: without cascade and orphanRemoval, deletion of quizzes might not work properly, so we reference mappings here, even if we do not use them
+    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "dragItem")
+    @JsonIgnore
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<DragAndDropMapping> mappings = new HashSet<>();
 
     public String getPictureFilePath() {
         return pictureFilePath;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
 import java.net.URI;
-import java.util.HashSet;
-import java.util.Set;
 
 import javax.persistence.*;
 
@@ -49,14 +47,8 @@ public class DragItem extends TempIdObject implements QuizQuestionComponent<Drag
     private Boolean invalid = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
     @JsonIgnore
     private DragAndDropQuestion question;
-
-    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "dragItem")
-    @JsonIgnore
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-    private Set<DragAndDropMapping> mappings = new HashSet<>();
 
     public String getPictureFilePath() {
         return pictureFilePath;
@@ -98,22 +90,6 @@ public class DragItem extends TempIdObject implements QuizQuestionComponent<Drag
 
     public void setInvalid(Boolean invalid) {
         this.invalid = invalid;
-    }
-
-    public Set<DragAndDropMapping> getMappings() {
-        return mappings;
-    }
-
-    public DragItem addMappings(DragAndDropMapping mapping) {
-        this.mappings.add(mapping);
-        mapping.setDragItem(this);
-        return this;
-    }
-
-    public DragItem removeMappings(DragAndDropMapping mapping) {
-        this.mappings.remove(mapping);
-        mapping.setDragItem(null);
-        return this;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
@@ -31,11 +31,7 @@ import de.tum.in.www1.artemis.service.FileService;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DragItem extends TempIdObject implements QuizQuestionComponent<DragAndDropQuestion> {
 
-    @Transient
-    private static final transient Logger log = LoggerFactory.getLogger(DragItem.class);
-
-    @Transient
-    private final transient FilePathService filePathService = new FilePathService();
+    private static final Logger log = LoggerFactory.getLogger(DragItem.class);
 
     @Transient
     private final transient FileService fileService = new FileService();
@@ -139,7 +135,7 @@ public class DragItem extends TempIdObject implements QuizQuestionComponent<Drag
         // delete old file if necessary
         try {
             if (pictureFilePath != null) {
-                fileService.schedulePathForDeletion(filePathService.actualPathForPublicPathOrThrow(URI.create(pictureFilePath)), 0);
+                fileService.schedulePathForDeletion(FilePathService.actualPathForPublicPathOrThrow(URI.create(pictureFilePath)), 0);
             }
         }
         catch (FilePathParsingException e) {

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
@@ -49,6 +49,7 @@ public class DragItem extends TempIdObject implements QuizQuestionComponent<Drag
     private Boolean invalid = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
     @JsonIgnore
     private DragAndDropQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
@@ -44,7 +44,7 @@ public class DropLocation extends TempIdObject implements QuizQuestionComponent<
     @JsonView(QuizView.Before.class)
     private Boolean invalid = false;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private DragAndDropQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
@@ -45,6 +45,7 @@ public class DropLocation extends TempIdObject implements QuizQuestionComponent<
     private Boolean invalid = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
     @JsonIgnore
     private DragAndDropQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.util.Set;
+import java.util.*;
 
 import javax.persistence.*;
 
@@ -44,9 +44,14 @@ public class DropLocation extends TempIdObject implements QuizQuestionComponent<
     private Boolean invalid = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
     @JsonIgnore
     private DragAndDropQuestion question;
+
+    // NOTE: without cascade and orphanRemoval, deletion of quizzes might not work properly, so we reference mappings here, even if we do not use them
+    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "dropLocation")
+    @JsonIgnore
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<DragAndDropMapping> mappings = new HashSet<>();
 
     public Double getPosX() {
         return posX;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -48,11 +47,6 @@ public class DropLocation extends TempIdObject implements QuizQuestionComponent<
     @JoinColumn(name = "question_id")
     @JsonIgnore
     private DragAndDropQuestion question;
-
-    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "dropLocation")
-    @JsonIgnore
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-    private Set<DragAndDropMapping> mappings = new HashSet<>();
 
     public Double getPosX() {
         return posX;
@@ -116,10 +110,6 @@ public class DropLocation extends TempIdObject implements QuizQuestionComponent<
 
     public void setQuestion(DragAndDropQuestion dragAndDropQuestion) {
         this.question = dragAndDropQuestion;
-    }
-
-    public Set<DragAndDropMapping> getMappings() {
-        return mappings;
     }
 
     public void setInvalid(Boolean invalid) {

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceQuestion.java
@@ -23,9 +23,8 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class MultipleChoiceQuestion extends QuizQuestion {
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderColumn
-    @JoinColumn(name = "question_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
     private List<AnswerOption> answerOptions = new ArrayList<>();

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceQuestion.java
@@ -23,7 +23,8 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class MultipleChoiceQuestion extends QuizQuestion {
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "question_id")
     @OrderColumn
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
@@ -75,6 +75,7 @@ public class QuizExercise extends Exercise implements QuizConfiguration {
     @JoinColumn(unique = true)
     private QuizPointStatistic quizPointStatistic;
 
+    // TODO: test if we should use mappedBy here as well
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderColumn
     @JoinColumn(name = "exercise_id")

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizQuestionStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizQuestionStatistic.java
@@ -7,9 +7,13 @@ import com.fasterxml.jackson.annotation.*;
 @Entity
 @DiscriminatorValue(value = "Q")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({ @JsonSubTypes.Type(value = MultipleChoiceQuestionStatistic.class, name = "multiple-choice"),
-        @JsonSubTypes.Type(value = DragAndDropQuestionStatistic.class, name = "drag-and-drop"),
-        @JsonSubTypes.Type(value = ShortAnswerQuestionStatistic.class, name = "short-answer") })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = MultipleChoiceQuestionStatistic.class, name = "multiple-choice"),
+    @JsonSubTypes.Type(value = DragAndDropQuestionStatistic.class, name = "drag-and-drop"),
+    @JsonSubTypes.Type(value = ShortAnswerQuestionStatistic.class, name = "short-answer")
+})
+// @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class QuizQuestionStatistic extends QuizStatistic implements QuizQuestionComponent<QuizQuestion> {
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerMapping.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerMapping.java
@@ -42,6 +42,7 @@ public class ShortAnswerMapping extends DomainObject implements QuizQuestionComp
     private ShortAnswerSpot spot;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
     @JsonIgnore
     private ShortAnswerQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerMapping.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerMapping.java
@@ -42,7 +42,6 @@ public class ShortAnswerMapping extends DomainObject implements QuizQuestionComp
     private ShortAnswerSpot spot;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
     @JsonIgnore
     private ShortAnswerQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
@@ -22,23 +22,20 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerQuestion extends QuizQuestion {
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderColumn
-    @JoinColumn(name = "question_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
     private List<ShortAnswerSpot> spots = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderColumn
-    @JoinColumn(name = "question_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
     private List<ShortAnswerSolution> solutions = new ArrayList<>();
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderColumn
-    @JoinColumn(name = "question_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.After.class)
     private List<ShortAnswerMapping> correctMappings = new ArrayList<>();

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
@@ -22,7 +22,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerQuestion extends QuizQuestion {
 
-    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
     // after 6.x upgrade
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
@@ -31,7 +31,7 @@ public class ShortAnswerQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private List<ShortAnswerSpot> spots = new ArrayList<>();
 
-    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
     // after 6.x upgrade
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
@@ -40,7 +40,7 @@ public class ShortAnswerQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private List<ShortAnswerSolution> solutions = new ArrayList<>();
 
-    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
     // after 6.x upgrade
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
@@ -28,7 +28,10 @@ public class ShortAnswerQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private List<ShortAnswerSpot> spots = new ArrayList<>();
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // after 6.x upgrade
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "question_id")
     @OrderColumn
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
@@ -22,7 +22,10 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerQuestion extends QuizQuestion {
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // after 6.x upgrade
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "question_id")
     @OrderColumn
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
@@ -37,7 +40,10 @@ public class ShortAnswerQuestion extends QuizQuestion {
     @JsonView(QuizView.Before.class)
     private List<ShortAnswerSolution> solutions = new ArrayList<>();
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    // TODO: making this a bidirectional relation leads to weired Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
+    // after 6.x upgrade
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "question_id")
     @OrderColumn
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.After.class)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -33,15 +30,8 @@ public class ShortAnswerSolution extends TempIdObject implements QuizQuestionCom
     private Boolean invalid = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
     @JsonIgnore
     private ShortAnswerQuestion question;
-
-    // added additionally, could possibly be created within artemis.jh?
-    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "solution")
-    @JsonIgnore
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-    private Set<ShortAnswerMapping> mappings = new HashSet<>();
 
     public String getText() {
         return text;
@@ -70,22 +60,6 @@ public class ShortAnswerSolution extends TempIdObject implements QuizQuestionCom
 
     public void setQuestion(ShortAnswerQuestion shortAnswerQuestion) {
         this.question = shortAnswerQuestion;
-    }
-
-    public Set<ShortAnswerMapping> getMappings() {
-        return mappings;
-    }
-
-    public ShortAnswerSolution addMappings(ShortAnswerMapping mapping) {
-        this.mappings.add(mapping);
-        mapping.setSolution(this);
-        return this;
-    }
-
-    public ShortAnswerSolution removeMappings(ShortAnswerMapping mapping) {
-        this.mappings.remove(mapping);
-        mapping.setSolution(null);
-        return this;
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
@@ -1,5 +1,8 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -32,6 +35,12 @@ public class ShortAnswerSolution extends TempIdObject implements QuizQuestionCom
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private ShortAnswerQuestion question;
+
+    // NOTE: without cascade and orphanRemoval, deletion of quizzes might not work properly, so we reference mappings here, even if we do not use them
+    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "solution")
+    @JsonIgnore
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<ShortAnswerMapping> mappings = new HashSet<>();
 
     public String getText() {
         return text;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
@@ -32,7 +32,7 @@ public class ShortAnswerSolution extends TempIdObject implements QuizQuestionCom
     @JsonView(QuizView.Before.class)
     private Boolean invalid = false;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private ShortAnswerQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
@@ -33,6 +33,7 @@ public class ShortAnswerSolution extends TempIdObject implements QuizQuestionCom
     private Boolean invalid = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
     @JsonIgnore
     private ShortAnswerQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
@@ -37,6 +37,7 @@ public class ShortAnswerSpot extends TempIdObject implements QuizQuestionCompone
     private Boolean invalid;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
     @JsonIgnore
     private ShortAnswerQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
@@ -1,5 +1,8 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -34,9 +37,14 @@ public class ShortAnswerSpot extends TempIdObject implements QuizQuestionCompone
     private Boolean invalid;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
     @JsonIgnore
     private ShortAnswerQuestion question;
+
+    // NOTE: without cascade and orphanRemoval, deletion of quizzes might not work properly, so we reference mappings here, even if we do not use them
+    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "spot")
+    @JsonIgnore
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<ShortAnswerMapping> mappings = new HashSet<>();
 
     public Integer getSpotNr() {
         return spotNr;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
@@ -36,7 +36,7 @@ public class ShortAnswerSpot extends TempIdObject implements QuizQuestionCompone
     @JsonView(QuizView.Before.class)
     private Boolean invalid;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private ShortAnswerQuestion question;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -40,11 +37,6 @@ public class ShortAnswerSpot extends TempIdObject implements QuizQuestionCompone
     @JoinColumn(name = "question_id")
     @JsonIgnore
     private ShortAnswerQuestion question;
-
-    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "spot")
-    @JsonIgnore
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-    private Set<ShortAnswerMapping> mappings = new HashSet<>();
 
     public Integer getSpotNr() {
         return spotNr;
@@ -86,22 +78,6 @@ public class ShortAnswerSpot extends TempIdObject implements QuizQuestionCompone
 
     public void setQuestion(ShortAnswerQuestion shortAnswerQuestion) {
         this.question = shortAnswerQuestion;
-    }
-
-    public Set<ShortAnswerMapping> getMappings() {
-        return mappings;
-    }
-
-    public ShortAnswerSpot addMappings(ShortAnswerMapping mapping) {
-        this.mappings.add(mapping);
-        mapping.setSpot(this);
-        return this;
-    }
-
-    public ShortAnswerSpot removeMappings(ShortAnswerMapping mapping) {
-        this.mappings.remove(mapping);
-        mapping.setSpot(null);
-        return this;
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedAnswer.java
@@ -24,7 +24,8 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerSubmittedAnswer extends SubmittedAnswer {
 
-    @OneToMany(mappedBy = "submittedAnswer", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "submitted_answer_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
     @Valid

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedAnswer.java
@@ -24,8 +24,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerSubmittedAnswer extends SubmittedAnswer {
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
-    @JoinColumn(name = "submitted_answer_id")
+    @OneToMany(mappedBy = "submittedAnswer", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
     @Valid

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedAnswer.java
@@ -24,6 +24,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerSubmittedAnswer extends SubmittedAnswer {
 
+    // NOTE: this relation cannot be bidirectional, because it would otherwise be ManyToMany
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "submitted_answer_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedText.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedText.java
@@ -42,6 +42,7 @@ public class ShortAnswerSubmittedText extends DomainObject {
     private ShortAnswerSpot spot;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "submitted_answer_id")
     @JsonIgnore
     private ShortAnswerSubmittedAnswer submittedAnswer;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedText.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedText.java
@@ -42,7 +42,6 @@ public class ShortAnswerSubmittedText extends DomainObject {
     private ShortAnswerSpot spot;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "submitted_answer_id")
     @JsonIgnore
     private ShortAnswerSubmittedAnswer submittedAnswer;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/SubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/SubmittedAnswer.java
@@ -25,8 +25,13 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 // Note: The "type" property has to be added on the front-end when making a request that includes a SubmittedAnswer Object
 // However, the "type" property will be automatically added by Jackson when an object is serialized
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({ @JsonSubTypes.Type(value = MultipleChoiceSubmittedAnswer.class, name = "multiple-choice"),
-        @JsonSubTypes.Type(value = DragAndDropSubmittedAnswer.class, name = "drag-and-drop"), @JsonSubTypes.Type(value = ShortAnswerSubmittedAnswer.class, name = "short-answer") })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = MultipleChoiceSubmittedAnswer.class, name = "multiple-choice"),
+    @JsonSubTypes.Type(value = DragAndDropSubmittedAnswer.class, name = "drag-and-drop"),
+    @JsonSubTypes.Type(value = ShortAnswerSubmittedAnswer.class, name = "short-answer")
+})
+// @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class SubmittedAnswer extends DomainObject {
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/scores/ParticipantScore.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/scores/ParticipantScore.java
@@ -40,7 +40,12 @@ import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 @DiscriminatorValue("PS")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 // Annotation necessary to distinguish between concrete implementations of ParticipantScore when deserializing from JSON
-@JsonSubTypes({ @JsonSubTypes.Type(value = StudentScore.class, name = "studentScore"), @JsonSubTypes.Type(value = TeamScore.class, name = "teamScore") })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = StudentScore.class, name = "studentScore"),
+    @JsonSubTypes.Type(value = TeamScore.class, name = "teamScore")
+})
+// @formatter:on
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class ParticipantScore extends DomainObject {
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/submissionpolicy/SubmissionPolicy.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/submissionpolicy/SubmissionPolicy.java
@@ -29,10 +29,12 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-// @formatter:on
-@JsonSubTypes({ @JsonSubTypes.Type(value = LockRepositoryPolicy.class, name = "lock_repository"),
-        @JsonSubTypes.Type(value = SubmissionPenaltyPolicy.class, name = "submission_penalty") })
 // @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = LockRepositoryPolicy.class, name = "lock_repository"),
+    @JsonSubTypes.Type(value = SubmissionPenaltyPolicy.class, name = "submission_penalty")
+})
+// @formatter:on
 public abstract class SubmissionPolicy extends DomainObject {
 
     @OneToOne(mappedBy = "submissionPolicy")

--- a/src/main/java/de/tum/in/www1/artemis/domain/submissionpolicy/SubmissionPolicy.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/submissionpolicy/SubmissionPolicy.java
@@ -29,8 +29,10 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+// @formatter:on
 @JsonSubTypes({ @JsonSubTypes.Type(value = LockRepositoryPolicy.class, name = "lock_repository"),
         @JsonSubTypes.Type(value = SubmissionPenaltyPolicy.class, name = "submission_penalty") })
+// @formatter:off
 public abstract class SubmissionPolicy extends DomainObject {
 
     @OneToOne(mappedBy = "submissionPolicy")

--- a/src/main/java/de/tum/in/www1/artemis/repository/DragItemRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/DragItemRepository.java
@@ -1,5 +1,8 @@
 package de.tum.in.www1.artemis.repository;
 
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,7 +15,10 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 @Repository
 public interface DragItemRepository extends JpaRepository<DragItem, Long> {
 
+    @EntityGraph(type = EntityGraph.EntityGraphType.LOAD, attributePaths = "question")
+    Optional<DragItem> findWithEagerQuestionById(Long id);
+
     default DragItem findByIdElseThrow(Long dragItemId) {
-        return findById(dragItemId).orElseThrow(() -> new EntityNotFoundException("DragItem", dragItemId));
+        return findWithEagerQuestionById(dragItemId).orElseThrow(() -> new EntityNotFoundException("DragItem", dragItemId));
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/QuizQuestionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/QuizQuestionRepository.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.artemis.repository;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,13 +21,20 @@ public interface QuizQuestionRepository extends JpaRepository<QuizQuestion, Long
     @Query("""
             SELECT question
             FROM QuizExercise exercise
-                LEFT JOIN  exercise.quizQuestions question
+                LEFT JOIN exercise.quizQuestions question
             WHERE exercise.id = :exerciseId
             """)
     Set<QuizQuestion> getQuizQuestionsByExerciseId(@Param("exerciseId") long exerciseId);
 
+    @Query("""
+            SELECT question
+                FROM DragAndDropQuestion question
+                WHERE question.id = :questionId
+                """)
+    Optional<DragAndDropQuestion> findDnDQuestionById(@Param("questionId") long questionId);
+
     default DragAndDropQuestion findDnDQuestionByIdOrElseThrow(Long questionId) {
-        return (DragAndDropQuestion) findById(questionId).orElseThrow(() -> new EntityNotFoundException("DragAndDropQuestion", questionId));
+        return findDnDQuestionById(questionId).orElseThrow(() -> new EntityNotFoundException("DragAndDropQuestion", questionId));
     }
 
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/QuizQuestionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/QuizQuestionRepository.java
@@ -18,13 +18,7 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 @Repository
 public interface QuizQuestionRepository extends JpaRepository<QuizQuestion, Long> {
 
-    @Query("""
-            SELECT question
-            FROM QuizExercise exercise
-                LEFT JOIN exercise.quizQuestions question
-            WHERE exercise.id = :exerciseId
-            """)
-    Set<QuizQuestion> getQuizQuestionsByExerciseId(@Param("exerciseId") long exerciseId);
+    Set<QuizQuestion> findByExercise_Id(long id);
 
     @Query("""
             SELECT question
@@ -36,5 +30,4 @@ public interface QuizQuestionRepository extends JpaRepository<QuizQuestion, Long
     default DragAndDropQuestion findDnDQuestionByIdOrElseThrow(Long questionId) {
         return findDnDQuestionById(questionId).orElseThrow(() -> new EntityNotFoundException("DragAndDropQuestion", questionId));
     }
-
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/QuizQuestionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/QuizQuestionRepository.java
@@ -28,9 +28,9 @@ public interface QuizQuestionRepository extends JpaRepository<QuizQuestion, Long
 
     @Query("""
             SELECT question
-                FROM DragAndDropQuestion question
-                WHERE question.id = :questionId
-                """)
+            FROM DragAndDropQuestion question
+            WHERE question.id = :questionId
+            """)
     Optional<DragAndDropQuestion> findDnDQuestionById(@Param("questionId") long questionId);
 
     default DragAndDropQuestion findDnDQuestionByIdOrElseThrow(Long questionId) {

--- a/src/main/java/de/tum/in/www1/artemis/service/AttachmentUnitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/AttachmentUnitService.java
@@ -154,7 +154,7 @@ public class AttachmentUnitService {
      */
     private void evictCache(MultipartFile file, AttachmentUnit attachmentUnit) {
         if (file != null && !file.isEmpty()) {
-            this.fileService.evictCacheForPath(filePathService.actualPathForPublicPathOrThrow(URI.create(attachmentUnit.getAttachment().getLink())));
+            this.fileService.evictCacheForPath(FilePathService.actualPathForPublicPathOrThrow(URI.create(attachmentUnit.getAttachment().getLink())));
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/AttachmentUnitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/AttachmentUnitService.java
@@ -25,18 +25,15 @@ public class AttachmentUnitService {
 
     private final FileService fileService;
 
-    private final FilePathService filePathService;
-
     private final SlideSplitterService slideSplitterService;
 
     private final SlideRepository slideRepository;
 
     public AttachmentUnitService(SlideRepository slideRepository, SlideSplitterService slideSplitterService, AttachmentUnitRepository attachmentUnitRepository,
-            AttachmentRepository attachmentRepository, FileService fileService, FilePathService filePathService) {
+            AttachmentRepository attachmentRepository, FileService fileService) {
         this.attachmentUnitRepository = attachmentUnitRepository;
         this.attachmentRepository = attachmentRepository;
         this.fileService = fileService;
-        this.filePathService = filePathService;
         this.slideSplitterService = slideSplitterService;
         this.slideRepository = slideRepository;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/EntityFileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/EntityFileService.java
@@ -59,7 +59,7 @@ public class EntityFileService {
         String filename = Path.of(entityFilePath).getFileName().toString();
         String extension = FilenameUtils.getExtension(filename);
         try {
-            Path source = filePathService.actualPathForPublicPathOrThrow(filePath);
+            Path source = FilePathService.actualPathForPublicPathOrThrow(filePath);
             if (!source.startsWith(FilePathService.getTempFilePath())) {
                 return entityFilePath;
             }
@@ -106,7 +106,7 @@ public class EntityFileService {
             resultingPath = moveFileBeforeEntityPersistenceWithIdIfIsTemp(newEntityFilePath, targetFolder, keepFilename, entityId);
         }
         if (oldEntityFilePath != null && !oldEntityFilePath.equals(resultingPath)) {
-            Path oldFilePath = filePathService.actualPathForPublicPathOrThrow(URI.create(oldEntityFilePath));
+            Path oldFilePath = FilePathService.actualPathForPublicPathOrThrow(URI.create(oldEntityFilePath));
             if (oldFilePath.toFile().exists()) {
                 fileService.schedulePathForDeletion(oldFilePath, 0);
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/EntityFileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/EntityFileService.java
@@ -23,11 +23,8 @@ public class EntityFileService {
 
     private final FileService fileService;
 
-    private final FilePathService filePathService;
-
-    public EntityFileService(FileService fileService, FilePathService filePathService) {
+    public EntityFileService(FileService fileService) {
         this.fileService = fileService;
-        this.filePathService = filePathService;
     }
 
     /**
@@ -76,7 +73,7 @@ public class EntityFileService {
                 FileUtils.delete(target.toFile());
             }
             FileUtils.moveFile(source.toFile(), target.toFile());
-            URI newPath = filePathService.publicPathForActualPathOrThrow(target, entityId);
+            URI newPath = FilePathService.publicPathForActualPathOrThrow(target, entityId);
             log.debug("Moved File from {} to {}", source, target);
             return newPath.toString();
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseDeletionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseDeletionService.java
@@ -129,8 +129,8 @@ public class ExerciseDeletionService {
         log.info("Request to delete {} with id {}", exercise.getClass().getSimpleName(), exerciseId);
 
         long start = System.nanoTime();
-        Channel exreciseChannel = channelRepository.findChannelByExerciseId(exerciseId);
-        channelService.deleteChannel(exreciseChannel);
+        Channel exerciseChannel = channelRepository.findChannelByExerciseId(exerciseId);
+        channelService.deleteChannel(exerciseChannel);
         log.info("Deleting the channel took {}", TimeLogUtil.formatDurationFrom(start));
 
         if (exercise instanceof ModelingExercise modelingExercise) {

--- a/src/main/java/de/tum/in/www1/artemis/service/FilePathService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FilePathService.java
@@ -74,7 +74,7 @@ public class FilePathService {
      * @throws FilePathParsingException if the path is unknown
      * @return the actual path to that file in the local filesystem
      */
-    public Path actualPathForPublicPathOrThrow(URI publicPath) {
+    public static Path actualPathForPublicPathOrThrow(URI publicPath) {
         Path actualPath = actualPathForPublicPath(publicPath);
         if (actualPath == null) {
             // path is unknown => cannot convert
@@ -98,26 +98,26 @@ public class FilePathService {
 
         // check for known path to convert
         if (uriPath.startsWith("/api/files/temp")) {
-            return FilePathService.getTempFilePath().resolve(filename);
+            return getTempFilePath().resolve(filename);
         }
         if (uriPath.startsWith("/api/files/drag-and-drop/backgrounds")) {
-            return FilePathService.getDragAndDropBackgroundFilePath().resolve(filename);
+            return getDragAndDropBackgroundFilePath().resolve(filename);
         }
         if (uriPath.startsWith("/api/files/drag-and-drop/drag-items")) {
-            return FilePathService.getDragItemFilePath().resolve(filename);
+            return getDragItemFilePath().resolve(filename);
         }
         if (uriPath.startsWith("/api/files/course/icons")) {
-            return FilePathService.getCourseIconFilePath().resolve(filename);
+            return getCourseIconFilePath().resolve(filename);
         }
         if (uriPath.startsWith("/api/files/exam-user/signatures")) {
-            return FilePathService.getExamUserSignatureFilePath().resolve(filename);
+            return getExamUserSignatureFilePath().resolve(filename);
         }
         if (uriPath.startsWith("/api/files/exam-user")) {
-            return FilePathService.getStudentImageFilePath().resolve(filename);
+            return getStudentImageFilePath().resolve(filename);
         }
         if (uriPath.startsWith("/api/files/attachments/lecture")) {
             String lectureId = path.getName(4).toString();
-            return FilePathService.getLectureAttachmentFilePath().resolve(Path.of(lectureId, filename));
+            return getLectureAttachmentFilePath().resolve(Path.of(lectureId, filename));
         }
         if (uriPath.startsWith("/api/files/attachments/attachment-unit")) {
             return actualPathForPublicAttachmentUnitFilePath(publicPath, filename);
@@ -133,7 +133,7 @@ public class FilePathService {
         Path path = Path.of(publicPath.getPath());
         if (!publicPath.toString().contains("/slide")) {
             String attachmentUnitId = path.getName(4).toString();
-            return FilePathService.getAttachmentUnitFilePath().resolve(Path.of(attachmentUnitId, filename));
+            return getAttachmentUnitFilePath().resolve(Path.of(attachmentUnitId, filename));
         }
         try {
             String attachmentUnitId = path.getName(4).toString();
@@ -141,7 +141,7 @@ public class FilePathService {
             // check if the ids are valid long values
             Long.parseLong(attachmentUnitId);
             Long.parseLong(slideId);
-            return FilePathService.getAttachmentUnitFilePath().resolve(Path.of(attachmentUnitId, "slide", slideId, filename));
+            return getAttachmentUnitFilePath().resolve(Path.of(attachmentUnitId, "slide", slideId, filename));
         }
         catch (IllegalArgumentException e) {
             throw new FilePathParsingException("Public path does not contain correct attachmentUnitId or slideId: " + publicPath, e);
@@ -170,7 +170,7 @@ public class FilePathService {
      * @throws FilePathParsingException if the path is unknown
      * @return the public file url that can be used by users to access the file from outside
      */
-    public URI publicPathForActualPathOrThrow(Path actualPathString, @Nullable Long entityId) {
+    public static URI publicPathForActualPathOrThrow(Path actualPathString, @Nullable Long entityId) {
         URI publicPath = publicPathForActualPath(actualPathString, entityId);
         if (publicPath == null) {
             // path is unknown => cannot convert
@@ -187,45 +187,45 @@ public class FilePathService {
      * @param entityId the id of the entity associated with the file
      * @return the public file url that can be used by users to access the file from outside
      */
-    public URI publicPathForActualPath(Path path, @Nullable Long entityId) {
+    public static URI publicPathForActualPath(Path path, @Nullable Long entityId) {
         // first extract filename
         String filename = path.getFileName().toString();
 
         // generate part for id
         String id = entityId == null ? Constants.FILEPATH_ID_PLACEHOLDER : entityId.toString();
         // check for known path to convert
-        if (path.startsWith(FilePathService.getTempFilePath())) {
+        if (path.startsWith(getTempFilePath())) {
             return URI.create(FileService.DEFAULT_FILE_SUBPATH + filename);
         }
-        if (path.startsWith(FilePathService.getDragAndDropBackgroundFilePath())) {
+        if (path.startsWith(getDragAndDropBackgroundFilePath())) {
             return URI.create("/api/files/drag-and-drop/backgrounds/" + id + "/" + filename);
         }
-        if (path.startsWith(FilePathService.getDragItemFilePath())) {
+        if (path.startsWith(getDragItemFilePath())) {
             return URI.create("/api/files/drag-and-drop/drag-items/" + id + "/" + filename);
         }
-        if (path.startsWith(FilePathService.getCourseIconFilePath())) {
+        if (path.startsWith(getCourseIconFilePath())) {
             return URI.create("/api/files/course/icons/" + id + "/" + filename);
         }
-        if (path.startsWith(FilePathService.getExamUserSignatureFilePath())) {
+        if (path.startsWith(getExamUserSignatureFilePath())) {
             return URI.create("/api/files/exam-user/signatures/" + id + "/" + filename);
         }
-        if (path.startsWith(FilePathService.getStudentImageFilePath())) {
+        if (path.startsWith(getStudentImageFilePath())) {
             return URI.create("/api/files/exam-user/" + id + "/" + filename);
         }
-        if (path.startsWith(FilePathService.getLectureAttachmentFilePath())) {
+        if (path.startsWith(getLectureAttachmentFilePath())) {
             return URI.create("/api/files/attachments/lecture/" + id + "/" + filename);
         }
-        if (path.startsWith(FilePathService.getAttachmentUnitFilePath())) {
+        if (path.startsWith(getAttachmentUnitFilePath())) {
             return publicPathForActualAttachmentUnitFilePath(path, filename, id);
         }
-        if (path.startsWith(FilePathService.getFileUploadExercisesFilePath())) {
+        if (path.startsWith(getFileUploadExercisesFilePath())) {
             return publicPathForActualFileUploadExercisesFilePath(path, filename, id);
         }
 
         return null;
     }
 
-    private URI publicPathForActualAttachmentUnitFilePath(Path path, String filename, String id) {
+    private static URI publicPathForActualAttachmentUnitFilePath(Path path, String filename, String id) {
         if (!path.toString().contains("/slide")) {
             return URI.create("/api/files/attachments/attachment-unit/" + id + "/" + filename);
         }
@@ -241,7 +241,7 @@ public class FilePathService {
         }
     }
 
-    private URI publicPathForActualFileUploadExercisesFilePath(Path path, String filename, String id) {
+    private static URI publicPathForActualFileUploadExercisesFilePath(Path path, String filename, String id) {
         try {
             // The last name is the file name, the one before that is the submissionId and the one before that is the exerciseId, in which we are interested
             final var expectedExerciseId = path.getName(path.getNameCount() - 3).toString();

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
@@ -37,21 +37,18 @@ public class FileUploadSubmissionService extends SubmissionService {
 
     private final FileService fileService;
 
-    private final FilePathService filePathService;
-
     private final ExerciseDateService exerciseDateService;
 
     public FileUploadSubmissionService(FileUploadSubmissionRepository fileUploadSubmissionRepository, SubmissionRepository submissionRepository, ResultRepository resultRepository,
             ParticipationService participationService, UserRepository userRepository, StudentParticipationRepository studentParticipationRepository, FileService fileService,
             AuthorizationCheckService authCheckService, FeedbackRepository feedbackRepository, ExamDateService examDateService, ExerciseDateService exerciseDateService,
             CourseRepository courseRepository, ParticipationRepository participationRepository, ComplaintRepository complaintRepository, FeedbackService feedbackService,
-            FilePathService filePathService, Optional<AthenaSubmissionSelectionService> athenaSubmissionSelectionService) {
+            Optional<AthenaSubmissionSelectionService> athenaSubmissionSelectionService) {
         super(submissionRepository, userRepository, authCheckService, resultRepository, studentParticipationRepository, participationService, feedbackRepository, examDateService,
                 exerciseDateService, courseRepository, participationRepository, complaintRepository, feedbackService, athenaSubmissionSelectionService);
         this.fileUploadSubmissionRepository = fileUploadSubmissionRepository;
         this.fileService = fileService;
         this.exerciseDateService = exerciseDateService;
-        this.filePathService = filePathService;
     }
 
     /**
@@ -157,7 +154,7 @@ public class FileUploadSubmissionService extends SubmissionService {
             fileUploadSubmission = fileUploadSubmissionRepository.save(fileUploadSubmission);
         }
         final Path savePath = saveFileForSubmission(file, fileUploadSubmission, exercise);
-        final URI newFilePath = filePathService.publicPathForActualPathOrThrow(savePath, fileUploadSubmission.getId());
+        final URI newFilePath = FilePathService.publicPathForActualPathOrThrow(savePath, fileUploadSubmission.getId());
 
         // We need to ensure that we can access the store file and the stored file is the same as was passed to us in the request
         final var storedFileHash = DigestUtils.md5Hex(Files.newInputStream(savePath));

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
@@ -162,7 +162,7 @@ public class LectureImportService {
         attachment.setVersion(importedAttachment.getVersion());
         attachment.setAttachmentType(importedAttachment.getAttachmentType());
 
-        Path oldPath = filePathService.actualPathForPublicPathOrThrow(URI.create(importedAttachment.getLink()));
+        Path oldPath = FilePathService.actualPathForPublicPathOrThrow(URI.create(importedAttachment.getLink()));
         Path tempPath = FilePathService.getTempFilePath().resolve(oldPath.getFileName());
 
         try {

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
@@ -32,14 +32,10 @@ public class LectureImportService {
 
     private final AttachmentRepository attachmentRepository;
 
-    private final FilePathService filePathService;
-
-    public LectureImportService(LectureRepository lectureRepository, LectureUnitRepository lectureUnitRepository, AttachmentRepository attachmentRepository,
-            FilePathService filePathService) {
+    public LectureImportService(LectureRepository lectureRepository, LectureUnitRepository lectureUnitRepository, AttachmentRepository attachmentRepository) {
         this.lectureRepository = lectureRepository;
         this.lectureUnitRepository = lectureUnitRepository;
         this.attachmentRepository = attachmentRepository;
-        this.filePathService = filePathService;
     }
 
     /**
@@ -170,7 +166,7 @@ public class LectureImportService {
             FileUtils.copyFile(oldPath.toFile(), tempPath.toFile(), REPLACE_EXISTING);
 
             // File was copied to a temp directory and will be moved once we persist the attachment
-            attachment.setLink(filePathService.publicPathForActualPathOrThrow(tempPath, null).toString());
+            attachment.setLink(FilePathService.publicPathForActualPathOrThrow(tempPath, null).toString());
         }
         catch (IOException e) {
             log.error("Error while copying file", e);

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseImportService.java
@@ -25,18 +25,14 @@ public class QuizExerciseImportService extends ExerciseImportService {
 
     private final FileService fileService;
 
-    private final FilePathService filePathService;
-
     private final ChannelService channelService;
 
     public QuizExerciseImportService(QuizExerciseService quizExerciseService, FileService fileService, ExampleSubmissionRepository exampleSubmissionRepository,
-            SubmissionRepository submissionRepository, ResultRepository resultRepository, ChannelService channelService, FeedbackService feedbackService,
-            FilePathService filePathService) {
+            SubmissionRepository submissionRepository, ResultRepository resultRepository, ChannelService channelService, FeedbackService feedbackService) {
         super(exampleSubmissionRepository, submissionRepository, resultRepository, feedbackService);
         this.quizExerciseService = quizExerciseService;
         this.fileService = fileService;
         this.channelService = channelService;
-        this.filePathService = filePathService;
     }
 
     /**
@@ -127,7 +123,7 @@ public class QuizExerciseImportService extends ExerciseImportService {
             // Need to copy the file and get a new path, otherwise two different questions would share the same image and would cause problems in case one was deleted
             Path oldPath = FilePathService.actualPathForPublicPath(backgroundFilePublicPath);
             Path newPath = fileService.copyExistingFileToTarget(oldPath, FilePathService.getDragAndDropBackgroundFilePath());
-            dndQuestion.setBackgroundFilePath(filePathService.publicPathForActualPath(newPath, null).toString());
+            dndQuestion.setBackgroundFilePath(FilePathService.publicPathForActualPathOrThrow(newPath, null).toString());
         }
         else {
             log.warn("BackgroundFilePath of DragAndDropQuestion {} is null", dndQuestion.getId());
@@ -158,7 +154,7 @@ public class QuizExerciseImportService extends ExerciseImportService {
             // Need to copy the file and get a new path, same as above
             Path oldDragItemPath = FilePathService.actualPathForPublicPath(pictureFilePublicPath);
             Path newDragItemPath = fileService.copyExistingFileToTarget(oldDragItemPath, FilePathService.getDragItemFilePath());
-            dragItem.setPictureFilePath(filePathService.publicPathForActualPath(newDragItemPath, null).toString());
+            dragItem.setPictureFilePath(FilePathService.publicPathForActualPathOrThrow(newDragItemPath, null).toString());
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
@@ -323,7 +323,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
         Set<String> exerciseFileNames = getAllPathsFromDragAndDropQuestionsOfExercise(quizExercise);
         Set<String> newFileNames = isCreate ? exerciseFileNames : exerciseFileNames.stream().filter(fileNameOrUri -> {
             try {
-                return !Files.exists(filePathService.actualPathForPublicPathOrThrow(URI.create(fileNameOrUri)));
+                return !Files.exists(FilePathService.actualPathForPublicPathOrThrow(URI.create(fileNameOrUri)));
             }
             catch (FilePathParsingException e) {
                 // File is not in the internal API format and hence expected to be a new file

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
@@ -59,12 +59,10 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
 
     private final FileService fileService;
 
-    private final FilePathService filePathService;
-
     public QuizExerciseService(QuizExerciseRepository quizExerciseRepository, ResultRepository resultRepository, QuizSubmissionRepository quizSubmissionRepository,
             QuizScheduleService quizScheduleService, QuizStatisticService quizStatisticService, QuizBatchService quizBatchService,
             ExerciseSpecificationService exerciseSpecificationService, FileService fileService, DragAndDropMappingRepository dragAndDropMappingRepository,
-            ShortAnswerMappingRepository shortAnswerMappingRepository, FilePathService filePathService) {
+            ShortAnswerMappingRepository shortAnswerMappingRepository) {
         super(dragAndDropMappingRepository, shortAnswerMappingRepository);
         this.quizExerciseRepository = quizExerciseRepository;
         this.resultRepository = resultRepository;
@@ -74,7 +72,6 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
         this.quizBatchService = quizBatchService;
         this.exerciseSpecificationService = exerciseSpecificationService;
         this.fileService = fileService;
-        this.filePathService = filePathService;
     }
 
     /**
@@ -382,7 +379,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
         String clearFileExtension = FileService.sanitizeFilename(FilenameUtils.getExtension(Objects.requireNonNull(file.getOriginalFilename())));
         Path savePath = basePath.resolve(fileService.generateFilename("dnd_image_", clearFileExtension));
         FileUtils.copyToFile(file.getInputStream(), savePath.toFile());
-        return filePathService.publicPathForActualPathOrThrow(savePath, entityId);
+        return FilePathService.publicPathForActualPathOrThrow(savePath, entityId);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIQueueWebsocketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIQueueWebsocketService.java
@@ -32,8 +32,6 @@ public class LocalCIQueueWebsocketService {
 
     private static final Logger log = LoggerFactory.getLogger(LocalCIQueueWebsocketService.class);
 
-    private final HazelcastInstance hazelcastInstance;
-
     private final IQueue<LocalCIBuildJobQueueItem> queue;
 
     private final IMap<Long, LocalCIBuildJobQueueItem> processingJobs;
@@ -53,12 +51,11 @@ public class LocalCIQueueWebsocketService {
      */
     public LocalCIQueueWebsocketService(HazelcastInstance hazelcastInstance, LocalCIWebsocketMessagingService localCIWebsocketMessagingService,
             LocalCISharedBuildJobQueueService localCISharedBuildJobQueueService) {
-        this.hazelcastInstance = hazelcastInstance;
         this.localCIWebsocketMessagingService = localCIWebsocketMessagingService;
         this.localCISharedBuildJobQueueService = localCISharedBuildJobQueueService;
-        this.queue = this.hazelcastInstance.getQueue("buildJobQueue");
-        this.processingJobs = this.hazelcastInstance.getMap("processingJobs");
-        this.buildAgentInformation = this.hazelcastInstance.getMap("buildAgentInformation");
+        this.queue = hazelcastInstance.getQueue("buildJobQueue");
+        this.processingJobs = hazelcastInstance.getMap("processingJobs");
+        this.buildAgentInformation = hazelcastInstance.getMap("buildAgentInformation");
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/export/DataExportQuizExerciseCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/export/DataExportQuizExerciseCreationService.java
@@ -73,7 +73,7 @@ public class DataExportQuizExerciseCreationService {
      */
     private boolean createQuizAnswersExport(QuizExercise quizExercise, StudentParticipation participation, Path outputDir, boolean includeResults,
             Optional<List<String>> exportErrors) {
-        Set<QuizQuestion> quizQuestions = quizQuestionRepository.getQuizQuestionsByExerciseId(quizExercise.getId());
+        Set<QuizQuestion> quizQuestions = quizQuestionRepository.findByExercise_Id(quizExercise.getId());
         boolean errorOccurred = false;
         for (var submission : participation.getSubmissions()) {
             QuizSubmission quizSubmission = quizSubmissionRepository.findWithEagerSubmittedAnswersById(submission.getId());

--- a/src/main/java/de/tum/in/www1/artemis/service/iris/session/codeeditor/file/FileChange.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/iris/session/codeeditor/file/FileChange.java
@@ -17,11 +17,11 @@ import de.tum.in.www1.artemis.service.iris.session.codeeditor.IrisChangeExceptio
  */
 // @formatter:off
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = RenameFileChange.class, name = "rename"),
-        @JsonSubTypes.Type(value = DeleteFileChange.class, name = "delete"),
-        @JsonSubTypes.Type(value = CreateFileChange.class, name = "create"),
-        @JsonSubTypes.Type(value = OverwriteFileChange.class, name = "overwrite"),
-        @JsonSubTypes.Type(value = ModifyFileChange.class, name = "modify")
+    @JsonSubTypes.Type(value = RenameFileChange.class, name = "rename"),
+    @JsonSubTypes.Type(value = DeleteFileChange.class, name = "delete"),
+    @JsonSubTypes.Type(value = CreateFileChange.class, name = "create"),
+    @JsonSubTypes.Type(value = OverwriteFileChange.class, name = "overwrite"),
+    @JsonSubTypes.Type(value = ModifyFileChange.class, name = "modify")
 })
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 // @formatter:on

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -394,7 +394,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
         // DURING EXAM
         else if (now.isBefore(examDateService.getLatestIndividualExamEndDate(exam))) {
             // This is only a backup (e.g. a crash of this node and restart during the exam)
-            // TODO: Christian Femers: this can lead to a weired edge case after the normal exam end date and before the last individual exam end date (in case of working time
+            // TODO: Christian Femers: this can lead to a weird edge case after the normal exam end date and before the last individual exam end date (in case of working time
             // extensions)
             var scheduledRunnable = Set.of(
                     new Tuple<>(now.plusSeconds(Constants.SECONDS_AFTER_RELEASE_DATE_FOR_UNLOCKING_STUDENT_EXAM_REPOS), unlockAllStudentRepositoriesAndParticipations(exercise)));

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -233,12 +233,12 @@ public class CourseResource {
             courseUpdate.setCourseIcon(filePathService.publicPathForActualPathOrThrow(savePath, courseId).toString());
             if (existingCourse.getCourseIcon() != null) {
                 // delete old course icon
-                fileService.schedulePathForDeletion(filePathService.actualPathForPublicPathOrThrow(new URI(existingCourse.getCourseIcon())), 0);
+                fileService.schedulePathForDeletion(FilePathService.actualPathForPublicPathOrThrow(new URI(existingCourse.getCourseIcon())), 0);
             }
         }
         else if (courseUpdate.getCourseIcon() == null && existingCourse.getCourseIcon() != null) {
             // delete old course icon
-            fileService.schedulePathForDeletion(filePathService.actualPathForPublicPathOrThrow(new URI(existingCourse.getCourseIcon())), 0);
+            fileService.schedulePathForDeletion(FilePathService.actualPathForPublicPathOrThrow(new URI(existingCourse.getCourseIcon())), 0);
         }
 
         if (courseUpdate.isOnlineCourse() != existingCourse.isOnlineCourse()) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -113,15 +113,13 @@ public class CourseResource {
 
     private final ExamRepository examRepository;
 
-    private final FilePathService filePathService;
-
     public CourseResource(UserRepository userRepository, CourseService courseService, CourseRepository courseRepository, ExerciseService exerciseService,
             Optional<OnlineCourseConfigurationService> onlineCourseConfigurationService, AuthorizationCheckService authCheckService,
             TutorParticipationRepository tutorParticipationRepository, SubmissionService submissionService, Optional<VcsUserManagementService> optionalVcsUserManagementService,
             AssessmentDashboardService assessmentDashboardService, ExerciseRepository exerciseRepository, Optional<CIUserManagementService> optionalCiUserManagementService,
             FileService fileService, TutorialGroupsConfigurationService tutorialGroupsConfigurationService, GradingScaleService gradingScaleService,
             CourseScoreCalculationService courseScoreCalculationService, GradingScaleRepository gradingScaleRepository, LearningPathService learningPathService,
-            ConductAgreementService conductAgreementService, ExamRepository examRepository, FilePathService filePathService) {
+            ConductAgreementService conductAgreementService, ExamRepository examRepository) {
         this.courseService = courseService;
         this.courseRepository = courseRepository;
         this.exerciseService = exerciseService;
@@ -142,7 +140,6 @@ public class CourseResource {
         this.learningPathService = learningPathService;
         this.conductAgreementService = conductAgreementService;
         this.examRepository = examRepository;
-        this.filePathService = filePathService;
     }
 
     /**
@@ -230,7 +227,7 @@ public class CourseResource {
         if (file != null) {
             Path basePath = FilePathService.getCourseIconFilePath();
             Path savePath = fileService.saveFile(file, basePath);
-            courseUpdate.setCourseIcon(filePathService.publicPathForActualPathOrThrow(savePath, courseId).toString());
+            courseUpdate.setCourseIcon(FilePathService.publicPathForActualPathOrThrow(savePath, courseId).toString());
             if (existingCourse.getCourseIcon() != null) {
                 // delete old course icon
                 fileService.schedulePathForDeletion(FilePathService.actualPathForPublicPathOrThrow(new URI(existingCourse.getCourseIcon())), 0);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
@@ -78,13 +78,10 @@ public class FileResource {
 
     private final CourseRepository courseRepository;
 
-    private final FilePathService filePathService;
-
     public FileResource(SlideRepository slideRepository, AuthorizationCheckService authorizationCheckService, FileService fileService, ResourceLoaderService resourceLoaderService,
             LectureRepository lectureRepository, FileUploadSubmissionRepository fileUploadSubmissionRepository, FileUploadExerciseRepository fileUploadExerciseRepository,
             AttachmentRepository attachmentRepository, AttachmentUnitRepository attachmentUnitRepository, AuthorizationCheckService authCheckService, UserRepository userRepository,
-            ExamUserRepository examUserRepository, QuizQuestionRepository quizQuestionRepository, DragItemRepository dragItemRepository, CourseRepository courseRepository,
-            FilePathService filePathService) {
+            ExamUserRepository examUserRepository, QuizQuestionRepository quizQuestionRepository, DragItemRepository dragItemRepository, CourseRepository courseRepository) {
         this.fileService = fileService;
         this.resourceLoaderService = resourceLoaderService;
         this.lectureRepository = lectureRepository;
@@ -100,7 +97,6 @@ public class FileResource {
         this.quizQuestionRepository = quizQuestionRepository;
         this.dragItemRepository = dragItemRepository;
         this.courseRepository = courseRepository;
-        this.filePathService = filePathService;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
@@ -492,7 +492,7 @@ public class FileResource {
         if (publicPath == null) {
             throw new EntityNotFoundException("No file linked");
         }
-        return filePathService.actualPathForPublicPathOrThrow(URI.create(publicPath));
+        return FilePathService.actualPathForPublicPathOrThrow(URI.create(publicPath));
     }
 
     private MediaType getMediaTypeFromFilename(String filename) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -109,15 +109,13 @@ public class QuizExerciseResource {
 
     private final ChannelRepository channelRepository;
 
-    private final FilePathService filePathService;
-
     public QuizExerciseResource(QuizExerciseService quizExerciseService, QuizMessagingService quizMessagingService, QuizExerciseRepository quizExerciseRepository,
             UserRepository userRepository, CourseService courseService, CourseRepository courseRepository, ExerciseService exerciseService,
             ExerciseDeletionService exerciseDeletionService, ExamDateService examDateService, QuizScheduleService quizScheduleService, QuizStatisticService quizStatisticService,
             QuizExerciseImportService quizExerciseImportService, AuthorizationCheckService authCheckService, GroupNotificationService groupNotificationService,
             GroupNotificationScheduleService groupNotificationScheduleService, StudentParticipationRepository studentParticipationRepository, QuizBatchService quizBatchService,
             QuizBatchRepository quizBatchRepository, SubmissionRepository submissionRepository, FileService fileService, ChannelService channelService,
-            ChannelRepository channelRepository, FilePathService filePathService) {
+            ChannelRepository channelRepository) {
         this.quizExerciseService = quizExerciseService;
         this.quizMessagingService = quizMessagingService;
         this.quizExerciseRepository = quizExerciseRepository;
@@ -140,7 +138,6 @@ public class QuizExerciseResource {
         this.fileService = fileService;
         this.channelService = channelService;
         this.channelRepository = channelRepository;
-        this.filePathService = filePathService;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -580,7 +580,7 @@ public class QuizExerciseResource {
                 return null;
             }
             try {
-                return filePathService.actualPathForPublicPathOrThrow(URI.create(path));
+                return FilePathService.actualPathForPublicPathOrThrow(URI.create(path));
             }
             catch (FilePathParsingException e) {
                 // if the path is invalid, we can't delete it, but we don't want to fail the whole deletion

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminCourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminCourseResource.java
@@ -158,7 +158,7 @@ public class AdminCourseResource {
 
         courseService.delete(course);
         if (course.getCourseIcon() != null) {
-            fileService.schedulePathForDeletion(filePathService.actualPathForPublicPathOrThrow(URI.create(course.getCourseIcon())), 0);
+            fileService.schedulePathForDeletion(FilePathService.actualPathForPublicPathOrThrow(URI.create(course.getCourseIcon())), 0);
         }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, Course.ENTITY_NAME, course.getTitle())).build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminCourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminCourseResource.java
@@ -54,10 +54,8 @@ public class AdminCourseResource {
 
     private final Optional<OnlineCourseConfigurationService> onlineCourseConfigurationService;
 
-    private final FilePathService filePathService;
-
     public AdminCourseResource(UserRepository userRepository, CourseService courseService, CourseRepository courseRepository, AuditEventRepository auditEventRepository,
-            FileService fileService, Optional<OnlineCourseConfigurationService> onlineCourseConfigurationService, ChannelService channelService, FilePathService filePathService) {
+            FileService fileService, Optional<OnlineCourseConfigurationService> onlineCourseConfigurationService, ChannelService channelService) {
         this.courseService = courseService;
         this.courseRepository = courseRepository;
         this.auditEventRepository = auditEventRepository;
@@ -65,7 +63,6 @@ public class AdminCourseResource {
         this.fileService = fileService;
         this.onlineCourseConfigurationService = onlineCourseConfigurationService;
         this.channelService = channelService;
-        this.filePathService = filePathService;
     }
 
     /**
@@ -130,7 +127,7 @@ public class AdminCourseResource {
         if (file != null) {
             Path basePath = FilePathService.getCourseIconFilePath();
             Path savePath = fileService.saveFile(file, basePath);
-            createdCourse.setCourseIcon(filePathService.publicPathForActualPathOrThrow(savePath, createdCourse.getId()).toString());
+            createdCourse.setCourseIcon(FilePathService.publicPathForActualPathOrThrow(savePath, createdCourse.getId()).toString());
             createdCourse = courseRepository.save(createdCourse);
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/examevent/ExamLiveEventDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/examevent/ExamLiveEventDTO.java
@@ -14,9 +14,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "eventType")
 // @formatter:off
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = ExamWideAnnouncementEventDTO.class, name = "examWideAnnouncement"),
-        @JsonSubTypes.Type(value = WorkingTimeUpdateEventDTO.class, name = "workingTimeUpdate"),
-        @JsonSubTypes.Type(value = ExamAttendanceCheckEventDTO.class, name = "examAttendanceCheck"),
+    @JsonSubTypes.Type(value = ExamWideAnnouncementEventDTO.class, name = "examWideAnnouncement"),
+    @JsonSubTypes.Type(value = WorkingTimeUpdateEventDTO.class, name = "workingTimeUpdate"),
+    @JsonSubTypes.Type(value = ExamAttendanceCheckEventDTO.class, name = "examAttendanceCheck"),
 })
 // @formatter:on
 public abstract class ExamLiveEventDTO {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ConversationDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ConversationDTO.java
@@ -10,8 +10,13 @@ import de.tum.in.www1.artemis.domain.metis.conversation.Conversation;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({ @JsonSubTypes.Type(value = OneToOneChatDTO.class, name = "oneToOneChat"), @JsonSubTypes.Type(value = GroupChatDTO.class, name = "groupChat"),
-        @JsonSubTypes.Type(value = ChannelDTO.class, name = "channel"), })
+// @formatter:off
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = OneToOneChatDTO.class, name = "oneToOneChat"),
+    @JsonSubTypes.Type(value = GroupChatDTO.class, name = "groupChat"),
+    @JsonSubTypes.Type(value = ChannelDTO.class, name = "channel"),
+})
+// @formatter:on
 public class ConversationDTO {
 
     /**

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -199,7 +199,7 @@ export class ExamNavigationBarComponent implements OnInit {
         }
 
         // start with a yellow status (edit icon)
-        // TODO: it's a bit weired, that it works that multiple icons (one per exercise) are hold in the same instance variable of the component
+        // TODO: it's a bit weird, that it works that multiple icons (one per exercise) are hold in the same instance variable of the component
         //  we should definitely refactor this and e.g. use the same ExamExerciseOverviewItem as in exam-exercise-overview-page.component.ts !
         this.icon = faEdit;
         const exercise = this.exercises[exerciseIndex];

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 import org.eclipse.jgit.lib.ObjectId;
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -1256,19 +1257,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
                 HttpStatus.OK, StudentExam.class);
         for (var exercise : studentExamResponse.getExercises()) {
             var participation = exercise.getStudentParticipations().iterator().next();
-            Submission submission = null;
-            if (exercise instanceof ProgrammingExercise) {
-                submission = new ProgrammingSubmission();
-            }
-            else if (exercise instanceof TextExercise) {
-                submission = new TextSubmission();
-            }
-            else if (exercise instanceof ModelingExercise) {
-                submission = new ModelingSubmission();
-            }
-            else if (exercise instanceof QuizExercise) {
-                submission = new QuizSubmission();
-            }
+            final var submission = createSubmission(exercise);
             if (submission != null) {
                 submission.addResult(new Result());
                 Set<Submission> submissions = new HashSet<>();
@@ -1294,6 +1283,23 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
             }
         }
         deleteExamWithInstructor(exam1);
+    }
+
+    @Nullable
+    private static Submission createSubmission(Exercise exercise) {
+        if (exercise instanceof ProgrammingExercise) {
+            return new ProgrammingSubmission();
+        }
+        else if (exercise instanceof TextExercise) {
+            return new TextSubmission();
+        }
+        else if (exercise instanceof ModelingExercise) {
+            return new ModelingSubmission();
+        }
+        else if (exercise instanceof QuizExercise) {
+            return new QuizSubmission();
+        }
+        return null;
     }
 
     @Test
@@ -1515,28 +1521,28 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         int saSpotIndex = 1;
         int mcSelectedOptionIndex = 0;
         quizExercise.getQuizQuestions().forEach(quizQuestion -> {
-            if (quizQuestion instanceof DragAndDropQuestion) {
+            if (quizQuestion instanceof DragAndDropQuestion dragAndDropQuestion) {
                 var submittedAnswer = new DragAndDropSubmittedAnswer();
                 DragAndDropMapping dndMapping = new DragAndDropMapping();
                 dndMapping.setDragItemIndex(dndDragItemIndex);
-                dndMapping.setDragItem(((DragAndDropQuestion) quizQuestion).getDragItems().get(dndDragItemIndex));
+                dndMapping.setDragItem(dragAndDropQuestion.getDragItems().get(dndDragItemIndex));
                 dndMapping.setDropLocationIndex(dndLocationIndex);
-                dndMapping.setDropLocation(((DragAndDropQuestion) quizQuestion).getDropLocations().get(dndLocationIndex));
+                dndMapping.setDropLocation(dragAndDropQuestion.getDropLocations().get(dndLocationIndex));
                 submittedAnswer.getMappings().add(dndMapping);
-                submittedAnswer.setQuizQuestion(quizQuestion);
+                submittedAnswer.setQuizQuestion(dragAndDropQuestion);
                 quizSubmission.getSubmittedAnswers().add(submittedAnswer);
             }
-            else if (quizQuestion instanceof ShortAnswerQuestion) {
+            else if (quizQuestion instanceof ShortAnswerQuestion shortAnswerQuestion) {
                 var submittedAnswer = new ShortAnswerSubmittedAnswer();
                 ShortAnswerSubmittedText shortAnswerSubmittedText = new ShortAnswerSubmittedText();
                 shortAnswerSubmittedText.setText(shortAnswerText);
-                shortAnswerSubmittedText.setSpot(((ShortAnswerQuestion) quizQuestion).getSpots().get(saSpotIndex));
+                shortAnswerSubmittedText.setSpot(shortAnswerQuestion.getSpots().get(saSpotIndex));
                 submittedAnswer.getSubmittedTexts().add(shortAnswerSubmittedText);
-                submittedAnswer.setQuizQuestion(quizQuestion);
+                submittedAnswer.setQuizQuestion(shortAnswerQuestion);
                 quizSubmission.getSubmittedAnswers().add(submittedAnswer);
             }
-            else if (quizQuestion instanceof MultipleChoiceQuestion) {
-                var answerOptions = ((MultipleChoiceQuestion) quizQuestion).getAnswerOptions();
+            else if (quizQuestion instanceof MultipleChoiceQuestion multipleChoiceQuestion) {
+                var answerOptions = multipleChoiceQuestion.getAnswerOptions();
                 var submittedAnswer = new MultipleChoiceSubmittedAnswer();
                 submittedAnswer.addSelectedOptions(answerOptions.get(mcSelectedOptionIndex));
                 submittedAnswer.setQuizQuestion(quizQuestion);
@@ -1932,8 +1938,8 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
                 textSubmission.setText(newText);
                 request.put("/api/exercises/" + exercise.getId() + "/text-submissions", textSubmission, HttpStatus.OK);
             }
-            else if (exercise instanceof QuizExercise) {
-                submitQuizInExam((QuizExercise) exercise, (QuizSubmission) submission);
+            else if (exercise instanceof QuizExercise quizExercise) {
+                submitQuizInExam(quizExercise, (QuizSubmission) submission);
             }
         }
         return studentExamFromServer;

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 import org.eclipse.jgit.lib.ObjectId;
-import org.jetbrains.annotations.Nullable;
 import org.json.JSONException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -1285,7 +1284,6 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         deleteExamWithInstructor(exam1);
     }
 
-    @Nullable
     private static Submission createSubmission(Exercise exercise) {
         if (exercise instanceof ProgrammingExercise) {
             return new ProgrammingSubmission();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileuploadexercise/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileuploadexercise/FileUploadSubmissionIntegrationTest.java
@@ -66,9 +66,6 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;
 
-    @Autowired
-    private FilePathService filePathService;
-
     private FileUploadExercise releasedFileUploadExercise;
 
     private FileUploadExercise finishedFileUploadExercise;
@@ -172,7 +169,7 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
             }
         }
 
-        URI publicFilePath = filePathService.publicPathForActualPathOrThrow(actualFilePath, returnedSubmission.getId());
+        URI publicFilePath = FilePathService.publicPathForActualPathOrThrow(actualFilePath, returnedSubmission.getId());
         assertThat(returnedSubmission).as("submission correctly posted").isNotNull();
         assertThat(returnedSubmission.getFilePath()).isEqualTo(publicFilePath.toString());
         var fileBytes = Files.readAllBytes(actualFilePath);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quizexercise/QuizExerciseFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quizexercise/QuizExerciseFactory.java
@@ -108,15 +108,6 @@ public class QuizExerciseFactory {
         sa.addSolution(shortAnswerSolution2);
 
         var mapping1 = new ShortAnswerMapping().spot(sa.getSpots().get(0)).solution(sa.getSolutions().get(0));
-        shortAnswerSolution1.addMappings(mapping1);
-        shortAnswerSpot1.addMappings(mapping1);
-        // also invoke remove once
-        shortAnswerSolution1.removeMappings(mapping1);
-        shortAnswerSpot1.removeMappings(mapping1);
-        shortAnswerSolution1.addMappings(mapping1);
-        shortAnswerSpot1.addMappings(mapping1);
-        assertThat(shortAnswerSolution1.getMappings()).isNotEmpty();
-        assertThat(shortAnswerSpot1.getMappings()).isNotEmpty();
 
         var mapping2 = new ShortAnswerMapping().spot(sa.getSpots().get(1)).solution(sa.getSolutions().get(1));
         sa.addCorrectMapping(mapping1);
@@ -176,11 +167,6 @@ public class QuizExerciseFactory {
         dnd.addDragItem(dragItem4);
 
         var mapping1 = new DragAndDropMapping().dragItem(dragItem1).dropLocation(dropLocation1);
-        dragItem1.addMappings(mapping1);
-        // also invoke remove
-        dragItem1.removeMappings(mapping1);
-        dragItem1.addMappings(mapping1);
-        assertThat(dragItem1.getMappings()).isNotEmpty();
 
         dnd.addCorrectMapping(mapping1);
         dnd.removeCorrectMapping(mapping1);
@@ -486,11 +472,6 @@ public class QuizExerciseFactory {
         dnd.addDragItem(dragItem5);
 
         var mapping1 = new DragAndDropMapping().dragItem(dragItem1).dropLocation(dropLocation1);
-        dragItem1.addMappings(mapping1);
-        // also invoke remove
-        dragItem1.removeMappings(mapping1);
-        dragItem1.addMappings(mapping1);
-        assertThat(dragItem1.getMappings()).isNotEmpty();
 
         dnd.addCorrectMapping(mapping1);
         dnd.removeCorrectMapping(mapping1);

--- a/src/test/java/de/tum/in/www1/artemis/service/FilePathServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FilePathServiceTest.java
@@ -6,15 +6,11 @@ import java.net.URI;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.exception.FilePathParsingException;
 
 class FilePathServiceTest extends AbstractSpringIntegrationIndependentTest {
-
-    @Autowired
-    private FilePathService filePathService;
 
     @Test
     void testActualPathForPublicPath() {
@@ -56,13 +52,13 @@ class FilePathServiceTest extends AbstractSpringIntegrationIndependentTest {
     @Test
     void testPublicPathForActualTempFilePath() {
         Path actualPath = FilePathService.getTempFilePath().resolve("test");
-        URI publicPath = filePathService.publicPathForActualPath(actualPath, 1L);
+        URI publicPath = FilePathService.publicPathForActualPath(actualPath, 1L);
         assertThat(publicPath).isEqualTo(URI.create(FileService.DEFAULT_FILE_SUBPATH + actualPath.getFileName()));
     }
 
     @Test
     void testPublicPathForActualPath_shouldReturnNull() {
-        URI otherPath = filePathService.publicPathForActualPath(Path.of("unknown-path", "unknown-file.pdf"), 1L);
+        URI otherPath = FilePathService.publicPathForActualPath(Path.of("unknown-path", "unknown-file.pdf"), 1L);
         assertThat(otherPath).isNull();
     }
 
@@ -70,11 +66,11 @@ class FilePathServiceTest extends AbstractSpringIntegrationIndependentTest {
     void testPublicPathForActualPath_shouldThrowException() {
         assertThatExceptionOfType(FilePathParsingException.class).isThrownBy(() -> {
             Path actualFileUploadPath = FilePathService.getFileUploadExercisesFilePath();
-            filePathService.publicPathForActualPathOrThrow(actualFileUploadPath, 1L);
+            FilePathService.publicPathForActualPathOrThrow(actualFileUploadPath, 1L);
 
         }).withMessageStartingWith("Unexpected String in upload file path. Exercise ID should be present here:");
 
-        assertThatExceptionOfType(FilePathParsingException.class).isThrownBy(() -> filePathService.publicPathForActualPathOrThrow(Path.of("unknown-path", "unknown-file.pdf"), 1L))
+        assertThatExceptionOfType(FilePathParsingException.class).isThrownBy(() -> FilePathService.publicPathForActualPathOrThrow(Path.of("unknown-path", "unknown-file.pdf"), 1L))
                 .withMessageStartingWith("Unknown Filepath:");
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/FilePathServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FilePathServiceTest.java
@@ -46,10 +46,10 @@ class FilePathServiceTest extends AbstractSpringIntegrationIndependentTest {
     @Test
     void testActualPathForPublicFileUploadExercisePathOrThrow_shouldThrowException() {
         assertThatExceptionOfType(FilePathParsingException.class)
-                .isThrownBy(() -> filePathService.actualPathForPublicPathOrThrow(URI.create("/api/files/file-upload-exercises/file.pdf")))
+                .isThrownBy(() -> FilePathService.actualPathForPublicPathOrThrow(URI.create("/api/files/file-upload-exercises/file.pdf")))
                 .withMessageStartingWith("Public path does not contain correct exerciseId or submissionId:");
 
-        assertThatExceptionOfType(FilePathParsingException.class).isThrownBy(() -> filePathService.actualPathForPublicPathOrThrow(URI.create("/api/unknown-path/unknown-file.pdf")))
+        assertThatExceptionOfType(FilePathParsingException.class).isThrownBy(() -> FilePathService.actualPathForPublicPathOrThrow(URI.create("/api/unknown-path/unknown-file.pdf")))
                 .withMessageStartingWith("Unknown Filepath:");
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [X] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [X] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We have to set a few more relations to lazy to break a loop that gets introduced by the Hibernate 6 upgrade.

### Description
<!-- Describe your changes in detail -->
- Updated fetch type for `DropLocation`, `ShortAnswerSolution`, `ShortAnswerSpot` 
- Improved some styling and comments
- Removed some entity service dependencies by setting FilePathService methods to `static`

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Create a Quiz Exercise with a Drag And Drop question
2. Test out preview and sample solution as the instructor
3. Participate in the quiz
4. Make sure the result is properly displayed

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Improved readability of annotation formatting across various domain entities.
	- Updated method calls to utilize static methods from `FilePathService` for file path handling.
	- Added comments to clarify bidirectional and unidirectional relationships in quiz-related entities.
	- Changed fetch strategies to `FetchType.LAZY` in certain `@ManyToOne` annotations to optimize loading behavior.
	- Reordered annotations and reformatted code blocks for consistency and clarity.

- **New Features**
	- Introduced new repository methods for eager loading of quiz entities.

- **Bug Fixes**
	- Fixed a variable name typo in `ExerciseDeletionService`.

- **Documentation**
	- Added clarifying comments on Hibernate behavior and necessity of mappings in quiz entities.

- **Tests**
	- Refactored submission creation logic in integration tests for better maintainability.
	- Adapted test cases to reflect changes in `FilePathService` method calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->