### PR TITLE
`Development`: Fix thread limit exception when executing server tests

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -959,6 +959,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
         }
 
         return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).thenApply(ignore -> {
+            threadPool.shutdown();
             log.info("Finished executing (scheduled) task '{}' for programming exercise with id {}.", operationName, programmingExercise.getId());
             if (!failedOperations.isEmpty()) {
                 var failedIds = failedOperations.stream().map(participation -> participation.getId().toString()).collect(Collectors.joining(","));

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,9 +1,9 @@
 # Enables junit5 parallel test execution. Tests are run on one JVM instance.
 junit.jupiter.execution.parallel.enabled = true
+# Limit the thread pool size to avoid exceptions like
 # java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
 junit.jupiter.execution.parallel.config.strategy = fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism = 4
-junit.jupiter.execution.parallel.config.fixed.max-pool-size = 200
+junit.jupiter.execution.parallel.config.fixed.parallelism = 2
 
 # Enables ordering test-classes with JUnit5 by class name.
 junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$ClassName

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -2,7 +2,8 @@
 junit.jupiter.execution.parallel.enabled = true
 # java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
 junit.jupiter.execution.parallel.config.strategy = fixed
-junit.jupiter.execution.parallel.config.fixed.max-pool-size = 20
+junit.jupiter.execution.parallel.config.fixed.parallelism = 4
+junit.jupiter.execution.parallel.config.fixed.max-pool-size = 200
 
 # Enables ordering test-classes with JUnit5 by class name.
 junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$ClassName

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,5 +1,9 @@
 # Enables junit5 parallel test execution. Tests are run on one JVM instance.
 junit.jupiter.execution.parallel.enabled = true
+# Limit JUnit to 4 parallel threads executing the tests
+# Otherwise we might run into this exception:
+# java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
+junit.jupiter.execution.parallel.config.fixed.parallelism = 4
 
 # Enables ordering test-classes with JUnit5 by class name.
 junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$ClassName

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,9 +1,8 @@
 # Enables junit5 parallel test execution. Tests are run on one JVM instance.
 junit.jupiter.execution.parallel.enabled = true
-# Limit JUnit to 4 parallel threads executing the tests
-# Otherwise we might run into this exception:
 # java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
-junit.jupiter.execution.parallel.config.fixed.parallelism = 4
+junit.jupiter.execution.parallel.mode.default = same_thread
+junit.jupiter.execution.parallel.mode.classes.default = concurrent
 
 # Enables ordering test-classes with JUnit5 by class name.
 junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$ClassName

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -3,7 +3,7 @@ junit.jupiter.execution.parallel.enabled = true
 # Limit the thread pool size to avoid exceptions like
 # java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
 junit.jupiter.execution.parallel.config.strategy = fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism = 3
+junit.jupiter.execution.parallel.config.fixed.parallelism = 2
 
 # Enables ordering test-classes with JUnit5 by class name.
 junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$ClassName

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -3,7 +3,7 @@ junit.jupiter.execution.parallel.enabled = true
 # Limit the thread pool size to avoid exceptions like
 # java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
 junit.jupiter.execution.parallel.config.strategy = fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism = 2
+junit.jupiter.execution.parallel.config.fixed.parallelism = 3
 
 # Enables ordering test-classes with JUnit5 by class name.
 junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$ClassName

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,8 +1,8 @@
 # Enables junit5 parallel test execution. Tests are run on one JVM instance.
 junit.jupiter.execution.parallel.enabled = true
 # java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
-junit.jupiter.execution.parallel.mode.default = same_thread
-junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.config.strategy = fixed
+junit.jupiter.execution.parallel.config.fixed.max-pool-size = 20
 
 # Enables ordering test-classes with JUnit5 by class name.
 junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$ClassName


### PR DESCRIPTION

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
The server tests are currently failing due to too many created threads.


### Description
I reduces the amout of parallel running test suites from 4 to 2.
This is definity not ideal but I did not find a different way to solve that, also using 3 parallel running tests sometimes threw an exception. 


### Steps for Testing
Ensure that server tests are consistently running again, on both GitHub and Bamboo runners.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured proper shutdown of thread pools after task execution to improve resource management.
- **Tests**
	- Added configuration to limit thread pool size during parallel test execution, preventing exceptions related to thread limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->