### PR TITLE
`General`: Use import icon consistently

### DIFF
--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
@@ -14,7 +14,7 @@
             </div>
             <div class="ms-auto text-truncate justify-content-end">
                 <button class="btn btn-primary" id="competencyImportButton" (click)="openImportModal()">
-                    <fa-icon [icon]="faPlus"></fa-icon>
+                    <fa-icon [icon]="faFileImport"></fa-icon>
                     <span>{{ 'artemisApp.competency.manageCompetencies.import' | artemisTranslate }}</span>
                 </button>
                 <a class="btn btn-primary" [routerLink]="['/course-management', courseId, 'competency-management', 'create']">

--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.html
@@ -226,10 +226,10 @@
         <div class="d-flex flex-wrap">
             <h2 jhiTranslate="artemisApp.competency.prerequisite.managePrerequisites.title">Prerequisite Management</h2>
             <div class="ms-auto text-truncate justify-content-end">
-                <a class="btn btn-primary" (click)="openPrerequisiteSelectionModal()">
+                <button class="btn btn-primary" (click)="openPrerequisiteSelectionModal()">
                     <fa-icon [icon]="faPlus"></fa-icon>
                     <span>{{ 'artemisApp.competency.prerequisite.managePrerequisites.select' | artemisTranslate }}</span>
-                </a>
+                </button>
             </div>
         </div>
         <div class="container-fluid" style="min-height: 100px">

--- a/src/main/webapp/app/course/competencies/competency-management/competency-management.component.ts
+++ b/src/main/webapp/app/course/competencies/competency-management/competency-management.component.ts
@@ -7,7 +7,7 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { filter, finalize, map, switchMap } from 'rxjs/operators';
 import { onError } from 'app/shared/util/global.utils';
 import { Subject, forkJoin } from 'rxjs';
-import { faPencilAlt, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faFileImport, faPencilAlt, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { PrerequisiteImportComponent } from 'app/course/competencies/competency-management/prerequisite-import.component';
 import { ClusterNode, Edge, Node } from '@swimlane/ngx-graph';
@@ -45,6 +45,7 @@ export class CompetencyManagementComponent implements OnInit, OnDestroy {
 
     // Icons
     faPlus = faPlus;
+    faFileImport = faFileImport;
     faTrash = faTrash;
     faPencilAlt = faPencilAlt;
 

--- a/src/main/webapp/app/course/tutorial-groups/tutorial-groups-management/tutorial-groups/tutorial-groups-management/tutorial-groups-import-dialog/tutorial-groups-registration-import-dialog.component.html
+++ b/src/main/webapp/app/course/tutorial-groups/tutorial-groups-management/tutorial-groups/tutorial-groups-management/tutorial-groups-import-dialog/tutorial-groups-registration-import-dialog.component.html
@@ -243,7 +243,7 @@
                 }
             </div>
         }
-        <div class="flex-grow-1 d-flex justify-content-end">
+        <div class="flex-grow-1 d-flex justify-content-end gap-2">
             @if (!isImportDone) {
                 <button type="button" class="btn btn-default cancel" data-dismiss="modal" (click)="clear()">
                     <fa-icon [icon]="faBan"></fa-icon>&nbsp;<span>{{ 'entity.action.cancel' | artemisTranslate }}</span>
@@ -251,7 +251,7 @@
             }
             @if (!isImportDone) {
                 <button type="submit" id="import" name="importButton" class="btn btn-primary" [disabled]="isSubmitDisabled" (click)="import()">
-                    <fa-icon [icon]="faUpload" class="me-2"></fa-icon>
+                    <fa-icon [icon]="faFileImport" class="me-2"></fa-icon>
                     <span>{{ 'entity.action.to-import' | artemisTranslate }}</span>
                     <fa-icon class="ms-1" [hidden]="!isImporting" [spin]="true" [icon]="faCircleNotch"></fa-icon>
                 </button>

--- a/src/main/webapp/app/course/tutorial-groups/tutorial-groups-management/tutorial-groups/tutorial-groups-management/tutorial-groups-import-dialog/tutorial-groups-registration-import-dialog.component.ts
+++ b/src/main/webapp/app/course/tutorial-groups/tutorial-groups-management/tutorial-groups/tutorial-groups-management/tutorial-groups-import-dialog/tutorial-groups-registration-import-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { faBan, faCheck, faCircleNotch, faSpinner, faUpload } from '@fortawesome/free-solid-svg-icons';
+import { faBan, faCheck, faCircleNotch, faFileImport, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { TutorialGroupRegistrationImportDTO } from 'app/entities/tutorial-group/tutorial-group-import-dto.model';
 import { ParseResult, parse } from 'papaparse';
 import { AlertService } from 'app/core/util/alert.service';
@@ -88,7 +88,7 @@ export class TutorialGroupsRegistrationImportDialogComponent implements OnInit, 
     faSpinner = faSpinner;
     faCheck = faCheck;
     faCircleNotch = faCircleNotch;
-    faUpload = faUpload;
+    faFileImport = faFileImport;
     selectedFilter: filterValues = 'all';
 
     constructor(

--- a/src/main/webapp/app/exam/manage/exam-management.component.html
+++ b/src/main/webapp/app/exam/manage/exam-management.component.html
@@ -6,7 +6,7 @@
             @if (course.isAtLeastInstructor) {
                 <div class="ms-auto text-truncate justify-content-end">
                     <a class="btn btn-primary me-1" (click)="openImportModal()">
-                        <fa-icon [icon]="faPlus"></fa-icon>
+                        <fa-icon [icon]="faFileImport"></fa-icon>
                         <span>{{ 'artemisApp.examManagement.importExam' | artemisTranslate }}</span>
                     </a>
                     <a class="btn btn-primary jh-create-entity create-exam" id="create-exam" [routerLink]="['new']">

--- a/src/main/webapp/app/exam/manage/exam-management.component.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.component.ts
@@ -13,7 +13,7 @@ import { SortService } from 'app/shared/service/sort.service';
 import { ExamInformationDTO } from 'app/entities/exam-information.model';
 import dayjs from 'dayjs/esm';
 import { EventManager } from 'app/core/util/event-manager.service';
-import { faClipboard, faEye, faListAlt, faPlus, faSort, faThList, faTimes, faUser, faWrench } from '@fortawesome/free-solid-svg-icons';
+import { faClipboard, faEye, faFileImport, faListAlt, faPlus, faSort, faThList, faTimes, faUser, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ExamImportComponent } from 'app/exam/manage/exams/exam-import/exam-import.component';
 import { DocumentationType } from 'app/shared/components/documentation-button/documentation-button.component';
@@ -38,6 +38,7 @@ export class ExamManagementComponent implements OnInit, OnDestroy {
     // Icons
     faSort = faSort;
     faPlus = faPlus;
+    faFileImport = faFileImport;
     faTimes = faTimes;
     faEye = faEye;
     faWrench = faWrench;

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -5,7 +5,7 @@
     @if (course?.isAtLeastEditor) {
         <div class="ms-auto d-flex flex-wrap">
             <a class="btn btn-primary me-1" id="import-group" (click)="openExerciseGroupImportModal()">
-                <fa-icon [icon]="faPlus"></fa-icon>
+                <fa-icon [icon]="faFileImport"></fa-icon>
                 <span class="hidden-sm-down" jhiTranslate="artemisApp.examManagement.exerciseGroup.import"> Import Exercise Group</span>
             </a>
             <a class="btn btn-primary jh-create-entity create-course" id="create-new-group" routerLink="new">

--- a/src/main/webapp/app/lecture/lecture.component.html
+++ b/src/main/webapp/app/lecture/lecture.component.html
@@ -71,7 +71,7 @@
                 </div>
                 <div class="d-flex-end text-end">
                     <button (click)="openImportModal()" class="btn btn-primary jh-create-entity import-lecture text-truncate mb-1" id="lecture-import-button">
-                        <fa-icon [icon]="faPlus"></fa-icon>
+                        <fa-icon [icon]="faFileImport"></fa-icon>
                         <span jhiTranslate="artemisApp.lecture.import.label">Import Lecture</span>
                     </button>
                     <a id="jh-create-entity" class="btn btn-primary jh-create-entity create-lecture mb-1" [routerLink]="['new']">

--- a/src/main/webapp/app/lecture/lecture.component.ts
+++ b/src/main/webapp/app/lecture/lecture.component.ts
@@ -8,7 +8,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { onError } from 'app/shared/util/global.utils';
 import { AlertService } from 'app/core/util/alert.service';
-import { faFile, faFilter, faPencilAlt, faPlus, faPuzzlePiece, faSort, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faFile, faFileImport, faFilter, faPencilAlt, faPlus, faPuzzlePiece, faSort, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { LectureImportComponent } from 'app/lecture/lecture-import.component';
 import { Subject } from 'rxjs';
 import { DocumentationType } from 'app/shared/components/documentation-button/documentation-button.component';
@@ -42,6 +42,7 @@ export class LectureComponent implements OnInit {
 
     // Icons
     faPlus = faPlus;
+    faFileImport = faFileImport;
     faTrash = faTrash;
     faPencilAlt = faPencilAlt;
     faFile = faFile;

--- a/src/main/webapp/app/shared/user-import/users-import-button.component.ts
+++ b/src/main/webapp/app/shared/user-import/users-import-button.component.ts
@@ -4,7 +4,7 @@ import { ButtonSize, ButtonType } from 'app/shared/components/button.component';
 import { UsersImportDialogComponent } from 'app/shared/user-import/users-import-dialog.component';
 import { CourseGroup } from 'app/entities/course.model';
 import { Exam } from 'app/entities/exam.model';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faFileImport } from '@fortawesome/free-solid-svg-icons';
 import { TutorialGroup } from 'app/entities/tutorial-group/tutorial-group.model';
 
 @Component({
@@ -13,7 +13,7 @@ import { TutorialGroup } from 'app/entities/tutorial-group/tutorial-group.model'
         <jhi-button
             [btnType]="ButtonType.PRIMARY"
             [btnSize]="buttonSize"
-            [icon]="faPlus"
+            [icon]="faFileImport"
             [title]="'artemisApp.importUsers.buttonLabel'"
             (onClick)="openUsersImportDialog($event)"
         ></jhi-button>
@@ -33,7 +33,7 @@ export class UsersImportButtonComponent {
     @Output() finish: EventEmitter<void> = new EventEmitter();
 
     // Icons
-    faPlus = faPlus;
+    faFileImport = faFileImport;
 
     constructor(private modalService: NgbModal) {}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
We used sometimes the "+" icon and only sometimes the "faFileImport" Icon for import actions.
This PR sets the import icon for all the remaining import buttons where "+" was used.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Check that all Import buttons you can find have only the faFileImport icon.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
![image](https://github.com/ls1intum/Artemis/assets/78978542/93fe0cd6-85b1-4cd8-b7e1-bffe28e899fc)
![image](https://github.com/ls1intum/Artemis/assets/78978542/7a5f31d2-a6ff-4f69-b041-61a5235d3aa2)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style Updates**
	- Updated icons across various components from plus (`faPlus`) to import (`faFileImport`) symbols to better represent import actions.
- **New Features**
	- Enhanced the user interface by adding more intuitive import buttons for competencies, tutorial groups, exams, exercise groups, lectures, and user import actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->