### PR TITLE
`Development`: Improve JPQL style for participation repositories

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ParticipantScoreRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ParticipantScoreRepository.java
@@ -36,7 +36,8 @@ public interface ParticipantScoreRepository extends JpaRepository<ParticipantSco
      * @return A list of outdated participant scores
      */
     @Query("""
-            SELECT p FROM ParticipantScore p
+            SELECT p
+            FROM ParticipantScore p
             WHERE p.lastResult IS NULL
             """)
     List<ParticipantScore> findAllOutdated();
@@ -51,7 +52,10 @@ public interface ParticipantScoreRepository extends JpaRepository<ParticipantSco
 
     @Query("""
             SELECT p
-            FROM ParticipantScore p LEFT JOIN FETCH p.exercise LEFT JOIN FETCH p.lastResult LEFT JOIN FETCH p.lastRatedResult
+            FROM ParticipantScore p
+                LEFT JOIN FETCH p.exercise
+                LEFT JOIN FETCH p.lastResult
+                LEFT JOIN FETCH p.lastRatedResult
             """)
     List<ParticipantScore> findAllEagerly();
 
@@ -115,7 +119,11 @@ public interface ParticipantScoreRepository extends JpaRepository<ParticipantSco
     Optional<Instant> getLatestModifiedDate();
 
     @Query("""
-            SELECT new de.tum.in.www1.artemis.web.rest.dto.ExerciseScoresAggregatedInformation(p.exercise.id, AVG(p.lastRatedScore), MAX(p.lastRatedScore))
+            SELECT new de.tum.in.www1.artemis.web.rest.dto.ExerciseScoresAggregatedInformation(
+                p.exercise.id,
+                AVG(p.lastRatedScore),
+                MAX(p.lastRatedScore)
+            )
             FROM ParticipantScore p
             WHERE p.exercise IN :exercises
             GROUP BY p.exercise.id

--- a/src/main/java/de/tum/in/www1/artemis/repository/ParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ParticipationRepository.java
@@ -23,7 +23,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
                 LEFT JOIN FETCH p.results
                 LEFT JOIN FETCH p.submissions s
                 LEFT JOIN FETCH s.results
-            WHERE p.id = :#{#participationId}
+            WHERE p.id = :participationId
             """)
     Optional<Participation> findByIdWithResultsAndSubmissionsResults(@Param("participationId") Long participationId);
 
@@ -33,7 +33,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
                 LEFT JOIN FETCH p.submissions s
                 LEFT JOIN FETCH s.results r
             WHERE p.id = :participationId
-                AND (s.id = (SELECT max(s2.id) FROM p.submissions s2) OR s.id = NULL)
+                AND (s.id = (SELECT MAX(s2.id) FROM p.submissions s2) OR s.id IS NULL)
             """)
     Optional<Participation> findByIdWithLatestSubmissionAndResult(@Param("participationId") Long participationId);
 
@@ -42,7 +42,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             FROM Participation p
                 LEFT JOIN FETCH p.submissions s
             WHERE p.id = :participationId
-                AND (s.id = (SELECT max(s2.id) FROM p.submissions s2) OR s.id = NULL)
+                AND (s.id = (SELECT MAX(s2.id) FROM p.submissions s2) OR s.id IS NULL)
             """)
     Optional<Participation> findByIdWithLatestSubmission(@Param("participationId") Long participationId);
 
@@ -55,7 +55,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             FROM Participation p
                 LEFT JOIN FETCH p.submissions s
             WHERE p.id = :participationId
-                AND (s.type <> 'ILLEGAL' OR s.type IS NULL)
+                AND (s.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL OR s.type IS NULL)
             """)
     Optional<Participation> findWithEagerLegalSubmissionsById(@Param("participationId") Long participationId);
 
@@ -85,18 +85,18 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     }
 
     @Query("""
-            SELECT max(p.individualDueDate)
+            SELECT MAX(p.individualDueDate)
             FROM Participation p
             WHERE p.exercise.id = :exerciseId
-                AND p.individualDueDate IS NOT null
+                AND p.individualDueDate IS NOT NULL
             """)
     Optional<ZonedDateTime> findLatestIndividualDueDate(@Param("exerciseId") Long exerciseId);
 
     @Query("""
-            SELECT min(p.individualDueDate)
+            SELECT MIN(p.individualDueDate)
             FROM Participation p
             WHERE p.exercise.id = :exerciseId
-                AND p.individualDueDate IS NOT null
+                AND p.individualDueDate IS NOT NULL
             """)
     Optional<ZonedDateTime> findEarliestIndividualDueDate(@Param("exerciseId") Long exerciseId);
 
@@ -104,7 +104,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             SELECT p
             FROM Participation p
             WHERE p.exercise.id = :exerciseId
-                AND p.individualDueDate IS NOT null
+                AND p.individualDueDate IS NOT NULL
             """)
     Set<Participation> findWithIndividualDueDateByExerciseId(@Param("exerciseId") Long exerciseId);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
@@ -44,8 +44,8 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH p.results r
                 LEFT JOIN FETCH p.team t
                 LEFT JOIN FETCH t.students
-            WHERE p.exercise.course.id = :#{#courseId}
-                AND (r.rated IS NULL OR r.rated = true)
+            WHERE p.exercise.course.id = :courseId
+                AND (r.rated IS NULL OR r.rated IS TRUE)
             """)
     List<StudentParticipation> findByCourseIdWithEagerRatedResults(@Param("courseId") Long courseId);
 
@@ -56,7 +56,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN p.team.students ts
             WHERE p.exercise.course.id = :courseId
                 AND (p.student.id = :studentId OR ts.id = :studentId)
-                AND (r.rated IS NULL OR r.rated = true)
+                AND (r.rated IS NULL OR r.rated IS TRUE)
             """)
     List<StudentParticipation> findByCourseIdAndStudentIdWithEagerRatedResults(@Param("courseId") Long courseId, @Param("studentId") Long studentId);
 
@@ -74,9 +74,9 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             FROM StudentParticipation p
                 LEFT JOIN FETCH p.submissions s
                 LEFT JOIN FETCH s.results r
-            WHERE p.testRun = false
+            WHERE p.testRun IS FALSE
                 AND p.exercise.exerciseGroup.exam.id = :examId
-                AND r.rated = true
+                AND r.rated IS TRUE
                 AND (s.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL OR s.type IS NULL)
             """)
     List<StudentParticipation> findByExamIdWithEagerLegalSubmissionsRatedResults(@Param("examId") Long examId);
@@ -85,7 +85,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             SELECT DISTINCT p
             FROM StudentParticipation p
             WHERE p.exercise.course.id = :courseId
-            AND p.team.shortName = :teamShortName
+                AND p.team.shortName = :teamShortName
             """)
     List<StudentParticipation> findAllByCourseIdAndTeamShortName(@Param("courseId") Long courseId, @Param("teamShortName") String teamShortName);
 
@@ -211,7 +211,8 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH r.submission s
                 LEFT JOIN FETCH p.submissions
             WHERE p.exercise.id = :exerciseId
-                AND (r.id = (SELECT max(p_r.id) FROM p.results p_r)
+                AND (
+                    r.id = (SELECT MAX(p_r.id) FROM p.results p_r)
                     OR r.assessmentType <> de.tum.in.www1.artemis.domain.enumeration.AssessmentType.AUTOMATIC
                     OR r IS NULL
                 )
@@ -225,7 +226,8 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH r.submission s
                 LEFT JOIN FETCH p.submissions
             WHERE p.exercise.id = :exerciseId
-                AND (r.id = (SELECT max(p_r.id) FROM p.results p_r WHERE p_r.rated = true)
+                AND (
+                    r.id = (SELECT MAX(p_r.id) FROM p.results p_r WHERE p_r.rated IS TRUE)
                     OR r.assessmentType <> de.tum.in.www1.artemis.domain.enumeration.AssessmentType.AUTOMATIC
                     OR r IS NULL
                 )
@@ -241,11 +243,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 AND p.testRun = :testRun
                 AND (s.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL OR s.type IS NULL)
                 AND r.assessmentType <> de.tum.in.www1.artemis.domain.enumeration.AssessmentType.AUTOMATIC
-                AND r.id = (
-                    SELECT max(r2.id)
-                    FROM p.results r2
-                    WHERE r2.completionDate IS NOT NULL
-                )
+                AND r.id = (SELECT MAX(r2.id) FROM p.results r2 WHERE r2.completionDate IS NOT NULL)
             """)
     Set<StudentParticipation> findByExerciseIdAndTestRunWithEagerLegalSubmissionsAndLatestResultWithCompletionDate(@Param("exerciseId") Long exerciseId,
             @Param("testRun") boolean testRun);
@@ -265,10 +263,10 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH r.submission s
             WHERE p.exercise.id = :exerciseId
                 AND (r.id = (
-                    SELECT max(pr.id)
+                    SELECT MAX(pr.id)
                     FROM p.results pr
                         LEFT JOIN pr.submission prs
-                    WHERE pr.assessmentType = 'AUTOMATIC'
+                    WHERE pr.assessmentType = de.tum.in.www1.artemis.domain.enumeration.AssessmentType.AUTOMATIC
                         AND (
                             prs.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL
                             OR prs.type IS NULL
@@ -297,10 +295,10 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH r.submission s
             WHERE p.id = :participationId
                 AND (r.id = (
-                    SELECT max(pr.id)
+                    SELECT MAX(pr.id)
                     FROM p.results pr
                         LEFT JOIN pr.submission prs
-                    WHERE pr.assessmentType = 'AUTOMATIC'
+                    WHERE pr.assessmentType = de.tum.in.www1.artemis.domain.enumeration.AssessmentType.AUTOMATIC
                         AND (
                             prs.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL
                             OR prs.type IS NULL
@@ -319,7 +317,10 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH r.submission s
             WHERE p.exercise.id = :exerciseId
                 AND (s.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL OR s.type IS NULL)
-                AND (r.assessmentType = 'MANUAL' OR r.assessmentType = 'SEMI_AUTOMATIC')
+                AND (
+                    r.assessmentType = de.tum.in.www1.artemis.domain.enumeration.AssessmentType.MANUAL
+                    OR r.assessmentType = de.tum.in.www1.artemis.domain.enumeration.AssessmentType.SEMI_AUTOMATIC
+                )
             """)
     List<StudentParticipation> findByExerciseIdWithManualResultAndFeedbacksAndTestCases(@Param("exerciseId") Long exerciseId);
 
@@ -336,7 +337,10 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH r.submission s
             WHERE p.id = :participationId
                 AND (s.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL OR s.type IS NULL)
-                AND (r.assessmentType = 'MANUAL' OR r.assessmentType = 'SEMI_AUTOMATIC')
+                AND (
+                    r.assessmentType = de.tum.in.www1.artemis.domain.enumeration.AssessmentType.MANUAL
+                    OR r.assessmentType = de.tum.in.www1.artemis.domain.enumeration.AssessmentType.SEMI_AUTOMATIC
+                )
             """)
     Optional<StudentParticipation> findByIdWithManualResultAndFeedbacks(@Param("participationId") Long participationId);
 
@@ -422,15 +426,13 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             WHERE p.exercise.id = :exerciseId
                 AND p.student.id = :studentId
                 AND p.testRun = :testRun
-                AND (
-                    r.id = (
-                        SELECT max(pr.id)
-                        FROM p.results pr
-                            LEFT JOIN pr.submission prs
-                        WHERE prs.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL
-                            OR prs.type IS NULL
-                    ) OR r.id IS NULL
-                )
+                AND (r.id = (
+                    SELECT MAX(pr.id)
+                    FROM p.results pr
+                        LEFT JOIN pr.submission prs
+                    WHERE prs.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL
+                        OR prs.type IS NULL
+                ) OR r.id IS NULL)
             """)
     Optional<StudentParticipation> findByExerciseIdAndStudentIdAndTestRunWithLatestResult(@Param("exerciseId") Long exerciseId, @Param("studentId") Long studentId,
             @Param("testRun") boolean testRun);
@@ -455,18 +457,18 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH feedbacks.testCase
                 LEFT JOIN FETCH result.assessor
             WHERE p.exercise.id = :exerciseId
-                AND p.testRun = FALSE
+                AND p.testRun IS FALSE
                 AND 0L = (
                     SELECT COUNT(r2)
                     FROM Result r2
                     WHERE r2.assessor IS NOT NULL
-                        AND (r2.rated IS NULL OR r2.rated = FALSE)
+                        AND (r2.rated IS NULL OR r2.rated IS FALSE)
                         AND r2.submission = submission
                 ) AND :correctionRound = (
                     SELECT COUNT(r)
                     FROM Result r
                     WHERE r.assessor IS NOT NULL
-                        AND r.rated = TRUE
+                        AND r.rated IS TRUE
                         AND r.submission = submission
                         AND r.completionDate IS NOT NULL
                         AND r.assessmentType IN (
@@ -474,14 +476,14 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                             de.tum.in.www1.artemis.domain.enumeration.AssessmentType.SEMI_AUTOMATIC
                         ) AND (p.exercise.dueDate IS NULL OR r.submission.submissionDate <= p.exercise.dueDate)
                 ) AND :correctionRound = (
-                    SELECT COUNT (prs)
+                    SELECT COUNT(prs)
                     FROM p.results prs
                     WHERE prs.assessmentType IN (
                         de.tum.in.www1.artemis.domain.enumeration.AssessmentType.MANUAL,
                         de.tum.in.www1.artemis.domain.enumeration.AssessmentType.SEMI_AUTOMATIC
                     )
                 ) AND submission.submitted = true
-                AND submission.id = (SELECT max(s.id) FROM p.submissions s)
+                AND submission.id = (SELECT MAX(s.id) FROM p.submissions s)
             """)
     List<StudentParticipation> findByExerciseIdWithLatestSubmissionWithoutManualResultsAndIgnoreTestRunParticipation(@Param("exerciseId") Long exerciseId,
             @Param("correctionRound") long correctionRound);
@@ -495,15 +497,16 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH f.testCase
             WHERE p.exercise.id = :exerciseId
                 AND (p.individualDueDate IS NULL OR p.individualDueDate <= :now)
-                AND p.testRun = false
+                AND p.testRun IS FALSE
                 AND NOT EXISTS (
-                    SELECT prs FROM p.results prs
+                    SELECT prs
+                    FROM p.results prs
                     WHERE prs.assessmentType IN (
                         de.tum.in.www1.artemis.domain.enumeration.AssessmentType.MANUAL,
                         de.tum.in.www1.artemis.domain.enumeration.AssessmentType.SEMI_AUTOMATIC
                     )
-                ) AND s.submitted = true
-                AND s.id = (SELECT max(s.id) FROM p.submissions s)
+                ) AND s.submitted IS TRUE
+                AND s.id = (SELECT MAX(s.id) FROM p.submissions s)
             """)
     List<StudentParticipation> findByExerciseIdWithLatestSubmissionWithoutManualResultsWithPassedIndividualDueDateIgnoreTestRuns(@Param("exerciseId") Long exerciseId,
             @Param("now") ZonedDateTime now);
@@ -564,7 +567,8 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
     Optional<StudentParticipation> findWithEagerLegalSubmissionsResultsFeedbacksById(@Param("participationId") Long participationId);
 
     @Query("""
-            SELECT p from StudentParticipation p
+            SELECT p
+            FROM StudentParticipation p
                 LEFT JOIN FETCH p.results r
                 LEFT JOIN FETCH r.submission rs
                 LEFT JOIN FETCH p.submissions s
@@ -585,7 +589,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH s.results r
                 LEFT JOIN FETCH r.assessor a
             WHERE p.exercise.id = :exerciseId
-                AND p.testRun = FALSE
+                AND p.testRun IS FALSE
             """)
     List<StudentParticipation> findAllWithEagerSubmissionsAndEagerResultsAndEagerAssessorByExerciseIdIgnoreTestRuns(@Param("exerciseId") long exerciseId);
 
@@ -634,7 +638,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH p.submissions s
                 LEFT JOIN FETCH s.results sr
             WHERE p.exercise.id = :exerciseId
-                AND p.testRun = FALSE
+                AND p.testRun IS FALSE
                 AND p.submissions IS NOT EMPTY
                 AND (s.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL OR s.type IS NULL)
                 AND (rs.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL OR rs.type IS NULL)
@@ -648,7 +652,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH s.results r
             WHERE p.student.id = :studentId
                 AND p.exercise IN :exercises
-                AND (p.testRun = FALSE OR :includeTestRuns = TRUE)
+                AND (p.testRun IS FALSE OR :includeTestRuns IS TRUE)
             """)
     Set<StudentParticipation> findByStudentIdAndIndividualExercisesWithEagerSubmissionsResult(@Param("studentId") Long studentId,
             @Param("exercises") Collection<Exercise> exercises, @Param("includeTestRuns") boolean includeTestRuns);
@@ -658,7 +662,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             FROM StudentParticipation p
                 LEFT JOIN FETCH p.submissions s
                 LEFT JOIN FETCH s.results r
-            WHERE p.testRun = FALSE
+            WHERE p.testRun IS FALSE
                 AND p.student.id = :studentId
                 AND p.exercise IN :exercises
             """)
@@ -669,7 +673,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             SELECT DISTINCT p
             FROM StudentParticipation p
                 LEFT JOIN FETCH p.submissions s
-            WHERE p.testRun = FALSE
+            WHERE p.testRun IS FALSE
                 AND p.student.id = :studentId
                 AND p.exercise IN :exercises
             """)
@@ -682,7 +686,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
                 LEFT JOIN FETCH p.submissions s
                 LEFT JOIN FETCH s.results r
                 LEFT JOIN FETCH r.assessor
-            WHERE p.testRun = FALSE
+            WHERE p.testRun IS FALSE
                 AND p.student.id = :studentId
                 AND p.exercise IN :exercises
             """)
@@ -694,7 +698,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             FROM StudentParticipation p
                 LEFT JOIN FETCH p.submissions s
                 LEFT JOIN FETCH s.results r
-            WHERE p.testRun = true
+            WHERE p.testRun IS true
                 AND p.student.id = :studentId
                 AND p.exercise IN :exercises
             """)
@@ -705,7 +709,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             SELECT DISTINCT p
             FROM StudentParticipation p
                 LEFT JOIN FETCH p.submissions s
-            WHERE p.testRun = true
+            WHERE p.testRun IS true
                 AND p.student.id = :studentId
                 AND p.exercise IN :exercises
             """)
@@ -773,17 +777,18 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
 
     // TODO SE Improve - maybe leave out max id line?
     @Query("""
-            SELECT DISTINCT p FROM StudentParticipation p
+            SELECT DISTINCT p
+            FROM StudentParticipation p
                 LEFT JOIN FETCH p.submissions s
                 LEFT JOIN FETCH s.results r
             WHERE p.exercise.id = :exerciseId
-                AND p.testRun = FALSE
-                AND s.id = (SELECT max(s1.id) FROM p.submissions s1)
+                AND p.testRun IS FALSE
+                AND s.id = (SELECT MAX(s1.id) FROM p.submissions s1)
                 AND EXISTS (
                     SELECT s1
                     FROM p.submissions s1
                     WHERE s1.participation.id = p.id
-                        AND s1.submitted = TRUE
+                        AND s1.submitted IS TRUE
                         AND (r.assessor = :assessor OR r.assessor.id IS NULL)
                 )
             """)
@@ -854,9 +859,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
      * @return an unmodifiable list of filtered participations
      */
     private List<StudentParticipation> filterParticipationsWithRelevantResults(List<StudentParticipation> participations, boolean resultInSubmission) {
-
         return participations.stream()
-
                 // Filter out participations without Students
                 // These participations are used e.g. to store template and solution build plans in programming exercises
                 .filter(participation -> participation.getParticipant() != null)
@@ -1050,12 +1053,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
     }
 
     @Query("""
-            SELECT
-            new de.tum.in.www1.artemis.domain.quiz.QuizSubmittedAnswerCount(
-                COUNT(a.id),
-                s.id,
-                p.id
-            )
+            SELECT new de.tum.in.www1.artemis.domain.quiz.QuizSubmittedAnswerCount(COUNT(a.id), s.id, p.id)
             FROM SubmittedAnswer a
                 LEFT JOIN a.submission s
                 LEFT JOIN s.participation p
@@ -1076,8 +1074,8 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             FROM StudentParticipation p
                 LEFT JOIN p.team.students ts
             WHERE p.exercise.course.id = :courseId
-                 AND p.presentationScore IS NOT NULL
-                 AND (p.student.id = :studentId OR ts.id = :studentId)
+                AND p.presentationScore IS NOT NULL
+                AND (p.student.id = :studentId OR ts.id = :studentId)
             """)
     double sumPresentationScoreByStudentIdAndCourseId(@Param("courseId") long courseId, @Param("studentId") long studentId);
 
@@ -1094,15 +1092,16 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             FROM StudentParticipation p
                 LEFT JOIN p.team.students ts
             WHERE p.exercise.course.id = :courseId
-                 AND p.presentationScore IS NOT NULL
-                 AND (p.student.id IN :studentIds OR ts.id IN :studentIds)
+                AND p.presentationScore IS NOT NULL
+                AND (p.student.id IN :studentIds OR ts.id IN :studentIds)
             GROUP BY COALESCE(p.student.id, ts.id)
             """)
     Set<IdToPresentationScoreSum> sumPresentationScoreByStudentIdsAndCourseId(@Param("courseId") long courseId, @Param("studentIds") Set<Long> studentIds);
 
     @Query("""
-            SELECT p FROM StudentParticipation p
-                  LEFT JOIN FETCH p.submissions s
+            SELECT p
+            FROM StudentParticipation p
+                LEFT JOIN FETCH p.submissions s
             WHERE p.exercise.id = :exerciseId
             """)
     Set<StudentParticipation> findByExerciseIdWithEagerSubmissions(long exerciseId);
@@ -1140,7 +1139,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             FROM StudentParticipation p
                 LEFT JOIN p.team.students ts
             WHERE p.exercise.course.id = :courseId
-                 AND p.presentationScore IS NOT NULL
+                AND p.presentationScore IS NOT NULL
             """)
     double getAvgPresentationScoreByCourseId(@Param("courseId") long courseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionPolicyRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionPolicyRepository.java
@@ -19,9 +19,9 @@ public interface SubmissionPolicyRepository extends JpaRepository<SubmissionPoli
     SubmissionPolicy findByProgrammingExerciseId(Long exerciseId);
 
     @Query("""
-                SELECT s
-                FROM SubmissionPolicy s
-                WHERE s.programmingExercise.id IN :exerciseIds
+            SELECT s
+            FROM SubmissionPolicy s
+            WHERE s.programmingExercise.id IN :exerciseIds
             """)
     Set<SubmissionPolicy> findAllByProgrammingExerciseIds(@Param("exerciseIds") Collection<Long> exerciseIds);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
@@ -40,7 +40,14 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     @EntityGraph(type = LOAD, attributePaths = { "results", "results.assessor" })
     Optional<Submission> findWithEagerResultsAndAssessorById(Long submissionId);
 
-    @Query("select distinct submission from Submission submission left join fetch submission.results r left join fetch r.feedbacks where submission.exampleSubmission = true and submission.id = :#{#submissionId}")
+    @Query("""
+            SELECT DISTINCT submission
+            FROM Submission submission
+                LEFT JOIN FETCH submission.results r
+                LEFT JOIN FETCH r.feedbacks
+            WHERE submission.exampleSubmission IS TRUE
+                AND submission.id = :submissionId
+            """)
     Optional<Submission> findExampleSubmissionByIdWithEagerResult(@Param("submissionId") long submissionId);
 
     /**
@@ -70,8 +77,9 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      */
     @EntityGraph(type = LOAD, attributePaths = { "results", "results.assessor" })
     @Query("""
-                SELECT DISTINCT s FROM Submission s
-                WHERE s.id IN :submissionIds
+            SELECT DISTINCT s
+            FROM Submission s
+            WHERE s.id IN :submissionIds
             """)
     List<Submission> findBySubmissionIdsWithEagerResults(@Param("submissionIds") List<Long> submissionIds);
 
@@ -84,8 +92,10 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the number of currently locked submissions for a specific user in the given course
      */
     @Query("""
-            SELECT COUNT (DISTINCT s) FROM Submission s left join s.results r
-                WHERE r.assessor.id = :userId
+            SELECT COUNT (DISTINCT s)
+            FROM Submission s
+                LEFT JOIN s.results r
+            WHERE r.assessor.id = :userId
                 AND r.completionDate IS NULL
                 AND s.participation.exercise.course.id = :courseId
             """)
@@ -98,8 +108,9 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the number of currently locked submissions for the given course
      */
     @Query("""
-            SELECT COUNT (DISTINCT s) FROM Submission s left join s.results r
-                WHERE r.completionDate IS NULL
+            SELECT COUNT (DISTINCT s)
+            FROM Submission s LEFT JOIN s.results r
+            WHERE r.completionDate IS NULL
                 AND s.participation.exercise.course.id = :courseId
             """)
     long countLockedSubmissionsByCourseId(@Param("courseId") Long courseId);
@@ -113,10 +124,11 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the number of currently locked submissions for a specific user in the given course
      */
     @Query("""
-            SELECT COUNT (DISTINCT s) FROM Submission s left join s.results r
-                WHERE r.assessor.id = :userId
+            SELECT COUNT (DISTINCT s)
+            FROM Submission s LEFT JOIN s.results r
+            WHERE r.assessor.id = :userId
                 AND r.completionDate IS NULL
-                AND s.participation.exercise.exerciseGroup.exam.id= :examId
+                AND s.participation.exercise.exerciseGroup.exam.id = :examId
             """)
     long countLockedSubmissionsByUserIdAndExamId(@Param("userId") Long userId, @Param("examId") Long examId);
 
@@ -128,8 +140,9 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the number of currently locked submissions for a specific user in the given course
      */
     @Query("""
-            SELECT COUNT (DISTINCT s) FROM Submission s left join s.results r
-                WHERE r.assessor.id IS NOT NULL
+            SELECT COUNT (DISTINCT s)
+            FROM Submission s LEFT JOIN s.results r
+            WHERE r.assessor.id IS NOT NULL
                 AND r.completionDate IS NULL
                 AND s.participation.exercise.exerciseGroup.exam.id = :examId
             """)
@@ -143,8 +156,9 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the number of currently locked submissions for a specific user in the given course
      */
     @Query("""
-            SELECT COUNT (DISTINCT s) FROM Submission s LEFT JOIN s.results r
-                WHERE r.assessor.id IS NOT NULL
+            SELECT COUNT (DISTINCT s)
+            FROM Submission s LEFT JOIN s.results r
+            WHERE r.assessor.id IS NOT NULL
                 AND r.completionDate IS NULL
                 AND s.participation.exercise.id = :exerciseId
             """)
@@ -159,10 +173,12 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return currently locked submissions for a specific user in the given course
      */
     @Query("""
-            SELECT DISTINCT submission FROM Submission submission LEFT JOIN FETCH submission.results r
-                WHERE r.assessor.id = :#{#userId}
+            SELECT DISTINCT submission
+            FROM Submission submission
+                LEFT JOIN FETCH submission.results r
+            WHERE r.assessor.id = :userId
                 AND r.completionDate IS NULL
-                AND submission.participation.exercise.course.id = :#{#courseId}
+                AND submission.participation.exercise.course.id = :courseId
                 """)
     List<Submission> getLockedSubmissionsAndResultsByUserIdAndCourseId(@Param("userId") Long userId, @Param("courseId") Long courseId);
 
@@ -174,9 +190,11 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return currently locked submissions for the given exam
      */
     @Query("""
-            SELECT DISTINCT s FROM Submission s LEFT JOIN FETCH s.results r
-                WHERE r.assessor.id IS NOT NULL
-                AND r.assessmentType <> 'AUTOMATIC'
+            SELECT DISTINCT s
+            FROM Submission s
+                LEFT JOIN FETCH s.results r
+            WHERE r.assessor.id IS NOT NULL
+                AND r.assessmentType <> de.tum.in.www1.artemis.domain.enumeration.AssessmentType.AUTOMATIC
                 AND r.completionDate IS NULL
                 AND s.participation.exercise.exerciseGroup.exam.id = :examId
             """)
@@ -199,12 +217,14 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      *         due date at all
      */
     @Query("""
-            SELECT COUNT (DISTINCT s) FROM Submission s join s.participation p join p.exercise e
-                WHERE TYPE(s) IN (ModelingSubmission, TextSubmission, FileUploadSubmission)
+            SELECT COUNT (DISTINCT s)
+            FROM Submission s
+                JOIN s.participation p
+                JOIN p.exercise e
+            WHERE TYPE(s) IN (ModelingSubmission, TextSubmission, FileUploadSubmission)
                 AND e.id IN :exerciseIds
-                AND s.submitted = TRUE
-                AND (s.submissionDate <= e.dueDate
-                    OR e.dueDate IS NULL)
+                AND s.submitted IS TRUE
+                AND (s.submissionDate <= e.dueDate OR e.dueDate IS NULL)
             """)
     long countAllByExerciseIdsSubmittedBeforeDueDate(@Param("exerciseIds") Set<Long> exerciseIds);
 
@@ -216,11 +236,12 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      *         due date at all
      */
     @Query("""
-            SELECT COUNT (DISTINCT submission) FROM Submission submission
+            SELECT COUNT (DISTINCT submission)
+            FROM Submission submission
             WHERE TYPE(submission) IN (ModelingSubmission, TextSubmission, FileUploadSubmission)
-                AND submission.participation.exercise.exerciseGroup.exam.id = :#{#examId}
-                AND submission.submitted = TRUE
-                AND submission.participation.testRun = FALSE
+                AND submission.participation.exercise.exerciseGroup.exam.id = :examId
+                AND submission.submitted IS TRUE
+                AND submission.participation.testRun IS FALSE
             """)
     long countByExamIdSubmittedSubmissionsIgnoreTestRuns(@Param("examId") long examId);
 
@@ -231,10 +252,13 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the number of submissions belonging to the course, which have the submitted flag set to true and the submission date after the exercise due date
      */
     @Query("""
-            SELECT COUNT (DISTINCT s) FROM Submission s join s.participation p join p.exercise e
-                WHERE TYPE(s) IN (ModelingSubmission, TextSubmission, FileUploadSubmission)
+            SELECT COUNT (DISTINCT s)
+            FROM Submission s
+                JOIN s.participation p
+                JOIN p.exercise e
+            WHERE TYPE(s) IN (ModelingSubmission, TextSubmission, FileUploadSubmission)
                 AND e.id IN :exerciseIds
-                AND s.submitted = TRUE
+                AND s.submitted IS TRUE
                 AND e.dueDate IS NOT NULL
                 AND s.submissionDate > e.dueDate
             """)
@@ -246,11 +270,13 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      *         exercise due date at all
      */
     @Query("""
-            SELECT COUNT (DISTINCT p) FROM StudentParticipation p join p.exercise e
-            JOIN p.submissions s
-                WHERE e.id = :#{#exerciseId}
-                AND s.submitted = TRUE
-                AND (s.type <> 'ILLEGAL' OR s.type IS NULL)
+            SELECT COUNT (DISTINCT p)
+            FROM StudentParticipation p
+                JOIN p.exercise e
+                JOIN p.submissions s
+            WHERE e.id = :exerciseId
+                AND s.submitted IS TRUE
+                AND (s.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL OR s.type IS NULL)
                 AND (e.dueDate IS NULL OR s.submissionDate <= e.dueDate)
             """)
     long countByExerciseIdSubmittedBeforeDueDate(@Param("exerciseId") long exerciseId);
@@ -263,12 +289,15 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      *         exercise due date at all
      */
     @Query("""
-            SELECT COUNT (DISTINCT p) FROM StudentParticipation p JOIN p.submissions s JOIN p.exercise e
-            WHERE e.id = :#{#exerciseId}
-            AND p.testRun = FALSE
-            AND s.submitted = TRUE
-            AND (s.type <> 'ILLEGAL' or s.type is null)
-            AND (e.dueDate IS NULL OR s.submissionDate <= e.dueDate)
+            SELECT COUNT (DISTINCT p)
+            FROM StudentParticipation p
+                JOIN p.submissions s
+                JOIN p.exercise e
+            WHERE e.id = :exerciseId
+                AND p.testRun IS FALSE
+                AND s.submitted IS TRUE
+                AND (s.type <> de.tum.in.www1.artemis.domain.enumeration.SubmissionType.ILLEGAL OR s.type IS NULL)
+                AND (e.dueDate IS NULL OR s.submissionDate <= e.dueDate)
             """)
     long countByExerciseIdSubmittedBeforeDueDateIgnoreTestRuns(@Param("exerciseId") long exerciseId);
 
@@ -280,18 +309,19 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      *         exercise due date at all
      */
     @Query("""
-            SELECT
-                new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
-                    p.exercise.id,
-                    count(DISTINCT p)
-                )
-            FROM StudentParticipation p JOIN p.submissions s JOIN p.exercise e
+            SELECT new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
+                p.exercise.id,
+                COUNT(DISTINCT p)
+            )
+            FROM StudentParticipation p
+                JOIN p.submissions s
+                JOIN p.exercise e
             WHERE e.id IN :exerciseIds
-                AND p.testRun = FALSE
-                AND s.submitted = TRUE
+                AND p.testRun IS FALSE
+                AND s.submitted IS TRUE
                 AND (e.dueDate IS NULL OR s.submissionDate <= e.dueDate)
             GROUP BY p.exercise.id
-                """)
+            """)
     List<ExerciseMapEntry> countByExerciseIdsSubmittedBeforeDueDateIgnoreTestRuns(@Param("exerciseIds") Set<Long> exerciseIds);
 
     /**
@@ -302,9 +332,10 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      */
     @Query("""
             SELECT COUNT (DISTINCT p)
-            FROM StudentParticipation p JOIN p.submissions s
-            WHERE p.exercise.id = :#{#exerciseId}
-                AND s.submitted = TRUE
+            FROM StudentParticipation p
+                JOIN p.submissions s
+            WHERE p.exercise.id = :exerciseId
+                AND s.submitted IS TRUE
             """)
     long countByExerciseIdSubmitted(@Param("exerciseId") long exerciseId);
 
@@ -317,9 +348,10 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      */
     @Query("""
             SELECT COUNT (DISTINCT s)
-            FROM StudentParticipation p JOIN p.submissions s
-            WHERE p.exercise.id = :#{#exerciseId}
-                AND p.student.login = :#{#studentLogin}
+            FROM StudentParticipation p
+                JOIN p.submissions s
+            WHERE p.exercise.id = :exerciseId
+                AND p.student.login = :studentLogin
             """)
     int countByExerciseIdAndStudentLogin(@Param("exerciseId") long exerciseId, @Param("studentLogin") String studentLogin);
 
@@ -328,17 +360,18 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the numbers of submissions belonging to each exercise id, which have the submitted flag set to true and the submission date after the exercise due date
      */
     @Query("""
-            SELECT
-                new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
-                    e.id,
-                    count(DISTINCT p)
-                    )
-            FROM StudentParticipation p JOIN p.submissions s JOIN p.exercise e
-             WHERE e.id IN :exerciseIds
-                 AND s.submitted = TRUE
-                 AND s.submissionDate > e.dueDate
-             GROUP BY e.id
-             """)
+            SELECT new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
+                e.id,
+                count(DISTINCT p)
+            )
+            FROM StudentParticipation p
+                JOIN p.submissions s
+                JOIN p.exercise e
+            WHERE e.id IN :exerciseIds
+                AND s.submitted IS TRUE
+                AND s.submissionDate > e.dueDate
+            GROUP BY e.id
+            """)
     List<ExerciseMapEntry> countByExerciseIdsSubmittedAfterDueDate(@Param("exerciseIds") Set<Long> exerciseIds);
 
     /**
@@ -353,10 +386,12 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      */
     @Query("""
             SELECT DISTINCT submission
-            FROM Submission submission LEFT JOIN FETCH submission.results r LEFT JOIN FETCH r.assessor a
-            WHERE submission.participation.exercise.id = :#{#exerciseId}
-                AND :#{#assessor} = a
-                AND submission.participation.testRun = false
+            FROM Submission submission
+                LEFT JOIN FETCH submission.results r
+                LEFT JOIN FETCH r.assessor a
+            WHERE submission.participation.exercise.id = :exerciseId
+                AND :assessor = a
+                AND submission.participation.testRun IS FALSE
             """)
     <T extends Submission> List<T> findAllByParticipationExerciseIdAndResultAssessorIgnoreTestRuns(@Param("exerciseId") Long exerciseId, @Param("assessor") User assessor);
 
@@ -365,12 +400,13 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the submission with its feedback and assessor
      */
     @Query("""
-            SELECT DISTINCT submission FROM Submission submission
-            LEFT JOIN FETCH submission.results r
-            LEFT JOIN FETCH r.feedbacks f
-            LEFT JOIN FETCH f.testCase
-            LEFT JOIN FETCH r.assessor
-            WHERE submission.id = :#{#submissionId}
+            SELECT DISTINCT submission
+            FROM Submission submission
+                LEFT JOIN FETCH submission.results r
+                LEFT JOIN FETCH r.feedbacks f
+                LEFT JOIN FETCH f.testCase
+                LEFT JOIN FETCH r.assessor
+            WHERE submission.id = :submissionId
             """)
     Optional<Submission> findWithEagerResultAndFeedbackById(@Param("submissionId") long submissionId);
 
@@ -452,15 +488,16 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return Page of Submissions
      */
     @Query("""
-                SELECT s FROM Submission s
-                WHERE s.participation.exercise.id = :exerciseId
-                      AND s.submitted = true
-                      AND s.submissionDate = (
-                        SELECT MAX(s2.submissionDate)
-                        FROM Submission s2
-                        WHERE s2.participation.id = s.participation.id
-                        AND s2.submitted = true
-                      )
+            SELECT s
+            FROM Submission s
+            WHERE s.participation.exercise.id = :exerciseId
+                AND s.submitted IS TRUE
+                AND s.submissionDate = (
+                    SELECT MAX(s2.submissionDate)
+                    FROM Submission s2
+                    WHERE s2.participation.id = s.participation.id
+                        AND s2.submitted IS TRUE
+                )
             """)
     Page<Submission> findLatestSubmittedSubmissionsByExerciseId(@Param("exerciseId") long exerciseId, Pageable pageable);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionVersionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionVersionRepository.java
@@ -21,11 +21,8 @@ public interface SubmissionVersionRepository extends JpaRepository<SubmissionVer
             FROM SubmissionVersion version
                 LEFT JOIN version.submission submission
                 LEFT JOIN submission.versions
-             WHERE
-                submission.id = :submissionId and version.id = (
-                    SELECT max(id)
-                    FROM submission.versions
-                    )
+            WHERE submission.id = :submissionId
+                AND version.id = (SELECT max(v.id) FROM submission.versions v)
             """)
     Optional<SubmissionVersion> findLatestVersion(@Param("submissionId") long submissionId);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I just fixed the style in one repository so I decided to go through some more repos to make the codebase more consistent and clean.

### Description
<!-- Describe your changes in detail -->
I enforced capitalisation (SELECT instead of select), simple variable declaration (:var instead of :#{#var}, explicit enum values, consistent newlines and indentations

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
No functional changes.