### PR TITLE
`Quiz exercises`: Save Apollon diagram when generating drag and drop question

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-detail.component.ts
@@ -166,7 +166,7 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
         };
 
         const result = await lastValueFrom(this.apollonDiagramService.update(updatedDiagram, this.courseId));
-        if (result.ok) {
+        if (result?.ok) {
             this.alertService.success('artemisApp.apollonDiagram.updated', { title: this.apollonDiagram?.title });
             this.isSaved = true;
             this.setAutoSaveTimer();

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-detail.component.ts
@@ -15,6 +15,7 @@ import { Course } from 'app/entities/course.model';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { DragAndDropQuestion } from 'app/entities/quiz/drag-and-drop-question.model';
 import { ConfirmAutofocusModalComponent } from 'app/shared/components/confirm-autofocus-modal.component';
+import { lastValueFrom } from 'rxjs';
 
 @Component({
     selector: 'jhi-apollon-diagram-detail',
@@ -154,9 +155,9 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
     /**
      * Saves the diagram
      */
-    saveDiagram() {
+    async saveDiagram(): Promise<boolean> {
         if (!this.apollonDiagram) {
-            return;
+            return false;
         }
         const umlModel = this.apollonEditor!.model;
         const updatedDiagram: ApollonDiagram = {
@@ -164,14 +165,16 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
             jsonRepresentation: JSON.stringify(umlModel),
         };
 
-        this.apollonDiagramService.update(updatedDiagram, this.courseId).subscribe({
-            next: () => {
-                this.alertService.success('artemisApp.apollonDiagram.updated', { title: this.apollonDiagram?.title });
-                this.isSaved = true;
-                this.setAutoSaveTimer();
-            },
-            error: () => this.alertService.error('artemisApp.apollonDiagram.update.error'),
-        });
+        const result = await lastValueFrom(this.apollonDiagramService.update(updatedDiagram, this.courseId));
+        if (result.ok) {
+            this.alertService.success('artemisApp.apollonDiagram.updated', { title: this.apollonDiagram?.title });
+            this.isSaved = true;
+            this.setAutoSaveTimer();
+            return true;
+        } else {
+            this.alertService.error('artemisApp.apollonDiagram.update.error');
+            return false;
+        }
     }
 
     /**
@@ -229,8 +232,11 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
         }
 
         if (this.apollonEditor && this.apollonDiagram) {
-            const question = await generateDragAndDropQuizExercise(this.course, this.apollonDiagram.title!, this.apollonEditor.model!);
-            this.closeEdit.emit(question);
+            const isSaved = await this.saveDiagram();
+            if (isSaved) {
+                const question = await generateDragAndDropQuizExercise(this.course, this.apollonDiagram.title!, this.apollonEditor.model!);
+                this.closeEdit.emit(question);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
When importing an Apollon Diagram into an Quiz Question, the apollon diagram did not save changes if you did any.


### Description
This PR awaits the diagram save before generating the quiz question.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Create or Edit quiz exercise
3. Click Add Apollon diagram drag and drop question
4. create new apollon diagram
5. add elements & make some interactive
6. Click Generate without clicking save
7. Click again on create apollon diagram drag and dop question
8. select your diagram changes are still there

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<img width="488" alt="image" src="https://github.com/ls1intum/Artemis/assets/78978542/7263ec8d-f58a-40e9-b9ca-ed0a9caa6774">
<img width="484" alt="image" src="https://github.com/ls1intum/Artemis/assets/78978542/9ee8c1ee-4c6a-4c56-8da3-b6a6ce55d1af">
<img width="1042" alt="image" src="https://github.com/ls1intum/Artemis/assets/78978542/088f1a1b-9a3d-4b5d-bae1-914886be2658">




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the diagram saving process to be asynchronous, improving response handling and feedback.
- **Refactor**
	- Improved the `editDiagram` method to ensure diagrams are saved prior to quiz question generation.
- **Bug Fixes**
	- Concealed internal details for security purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->