### PR TITLE
`Adaptive learning`: Make exercise competencies management consistent

### DIFF
--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-detail.component.ts
@@ -97,7 +97,7 @@ export class FileUploadExerciseDetailComponent implements OnInit, OnDestroy {
         const exercise = this.fileUploadExercise;
         const generalSection = getExerciseGeneralDetailsSection(exercise);
         const modeSection = getExerciseModeDetailSection(exercise);
-        const problemSection = getExerciseProblemDetailSection(this.formattedProblemStatement);
+        const problemSection = getExerciseProblemDetailSection(this.formattedProblemStatement, this.fileUploadExercise);
         const solutionSection = getExerciseMarkdownSolution(exercise, this.formattedExampleSolution);
         const defaultGradingDetails = getExerciseGradingDefaultDetails(exercise);
         const gradingInstructionsCriteriaDetails = getExerciseGradingInstructionsCriteriaDetails(exercise, this.formattedGradingInstructions);

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
@@ -49,6 +49,17 @@
                 [editorMode]="EditorMode.LATEX"
             />
         </div>
+        @if (!isExamMode) {
+            <div class="form-group">
+                <jhi-competency-selection
+                    id="competencies"
+                    [labelName]="'artemisApp.competency.link.title' | artemisTranslate"
+                    [labelTooltip]="'artemisApp.competency.link.exercise' | artemisTranslate"
+                    [(ngModel)]="fileUploadExercise.competencies"
+                    name="competencies"
+                />
+            </div>
+        }
         <h3 jhiTranslate="artemisApp.exercise.sections.solution" id="artemisApp.exercise.sections.solution">Example Solution</h3>
         <!-- TODO we want to have a file upload here and store a PDF, not a text. We could allow to add text in the sample_solution_explanation field -->
         <div class="form-group" id="field_exampleSolution">
@@ -207,17 +218,6 @@
             <input required minlength="2" type="text" class="form-control" name="filePattern" id="field_filePattern" [(ngModel)]="fileUploadExercise.filePattern" />
         </div>
         <jhi-presentation-score-checkbox [exercise]="fileUploadExercise" />
-        @if (!isExamMode) {
-            <div class="form-group">
-                <jhi-competency-selection
-                    id="competencies"
-                    [labelName]="'artemisApp.competency.link.title' | artemisTranslate"
-                    [labelTooltip]="'artemisApp.competency.link.exercise' | artemisTranslate"
-                    [(ngModel)]="fileUploadExercise.competencies"
-                    name="competencies"
-                />
-            </div>
-        }
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.assessmentInstructions" for="gradingInstructions">Assessment Instructions</label>
             <jhi-grading-instructions-details id="gradingInstructions" [exercise]="fileUploadExercise" />

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.ts
@@ -102,7 +102,7 @@ export class ModelingExerciseDetailComponent implements OnInit, OnDestroy {
         const exercise = this.modelingExercise;
         const generalSection = getExerciseGeneralDetailsSection(exercise);
         const modeSection = getExerciseModeDetailSection(exercise);
-        const problemSection = getExerciseProblemDetailSection(this.problemStatement);
+        const problemSection = getExerciseProblemDetailSection(this.problemStatement, this.modelingExercise);
         const defaultGradingDetails = getExerciseGradingDefaultDetails(exercise);
         const gradingInstructionsCriteriaDetails = getExerciseGradingInstructionsCriteriaDetails(exercise, this.gradingInstructions);
         return [

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
@@ -43,6 +43,17 @@
                 [editorMode]="EditorMode.LATEX"
             />
         </div>
+        @if (!isExamMode) {
+            <div class="form-group">
+                <jhi-competency-selection
+                    id="competencies"
+                    [labelName]="'artemisApp.competency.link.title' | artemisTranslate"
+                    [labelTooltip]="'artemisApp.competency.link.exercise' | artemisTranslate"
+                    [(ngModel)]="modelingExercise.competencies"
+                    name="competencies"
+                />
+            </div>
+        }
         <h3 jhiTranslate="artemisApp.exercise.sections.solution" id="artemisApp.exercise.sections.solution">Example Solution</h3>
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="artemisApp.modelingExercise.exampleSolution">Example Solution</label>
@@ -259,17 +270,6 @@
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.assessmentInstructions" for="gradingInstructions">Assessment Instructions</label>
             <jhi-grading-instructions-details id="gradingInstructions" [exercise]="modelingExercise" />
         </div>
-        @if (!isExamMode) {
-            <div class="form-group">
-                <jhi-competency-selection
-                    id="competencies"
-                    [labelName]="'artemisApp.competency.link.title' | artemisTranslate"
-                    [labelTooltip]="'artemisApp.competency.link.exercise' | artemisTranslate"
-                    [(ngModel)]="modelingExercise.competencies"
-                    name="competencies"
-                />
-            </div>
-        }
         <jhi-exercise-update-notification [exercise]="modelingExercise" [isImport]="isImport" [(notificationText)]="notificationText" />
     </div>
     <div>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -446,14 +446,26 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
     }
 
     getExerciseDetailsProblemSection(exercise: ProgrammingExercise): DetailOverviewSection {
+        const hasCompetencies = !!exercise.competencies?.length;
+        const details: Detail[] = [
+            {
+                title: hasCompetencies ? 'artemisApp.programmingExercise.wizardMode.detailedSteps.problemStepTitle' : undefined,
+                type: DetailType.ProgrammingProblemStatement,
+                data: { exercise: exercise },
+            },
+        ];
+
+        if (hasCompetencies) {
+            details.push({
+                title: 'artemisApp.competency.link.title',
+                type: DetailType.Text,
+                data: { text: exercise.competencies?.map((competency) => competency.title).join(', ') },
+            });
+        }
+
         return {
             headline: 'artemisApp.programmingExercise.wizardMode.detailedSteps.problemStepTitle',
-            details: [
-                {
-                    type: DetailType.ProgrammingProblemStatement,
-                    data: { exercise: exercise },
-                },
-            ],
+            details: details,
         };
     }
 

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -60,6 +60,7 @@ import { DetailOverviewSection, DetailType } from 'app/detail-overview-list/deta
 import { IrisSettingsService } from 'app/iris/settings/shared/iris-settings.service';
 import { IrisSubSettingsType } from 'app/entities/iris/settings/iris-sub-settings.model';
 import { Detail } from 'app/detail-overview-list/detail.model';
+import { Competency } from 'app/entities/competency.model';
 
 @Component({
     selector: 'jhi-programming-exercise-detail',
@@ -79,6 +80,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
     readonly documentationType: DocumentationType = 'Programming';
 
     programmingExercise: ProgrammingExercise;
+    competencies: Competency[];
     isExamExercise: boolean;
     supportsAuxiliaryRepositories: boolean;
     baseResource: string;
@@ -157,6 +159,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
 
         this.activatedRoute.data.subscribe(({ programmingExercise }) => {
             this.programmingExercise = programmingExercise;
+            this.competencies = programmingExercise.competencies;
             const exerciseId = this.programmingExercise.id!;
             this.isExamExercise = !!this.programmingExercise.exerciseGroup;
             this.courseId = this.isExamExercise ? this.programmingExercise.exerciseGroup!.exam!.course!.id! : this.programmingExercise.course!.id!;
@@ -446,7 +449,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
     }
 
     getExerciseDetailsProblemSection(exercise: ProgrammingExercise): DetailOverviewSection {
-        const hasCompetencies = !!exercise.competencies?.length;
+        const hasCompetencies = !!this.competencies?.length;
         const details: Detail[] = [
             {
                 title: hasCompetencies ? 'artemisApp.programmingExercise.wizardMode.detailedSteps.problemStepTitle' : undefined,
@@ -459,7 +462,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
             details.push({
                 title: 'artemisApp.competency.link.title',
                 type: DetailType.Text,
-                data: { text: exercise.competencies?.map((competency) => competency.title).join(', ') },
+                data: { text: this.competencies?.map((competency) => competency.title).join(', ') },
             });
         }
 

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -77,6 +77,14 @@ export class QuizExerciseDetailComponent implements OnInit {
         const generalSection = getExerciseGeneralDetailsSection(exercise);
         const modeSection = getExerciseModeDetailSection(exercise);
         const defaultGradingDetails = getExerciseGradingDefaultDetails(exercise);
+
+        if (exercise.competencies?.length) {
+            modeSection.details.push({
+                title: 'artemisApp.competency.link.title',
+                type: DetailType.Text,
+                data: { text: exercise.competencies?.map((competency) => competency.title).join(', ') },
+            });
+        }
         return [
             generalSection,
             {

--- a/src/main/webapp/app/exercises/shared/utils.ts
+++ b/src/main/webapp/app/exercises/shared/utils.ts
@@ -62,15 +62,26 @@ export function getExerciseModeDetailSection(exercise: Exercise): DetailOverview
     };
 }
 
-export function getExerciseProblemDetailSection(formattedProblemStatement: SafeHtml | null): DetailOverviewSection {
+export function getExerciseProblemDetailSection(formattedProblemStatement: SafeHtml | null, exercise: Exercise): DetailOverviewSection {
+    const hasCompetencies = !!exercise.competencies?.length;
+    const details: Detail[] = [
+        {
+            title: hasCompetencies ? 'artemisApp.exercise.sections.problem' : undefined,
+            type: DetailType.Markdown,
+            data: { innerHtml: formattedProblemStatement },
+        },
+    ];
+
+    if (hasCompetencies) {
+        details.push({
+            title: 'artemisApp.competency.link.title',
+            type: DetailType.Text,
+            data: { text: exercise.competencies?.map((competency) => competency.title).join(', ') },
+        });
+    }
     return {
         headline: 'artemisApp.exercise.sections.problem',
-        details: [
-            {
-                type: DetailType.Markdown,
-                data: { innerHtml: formattedProblemStatement },
-            },
-        ],
+        details: details,
     };
 }
 

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts
@@ -92,7 +92,7 @@ export class TextExerciseDetailComponent implements OnInit, OnDestroy {
         const exercise = this.textExercise;
         const generalSection = getExerciseGeneralDetailsSection(exercise);
         const modeSection = getExerciseModeDetailSection(exercise);
-        const problemSection = getExerciseProblemDetailSection(this.formattedProblemStatement);
+        const problemSection = getExerciseProblemDetailSection(this.formattedProblemStatement, this.textExercise);
         const solutionSection = getExerciseMarkdownSolution(exercise, this.formattedExampleSolution);
         const defaultGradingDetails = getExerciseGradingDefaultDetails(exercise);
         const gradingInstructionsCriteriaDetails = getExerciseGradingInstructionsCriteriaDetails(exercise, this.formattedGradingInstructions);

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
@@ -44,6 +44,17 @@
                 (markdownChange)="calculateFormSectionStatus()"
             />
         </div>
+        @if (!isExamMode) {
+            <div class="form-group">
+                <jhi-competency-selection
+                    id="competencies"
+                    [labelName]="'artemisApp.competency.link.title' | artemisTranslate"
+                    [labelTooltip]="'artemisApp.competency.link.exercise' | artemisTranslate"
+                    [(ngModel)]="textExercise.competencies"
+                    name="competencies"
+                />
+            </div>
+        }
         <h3 jhiTranslate="artemisApp.exercise.sections.solution" id="artemisApp.exercise.sections.solution">Example Solution</h3>
         <div class="form-group">
             <label jhiTranslate="artemisApp.exercise.exampleSolution" for="exampleSolution">Example Solution</label>
@@ -210,17 +221,6 @@
             <jhi-exercise-update-plagiarism [exercise]="textExercise" />
         }
         <jhi-presentation-score-checkbox [exercise]="textExercise" />
-        @if (!isExamMode) {
-            <div class="form-group">
-                <jhi-competency-selection
-                    id="competencies"
-                    [labelName]="'artemisApp.competency.link.title' | artemisTranslate"
-                    [labelTooltip]="'artemisApp.competency.link.exercise' | artemisTranslate"
-                    [(ngModel)]="textExercise.competencies"
-                    name="competencies"
-                />
-            </div>
-        }
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.assessmentInstructions" for="gradingInstructions">Assessment Instructions</label>
             <jhi-grading-instructions-details id="gradingInstructions" [exercise]="textExercise" />


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
The competency selector for exercises has been located at a different position in the different exercise type edit views and the current selected competencies have not been shown on the exercise detail page.

### Description
This PR moves the Competency Selector for all exercise types to the end of the problem statement section. Both in the edit view and the detail view.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Course with competencies

1. Log in to Artemis
2. Navigate to Exercise Overview
3. Check for all exercise types that the competency selector is placed below the problem statement in the edit mode
4. Check for all exercise types that the selected competencies are shown on the detail page of the exercise

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Test Coverage
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [file-upload-exercise-detail.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6119/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/file-upload/manage/file-upload-exercise-detail.component.ts.html) | 97.91% | ✅  |
| [modeling-exercise-detail.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6119/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/modeling/manage/modeling-exercise-detail.component.ts.html) | 93.05% | ✅  |
| [programming-exercise-detail.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6119/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/programming/manage/programming-exercise-detail.component.ts.html) | 86.47% | ✅  |
| [quiz-exercise-detail.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6119/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/quiz/manage/quiz-exercise-detail.component.ts.html) | 95.65% | ✅ |
| [utils.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6119/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/shared/utils.ts.html) | 86.36% | ✅ |
| [text-exercise-detail.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6119/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts.html) | 100% | ✅ |

 
### Screenshots

![image](https://github.com/ls1intum/Artemis/assets/78978542/c110b52d-3a28-4b5e-a5b2-8ba4b2a4268d)
![image](https://github.com/ls1intum/Artemis/assets/78978542/adf3dc0c-28f5-449c-8a24-2f07b7467079)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a competency selection section for exercises across various types (file upload, modeling, programming, quiz, and text) based on exam mode conditions.
	- Enhanced display of exercise details to include competencies when present, improving information accessibility for users.

- **Enhancements**
	- Reorganized HTML structure for file upload and text exercise update components for better usability.
	- Modified exercise detail components to dynamically display competencies, enriching the exercise information provided to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->