### PR TITLE
`Integrated code lifecycle`: Add build script to build job queue item

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildConfigurationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildConfigurationService.java
@@ -3,12 +3,10 @@ package de.tum.in.www1.artemis.service.connectors.localci;
 import static de.tum.in.www1.artemis.config.Constants.LOCALCI_WORKING_DIRECTORY;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -38,10 +36,10 @@ public class LocalCIBuildConfigurationService {
      * The build script is stored in a file in the local-ci-scripts directory.
      * The build script is used to build the programming exercise in a Docker container.
      *
-     * @param buildJobId    the id of the build job for which to create the build script
      * @param participation the participation for which to create the build script
+     * @return the build script
      */
-    public void createBuildScript(ProgrammingExerciseParticipation participation, String buildJobId) {
+    public String createBuildScript(ProgrammingExerciseParticipation participation) {
         ProgrammingExercise programmingExercise = participation.getProgrammingExercise();
 
         Path scriptsPath = Path.of(localCIBuildScriptBasePath);
@@ -54,9 +52,6 @@ public class LocalCIBuildConfigurationService {
                 throw new LocalCIException("Failed to create directory for local CI scripts", e);
             }
         }
-
-        // We use the container name as part of the file name to avoid conflicts when multiple build jobs are running at the same time.
-        Path buildScriptPath = scriptsPath.toAbsolutePath().resolve(buildJobId + "-build.sh");
 
         StringBuilder buildScript = new StringBuilder();
         buildScript.append("#!/bin/bash\n");
@@ -94,12 +89,7 @@ public class LocalCIBuildConfigurationService {
             });
 
         }
-        try {
-            FileUtils.writeStringToFile(buildScriptPath.toFile(), buildScript.toString(), StandardCharsets.UTF_8);
-        }
-        catch (IOException e) {
-            throw new LocalCIException("Failed to create build script file", e);
-        }
+        return buildScript.toString();
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIBuildJobExecutionService.java
@@ -159,12 +159,10 @@ public class LocalCIBuildJobExecutionService {
             throw new LocalCIException("Could not find last commit hash for test repository " + testsRepoUri.repositorySlug(), e);
         }
 
-        CreateContainerResponse container = localCIContainerService.configureContainer(containerName, buildJob.buildConfig().dockerImage());
-
-        Path buildScriptPath = Path.of(localCIBuildScriptBasePath).toAbsolutePath().resolve(buildJob.id() + "-build.sh");
+        CreateContainerResponse container = localCIContainerService.configureContainer(containerName, buildJob.buildConfig().dockerImage(), buildJob.buildConfig().buildScript());
 
         return runScriptAndParseResults(buildJob, containerName, container.getId(), assignmentRepoUri, assignmentRepositoryPath, testsRepositoryPath, solutionRepositoryPath,
-                auxiliaryRepositoriesPaths, buildScriptPath, isPushToTestOrAuxRepository, assignmentCommitHash, testCommitHash);
+                auxiliaryRepositoriesPaths, isPushToTestOrAuxRepository, assignmentCommitHash, testCommitHash);
     }
 
     /**
@@ -177,8 +175,8 @@ public class LocalCIBuildJobExecutionService {
      * @throws LocalCIException if something went wrong while running the build job.
      */
     private LocalCIBuildResult runScriptAndParseResults(LocalCIBuildJobQueueItem buildJob, String containerName, String containerId, VcsRepositoryUri assignmentRepositoryUri,
-            Path assignmentRepositoryPath, Path testsRepositoryPath, Path solutionRepositoryPath, Path[] auxiliaryRepositoriesPaths, Path buildScriptPath,
-            boolean isPushToTestRepository, String assignmentRepoCommitHash, String testRepoCommitHash) {
+            Path assignmentRepositoryPath, Path testsRepositoryPath, Path solutionRepositoryPath, Path[] auxiliaryRepositoriesPaths, boolean isPushToTestRepository,
+            String assignmentRepoCommitHash, String testRepoCommitHash) {
 
         long timeNanoStart = System.nanoTime();
 
@@ -187,7 +185,7 @@ public class LocalCIBuildJobExecutionService {
         log.info("Started container for build job {}", containerName);
 
         localCIContainerService.populateBuildJobContainer(containerId, assignmentRepositoryPath, testsRepositoryPath, solutionRepositoryPath, auxiliaryRepositoriesPaths,
-                buildJob.repositoryInfo().auxiliaryRepositoryCheckoutDirectories(), buildScriptPath, buildJob.buildConfig().programmingLanguage());
+                buildJob.repositoryInfo().auxiliaryRepositoryCheckoutDirectories(), buildJob.buildConfig().programmingLanguage());
 
         List<BuildLogEntry> buildLogEntries = localCIContainerService.runScriptInContainer(containerId);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -84,13 +84,14 @@ public class LocalCIContainerService {
      * @param image         the Docker image to use for the container
      * @return {@link CreateContainerResponse} that can be used to start the container
      */
-    public CreateContainerResponse configureContainer(String containerName, String image) {
+    public CreateContainerResponse configureContainer(String containerName, String image, String buildScript) {
         List<String> envVars = new ArrayList<>();
         if (useSystemProxy) {
             envVars.add("HTTP_PROXY=" + httpProxy);
             envVars.add("HTTPS_PROXY=" + httpsProxy);
             envVars.add("NO_PROXY=" + noProxy);
         }
+        envVars.add("SCRIPT=" + buildScript);
         return dockerClient.createContainerCmd(image).withName(containerName).withHostConfig(hostConfig).withEnv(envVars)
                 // Command to run when the container starts. This is the command that will be executed in the container's main process, which runs in the foreground and blocks the
                 // container from exiting until it finishes.
@@ -199,11 +200,10 @@ public class LocalCIContainerService {
      * @param solutionRepositoryPath                 the path to the solution repository
      * @param auxiliaryRepositoriesPaths             the paths to the auxiliary repositories
      * @param auxiliaryRepositoryCheckoutDirectories the names of the auxiliary repositories
-     * @param buildScriptPath                        the path to the build script
      * @param programmingLanguage                    the programming language of the exercise
      */
     public void populateBuildJobContainer(String buildJobContainerId, Path assignmentRepositoryPath, Path testRepositoryPath, Path solutionRepositoryPath,
-            Path[] auxiliaryRepositoriesPaths, String[] auxiliaryRepositoryCheckoutDirectories, Path buildScriptPath, ProgrammingLanguage programmingLanguage) {
+            Path[] auxiliaryRepositoriesPaths, String[] auxiliaryRepositoryCheckoutDirectories, ProgrammingLanguage programmingLanguage) {
         String testCheckoutPath = RepositoryCheckoutPath.TEST.forProgrammingLanguage(programmingLanguage);
         String assignmentCheckoutPath = RepositoryCheckoutPath.ASSIGNMENT.forProgrammingLanguage(programmingLanguage);
 
@@ -222,8 +222,12 @@ public class LocalCIContainerService {
         }
         convertDosFilesToUnix(LOCALCI_WORKING_DIRECTORY + "/testing-dir/", buildJobContainerId);
 
-        addAndPrepareDirectory(buildJobContainerId, buildScriptPath, LOCALCI_WORKING_DIRECTORY + "/script.sh");
-        convertDosFilesToUnix(LOCALCI_WORKING_DIRECTORY + "/script.sh", buildJobContainerId);
+        createScriptFile(buildJobContainerId);
+    }
+
+    private void createScriptFile(String buildJobContainerId) {
+        executeDockerCommand(buildJobContainerId, false, false, true, "bash", "-c", "echo \"$SCRIPT\" > " + LOCALCI_WORKING_DIRECTORY + "/script.sh");
+        executeDockerCommand(buildJobContainerId, false, false, true, "bash", "-c", "chmod +x " + LOCALCI_WORKING_DIRECTORY + "/script.sh");
     }
 
     private void addAndPrepareDirectory(String containerId, Path repositoryPath, String newDirectoryName) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -97,8 +97,8 @@ public class LocalCIContainerService {
                 // container from exiting until it finishes.
                 // It waits until the script that is running the tests (see below execCreateCmdResponse) is completed, and until the result files are extracted which is indicated
                 // by the creation of a file "stop_container.txt" in the container's root directory.
-                // .withCmd("sh", "-c", "while [ ! -f " + LOCALCI_WORKING_DIRECTORY + "/stop_container.txt ]; do sleep 0.5; done")
-                .withCmd("tail", "-f", "/dev/null") // Activate for debugging purposes instead of the above command to get a running container that you can peek into using
+                .withCmd("sh", "-c", "while [ ! -f " + LOCALCI_WORKING_DIRECTORY + "/stop_container.txt ]; do sleep 0.5; done")
+                // .withCmd("tail", "-f", "/dev/null") // Activate for debugging purposes instead of the above command to get a running container that you can peek into using
                 // "docker exec -it <container-id> /bin/bash".
                 .exec();
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -82,6 +82,7 @@ public class LocalCIContainerService {
      *
      * @param containerName the name of the container to be created
      * @param image         the Docker image to use for the container
+     * @param buildScript   the script that is to be executed in the container
      * @return {@link CreateContainerResponse} that can be used to start the container
      */
     public CreateContainerResponse configureContainer(String containerName, String image, String buildScript) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIContainerService.java
@@ -96,8 +96,8 @@ public class LocalCIContainerService {
                 // container from exiting until it finishes.
                 // It waits until the script that is running the tests (see below execCreateCmdResponse) is completed, and until the result files are extracted which is indicated
                 // by the creation of a file "stop_container.txt" in the container's root directory.
-                .withCmd("sh", "-c", "while [ ! -f " + LOCALCI_WORKING_DIRECTORY + "/stop_container.txt ]; do sleep 0.5; done")
-                // .withCmd("tail", "-f", "/dev/null") // Activate for debugging purposes instead of the above command to get a running container that you can peek into using
+                // .withCmd("sh", "-c", "while [ ! -f " + LOCALCI_WORKING_DIRECTORY + "/stop_container.txt ]; do sleep 0.5; done")
+                .withCmd("tail", "-f", "/dev/null") // Activate for debugging purposes instead of the above command to get a running container that you can peek into using
                 // "docker exec -it <container-id> /bin/bash".
                 .exec();
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -120,8 +120,6 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
         LocalCIBuildJobQueueItem buildJobQueueItem = new LocalCIBuildJobQueueItem(buildJobId, participation.getBuildPlanId(), null, participation.getId(), courseId,
                 programmingExercise.getId(), 0, priority, null, repositoryInfo, jobTimingInfo, buildConfig);
 
-        localCIBuildConfigurationService.createBuildScript(participation, buildJobId);
-
         queue.add(buildJobQueueItem);
     }
 
@@ -228,7 +226,10 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
 
         List<String> resultPaths = getTestResultPaths(windfile);
 
-        return new BuildConfig(dockerImage, commitHash, branch, programmingLanguage, projectType, staticCodeAnalysisEnabled, sequentialTestRunsEnabled, testwiseCoverageEnabled,
-                resultPaths);
+        // Todo: If build agent does not have access to filesystem, we need to send the build script to the build agent and execute it there.
+        String buildScript = localCIBuildConfigurationService.createBuildScript(participation);
+
+        return new BuildConfig(buildScript, dockerImage, commitHash, branch, programmingLanguage, projectType, staticCodeAnalysisEnabled, sequentialTestRunsEnabled,
+                testwiseCoverageEnabled, resultPaths);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -229,6 +229,10 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
         // Todo: If build agent does not have access to filesystem, we need to send the build script to the build agent and execute it there.
         String buildScript = localCIBuildConfigurationService.createBuildScript(participation);
 
+        if (buildScript == null) {
+            log.error("Build script could not be retrieved");
+        }
+
         return new BuildConfig(buildScript, dockerImage, commitHash, branch, programmingLanguage, projectType, staticCodeAnalysisEnabled, sequentialTestRunsEnabled,
                 testwiseCoverageEnabled, resultPaths);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/BuildConfig.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/BuildConfig.java
@@ -6,6 +6,6 @@ import java.util.List;
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 import de.tum.in.www1.artemis.domain.enumeration.ProjectType;
 
-public record BuildConfig(String dockerImage, String commitHash, String branch, ProgrammingLanguage programmingLanguage, ProjectType projectType, boolean scaEnabled,
-        boolean sequentialTestRunsEnabled, boolean testwiseCoverageEnabled, List<String> resultPaths) implements Serializable {
+public record BuildConfig(String buildScript, String dockerImage, String commitHash, String branch, ProgrammingLanguage programmingLanguage, ProjectType projectType,
+        boolean scaEnabled, boolean sequentialTestRunsEnabled, boolean testwiseCoverageEnabled, List<String> resultPaths) implements Serializable {
 }

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCIResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCIResourceIntegrationTest.java
@@ -45,7 +45,7 @@ class LocalCIResourceIntegrationTest extends AbstractLocalCILocalVCIntegrationTe
         localCISharedBuildJobQueueService.removeListener();
 
         JobTimingInfo jobTimingInfo = new JobTimingInfo(ZonedDateTime.now(), ZonedDateTime.now().plusMinutes(1), ZonedDateTime.now().plusMinutes(2));
-        BuildConfig buildConfig = new BuildConfig("test", "test", "test", null, null, false, false, false, null);
+        BuildConfig buildConfig = new BuildConfig("test", "test", "test", "test", null, null, false, false, false, null);
         RepositoryInfo repositoryInfo = new RepositoryInfo("test", null, RepositoryType.USER, "test", "test", "test", null, null);
 
         job1 = new LocalCIBuildJobQueueItem("1", "job1", "address1", 1, course.getId(), 1, 1, 1, null, repositoryInfo, jobTimingInfo, buildConfig);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Description
<!-- Describe your changes in detail -->
This PR fixes a bug introduced by #7944. The build script was retrieved from a file using a predefined file path. This could cause some issues depending which server node tried to resolve the path. Now, the build script is not saved as a file anymore but added to the build job queue and directly injected into the container as a string.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Trigger some build jobs. Build should not fail

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced local CI build process to directly use build scripts, improving efficiency.
- **Refactor**
	- Simplified the creation and handling of build scripts in the CI pipeline.
	- Streamlined method signatures and parameters for better clarity and performance.
- **Bug Fixes**
	- Added error handling for scenarios where the build script is null, preventing potential build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->