### PR TITLE
`General`: Fix an error in the detail overview list due to an empty submission policy

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/services/submission-policy.service.ts
+++ b/src/main/webapp/app/exercises/programming/manage/services/submission-policy.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { SubmissionPolicy } from 'app/entities/submission-policy.model';
 
 export interface ISubmissionPolicyService {
     addSubmissionPolicyToProgrammingExercise: (submissionPolicy: SubmissionPolicy, exerciseId: number) => Observable<SubmissionPolicy>;
-    getSubmissionPolicyOfProgrammingExercise: (exerciseId: number) => Observable<SubmissionPolicy>;
+    getSubmissionPolicyOfProgrammingExercise: (exerciseId: number) => Observable<SubmissionPolicy | undefined>;
     removeSubmissionPolicyFromProgrammingExercise: (exerciseId: number) => Observable<HttpResponse<void>>;
     enableSubmissionPolicyOfProgrammingExercise: (exerciseId: number) => Observable<HttpResponse<void>>;
     disableSubmissionPolicyOfProgrammingExercise: (exerciseId: number) => Observable<HttpResponse<void>>;
@@ -24,8 +24,14 @@ export class SubmissionPolicyService implements ISubmissionPolicyService {
      *
      * @param exerciseId of the programming exercise for which the submission policy should be loaded
      */
-    getSubmissionPolicyOfProgrammingExercise(exerciseId: number): Observable<SubmissionPolicy> {
-        return this.http.get<SubmissionPolicy>(this.requestUrl(exerciseId));
+    getSubmissionPolicyOfProgrammingExercise(exerciseId: number): Observable<SubmissionPolicy | undefined> {
+        return this.http.get<SubmissionPolicy | undefined>(this.requestUrl(exerciseId)).pipe(
+            // using any as it can be null
+            map((response: any) => {
+                // Ensure that null is replaced by undefined
+                return response === null ? undefined : response;
+            }),
+        );
     }
 
     /**

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -97,7 +97,7 @@ export class CourseExerciseDetailsComponent extends AbstractScienceComponent imp
     private discussionComponent?: DiscussionSectionComponent;
     baseResource: string;
     isExamExercise: boolean;
-    submissionPolicy: SubmissionPolicy;
+    submissionPolicy?: SubmissionPolicy;
     exampleSolutionCollapsed: boolean;
     plagiarismCaseInfo?: PlagiarismCaseInfo;
     availableExerciseHints: ExerciseHint[];


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In the new release, some errors show up in the console when looking at an exercise details overview that does not have a submission policy. The submission policy is fetched separately from the server. If there is none, it returns an empty response. The http client returns `null` for that case. However, the details overview only checks for `undefined`.
This is probably related to changes in #7938, but they are not the root cause.

![CleanShot 2024-02-13 at 17 31 20](https://github.com/ls1intum/Artemis/assets/23171488/5090a69b-2cab-4e05-8c95-a2bebf58d821)

### Description
<!-- Describe your changes in detail -->

Added a `pipe` to the submission policy service method that loads the submission policy that converts `null` to `undefined` as we want to avoid `null` in the client as per the guidelines.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor


1. Log in to Artemis
2. Navigate to a programming exercise management overview page
3. Check that there are no errors like in the screenshot above.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of `null` responses in submission policy retrieval to ensure consistent return types.
- **Refactor**
	- Made `submissionPolicy` property optional in `CourseExerciseDetailsComponent` for better flexibility.
	- Enhanced the submission policy service test suite for more robust testing and error avoidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->