### PR TITLE
`Iris`: Fix enable/disable settings buttons to show correct state to instructors

### DIFF
--- a/src/main/webapp/app/iris/settings/iris-settings-update/iris-common-sub-settings-update/iris-common-sub-settings-update.component.html
+++ b/src/main/webapp/app/iris/settings/iris-settings-update/iris-common-sub-settings-update/iris-common-sub-settings-update.component.html
@@ -9,20 +9,10 @@
     }
 }
 <div class="btn-group">
-    <div
-        class="btn"
-        [ngClass]="{ 'btn-success selected': !isChatSettingsSwitchDisabled && enabled, 'btn-default': isChatSettingsSwitchDisabled || !enabled }"
-        [class.disabled]="isChatSettingsSwitchDisabled"
-        (click)="onEnable()"
-    >
+    <div class="btn" [ngClass]="{ 'btn-success selected': enabled, 'btn-default': !enabled }" [class.disabled]="isSettingsSwitchDisabled" (click)="onEnable()">
         {{ 'artemisApp.iris.settings.subSettings.enabled.on' | artemisTranslate }}
     </div>
-    <div
-        class="btn"
-        [ngClass]="{ 'btn-danger selected': isChatSettingsSwitchDisabled || !enabled, 'btn-default': !isChatSettingsSwitchDisabled && enabled }"
-        [class.disabled]="isChatSettingsSwitchDisabled"
-        (click)="onDisable()"
-    >
+    <div class="btn" [ngClass]="{ 'btn-danger selected': !enabled, 'btn-default': enabled }" [class.disabled]="isSettingsSwitchDisabled" (click)="onDisable()">
         {{ 'artemisApp.iris.settings.subSettings.enabled.off' | artemisTranslate }}
     </div>
 </div>

--- a/src/main/webapp/app/iris/settings/iris-settings-update/iris-common-sub-settings-update/iris-common-sub-settings-update.component.ts
+++ b/src/main/webapp/app/iris/settings/iris-settings-update/iris-common-sub-settings-update/iris-common-sub-settings-update.component.ts
@@ -116,11 +116,10 @@ export class IrisCommonSubSettingsUpdateComponent implements OnInit, OnChanges {
         }
         return false;
     }
-    get isChatSettingsSwitchDisabled() {
+    get isSettingsSwitchDisabled() {
         return this.inheritDisabled || (!this.isAdmin && this.settingsType !== this.EXERCISE);
     }
 
     protected readonly IrisSubSettings = IrisSubSettings;
     protected readonly IrisSubSettingsType = IrisSubSettingsType;
-    protected readonly IrisSettingsType = IrisSettingsType;
 }

--- a/src/test/javascript/spec/component/iris/settings/iris-common-sub-settings-update.component.spec.ts
+++ b/src/test/javascript/spec/component/iris/settings/iris-common-sub-settings-update.component.spec.ts
@@ -79,7 +79,7 @@ describe('IrisCommonSubSettingsUpdateComponent Component', () => {
         fixture.detectChanges();
 
         expect(comp.inheritDisabled).toBeTrue();
-        expect(comp.isChatSettingsSwitchDisabled).toBeTrue();
+        expect(comp.isSettingsSwitchDisabled).toBeTrue();
     });
 
     it('change allowed model', () => {


### PR DESCRIPTION
> Only testable on ts9 due to Iris

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.


### Motivation and Context
The enable/disable buttons in the Iris settings always showed up as disabled for instructors, even when the opposite was the case.


### Description
Removed a conditional that caused buttons to always be disabled for instructors.


### Steps for Testing
Prerequisites:
- 1 Admin
- 1 Instructor

1. Log in to Artemis as an Admin
2. Go to course management -> Iris Settings (you can use [Raphael Test Course](https://artemis-test9.artemis.cit.tum.de/courses/22)
3. Enable some features, disable others
4. Login **as an instructor**
5. Go to course management -> Iris Settings
6. See that all enable/disable buttons are displayed correctly **!!!BUT ARE NOT CLICKABLE!!!**


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
No coverage changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Simplified button styling in settings update component.
- **Refactor**
	- Renamed property for clarity in settings update component and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->