### PR TITLE
`Development`: Improve JPQL style for notification repositories

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/NotificationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/NotificationRepository.java
@@ -22,60 +22,69 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     // we can try to use something like TREAT(notification AS GroupNotification) here to avoid warnings
     @Query("""
-                SELECT notification
-                FROM Notification notification
-                    LEFT JOIN notification.course
-                    LEFT JOIN notification.recipient
-                WHERE notification.notificationDate > :hideUntil
-                    AND (
-                        (type(notification) = GroupNotification
-                            AND ((notification.course.instructorGroupName IN :currentGroups AND notification.type = 'INSTRUCTOR')
-                                OR (notification.course.teachingAssistantGroupName IN :currentGroups AND notification.type = 'TA')
-                                OR (notification.course.editorGroupName IN :currentGroups AND notification.type = 'EDITOR')
-                                OR (notification.course.studentGroupName IN :currentGroups AND notification.type = 'STUDENT')
+            SELECT notification
+            FROM Notification notification
+                LEFT JOIN notification.course
+                LEFT JOIN notification.recipient
+            WHERE notification.notificationDate > :hideUntil
+                AND (
+                    (TYPE(notification) = GroupNotification
+                        AND ((
+                                notification.course.instructorGroupName IN :currentGroups
+                                AND notification.type = de.tum.in.www1.artemis.domain.enumeration.GroupNotificationType.INSTRUCTOR
+                            ) OR (
+                                notification.course.teachingAssistantGroupName IN :currentGroups
+                                AND notification.type = de.tum.in.www1.artemis.domain.enumeration.GroupNotificationType.TA
+                            ) OR (
+                                notification.course.editorGroupName IN :currentGroups
+                                AND notification.type = de.tum.in.www1.artemis.domain.enumeration.GroupNotificationType.EDITOR
+                            ) OR (
+                                notification.course.studentGroupName IN :currentGroups
+                                AND notification.type = de.tum.in.www1.artemis.domain.enumeration.GroupNotificationType.STUDENT
                             )
                         )
-                        OR type(notification) = SingleUserNotification AND notification.recipient.login = :login
-                        AND (notification.title NOT IN :titlesToNotLoadNotification
-                            OR notification.title IS NULL
-                        )
-                        OR type(notification) = TutorialGroupNotification and notification.tutorialGroup.id IN :tutorialGroupIds
+                    ) OR (TYPE(notification) = SingleUserNotification
+                        AND notification.recipient.login = :login
+                        AND (notification.title NOT IN :titlesToNotLoadNotification OR notification.title IS NULL)
+                    ) OR (TYPE(notification) = TutorialGroupNotification
+                        AND notification.tutorialGroup.id IN :tutorialGroupIds
                     )
+                )
             """)
     Page<Notification> findAllNotificationsForRecipientWithLogin(@Param("currentGroups") Set<String> currentGroups, @Param("login") String login,
             @NotNull @Param("hideUntil") ZonedDateTime hideUntil, @Param("tutorialGroupIds") Set<Long> tutorialGroupIds,
             @Param("titlesToNotLoadNotification") Set<String> titlesToNotLoadNotification, Pageable pageable);
 
     @Query("""
-                SELECT notification
-                FROM Notification notification
-                    LEFT JOIN notification.course
-                    LEFT JOIN notification.recipient
-                WHERE notification.notificationDate > :hideUntil
-                    AND (
-                        (type(notification) = GroupNotification
-                            AND (notification.title NOT IN :deactivatedTitles
-                                OR notification.title IS NULL
+            SELECT notification
+            FROM Notification notification
+                LEFT JOIN notification.course
+                LEFT JOIN notification.recipient
+            WHERE notification.notificationDate > :hideUntil
+                AND (
+                    (TYPE(notification) = GroupNotification
+                        AND ((
+                                notification.course.instructorGroupName IN :currentGroups
+                                AND notification.type = de.tum.in.www1.artemis.domain.enumeration.GroupNotificationType.INSTRUCTOR
+                            ) OR (
+                                notification.course.teachingAssistantGroupName IN :currentGroups
+                                AND notification.type = de.tum.in.www1.artemis.domain.enumeration.GroupNotificationType.TA
+                            ) OR (
+                                notification.course.editorGroupName IN :currentGroups
+                                AND notification.type = de.tum.in.www1.artemis.domain.enumeration.GroupNotificationType.EDITOR
+                            ) OR (
+                                notification.course.studentGroupName IN :currentGroups
+                                AND notification.type = de.tum.in.www1.artemis.domain.enumeration.GroupNotificationType.STUDENT
                             )
-                            AND ((notification.course.instructorGroupName IN :currentGroups AND notification.type = 'INSTRUCTOR')
-                           OR (notification.course.teachingAssistantGroupName IN :currentGroups AND notification.type = 'TA')
-                           OR (notification.course.editorGroupName IN :currentGroups AND notification.type = 'EDITOR')
-                           OR (notification.course.studentGroupName IN :currentGroups AND notification.type = 'STUDENT'))
-                     )
-                     OR (type(notification) = SingleUserNotification
+                        )
+                    ) OR (TYPE(notification) = SingleUserNotification
                         AND notification.recipient.login = :login
-                        AND (notification.title NOT IN :titlesToNotLoadNotification
-                            OR notification.title IS NULL
-                        )
-                        AND (notification.title NOT IN :deactivatedTitles
-                            OR notification.title IS NULL
-                        )
-                     )
-                     OR (type(notification) = TutorialGroupNotification and notification.tutorialGroup.id IN :tutorialGroupIds
-                        AND (notification.title NOT IN :deactivatedTitles
-                            OR notification.title IS NULL
-                        )
-                     )
+                        AND (notification.title NOT IN :titlesToNotLoadNotification OR notification.title IS NULL)
+                        AND (notification.title NOT IN :deactivatedTitles OR notification.title IS NULL)
+                    ) OR (type(notification) = TutorialGroupNotification
+                        AND notification.tutorialGroup.id IN :tutorialGroupIds
+                        AND (notification.title NOT IN :deactivatedTitles OR notification.title IS NULL)
+                    )
                 )
             """)
     Page<Notification> findAllNotificationsFilteredBySettingsForRecipientWithLogin(@Param("currentGroups") Set<String> currentGroups, @Param("login") String login,

--- a/src/main/java/de/tum/in/www1/artemis/repository/NotificationSettingRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/NotificationSettingRepository.java
@@ -42,7 +42,7 @@ public interface NotificationSettingRepository extends JpaRepository<Notificatio
             SELECT setting
             FROM NotificationSetting setting
             WHERE setting.settingId = :settingId
-                AND setting.email = TRUE
+                AND setting.email IS TRUE
             """)
     Set<NotificationSetting> findAllNotificationSettingsForUsersWhoEnabledSpecifiedEmailSettingWithEagerGroupsAndAuthorities(@Param("settingId") String settingId);
 
@@ -64,7 +64,7 @@ public interface NotificationSettingRepository extends JpaRepository<Notificatio
     @Query("""
             SELECT cp.conversation.id
             FROM ConversationParticipant cp
-            WHERE cp.user.id = :userId AND cp.isHidden = true
+            WHERE cp.user.id = :userId AND cp.isHidden IS TRUE
             """)
     Set<Long> findMutedConversations(@Param("userId") long userId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/PushNotificationDeviceConfigurationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/PushNotificationDeviceConfigurationRepository.java
@@ -28,7 +28,7 @@ public interface PushNotificationDeviceConfigurationRepository extends JpaReposi
      */
     @Query("""
             SELECT p FROM PushNotificationDeviceConfiguration p
-            WHERE p.expirationDate > now()
+            WHERE p.expirationDate > NOW()
                 AND p.owner IN :users
                 AND p.deviceType = :deviceType
             """)
@@ -39,6 +39,9 @@ public interface PushNotificationDeviceConfigurationRepository extends JpaReposi
      */
     @Transactional
     @Modifying
-    @Query("DELETE FROM PushNotificationDeviceConfiguration p WHERE p.expirationDate <= now()")
+    @Query("""
+            DELETE FROM PushNotificationDeviceConfiguration p
+            WHERE p.expirationDate <= NOW()
+            """)
     void deleteExpiredDeviceConfigurations();
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I just fixed the style in one repository so I decided to go through some more repos to make the codebase more consistent and clean.

### Description
<!-- Describe your changes in detail -->
I enforced capitalisation (SELECT instead of select), simple variable declaration (:var instead of :#{#var}, explicit enum values, consistent newlines and indentations

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
No functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the performance and readability of database queries for course information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->