### PR TITLE
`Development`: Fix exam exercise creation & e2e tests

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise/exercise.service.ts
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise.service.ts
@@ -122,7 +122,6 @@ export class ExerciseService {
     hasExampleSolutionPublicationDateError(exercise: Exercise) {
         if (exercise.exampleSolutionPublicationDate) {
             return (
-                !dayjs(exercise.exampleSolutionPublicationDate).isValid() ||
                 dayjs(exercise.exampleSolutionPublicationDate).isBefore(exercise.startDate ?? exercise.releaseDate) ||
                 (dayjs(exercise.exampleSolutionPublicationDate).isBefore(exercise.dueDate) && exercise.includedInOverallScore !== IncludedInOverallScore.NOT_INCLUDED)
             );

--- a/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
+++ b/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
@@ -19,7 +19,7 @@ export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnIn
     @Input() initChannelName = true;
 
     @ViewChild('field_title') field_title: NgModel;
-    @ViewChild('field_channel_name') field_channel_name: NgModel;
+    @ViewChild('field_channel_name') field_channel_name?: NgModel;
 
     @Output() titleChange = new EventEmitter<string>();
     @Output() channelNameChange = new EventEmitter<string>();
@@ -48,7 +48,7 @@ export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnIn
 
     ngAfterViewInit() {
         this.fieldTitleSubscription = this.field_title.valueChanges?.subscribe(() => this.calculateFormValid());
-        this.fieldChannelNameSubscription = this.field_channel_name.valueChanges?.subscribe(() => this.calculateFormValid());
+        this.fieldChannelNameSubscription = this.field_channel_name?.valueChanges?.subscribe(() => this.calculateFormValid());
     }
 
     ngOnDestroy() {
@@ -57,7 +57,7 @@ export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnIn
     }
 
     calculateFormValid(): void {
-        this.formValid = Boolean(this.field_title.valid && (this.hideChannelName || this.field_channel_name.valid));
+        this.formValid = Boolean(this.field_title.valid && (this.hideChannelName || this.field_channel_name?.valid));
         this.formValidChanges.next(this.formValid);
     }
 

--- a/src/test/cypress/e2e/exam/ExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/ExamManagement.cy.ts
@@ -76,7 +76,7 @@ describe('Exam management', () => {
             });
         });
 
-        it('Adds a text exercise', () => {
+        it('Adds a text exercise', { scrollBehavior: 'center' }, () => {
             cy.visit(`/course-management/${course.id}/exams`);
             examManagement.openExerciseGroups(exam.id!);
             examExerciseGroups.clickAddTextExercise(exerciseGroup.id!);

--- a/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
+++ b/src/test/cypress/e2e/exam/test-exam/TestExamManagement.cy.ts
@@ -73,7 +73,7 @@ describe('Test Exam management', () => {
             });
         });
 
-        it('Adds a text exercise', () => {
+        it('Adds a text exercise', { scrollBehavior: 'center' }, () => {
             cy.visit(`/course-management/${course.id}/exams`);
             examManagement.openExerciseGroups(exam.id!);
             examExerciseGroups.clickAddTextExercise(exerciseGroup.id!);

--- a/src/test/cypress/e2e/exercises/text/TextExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/text/TextExerciseManagement.cy.ts
@@ -27,7 +27,7 @@ describe('Text exercise management', () => {
         });
     });
 
-    it('Creates a text exercise in the UI', () => {
+    it('Creates a text exercise in the UI', { scrollBehavior: 'center' }, () => {
         cy.visit('/');
         navigationBar.openCourseManagement();
         courseManagement.openExercisesOfCourse(course.id!);

--- a/src/test/javascript/spec/component/text-exercise/text-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/text-exercise-update.component.spec.ts
@@ -149,7 +149,7 @@ describe('TextExercise Management Update Component', () => {
         });
     });
 
-    describe('ngOnInit cl for exam exercise', () => {
+    describe('exam exercise', () => {
         const textExercise = new TextExercise(undefined, new ExerciseGroup());
 
         beforeEach(() => {
@@ -165,6 +165,18 @@ describe('TextExercise Management Update Component', () => {
             // THEN
             expect(comp.isExamMode).toBeTrue();
             expect(comp.textExercise).toEqual(textExercise);
+        }));
+
+        it('should not set dateErrors', fakeAsync(() => {
+            const calculatValidationSectionsSpy = jest.spyOn(comp, 'calculateFormSectionStatus').mockReturnValue();
+            const dateErrorNames = ['dueDateError', 'startDateError', 'assessmentDueDateError', 'exampleSolutionPublicationDateError'];
+            comp.ngOnInit();
+            tick();
+            comp.validateDate();
+            expect(calculatValidationSectionsSpy).toHaveBeenCalledOnce();
+            for (const errorName of dateErrorNames) {
+                expect(comp.textExercise[errorName]).toBeFalsy();
+            }
         }));
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
There is a bug in the exam exercise creation & some failing e2e tests coming through #7875.
This PR reverts the wrong validation & fixes the e2e tests.

(it was not possible to create exam exercises, since the validation marked the creation form as invalid if there has been an unset exampleSolution Date. But Exams do not have dates.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Exam

1. Log in to Artemis
2. Navigate to Exam Administration
3. Create an exercise group and 1 exercise within
4. Verify that it is possible to create an exercise

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the exercise service logic for better validation of example solution publication dates.
- **Refactor**
	- Updated the handling of optional fields in the TitleChannelName component for improved form validation.
- **Tests**
	- Modified Cypress tests for exam and text exercise management to include better scroll behavior during test execution.
	- Added a new test case to verify date error handling in the TextExercise Management Update Component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->