### PR TITLE
`Development`: Move PageableSearchDTOs to the same package

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
@@ -27,7 +27,7 @@ import de.tum.in.www1.artemis.domain.enumeration.SortingOrder;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.dto.UserDTO;
-import de.tum.in.www1.artemis.web.rest.dto.UserPageableSearchDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.UserPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 /**

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -60,6 +60,7 @@ import de.tum.in.www1.artemis.service.notifications.GroupNotificationService;
 import de.tum.in.www1.artemis.service.user.UserService;
 import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 import de.tum.in.www1.artemis.web.rest.dto.*;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
 
@@ -200,13 +201,13 @@ public class CourseService {
     }
 
     /**
-     * Search for all courses fitting a {@link PageableSearchDTO search query}. The result is paged.
+     * Search for all courses fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged.
      *
      * @param search The search query defining the search term and the size of the returned page
      * @param user   The user for whom to fetch all available lectures
      * @return A wrapper object containing a list of all found courses and the total number of pages
      */
-    public SearchResultPageDTO<Course> getAllOnPageWithSize(final PageableSearchDTO<String> search, final User user) {
+    public SearchResultPageDTO<Course> getAllOnPageWithSize(final SearchTermPageableSearchDTO<String> search, final User user) {
         final var pageable = PageUtil.createDefaultPageRequest(search, PageUtil.ColumnMapping.COURSE);
 
         final var searchTerm = search.getSearchTerm();

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseSpecificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseSpecificationService.java
@@ -17,7 +17,7 @@ import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.exam.Exam_;
 import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.exam.ExerciseGroup_;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 
 @Profile(PROFILE_CORE)
 @Service
@@ -101,7 +101,8 @@ public class ExerciseSpecificationService {
      *
      * @param programmingLanguage the language to filter for
      * @return a Specification that can get passed to the @{@link de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository}
-     * @see de.tum.in.www1.artemis.service.programming.ProgrammingExerciseService#getAllWithSCAOnPageWithSize(PageableSearchDTO, boolean, boolean, ProgrammingLanguage, User)
+     * @see de.tum.in.www1.artemis.service.programming.ProgrammingExerciseService#getAllWithSCAOnPageWithSize(SearchTermPageableSearchDTO, boolean, boolean, ProgrammingLanguage,
+     *      User)
      */
     public Specification<ProgrammingExercise> createSCAFilter(ProgrammingLanguage programmingLanguage) {
         return (root, query, criteriaBuilder) -> {

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadExerciseService.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Service;
 import de.tum.in.www1.artemis.domain.FileUploadExercise;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.FileUploadExerciseRepository;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
 
 @Profile(PROFILE_CORE)
@@ -31,7 +31,7 @@ public class FileUploadExerciseService {
     }
 
     /**
-     * Search for all file upload exercises fitting a {@link PageableSearchDTO search query}. The result is paged,
+     * Search for all file upload exercises fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged,
      * meaning that there is only a predefined portion of the result returned to the user, so that the server doesn't
      * have to send hundreds/thousands of exercises if there are that many in Artemis.
      *
@@ -41,7 +41,7 @@ public class FileUploadExerciseService {
      * @param user           The user for whom to fetch all available exercises
      * @return A wrapper object containing a list of all found exercises and the total number of pages
      */
-    public SearchResultPageDTO<FileUploadExercise> getAllOnPageWithSize(final PageableSearchDTO<String> search, final Boolean isCourseFilter, final Boolean isExamFilter,
+    public SearchResultPageDTO<FileUploadExercise> getAllOnPageWithSize(final SearchTermPageableSearchDTO<String> search, final Boolean isCourseFilter, final Boolean isExamFilter,
             final User user) {
         if (!isCourseFilter && !isExamFilter) {
             return new SearchResultPageDTO<>(Collections.emptyList(), 0);

--- a/src/main/java/de/tum/in/www1/artemis/service/GradingScaleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/GradingScaleService.java
@@ -16,8 +16,8 @@ import de.tum.in.www1.artemis.domain.GradeStep;
 import de.tum.in.www1.artemis.domain.GradingScale;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
 
@@ -56,7 +56,7 @@ public class GradingScaleService {
     }
 
     /**
-     * Search for all grading scales fitting a {@link PageableSearchDTO search query} among the grading scales having grade type BONUS.
+     * Search for all grading scales fitting a {@link SearchTermPageableSearchDTO search query} among the grading scales having grade type BONUS.
      * If the user does not have ADMIN role, they can only access the grading scales if they are an instructor in the course related to it.
      * The result is paged, meaning that there is only a predefined portion of the result returned to the user, so that the server doesn't
      * have to send too many results.
@@ -67,7 +67,7 @@ public class GradingScaleService {
      * @param user   The user for whom to fetch all available grading scales
      * @return A wrapper object containing a list of all found exercises and the total number of pages
      */
-    public SearchResultPageDTO<GradingScale> getAllOnPageWithSize(final PageableSearchDTO<String> search, final User user) {
+    public SearchResultPageDTO<GradingScale> getAllOnPageWithSize(final SearchTermPageableSearchDTO<String> search, final User user) {
         final var pageable = PageUtil.createDefaultPageRequest(search, PageUtil.ColumnMapping.GRADING_SCALE);
         final var searchTerm = search.getSearchTerm();
         final Page<GradingScale> gradingScalePage;

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureService.java
@@ -16,8 +16,8 @@ import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
 import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
 
 @Profile(PROFILE_CORE)
@@ -102,13 +102,13 @@ public class LectureService {
     }
 
     /**
-     * Search for all lectures fitting a {@link PageableSearchDTO search query}. The result is paged.
+     * Search for all lectures fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged.
      *
      * @param search The search query defining the search term and the size of the returned page
      * @param user   The user for whom to fetch all available lectures
      * @return A wrapper object containing a list of all found lectures and the total number of pages
      */
-    public SearchResultPageDTO<Lecture> getAllOnPageWithSize(final PageableSearchDTO<String> search, final User user) {
+    public SearchResultPageDTO<Lecture> getAllOnPageWithSize(final SearchTermPageableSearchDTO<String> search, final User user) {
         final var pageable = PageUtil.createDefaultPageRequest(search, PageUtil.ColumnMapping.LECTURE);
         final var searchTerm = search.getSearchTerm();
         final Page<Lecture> lecturePage;

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingExerciseService.java
@@ -17,8 +17,8 @@ import de.tum.in.www1.artemis.repository.ModelClusterRepository;
 import de.tum.in.www1.artemis.repository.ModelElementRepository;
 import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;
 import de.tum.in.www1.artemis.service.messaging.InstanceMessageSendService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
 
 @Profile(PROFILE_CORE)
@@ -45,7 +45,7 @@ public class ModelingExerciseService {
     }
 
     /**
-     * Search for all modeling exercises fitting a {@link PageableSearchDTO search query}. The result is paged,
+     * Search for all modeling exercises fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged,
      * meaning that there is only a predefined portion of the result returned to the user, so that the server doesn't
      * have to send hundreds/thousands of exercises if there are that many in Artemis.
      *
@@ -55,7 +55,7 @@ public class ModelingExerciseService {
      * @param user           The user for whom to fetch all available exercises
      * @return A wrapper object containing a list of all found exercises and the total number of pages
      */
-    public SearchResultPageDTO<ModelingExercise> getAllOnPageWithSize(final PageableSearchDTO<String> search, final boolean isCourseFilter, final boolean isExamFilter,
+    public SearchResultPageDTO<ModelingExercise> getAllOnPageWithSize(final SearchTermPageableSearchDTO<String> search, final boolean isCourseFilter, final boolean isExamFilter,
             final User user) {
         if (!isCourseFilter && !isExamFilter) {
             return new SearchResultPageDTO<>(Collections.emptyList(), 0);

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
@@ -34,8 +34,8 @@ import de.tum.in.www1.artemis.domain.quiz.*;
 import de.tum.in.www1.artemis.exception.FilePathParsingException;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.scheduled.cache.quiz.QuizScheduleService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
 
@@ -196,7 +196,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
     }
 
     /**
-     * Search for all quiz exercises fitting a {@link PageableSearchDTO search query}. The result is paged,
+     * Search for all quiz exercises fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged,
      * meaning that there is only a predefined portion of the result returned to the user, so that the server doesn't
      * have to send hundreds/thousands of exercises if there are that many in Artemis.
      *
@@ -206,7 +206,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
      * @param user           The user for whom to fetch all available exercises
      * @return A wrapper object containing a list of all found exercises and the total number of pages
      */
-    public SearchResultPageDTO<QuizExercise> getAllOnPageWithSize(final PageableSearchDTO<String> search, final Boolean isCourseFilter, final Boolean isExamFilter,
+    public SearchResultPageDTO<QuizExercise> getAllOnPageWithSize(final SearchTermPageableSearchDTO<String> search, final Boolean isCourseFilter, final Boolean isExamFilter,
             final User user) {
         if (!isCourseFilter && !isExamFilter) {
             return new SearchResultPageDTO<>(Collections.emptyList(), 0);

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
@@ -23,9 +23,9 @@ import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.connectors.athena.AthenaSubmissionSelectionService;
 import de.tum.in.www1.artemis.service.exam.ExamDateService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SubmissionWithComplaintDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
@@ -771,7 +771,7 @@ public class SubmissionService {
     }
 
     /**
-     * Search for all submissions fitting a {@link PageableSearchDTO search query}. The result is paged,
+     * Search for all submissions fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged,
      * meaning that there is only a predefined portion of the result returned to the user, so that the server doesn't
      * have to send hundreds/thousands of submissions if there are that many in Artemis.
      *
@@ -779,7 +779,7 @@ public class SubmissionService {
      * @param exerciseId Id of the exercise the submissions belongs to
      * @return A wrapper object containing a list of all found submissions and the total number of pages
      */
-    public SearchResultPageDTO<Submission> getSubmissionsOnPageWithSize(PageableSearchDTO<String> search, Long exerciseId) {
+    public SearchResultPageDTO<Submission> getSubmissionsOnPageWithSize(SearchTermPageableSearchDTO<String> search, Long exerciseId) {
         final var pageable = PageUtil.createDefaultPageRequest(search, PageUtil.ColumnMapping.STUDENT_PARTICIPATION);
         String searchTerm = search.getSearchTerm();
         Page<StudentParticipation> studentParticipationPage = studentParticipationRepository.findAllWithEagerSubmissionsAndEagerResultsByExerciseId(exerciseId, searchTerm,

--- a/src/main/java/de/tum/in/www1/artemis/service/TextExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextExerciseService.java
@@ -13,8 +13,8 @@ import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.service.messaging.InstanceMessageSendService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
 
 @Profile(PROFILE_CORE)
@@ -35,7 +35,7 @@ public class TextExerciseService {
     }
 
     /**
-     * Search for all text exercises fitting a {@link PageableSearchDTO search query}. The result is paged,
+     * Search for all text exercises fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged,
      * meaning that there is only a predefined portion of the result returned to the user, so that the server doesn't
      * have to send hundreds/thousands of exercises if there are that many in Artemis.
      *
@@ -45,7 +45,7 @@ public class TextExerciseService {
      * @param user           The user for whom to fetch all available exercises
      * @return A wrapper object containing a list of all found exercises and the total number of pages
      */
-    public SearchResultPageDTO<TextExercise> getAllOnPageWithSize(final PageableSearchDTO<String> search, final boolean isCourseFilter, final boolean isExamFilter,
+    public SearchResultPageDTO<TextExercise> getAllOnPageWithSize(final SearchTermPageableSearchDTO<String> search, final boolean isCourseFilter, final boolean isExamFilter,
             final User user) {
         if (!isCourseFilter && !isExamFilter) {
             return new SearchResultPageDTO<>(Collections.emptyList(), 0);

--- a/src/main/java/de/tum/in/www1/artemis/service/competency/CompetencyService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/competency/CompetencyService.java
@@ -25,6 +25,7 @@ import de.tum.in.www1.artemis.web.rest.dto.*;
 import de.tum.in.www1.artemis.web.rest.dto.competency.CompetencyRelationDTO;
 import de.tum.in.www1.artemis.web.rest.dto.competency.CompetencyWithTailRelationDTO;
 import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.CompetencyPageableSearchDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
 
 /**
@@ -77,13 +78,13 @@ public class CompetencyService {
     }
 
     /**
-     * Search for all competencies fitting a {@link PageableSearchDTO search query}. The result is paged.
+     * Search for all competencies fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged.
      *
      * @param search The search query defining the search term and the size of the returned page
      * @param user   The user for whom to the competencies
      * @return A wrapper object containing a list of all found competencies and the total number of pages
      */
-    public SearchResultPageDTO<Competency> getAllOnPageWithSize(final PageableSearchDTO<String> search, final User user) {
+    public SearchResultPageDTO<Competency> getAllOnPageWithSize(final SearchTermPageableSearchDTO<String> search, final User user) {
         final var pageable = PageUtil.createDefaultPageRequest(search, PageUtil.ColumnMapping.COMPETENCY);
         final var searchTerm = search.getSearchTerm();
         final Page<Competency> competencyPage;

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -105,11 +105,11 @@ import de.tum.in.www1.artemis.web.rest.dto.BonusSourceResultDTO;
 import de.tum.in.www1.artemis.web.rest.dto.DueDateStat;
 import de.tum.in.www1.artemis.web.rest.dto.ExamChecklistDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ExamScoresDTO;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 import de.tum.in.www1.artemis.web.rest.dto.StatsForDashboardDTO;
 import de.tum.in.www1.artemis.web.rest.dto.StudentExamWithGradeDTO;
 import de.tum.in.www1.artemis.web.rest.dto.TutorLeaderboardDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
@@ -1354,7 +1354,7 @@ public class ExamService {
     }
 
     /**
-     * Search for all exams fitting a {@link PageableSearchDTO search query}. The result is paged,
+     * Search for all exams fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged,
      * meaning that there is only a predefined portion of the result returned to the user, so that the server doesn't
      * have to send hundreds/thousands of exams if there are that many in Artemis.
      *
@@ -1363,7 +1363,7 @@ public class ExamService {
      * @param withExercises If only exams with exercises should be searched
      * @return A wrapper object containing a list of all found exercises and the total number of pages
      */
-    public SearchResultPageDTO<Exam> getAllOnPageWithSize(final PageableSearchDTO<String> search, final User user, final boolean withExercises) {
+    public SearchResultPageDTO<Exam> getAllOnPageWithSize(final SearchTermPageableSearchDTO<String> search, final User user, final boolean withExercises) {
         final var pageable = PageUtil.createDefaultPageRequest(search, PageUtil.ColumnMapping.EXAM);
         final var searchTerm = search.getSearchTerm();
         final Page<Exam> examPage;

--- a/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathService.java
@@ -19,11 +19,11 @@ import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.competency.*;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.competency.CompetencyProgressService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 import de.tum.in.www1.artemis.web.rest.dto.competency.LearningPathHealthDTO;
 import de.tum.in.www1.artemis.web.rest.dto.competency.LearningPathInformationDTO;
 import de.tum.in.www1.artemis.web.rest.dto.competency.NgxLearningPathDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
 
 /**
@@ -116,13 +116,13 @@ public class LearningPathService {
     }
 
     /**
-     * Search for all learning paths fitting a {@link PageableSearchDTO search query}. The result is paged.
+     * Search for all learning paths fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged.
      *
      * @param search the search query defining the search term and the size of the returned page
      * @param course the course the learning paths are linked to
      * @return A wrapper object containing a list of all found learning paths and the total number of pages
      */
-    public SearchResultPageDTO<LearningPathInformationDTO> getAllOfCourseOnPageWithSize(@NotNull PageableSearchDTO<String> search, @NotNull Course course) {
+    public SearchResultPageDTO<LearningPathInformationDTO> getAllOfCourseOnPageWithSize(@NotNull SearchTermPageableSearchDTO<String> search, @NotNull Course course) {
         final var pageable = PageUtil.createDefaultPageRequest(search, PageUtil.ColumnMapping.LEARNING_PATH);
         final var searchTerm = search.getSearchTerm();
         final Page<LearningPath> learningPathPage = learningPathRepository.findByLoginOrNameInCourse(searchTerm, course.getId(), pageable);

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -57,8 +57,8 @@ import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationScheduleService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationService;
 import de.tum.in.www1.artemis.service.util.structureoraclegenerator.OracleGenerator;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 import de.tum.in.www1.artemis.web.rest.util.PageUtil;
@@ -764,7 +764,7 @@ public class ProgrammingExerciseService {
     }
 
     /**
-     * Search for all programming exercises fitting a {@link PageableSearchDTO search query}. The result is paged,
+     * Search for all programming exercises fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged,
      * meaning that there is only a predefined portion of the result returned to the user, so that the server doesn't
      * have to send hundreds/thousands of exercises if there are that many in Artemis.
      *
@@ -774,7 +774,7 @@ public class ProgrammingExerciseService {
      * @param user           The user for whom to fetch all available exercises
      * @return A wrapper object containing a list of all found exercises and the total number of pages
      */
-    public SearchResultPageDTO<ProgrammingExercise> getAllOnPageWithSize(final PageableSearchDTO<String> search, final boolean isCourseFilter, final boolean isExamFilter,
+    public SearchResultPageDTO<ProgrammingExercise> getAllOnPageWithSize(final SearchTermPageableSearchDTO<String> search, final boolean isCourseFilter, final boolean isExamFilter,
             final User user) {
         if (!isCourseFilter && !isExamFilter) {
             return new SearchResultPageDTO<>(Collections.emptyList(), 0);
@@ -795,7 +795,7 @@ public class ProgrammingExerciseService {
      * @param programmingLanguage The result will only include exercises in this language
      * @return A wrapper object containing a list of all found exercises and the total number of pages
      */
-    public SearchResultPageDTO<ProgrammingExercise> getAllWithSCAOnPageWithSize(PageableSearchDTO<String> search, boolean isCourseFilter, boolean isExamFilter,
+    public SearchResultPageDTO<ProgrammingExercise> getAllWithSCAOnPageWithSize(SearchTermPageableSearchDTO<String> search, boolean isCourseFilter, boolean isExamFilter,
             ProgrammingLanguage programmingLanguage, User user) {
         if (!isCourseFilter && !isExamFilter) {
             return new SearchResultPageDTO<>(Collections.emptyList(), 0);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CompetencyResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CompetencyResource.java
@@ -31,10 +31,10 @@ import de.tum.in.www1.artemis.service.competency.CompetencyService;
 import de.tum.in.www1.artemis.service.iris.session.IrisCompetencyGenerationSessionService;
 import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 import de.tum.in.www1.artemis.web.rest.dto.CourseCompetencyProgressDTO;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 import de.tum.in.www1.artemis.web.rest.dto.competency.CompetencyWithTailRelationDTO;
 import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.CompetencyPageableSearchDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
@@ -115,7 +115,7 @@ public class CompetencyResource {
      */
     @GetMapping("competencies")
     @EnforceAtLeastEditor
-    public ResponseEntity<SearchResultPageDTO<Competency>> getAllCompetenciesOnPage(PageableSearchDTO<String> search) {
+    public ResponseEntity<SearchResultPageDTO<Competency>> getAllCompetenciesOnPage(SearchTermPageableSearchDTO<String> search) {
         final var user = userRepository.getUserWithGroupsAndAuthorities();
         return ResponseEntity.ok(competencyService.getAllOnPageWithSize(search, user));
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -61,6 +61,7 @@ import de.tum.in.www1.artemis.web.rest.dto.CourseManagementDetailViewDTO;
 import de.tum.in.www1.artemis.web.rest.dto.CourseManagementOverviewStatisticsDTO;
 import de.tum.in.www1.artemis.web.rest.dto.OnlineCourseDTO;
 import de.tum.in.www1.artemis.web.rest.dto.StatsForDashboardDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.user.UserNameAndLoginDTO;
 import de.tum.in.www1.artemis.web.rest.errors.*;
 import tech.jhipster.web.util.PaginationUtil;
@@ -417,7 +418,7 @@ public class CourseResource {
      */
     @GetMapping("courses/for-import")
     @EnforceAtLeastInstructor
-    public ResponseEntity<SearchResultPageDTO<CourseForImportDTO>> getCoursesForImport(PageableSearchDTO<String> search) {
+    public ResponseEntity<SearchResultPageDTO<CourseForImportDTO>> getCoursesForImport(SearchTermPageableSearchDTO<String> search) {
         log.debug("REST request to get a list of courses for import.");
         User user = userRepository.getUserWithGroupsAndAuthorities();
         var coursePage = courseService.getAllOnPageWithSize(search, user);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -51,6 +51,7 @@ import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
 import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 import de.tum.in.www1.artemis.web.rest.dto.*;
 import de.tum.in.www1.artemis.web.rest.dto.examevent.ExamWideAnnouncementEventDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.*;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 import io.swagger.annotations.ApiParam;
@@ -509,7 +510,7 @@ public class ExamResource {
      */
     @GetMapping("exams")
     @EnforceAtLeastEditor
-    public ResponseEntity<SearchResultPageDTO<Exam>> getAllExamsOnPage(@RequestParam(defaultValue = "false") boolean withExercises, PageableSearchDTO<String> search) {
+    public ResponseEntity<SearchResultPageDTO<Exam>> getAllExamsOnPage(@RequestParam(defaultValue = "false") boolean withExercises, SearchTermPageableSearchDTO<String> search) {
         final var user = userRepository.getUserWithGroupsAndAuthorities();
         return ResponseEntity.ok(examService.getAllOnPageWithSize(search, user, withExercises));
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -32,9 +32,9 @@ import de.tum.in.www1.artemis.service.feature.Feature;
 import de.tum.in.www1.artemis.service.feature.FeatureToggle;
 import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationScheduleService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SubmissionExportOptionsDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
@@ -216,7 +216,7 @@ public class FileUploadExerciseResource {
      */
     @GetMapping("file-upload-exercises")
     @EnforceAtLeastEditor
-    public ResponseEntity<SearchResultPageDTO<FileUploadExercise>> getAllExercisesOnPage(PageableSearchDTO<String> search,
+    public ResponseEntity<SearchResultPageDTO<FileUploadExercise>> getAllExercisesOnPage(SearchTermPageableSearchDTO<String> search,
             @RequestParam(defaultValue = "true") Boolean isCourseFilter, @RequestParam(defaultValue = "true") Boolean isExamFilter) {
         final var user = userRepository.getUserWithGroupsAndAuthorities();
         return ResponseEntity.ok(fileUploadExerciseService.getAllOnPageWithSize(search, isCourseFilter, isExamFilter, user));

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/GradingScaleResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/GradingScaleResource.java
@@ -27,8 +27,8 @@ import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastInstructor;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.GradingScaleService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
@@ -112,7 +112,7 @@ public class GradingScaleResource {
      */
     @GetMapping("grading-scales")
     @EnforceAtLeastInstructor
-    public ResponseEntity<SearchResultPageDTO<GradingScale>> getAllGradingScalesInInstructorGroupOnPage(PageableSearchDTO<String> search) {
+    public ResponseEntity<SearchResultPageDTO<GradingScale>> getAllGradingScalesInInstructorGroupOnPage(SearchTermPageableSearchDTO<String> search) {
         final var user = userRepository.getUserWithGroupsAndAuthorities();
         return ResponseEntity.ok(gradingScaleService.getAllOnPageWithSize(search, user));
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LearningPathResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LearningPathResource.java
@@ -26,9 +26,9 @@ import de.tum.in.www1.artemis.service.competency.CompetencyProgressService;
 import de.tum.in.www1.artemis.service.feature.Feature;
 import de.tum.in.www1.artemis.service.feature.FeatureToggle;
 import de.tum.in.www1.artemis.service.learningpath.LearningPathService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 import de.tum.in.www1.artemis.web.rest.dto.competency.*;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 
 @Profile(PROFILE_CORE)
@@ -110,7 +110,7 @@ public class LearningPathResource {
     @GetMapping("courses/{courseId}/learning-paths")
     @FeatureToggle(Feature.LearningPaths)
     @EnforceAtLeastInstructor
-    public ResponseEntity<SearchResultPageDTO<LearningPathInformationDTO>> getLearningPathsOnPage(@PathVariable long courseId, PageableSearchDTO<String> search) {
+    public ResponseEntity<SearchResultPageDTO<LearningPathInformationDTO>> getLearningPathsOnPage(@PathVariable long courseId, SearchTermPageableSearchDTO<String> search) {
         log.debug("REST request to get learning paths for course with id: {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
@@ -35,8 +35,8 @@ import de.tum.in.www1.artemis.service.ExerciseService;
 import de.tum.in.www1.artemis.service.LectureImportService;
 import de.tum.in.www1.artemis.service.LectureService;
 import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
@@ -145,7 +145,7 @@ public class LectureResource {
      */
     @GetMapping("lectures")
     @EnforceAtLeastEditor
-    public ResponseEntity<SearchResultPageDTO<Lecture>> getAllLecturesOnPage(PageableSearchDTO<String> search) {
+    public ResponseEntity<SearchResultPageDTO<Lecture>> getAllLecturesOnPage(SearchTermPageableSearchDTO<String> search) {
         final var user = userRepository.getUserWithGroupsAndAuthorities();
         return ResponseEntity.ok(lectureService.getAllOnPageWithSize(search, user));
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -36,9 +36,9 @@ import de.tum.in.www1.artemis.service.notifications.GroupNotificationScheduleSer
 import de.tum.in.www1.artemis.service.plagiarism.PlagiarismDetectionConfigHelper;
 import de.tum.in.www1.artemis.service.plagiarism.PlagiarismDetectionService;
 import de.tum.in.www1.artemis.service.util.TimeLogUtil;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SubmissionExportOptionsDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.plagiarism.PlagiarismResultDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.ConflictException;
@@ -169,7 +169,7 @@ public class ModelingExerciseResource {
      */
     @GetMapping("modeling-exercises")
     @EnforceAtLeastEditor
-    public ResponseEntity<SearchResultPageDTO<ModelingExercise>> getAllExercisesOnPage(PageableSearchDTO<String> search,
+    public ResponseEntity<SearchResultPageDTO<ModelingExercise>> getAllExercisesOnPage(SearchTermPageableSearchDTO<String> search,
             @RequestParam(defaultValue = "true") boolean isCourseFilter, @RequestParam(defaultValue = "true") boolean isExamFilter) {
         final var user = userRepository.getUserWithGroupsAndAuthorities();
         return ResponseEntity.ok(modelingExerciseService.getAllOnPageWithSize(search, isCourseFilter, isExamFilter, user));

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -44,9 +44,9 @@ import de.tum.in.www1.artemis.service.messaging.InstanceMessageSendService;
 import de.tum.in.www1.artemis.service.plagiarism.PlagiarismDetectionConfigHelper;
 import de.tum.in.www1.artemis.service.programming.*;
 import de.tum.in.www1.artemis.web.rest.dto.BuildLogStatisticsDTO;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ProgrammingExerciseResetOptionsDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.ConflictException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
@@ -590,7 +590,7 @@ public class ProgrammingExerciseResource {
      */
     @GetMapping(PROGRAMMING_EXERCISES)
     @EnforceAtLeastEditor
-    public ResponseEntity<SearchResultPageDTO<ProgrammingExercise>> getAllExercisesOnPage(PageableSearchDTO<String> search,
+    public ResponseEntity<SearchResultPageDTO<ProgrammingExercise>> getAllExercisesOnPage(SearchTermPageableSearchDTO<String> search,
             @RequestParam(defaultValue = "true") boolean isCourseFilter, @RequestParam(defaultValue = "true") boolean isExamFilter) {
         final var user = userRepository.getUserWithGroupsAndAuthorities();
         return ResponseEntity.ok(programmingExerciseService.getAllOnPageWithSize(search, isCourseFilter, isExamFilter, user));
@@ -608,7 +608,7 @@ public class ProgrammingExerciseResource {
      */
     @GetMapping(PROGRAMMING_EXERCISES + "/with-sca")
     @EnforceAtLeastEditor
-    public ResponseEntity<SearchResultPageDTO<ProgrammingExercise>> getAllExercisesWithSCAOnPage(PageableSearchDTO<String> search,
+    public ResponseEntity<SearchResultPageDTO<ProgrammingExercise>> getAllExercisesWithSCAOnPage(SearchTermPageableSearchDTO<String> search,
             @RequestParam(defaultValue = "true") boolean isCourseFilter, @RequestParam(defaultValue = "true") boolean isExamFilter,
             @RequestParam ProgrammingLanguage programmingLanguage) {
         User user = userRepository.getUserWithGroupsAndAuthorities();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -47,9 +47,9 @@ import de.tum.in.www1.artemis.service.metis.conversation.ChannelService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationScheduleService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationService;
 import de.tum.in.www1.artemis.service.scheduled.cache.quiz.QuizScheduleService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.QuizBatchJoinDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
@@ -655,8 +655,8 @@ public class QuizExerciseResource {
      */
     @GetMapping("quiz-exercises")
     @EnforceAtLeastEditor
-    public ResponseEntity<SearchResultPageDTO<QuizExercise>> getAllExercisesOnPage(PageableSearchDTO<String> search, @RequestParam(defaultValue = "true") boolean isCourseFilter,
-            @RequestParam(defaultValue = "true") boolean isExamFilter) {
+    public ResponseEntity<SearchResultPageDTO<QuizExercise>> getAllExercisesOnPage(SearchTermPageableSearchDTO<String> search,
+            @RequestParam(defaultValue = "true") boolean isCourseFilter, @RequestParam(defaultValue = "true") boolean isExamFilter) {
         final var user = userRepository.getUserWithGroupsAndAuthorities();
         return ResponseEntity.ok(quizExerciseService.getAllOnPageWithSize(search, isCourseFilter, isExamFilter, user));
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/SubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/SubmissionResource.java
@@ -25,6 +25,7 @@ import de.tum.in.www1.artemis.service.BuildLogEntryService;
 import de.tum.in.www1.artemis.service.ResultService;
 import de.tum.in.www1.artemis.service.SubmissionService;
 import de.tum.in.www1.artemis.web.rest.dto.*;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
@@ -200,7 +201,7 @@ public class SubmissionResource {
      */
     @GetMapping("exercises/{exerciseId}/submissions-for-import")
     @EnforceAtLeastInstructor
-    public ResponseEntity<SearchResultPageDTO<Submission>> getSubmissionsOnPageWithSize(@PathVariable Long exerciseId, PageableSearchDTO<String> search) {
+    public ResponseEntity<SearchResultPageDTO<Submission>> getSubmissionsOnPageWithSize(@PathVariable Long exerciseId, SearchTermPageableSearchDTO<String> search) {
         log.debug("REST request to get all Submissions for import : {}", exerciseId);
 
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -42,9 +42,9 @@ import de.tum.in.www1.artemis.service.notifications.GroupNotificationScheduleSer
 import de.tum.in.www1.artemis.service.plagiarism.PlagiarismDetectionConfigHelper;
 import de.tum.in.www1.artemis.service.plagiarism.PlagiarismDetectionService;
 import de.tum.in.www1.artemis.service.util.TimeLogUtil;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SubmissionExportOptionsDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.plagiarism.PlagiarismResultDTO;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
@@ -416,8 +416,8 @@ public class TextExerciseResource {
      */
     @GetMapping("text-exercises")
     @EnforceAtLeastEditor
-    public ResponseEntity<SearchResultPageDTO<TextExercise>> getAllExercisesOnPage(PageableSearchDTO<String> search, @RequestParam(defaultValue = "true") boolean isCourseFilter,
-            @RequestParam(defaultValue = "true") boolean isExamFilter) {
+    public ResponseEntity<SearchResultPageDTO<TextExercise>> getAllExercisesOnPage(SearchTermPageableSearchDTO<String> search,
+            @RequestParam(defaultValue = "true") boolean isCourseFilter, @RequestParam(defaultValue = "true") boolean isExamFilter) {
         final var user = userRepository.getUserWithGroupsAndAuthorities();
         return ResponseEntity.ok(textExerciseService.getAllOnPageWithSize(search, isCourseFilter, isExamFilter, user));
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminUserResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminUserResource.java
@@ -30,7 +30,7 @@ import de.tum.in.www1.artemis.service.dto.UserDTO;
 import de.tum.in.www1.artemis.service.ldap.LdapUserService;
 import de.tum.in.www1.artemis.service.user.UserCreationService;
 import de.tum.in.www1.artemis.service.user.UserService;
-import de.tum.in.www1.artemis.web.rest.dto.UserPageableSearchDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.UserPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.EmailAlreadyUsedException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/SearchResultPageDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/SearchResultPageDTO.java
@@ -5,11 +5,13 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
+
 /**
  * Wrapper for a search result which is paged <br>
  *
  * @see org.springframework.data.domain.Pageable
- * @see PageableSearchDTO
+ * @see SearchTermPageableSearchDTO
  * @param <T>
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/pageablesearch/CompetencyPageableSearchDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/pageablesearch/CompetencyPageableSearchDTO.java
@@ -8,7 +8,7 @@ import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
  *
  * @see SearchResultPageDTO
  */
-public class CompetencyPageableSearchDTO extends BasePageableSearchDTO<String> {
+public class CompetencyPageableSearchDTO extends PageableSearchDTO<String> {
 
     /**
      * The search terms

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/pageablesearch/PageableSearchDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/pageablesearch/PageableSearchDTO.java
@@ -3,15 +3,13 @@ package de.tum.in.www1.artemis.web.rest.dto.pageablesearch;
 import de.tum.in.www1.artemis.domain.enumeration.SortingOrder;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 
-// TODO (follow-up, as it changes 40+ files) rename this, move & rename PageableSearchDTO, move UserPageableSearchDTO.
-
 /**
  * Wrapper for a generic search for any list of entities. The result should be paged,
  * meaning that it only contains a predefined number of elements in order to not fetch and return too many.
  *
  * @see SearchResultPageDTO
  */
-public class BasePageableSearchDTO<T> {
+public class PageableSearchDTO<T> {
 
     /**
      * The number of the page to return

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/pageablesearch/SearchTermPageableSearchDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/pageablesearch/SearchTermPageableSearchDTO.java
@@ -1,8 +1,8 @@
-package de.tum.in.www1.artemis.web.rest.dto;
+package de.tum.in.www1.artemis.web.rest.dto.pageablesearch;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.BasePageableSearchDTO;
+import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 
 /**
  * Wrapper for a generic search for any list of entities matching a given search term. The result should be paged,
@@ -12,7 +12,7 @@ import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.BasePageableSearchDTO;
  * @see SearchResultPageDTO
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class PageableSearchDTO<T> extends BasePageableSearchDTO<T> {
+public class SearchTermPageableSearchDTO<T> extends PageableSearchDTO<T> {
 
     /**
      * The string to search for

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/pageablesearch/UserPageableSearchDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/pageablesearch/UserPageableSearchDTO.java
@@ -1,4 +1,4 @@
-package de.tum.in.www1.artemis.web.rest.dto;
+package de.tum.in.www1.artemis.web.rest.dto.pageablesearch;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -6,7 +6,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class UserPageableSearchDTO extends PageableSearchDTO<String> {
+public class UserPageableSearchDTO extends SearchTermPageableSearchDTO<String> {
 
     /**
      * Set of authorities users need to match.

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/util/PageUtil.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/util/PageUtil.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
 import de.tum.in.www1.artemis.domain.enumeration.SortingOrder;
-import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.BasePageableSearchDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.PageableSearchDTO;
 
 public class PageUtil {
 
@@ -83,7 +83,7 @@ public class PageUtil {
     }
 
     @NotNull
-    public static PageRequest createDefaultPageRequest(BasePageableSearchDTO<String> search, ColumnMapping columnMapping) {
+    public static PageRequest createDefaultPageRequest(PageableSearchDTO<String> search, ColumnMapping columnMapping) {
         var sortOptions = Sort.by(columnMapping.getMappedColumnName(search.getSortedColumn()));
         sortOptions = search.getSortingOrder() == SortingOrder.ASCENDING ? sortOptions.ascending() : sortOptions.descending();
         return PageRequest.of(search.getPage() - 1, search.getPageSize(), sortOptions);

--- a/src/main/webapp/app/course/competencies/competency-paging.service.ts
+++ b/src/main/webapp/app/course/competencies/competency-paging.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Competency } from 'app/entities/competency.model';
 import { PagingService } from 'app/exercises/shared/manage/paging.service';
-import { PageableSearch, SearchResult } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch } from 'app/shared/table/pageable-table';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -16,7 +16,7 @@ export class CompetencyPagingService extends PagingService<Competency> {
         super();
     }
 
-    override search(pageable: PageableSearch): Observable<EntityResponseType> {
+    override search(pageable: SearchTermPageableSearch): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
         return this.http.get(`${this.resourceUrl}`, { params, observe: 'response' }).pipe(map((resp: HttpResponse<SearchResult<Competency>>) => resp && resp.body!));
     }

--- a/src/main/webapp/app/course/competencies/import-competencies/competency-table.component.ts
+++ b/src/main/webapp/app/course/competencies/import-competencies/competency-table.component.ts
@@ -1,6 +1,6 @@
 import { Component, ContentChild, EventEmitter, Input, OnInit, Output, TemplateRef } from '@angular/core';
 import { faSort } from '@fortawesome/free-solid-svg-icons';
-import { BasePageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
+import { PageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
 import { Competency } from 'app/entities/competency.model';
 
 @Component({
@@ -9,10 +9,10 @@ import { Competency } from 'app/entities/competency.model';
 })
 export class CompetencyTableComponent implements OnInit {
     @Input() content: SearchResult<Competency>;
-    @Input() search: BasePageableSearch;
+    @Input() search: PageableSearch;
     @Input() displayPagination = true;
 
-    @Output() searchChange = new EventEmitter<BasePageableSearch>();
+    @Output() searchChange = new EventEmitter<PageableSearch>();
 
     @ContentChild(TemplateRef) buttonsTemplate: TemplateRef<any>;
 

--- a/src/main/webapp/app/course/competencies/import-competencies/import-competencies.component.ts
+++ b/src/main/webapp/app/course/competencies/import-competencies/import-competencies.component.ts
@@ -9,7 +9,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { onError } from 'app/shared/util/global.utils';
 import { AlertService } from 'app/core/util/alert.service';
 import { Competency } from 'app/entities/competency.model';
-import { BasePageableSearch, CompetencyFilter, CompetencyPageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
+import { CompetencyFilter, CompetencyPageableSearch, PageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
 import { SortService } from 'app/shared/service/sort.service';
 
 @Component({
@@ -33,7 +33,7 @@ export class ImportCompetenciesComponent implements OnInit, ComponentCanDeactiva
         semester: '',
         title: '',
     };
-    search: BasePageableSearch = {
+    search: PageableSearch = {
         page: 1,
         pageSize: 10,
         sortingOrder: SortingOrder.DESCENDING,
@@ -41,7 +41,7 @@ export class ImportCompetenciesComponent implements OnInit, ComponentCanDeactiva
     };
 
     //search object for the selected competencies. As we don't want pagination page and pageSize are 0
-    selectedCompetenciesSearch: BasePageableSearch = {
+    selectedCompetenciesSearch: PageableSearch = {
         page: 0,
         pageSize: 0,
         sortingOrder: SortingOrder.DESCENDING,
@@ -106,7 +106,7 @@ export class ImportCompetenciesComponent implements OnInit, ComponentCanDeactiva
      *
      * @param search the new pagination/sorting
      */
-    searchChange(search: BasePageableSearch) {
+    searchChange(search: PageableSearch) {
         this.search = search;
         this.performSearch({ ...this.filter, ...this.search });
     }
@@ -132,7 +132,7 @@ export class ImportCompetenciesComponent implements OnInit, ComponentCanDeactiva
      *
      * @param search the PageableSerach object with the updated sorting data
      */
-    sortSelected(search: BasePageableSearch) {
+    sortSelected(search: PageableSearch) {
         this.selectedCompetencies.resultsOnPage = this.sortingService.sortByProperty(
             this.selectedCompetencies.resultsOnPage,
             this.columnMapping[search.sortedColumn],

--- a/src/main/webapp/app/course/competencies/import-competencies/import-competencies.component.ts
+++ b/src/main/webapp/app/course/competencies/import-competencies/import-competencies.component.ts
@@ -9,7 +9,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { onError } from 'app/shared/util/global.utils';
 import { AlertService } from 'app/core/util/alert.service';
 import { Competency } from 'app/entities/competency.model';
-import { CompetencyFilter, CompetencyPageableSearch, PageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
+import { CompetencyFilter, PageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
 import { SortService } from 'app/shared/service/sort.service';
 
 @Component({
@@ -76,7 +76,7 @@ export class ImportCompetenciesComponent implements OnInit, ComponentCanDeactiva
     ngOnInit(): void {
         this.activatedRoute.params.subscribe((params) => {
             this.courseId = Number(params['courseId']);
-            this.performSearch({ ...this.filter, ...this.search });
+            this.performSearch();
             //load competencies of this course to disable their import buttons
             this.competencyService.getAllForCourse(this.courseId).subscribe({
                 next: (res) => {
@@ -98,7 +98,7 @@ export class ImportCompetenciesComponent implements OnInit, ComponentCanDeactiva
         this.filter = filter;
         //navigate back to the first page when the filter changes
         this.search.page = 1;
-        this.performSearch({ ...this.filter, ...this.search });
+        this.performSearch();
     }
 
     /**
@@ -108,17 +108,16 @@ export class ImportCompetenciesComponent implements OnInit, ComponentCanDeactiva
      */
     searchChange(search: PageableSearch) {
         this.search = search;
-        this.performSearch({ ...this.filter, ...this.search });
+        this.performSearch();
     }
 
     /**
      * Fetches a page of competencies matching a PageableSearch from the server.
      *
-     * @param search the complete PageableSearch object
      */
-    performSearch(search: CompetencyPageableSearch) {
+    performSearch() {
         this.isLoading = true;
-        this.competencyService.getForImport(search).subscribe({
+        this.competencyService.getForImport({ ...this.filter, ...this.search }).subscribe({
             next: (res) => {
                 this.searchedCompetencies = res;
                 this.isLoading = false;
@@ -130,7 +129,7 @@ export class ImportCompetenciesComponent implements OnInit, ComponentCanDeactiva
     /**
      * Callback that sorts the selected competencies
      *
-     * @param search the PageableSerach object with the updated sorting data
+     * @param search the PageableSearch object with the updated sorting data
      */
     sortSelected(search: PageableSearch) {
         this.selectedCompetencies.resultsOnPage = this.sortingService.sortByProperty(

--- a/src/main/webapp/app/course/course-for-import-dto-paging-service.ts
+++ b/src/main/webapp/app/course/course-for-import-dto-paging-service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { PagingService } from 'app/exercises/shared/manage/paging.service';
-import { PageableSearch, SearchResult } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch } from 'app/shared/table/pageable-table';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { CourseForImportDTO } from 'app/entities/course.model';
@@ -16,7 +16,7 @@ export class CourseForImportDTOPagingService extends PagingService<CourseForImpo
         super();
     }
 
-    override search(pageable: PageableSearch): Observable<EntityResponseType> {
+    override search(pageable: SearchTermPageableSearch): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
         return this.http.get(`${this.resourceUrl}/for-import`, { params, observe: 'response' }).pipe(map((resp: HttpResponse<EntityResponseType>) => resp && resp.body!));
     }

--- a/src/main/webapp/app/course/learning-paths/learning-path-management/learning-path-management.component.ts
+++ b/src/main/webapp/app/course/learning-paths/learning-path-management/learning-path-management.component.ts
@@ -6,7 +6,7 @@ import { debounceTime, finalize, switchMap, tap } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
 import { onError } from 'app/shared/util/global.utils';
 import { AlertService } from 'app/core/util/alert.service';
-import { PageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch, SortingOrder } from 'app/shared/table/pageable-table';
 import { LearningPathPagingService } from 'app/course/learning-paths/learning-path-paging.service';
 import { SortService } from 'app/shared/service/sort.service';
 import { LearningPathInformationDTO } from 'app/entities/competency/learning-path.model';
@@ -34,7 +34,7 @@ export class LearningPathManagementComponent implements OnInit {
 
     searchLoading = false;
     readonly column = TableColumn;
-    state: PageableSearch = {
+    state: SearchTermPageableSearch = {
         page: 1,
         pageSize: 50,
         searchTerm: '',
@@ -192,7 +192,7 @@ export class LearningPathManagementComponent implements OnInit {
         this.sortService.sortByProperty(this.content.resultsOnPage, this.sortedColumn, this.listSorting);
     }
 
-    private setSearchParam(patch: Partial<PageableSearch>): void {
+    private setSearchParam(patch: Partial<SearchTermPageableSearch>): void {
         Object.assign(this.state, patch);
         this.sort.next();
     }

--- a/src/main/webapp/app/course/learning-paths/learning-path-paging.service.ts
+++ b/src/main/webapp/app/course/learning-paths/learning-path-paging.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { PagingService } from 'app/exercises/shared/manage/paging.service';
-import { PageableSearch, SearchResult } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch } from 'app/shared/table/pageable-table';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { LearningPathInformationDTO } from 'app/entities/competency/learning-path.model';
@@ -15,7 +15,7 @@ export class LearningPathPagingService extends PagingService<LearningPathInforma
         super();
     }
 
-    override search(pageable: PageableSearch, options: { courseId: number }): Observable<EntityResponseType> {
+    override search(pageable: SearchTermPageableSearch, options: { courseId: number }): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
         return this.http
             .get(`${this.resourceUrl}/courses/${options.courseId}/learning-paths`, { params, observe: 'response' })

--- a/src/main/webapp/app/exam/manage/exams/exam-import/exam-import-paging.service.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-import/exam-import-paging.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Exam } from 'app/entities/exam.model';
 import { PagingService } from 'app/exercises/shared/manage/paging.service';
-import { PageableSearch, SearchResult } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch } from 'app/shared/table/pageable-table';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -21,7 +21,7 @@ export class ExamImportPagingService extends PagingService<Exam> {
      * @param pageable object specifying search parameters
      * @param options withExercises if only exams with exercises should be included in the results
      */
-    override search(pageable: PageableSearch, options: { withExercises: boolean }): Observable<EntityResponseType> {
+    override search(pageable: SearchTermPageableSearch, options: { withExercises: boolean }): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
         return this.http
             .get(`${ExamImportPagingService.resourceUrl}?withExercises=${options.withExercises}`, { params, observe: 'response' })

--- a/src/main/webapp/app/exercises/shared/example-submission/example-submission-import/example-submission-import-paging.service.ts
+++ b/src/main/webapp/app/exercises/shared/example-submission/example-submission-import/example-submission-import-paging.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Submission } from 'app/entities/submission.model';
 import { PagingService } from 'app/exercises/shared/manage/paging.service';
-import { PageableSearch, SearchResult } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch } from 'app/shared/table/pageable-table';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -21,7 +21,7 @@ export class ExampleSubmissionImportPagingService extends PagingService<Submissi
      * @param pageable   pageable search containing information required for pagination and sorting
      * @param options exerciseId id of exercise which submissions belongs to
      */
-    override search(pageable: PageableSearch, options: { exerciseId: number }): Observable<EntityResponseType> {
+    override search(pageable: SearchTermPageableSearch, options: { exerciseId: number }): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
         return this.http
             .get(`${ExampleSubmissionImportPagingService.resourceUrl}/${options.exerciseId}/submissions-for-import`, { params, observe: 'response' })

--- a/src/main/webapp/app/exercises/shared/manage/exercise-paging.service.ts
+++ b/src/main/webapp/app/exercises/shared/manage/exercise-paging.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Exercise } from 'app/entities/exercise.model';
 import { ProgrammingLanguage } from 'app/entities/programming-exercise.model';
 import { PagingService } from 'app/exercises/shared/manage/paging.service';
-import { PageableSearch, SearchResult } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch } from 'app/shared/table/pageable-table';
 import { Observable, map } from 'rxjs';
 
 export abstract class ExercisePagingService<T extends Exercise> extends PagingService<T> {
@@ -22,7 +22,7 @@ export abstract class ExercisePagingService<T extends Exercise> extends PagingSe
      * - programmingLanguage set to a language if only programming exercises of this language should be included. undefined for other exercise types.
      */
     public override search(
-        pageable: PageableSearch,
+        pageable: SearchTermPageableSearch,
         options: { isCourseFilter: boolean; isExamFilter: boolean; programmingLanguage?: ProgrammingLanguage },
     ): Observable<SearchResult<T>> {
         let params = this.createHttpParams(pageable);

--- a/src/main/webapp/app/exercises/shared/manage/paging.service.ts
+++ b/src/main/webapp/app/exercises/shared/manage/paging.service.ts
@@ -1,9 +1,9 @@
 import { HttpParams } from '@angular/common/http';
-import { PageableSearch, SearchResult } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch } from 'app/shared/table/pageable-table';
 import { Observable } from 'rxjs';
 
 export abstract class PagingService<T> {
-    protected createHttpParams(pageable: PageableSearch): HttpParams {
+    protected createHttpParams(pageable: SearchTermPageableSearch): HttpParams {
         return new HttpParams()
             .set('pageSize', String(pageable.pageSize))
             .set('page', String(pageable.page))
@@ -12,5 +12,5 @@ export abstract class PagingService<T> {
             .set('sortedColumn', pageable.sortedColumn);
     }
 
-    public abstract search(pageable: PageableSearch, options?: object): Observable<SearchResult<T>>;
+    public abstract search(pageable: SearchTermPageableSearch, options?: object): Observable<SearchResult<T>>;
 }

--- a/src/main/webapp/app/grading-system/bonus/bonus.component.ts
+++ b/src/main/webapp/app/grading-system/bonus/bonus.component.ts
@@ -10,7 +10,7 @@ import { GradeStep, GradeStepsDTO } from 'app/entities/grade-step.model';
 import { ButtonSize } from 'app/shared/components/button.component';
 import { Subject, forkJoin, of } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
-import { PageableSearch, SortingOrder } from 'app/shared/table/pageable-table';
+import { SearchTermPageableSearch, SortingOrder } from 'app/shared/table/pageable-table';
 import { GradeEditMode } from 'app/grading-system/base-grading-system/base-grading-system.component';
 import { AlertService } from 'app/core/util/alert.service';
 
@@ -90,7 +90,7 @@ export class BonusComponent implements OnInit {
     bonus = new Bonus();
     hasBonusStrategyWeightMismatch = false;
 
-    private state: PageableSearch = {
+    private state: SearchTermPageableSearch = {
         page: 1,
         pageSize: 100,
         searchTerm: '',

--- a/src/main/webapp/app/grading-system/grading-system.service.ts
+++ b/src/main/webapp/app/grading-system/grading-system.service.ts
@@ -4,7 +4,7 @@ import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { GradeDTO, GradeStep, GradeStepsDTO } from 'app/entities/grade-step.model';
 import { map } from 'rxjs/operators';
-import { PageableSearch, SearchResult } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch } from 'app/shared/table/pageable-table';
 import { captureException } from '@sentry/angular-ivy';
 import { Course } from 'app/entities/course.model';
 
@@ -138,7 +138,7 @@ export class GradingSystemService {
      *
      * @param pageable search, sort and pagination parameters
      */
-    findWithBonusGradeTypeForInstructor(pageable: PageableSearch): Observable<HttpResponse<SearchResult<GradingScale>>> {
+    findWithBonusGradeTypeForInstructor(pageable: SearchTermPageableSearch): Observable<HttpResponse<SearchResult<GradingScale>>> {
         const params = new HttpParams()
             .set('pageSize', String(pageable.pageSize))
             .set('page', String(pageable.page))

--- a/src/main/webapp/app/lecture/lecture-paging.service.ts
+++ b/src/main/webapp/app/lecture/lecture-paging.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Lecture } from 'app/entities/lecture.model';
 import { PagingService } from 'app/exercises/shared/manage/paging.service';
-import { PageableSearch, SearchResult } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch } from 'app/shared/table/pageable-table';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -16,7 +16,7 @@ export class LecturePagingService extends PagingService<Lecture> {
         super();
     }
 
-    override search(pageable: PageableSearch): Observable<EntityResponseType> {
+    override search(pageable: SearchTermPageableSearch): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
         return this.http.get(`${LecturePagingService.resourceUrl}`, { params, observe: 'response' }).pipe(map((resp: HttpResponse<EntityResponseType>) => resp && resp.body!));
     }

--- a/src/main/webapp/app/shared/import/import.component.ts
+++ b/src/main/webapp/app/shared/import/import.component.ts
@@ -5,7 +5,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { PagingService } from 'app/exercises/shared/manage/paging.service';
 import { BaseEntity } from 'app/shared/model/base-entity';
 import { SortService } from 'app/shared/service/sort.service';
-import { PageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch, SortingOrder } from 'app/shared/table/pageable-table';
 import { Subject, debounceTime, switchMap, tap } from 'rxjs';
 
 /**
@@ -24,7 +24,7 @@ export abstract class ImportComponent<T extends BaseEntity> implements OnInit {
     loading = false;
     content: SearchResult<T>;
     total = 0;
-    state: PageableSearch = {
+    state: SearchTermPageableSearch = {
         page: 1,
         pageSize: 10,
         searchTerm: '',
@@ -175,7 +175,7 @@ export abstract class ImportComponent<T extends BaseEntity> implements OnInit {
      */
     protected onSearchResult(): void {}
 
-    protected setSearchParam(patch: Partial<PageableSearch>) {
+    protected setSearchParam(patch: Partial<SearchTermPageableSearch>) {
         Object.assign(this.state, patch);
         this.sort.next();
     }

--- a/src/main/webapp/app/shared/table/pageable-table.ts
+++ b/src/main/webapp/app/shared/table/pageable-table.ts
@@ -11,14 +11,14 @@ export enum SortingOrder {
     DESCENDING = 'DESCENDING',
 }
 
-export interface BasePageableSearch {
+export interface PageableSearch {
     page: number;
     pageSize: number;
     sortingOrder: SortingOrder;
     sortedColumn: string;
 }
 
-export interface PageableSearch extends BasePageableSearch {
+export interface SearchTermPageableSearch extends PageableSearch {
     searchTerm: string;
 }
 
@@ -29,4 +29,4 @@ export interface CompetencyFilter {
     semester: string;
 }
 
-export interface CompetencyPageableSearch extends BasePageableSearch, CompetencyFilter {}
+export interface CompetencyPageableSearch extends PageableSearch, CompetencyFilter {}

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -61,6 +61,7 @@ import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 import de.tum.in.www1.artemis.util.ZipFileTestUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.*;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -1496,7 +1497,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         var exam = ExamFactory.generateExam(course1);
         exam.setTitle(title);
         examRepository.save(exam);
-        final PageableSearchDTO<String> search = pageableSearchUtilService.configureSearch(title);
+        final SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureSearch(title);
         final var result = request.getSearchResult("/api/exams", HttpStatus.OK, Exam.class, pageableSearchUtilService.searchMapping(search));
         assertThat(result.getResultsOnPage()).hasSize(1).containsExactly(exam);
     }
@@ -1508,7 +1509,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         var searchTerm = "A very distinct title that should only ever exist once in the database";
         newExam.setTitle(searchTerm);
         examRepository.save(newExam);
-        final PageableSearchDTO<String> search = pageableSearchUtilService.configureSearch(searchTerm);
+        final SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureSearch(searchTerm);
         final var result = request.getSearchResult("/api/exams?withExercises=true", HttpStatus.OK, Exam.class, pageableSearchUtilService.searchMapping(search));
         List<Exam> foundExams = result.getResultsOnPage();
         assertThat(foundExams).hasSize(1).containsExactly(newExam);
@@ -1524,7 +1525,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         var exam = examUtilService.addExamWithExerciseGroup(course, true);
         exam.setTitle(title);
         examRepository.save(exam);
-        final PageableSearchDTO<String> search = pageableSearchUtilService.configureSearch(title);
+        final SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureSearch(title);
         final var result = request.getSearchResult("/api/exams", HttpStatus.OK, Exam.class, pageableSearchUtilService.searchMapping(search));
         assertThat(result.getResultsOnPage()).hasSize(0);
     }
@@ -1539,7 +1540,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         var exam = examUtilService.addExamWithExerciseGroup(course, true);
         exam.setTitle(title);
         examRepository.save(exam);
-        final PageableSearchDTO<String> search = pageableSearchUtilService.configureSearch(title);
+        final SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureSearch(title);
         final var result = request.getSearchResult("/api/exams", HttpStatus.OK, Exam.class, pageableSearchUtilService.searchMapping(search));
         assertThat(result.getResultsOnPage()).hasSize(1).contains(exam);
     }
@@ -1547,14 +1548,14 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TUTOR")
     void testGetAllExamsOnPage_asTutor_failsWithForbidden() throws Exception {
-        final PageableSearchDTO<String> search = pageableSearchUtilService.configureSearch("");
+        final SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureSearch("");
         request.getSearchResult("/api/exams", HttpStatus.FORBIDDEN, Exam.class, pageableSearchUtilService.searchMapping(search));
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetAllExamsOnPage_asStudent_failsWithForbidden() throws Exception {
-        final PageableSearchDTO<String> search = pageableSearchUtilService.configureSearch("");
+        final SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureSearch("");
         request.getSearchResult("/api/exams", HttpStatus.FORBIDDEN, Exam.class, pageableSearchUtilService.searchMapping(search));
     }
     // </editor-fold>

--- a/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
@@ -21,8 +21,8 @@ import de.tum.in.www1.artemis.exercise.textexercise.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SubmissionVersionDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 
 class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -166,7 +166,7 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest
         TextSubmission submission = ParticipationFactory.generateTextSubmission("submissionText", Language.ENGLISH, true);
         submission = textExerciseUtilService.saveTextSubmission(textExercise, submission, TEST_PREFIX + "student1");
         participationUtilService.addResultToSubmission(submission, AssessmentType.MANUAL, userUtilService.getUserByLogin(TEST_PREFIX + "instructor1"));
-        PageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
+        SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
 
         var resultPage = request.getSearchResult("/api/exercises/" + textExercise.getId() + "/submissions-for-import", HttpStatus.OK, Submission.class,
                 pageableSearchUtilService.searchMapping(search));
@@ -177,7 +177,7 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testGetSubmissionsOnPageWithSize_exerciseNotFound() throws Exception {
         long randomExerciseId = UUID.nameUUIDFromBytes("test".getBytes()).getMostSignificantBits();
-        PageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
+        SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
         request.getSearchResult("/api/exercises/" + randomExerciseId + "/submissions-for-import", HttpStatus.NOT_FOUND, Submission.class,
                 pageableSearchUtilService.searchMapping(search));
     }
@@ -190,7 +190,7 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest
         assertThat(textExercise).isNotNull();
         course.setInstructorGroupName("test");
         courseRepository.save(course);
-        PageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
+        SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
         request.getSearchResult("/api/exercises/" + textExercise.getId() + "/submissions-for-import", HttpStatus.FORBIDDEN, Submission.class,
                 pageableSearchUtilService.searchMapping(search));
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/LectureServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/LectureServiceTest.java
@@ -21,8 +21,8 @@ import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 
 class LectureServiceTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -122,7 +122,7 @@ class LectureServiceTest extends AbstractSpringIntegrationIndependentTest {
         lectureRepository.saveAll(course.getLectures());
         lecture = lectureRepository.findByIdElseThrow(lecture.getId());
 
-        PageableSearchDTO<String> pageable = pageableSearchUtilService.configureLectureSearch(lecture.getTitle());
+        SearchTermPageableSearchDTO<String> pageable = pageableSearchUtilService.configureLectureSearch(lecture.getTitle());
         pageable.setSortedColumn("ID");
         pageable.setPageSize(1);
 
@@ -136,7 +136,7 @@ class LectureServiceTest extends AbstractSpringIntegrationIndependentTest {
     }
 
     private SearchResultPageDTO<Lecture> searchQueryWithUser(String query, User user) {
-        PageableSearchDTO<String> pageable = pageableSearchUtilService.configureLectureSearch(query);
+        SearchTermPageableSearchDTO<String> pageable = pageableSearchUtilService.configureLectureSearch(query);
         return lectureService.getAllOnPageWithSize(pageable, user);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/PageableSearchUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/PageableSearchUtilService.java
@@ -9,9 +9,9 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
 import de.tum.in.www1.artemis.domain.enumeration.SortingOrder;
-import de.tum.in.www1.artemis.web.rest.dto.PageableSearchDTO;
-import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.BasePageableSearchDTO;
 import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.CompetencyPageableSearchDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.PageableSearchDTO;
+import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
 
 /**
  * Service responsible for initializing the database with specific testdata related to searches for use in integration tests.
@@ -25,8 +25,8 @@ public class PageableSearchUtilService {
      * @param searchTerm The searchTerm to use
      * @return The generated PageableSearchDTO
      */
-    public PageableSearchDTO<String> configureSearch(String searchTerm) {
-        final var search = new PageableSearchDTO<String>();
+    public SearchTermPageableSearchDTO<String> configureSearch(String searchTerm) {
+        final var search = new SearchTermPageableSearchDTO<String>();
         search.setPage(1);
         search.setPageSize(10);
         search.setSearchTerm(searchTerm);
@@ -46,8 +46,8 @@ public class PageableSearchUtilService {
      * @param searchTerm The searchTerm to use
      * @return The generated PageableSearchDTO
      */
-    public PageableSearchDTO<String> configureStudentParticipationSearch(String searchTerm) {
-        final var search = new PageableSearchDTO<String>();
+    public SearchTermPageableSearchDTO<String> configureStudentParticipationSearch(String searchTerm) {
+        final var search = new SearchTermPageableSearchDTO<String>();
         search.setPage(1);
         search.setPageSize(10);
         search.setSearchTerm(searchTerm);
@@ -67,8 +67,8 @@ public class PageableSearchUtilService {
      * @param searchTerm The searchTerm to use
      * @return The generated PageableSearchDTO
      */
-    public PageableSearchDTO<String> configureLectureSearch(String searchTerm) {
-        final var search = new PageableSearchDTO<String>();
+    public SearchTermPageableSearchDTO<String> configureLectureSearch(String searchTerm) {
+        final var search = new SearchTermPageableSearchDTO<String>();
         search.setPage(1);
         search.setPageSize(10);
         search.setSearchTerm(searchTerm);
@@ -105,7 +105,7 @@ public class PageableSearchUtilService {
      * @param search The PageableSearchDTO to use
      * @return The generated LinkedMultiValueMap
      */
-    public LinkedMultiValueMap<String, String> searchMapping(BasePageableSearchDTO<String> search) {
+    public LinkedMultiValueMap<String, String> searchMapping(PageableSearchDTO<String> search) {
         final var mapType = new TypeToken<Map<String, String>>() {
         }.getType();
         final var gson = new Gson();

--- a/src/test/javascript/spec/component/bonus/bonus.component.spec.ts
+++ b/src/test/javascript/spec/component/bonus/bonus.component.spec.ts
@@ -8,7 +8,7 @@ import { SafeHtmlPipe } from 'app/shared/pipes/safe-html.pipe';
 import { BonusService, EntityResponseType } from 'app/grading-system/bonus/bonus.service';
 import { GradingSystemService } from 'app/grading-system/grading-system.service';
 import { ModePickerComponent } from 'app/exercises/shared/mode-picker/mode-picker.component';
-import { PageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch, SortingOrder } from 'app/shared/table/pageable-table';
 import { of, throwError } from 'rxjs';
 import { Bonus, BonusExample, BonusStrategy } from 'app/entities/bonus.model';
 import { GradeType, GradingScale } from 'app/entities/grading-scale.model';
@@ -304,7 +304,7 @@ describe('BonusComponent', () => {
         expect(findBonusForExamSpy).toHaveBeenCalledOnce();
         expect(findBonusForExamSpy).toHaveBeenCalledWith(courseId, examId);
 
-        const state: PageableSearch = {
+        const state: SearchTermPageableSearch = {
             page: 1,
             pageSize: 100,
             searchTerm: '',

--- a/src/test/javascript/spec/component/competencies/import/competency-table-stub.component.ts
+++ b/src/test/javascript/spec/component/competencies/import/competency-table-stub.component.ts
@@ -1,4 +1,4 @@
-import { BasePageableSearch, SearchResult } from 'app/shared/table/pageable-table';
+import { PageableSearch, SearchResult } from 'app/shared/table/pageable-table';
 import { Competency } from 'app/entities/competency.model';
 import { Component, ContentChild, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
 
@@ -8,10 +8,10 @@ import { Component, ContentChild, EventEmitter, Input, Output, TemplateRef } fro
 })
 export class CompetencyTableStubComponent {
     @Input() content: SearchResult<Competency>;
-    @Input() search: BasePageableSearch;
+    @Input() search: PageableSearch;
     @Input() displayPagination = true;
 
-    @Output() searchChange = new EventEmitter<BasePageableSearch>();
+    @Output() searchChange = new EventEmitter<PageableSearch>();
 
     @ContentChild(TemplateRef) buttonsTemplate: TemplateRef<any>;
 }

--- a/src/test/javascript/spec/component/competencies/import/import-competencies.component.spec.ts
+++ b/src/test/javascript/spec/component/competencies/import/import-competencies.component.spec.ts
@@ -15,7 +15,7 @@ import { HttpResponse } from '@angular/common/http';
 import { CompetencyTableStubComponent } from './competency-table-stub.component';
 import { CompetencySearchStubComponent } from './competency-search-stub.component';
 import { By } from '@angular/platform-browser';
-import { BasePageableSearch, CompetencyFilter } from 'app/shared/table/pageable-table';
+import { CompetencyFilter, PageableSearch } from 'app/shared/table/pageable-table';
 
 describe('ImportCompetenciesComponent', () => {
     let componentFixture: ComponentFixture<ImportCompetenciesComponent>;
@@ -148,7 +148,7 @@ describe('ImportCompetenciesComponent', () => {
         expect(competencyTables).toHaveLength(2);
         for (const element of competencyTables) {
             const table: CompetencyTableStubComponent = element.componentInstance;
-            table.searchChange.emit({} as BasePageableSearch);
+            table.searchChange.emit({} as PageableSearch);
         }
 
         expect(searchChangeSpy).toHaveBeenCalledOnce();

--- a/src/test/javascript/spec/component/import/exercise-import.component.spec.ts
+++ b/src/test/javascript/spec/component/import/exercise-import.component.spec.ts
@@ -19,7 +19,7 @@ import { ExerciseCourseTitlePipe } from 'app/shared/pipes/exercise-course-title.
 import { SortService } from 'app/shared/service/sort.service';
 import { SortByDirective } from 'app/shared/sort/sort-by.directive';
 import { SortDirective } from 'app/shared/sort/sort.directive';
-import { PageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch, SortingOrder } from 'app/shared/table/pageable-table';
 import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
 import { of } from 'rxjs';
 import { ArtemisTestModule } from '../../test.module';
@@ -36,7 +36,7 @@ describe('ExerciseImportComponent', () => {
     let searchStub: jest.SpyInstance;
     let sortByPropertyStub: jest.SpyInstance;
     let searchResult: SearchResult<Exercise>;
-    let state: PageableSearch;
+    let state: SearchTermPageableSearch;
     let quizExercise: QuizExercise;
 
     beforeEach(() => {

--- a/src/test/javascript/spec/component/import/import.component.spec.ts
+++ b/src/test/javascript/spec/component/import/import.component.spec.ts
@@ -10,7 +10,7 @@ import { BaseEntity } from 'app/shared/model/base-entity';
 import { SortService } from 'app/shared/service/sort.service';
 import { SortByDirective } from 'app/shared/sort/sort-by.directive';
 import { SortDirective } from 'app/shared/sort/sort.directive';
-import { PageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch, SortingOrder } from 'app/shared/table/pageable-table';
 import { MockComponent, MockDirective } from 'ng-mocks';
 import { Subject, of } from 'rxjs';
 import { ArtemisTestModule } from '../../test.module';
@@ -32,7 +32,7 @@ describe('ImportComponent', () => {
     let activeModal: NgbActiveModal;
 
     let searchResult: SearchResult<BaseEntity>;
-    let state: PageableSearch;
+    let state: SearchTermPageableSearch;
 
     const content: BaseEntity = { id: 2 };
 

--- a/src/test/javascript/spec/component/learning-paths/management/learning-path-management.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-paths/management/learning-path-management.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { LearningPathManagementComponent, TableColumn } from 'app/course/learning-paths/learning-path-management/learning-path-management.component';
 import { LearningPathPagingService } from 'app/course/learning-paths/learning-path-paging.service';
 import { SortService } from 'app/shared/service/sort.service';
-import { PageableSearch, SearchResult, SortingOrder } from 'app/shared/table/pageable-table';
+import { SearchResult, SearchTermPageableSearch, SortingOrder } from 'app/shared/table/pageable-table';
 import { LearningPath } from 'app/entities/competency/learning-path.model';
 import { ArtemisTestModule } from '../../../test.module';
 import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
@@ -28,7 +28,7 @@ describe('LearningPathManagementComponent', () => {
     let searchStub: jest.SpyInstance;
     let sortByPropertyStub: jest.SpyInstance;
     let searchResult: SearchResult<LearningPath>;
-    let state: PageableSearch;
+    let state: SearchTermPageableSearch;
     let learningPath: LearningPath;
     let learningPathService: LearningPathService;
     let enableLearningPathsStub: jest.SpyInstance;

--- a/src/test/javascript/spec/service/learning-path-paging.service.spec.ts
+++ b/src/test/javascript/spec/service/learning-path-paging.service.spec.ts
@@ -1,6 +1,6 @@
 import { MockHttpService } from '../helpers/mocks/service/mock-http.service';
 import { LearningPathPagingService } from 'app/course/learning-paths/learning-path-paging.service';
-import { PageableSearch, SortingOrder } from 'app/shared/table/pageable-table';
+import { SearchTermPageableSearch, SortingOrder } from 'app/shared/table/pageable-table';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { TableColumn } from 'app/course/learning-paths/learning-path-management/learning-path-management.component';
 import { ArtemisTestModule } from '../test.module';
@@ -35,7 +35,7 @@ describe('LearningPathPagingService', () => {
             searchTerm: 'initialSearchTerm',
             sortingOrder: SortingOrder.DESCENDING,
             sortedColumn: TableColumn.ID,
-        } as PageableSearch;
+        } as SearchTermPageableSearch;
         learningPathPagingService.search(pageable, { courseId: 1 }).subscribe();
         const params = new HttpParams()
             .set('pageSize', String(pageable.pageSize))


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
PageableSearchDTOs had unintuitive names and were not in the same package.


### Description
- Rename BasePageableSearchDTO -> PageableSearchDTO
- Rename PageableSearchDTO-> SearchTermPageableSearchDTO
- Move SearchTermPageableSearchDTO to pageablesearch package
- Move UserPageableSearchDTO to pageablesearch package
- Rename PageableSearches in the client aswell
- Piggyback: minor refactoring of import-competencies-component (move a parameter to method body)


### Steps for Testing
Prerequisites:
- 1 Instructor/Admin

1. Log in to Artemis
2. Navigate to Course Management -> Competencies -> Import Competencies
3. See that the table gets populated

No further testing is needed as the server-side was auto-refactored by IntelliJ.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
Unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced search functionality across the application by updating the usage of search-related data transfer objects and method signatures to improve semantic clarity and efficiency in course, exercise, and user searches.
- **Tests**
	- Updated test suites to align with the refactored search functionality, ensuring that the application's search capabilities are thoroughly verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->