### PR TITLE
`Integrated code lifecycle`: Always add tag to docker image

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/DockerConfig.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/DockerConfig.java
@@ -48,7 +48,8 @@ public class DockerConfig {
     }
 
     /**
-     * Returns the full image name including the tag
+     * Returns the full image name including the tag, if a tag is defined within the image, that tag is used
+     * instead of the tag
      *
      * @return the full image name including the tag
      */
@@ -57,6 +58,8 @@ public class DockerConfig {
             if (!image.contains(":")) {
                 return image + ":" + "latest";
             }
+        }
+        if (image.contains(":")) {
             return image;
         }
         return image + ":" + tag;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/DockerConfig.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/DockerConfig.java
@@ -54,6 +54,9 @@ public class DockerConfig {
      * @return the full image name including the tag
      */
     public String getFullImageName() {
+        if (image == null) {
+            return null;
+        }
         if (tag == null) {
             if (!image.contains(":")) {
                 return image + ":" + "latest";

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/DockerConfig.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/DockerConfig.java
@@ -46,4 +46,19 @@ public class DockerConfig {
     public void setParameters(List<String> parameters) {
         this.parameters = parameters;
     }
+
+    /**
+     * Returns the full image name including the tag
+     *
+     * @return the full image name including the tag
+     */
+    public String getFullImageName() {
+        if (tag == null) {
+            if (!image.contains(":")) {
+                return image + ":" + "latest";
+            }
+            return image;
+        }
+        return image + ":" + tag;
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -218,7 +218,7 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
         String dockerImage;
         try {
             windfile = programmingExercise.getWindfile();
-            dockerImage = windfile.getMetadata().getDocker().getImage();
+            dockerImage = windfile.getMetadata().getDocker().getFullImageName();
         }
         catch (NullPointerException e) {
             log.warn("Could not retrieve windfile for programming exercise {}. Using default windfile instead.", programmingExercise.getId());

--- a/src/test/java/de/tum/in/www1/artemis/connectors/AeolusTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/connectors/AeolusTest.java
@@ -155,4 +155,17 @@ class AeolusTest {
         aeolusRepository.setPath("path");
         assertThat(aeolusRepository.getPath()).isEqualTo("path");
     }
+
+    @Test
+    void testImageTagCombinations() {
+        DockerConfig dockerConfig = new DockerConfig();
+        dockerConfig.setImage("image");
+        dockerConfig.setTag("tag");
+        assertThat(dockerConfig.getFullImageName()).isEqualTo("image:tag");
+        dockerConfig.setTag(null);
+        assertThat(dockerConfig.getFullImageName()).isEqualTo("image:latest");
+        dockerConfig.setImage("image:tag");
+        dockerConfig.setTag("notshown");
+        assertThat(dockerConfig.getFullImageName()).isEqualTo("image:tag");
+    }
 }

--- a/src/test/java/de/tum/in/www1/artemis/connectors/AeolusTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/connectors/AeolusTest.java
@@ -162,10 +162,15 @@ class AeolusTest {
         dockerConfig.setImage("image");
         dockerConfig.setTag("tag");
         assertThat(dockerConfig.getFullImageName()).isEqualTo("image:tag");
+
         dockerConfig.setTag(null);
         assertThat(dockerConfig.getFullImageName()).isEqualTo("image:latest");
+
         dockerConfig.setImage("image:tag");
         dockerConfig.setTag("notshown");
         assertThat(dockerConfig.getFullImageName()).isEqualTo("image:tag");
+
+        dockerConfig.setImage(null);
+        assertThat(dockerConfig.getFullImageName()).isNull();
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCIIntegrationTest.java
@@ -109,7 +109,7 @@ class LocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
         assertThat(buildJob.getCourseId()).isEqualTo(course.getId());
         assertThat(buildJob.getExerciseId()).isEqualTo(programmingExercise.getId());
         assertThat(buildJob.getParticipationId()).isEqualTo(studentParticipation.getId());
-        assertThat(buildJob.getDockerImage()).isEqualTo(programmingExercise.getWindfile().getMetadata().getDocker().getImage());
+        assertThat(buildJob.getDockerImage()).isEqualTo(programmingExercise.getWindfile().getMetadata().getDocker().getFullImageName());
         assertThat(buildJob.getRepositoryName()).isEqualTo(assignmentRepositorySlug);
         assertThat(buildJob.getBuildAgentAddress()).isNotEmpty();
         assertThat(buildJob.getPriority()).isEqualTo(2);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
If no tag is specified, the docker java API will pull all images with that name. This PR fixes that by always specifying a tag.
### Description
<!-- Describe your changes in detail -->
I added a new method that fixes that.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise 

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a Programming Exercise with custom build plan and remove the tag
4. Observe your Artemis instance only pulling and executing one image

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Server

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [DockerConfig.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6060/latest/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.connectors.aeolus/DockerConfig.html) | 100% | ✅ |
| [LocalCITriggerService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6060/latest/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.service.connectors.localci/LocalCITriggerService.html) | 90% | ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced Docker configuration to ensure full image names, including tags, are properly formatted and utilized within the system.
	- Modified functionality to retrieve Docker image names from a `windfile` metadata object using a new method call `getFullImageName()` on the `Docker` object.
	- Updated assertion for `dockerImage` comparison in `LocalCIIntegrationTest.java` to check for `fullImageName` instead of just `image`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->