### PR TITLE
`Programming exercises`: Conditionally show build plans in edit view

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-plans-and-repositories-preview.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-plans-and-repositories-preview.component.html
@@ -42,23 +42,27 @@
                 </ul>
             </div>
         </div>
-        <div class="col-auto rounded pt-1 pb-1 preview-box">
-            <div>
-                <span class="font-weight-bold" jhiTranslate="artemisApp.programmingExercise.preview.buildPlans">Build Plans: </span>
+        @if (!isLocal) {
+            <div class="col-auto rounded pt-1 pb-1 preview-box">
+                <div>
+                    <span class="font-weight-bold" jhiTranslate="artemisApp.programmingExercise.preview.buildPlans">Build Plans: </span>
+                </div>
+                <hr class="pt-0 pb-0 mt-1 mb-1" />
+                <ul>
+                    <li>
+                        <code class="text-white badge bg-primary label-preview"
+                            >{{ getCourseShortName()?.toUpperCase() }}{{ programmingExercise.shortName.toUpperCase() }}-BASE</code
+                        >
+                        <jhi-help-icon text="artemisApp.programmingExercise.preview.templateBuildPlanTooltip" />
+                    </li>
+                    <li>
+                        <code class="text-white badge bg-primary label-preview"
+                            >{{ getCourseShortName()?.toUpperCase() }}{{ programmingExercise.shortName.toUpperCase() }}-SOLUTION</code
+                        >
+                        <jhi-help-icon text="artemisApp.programmingExercise.preview.solutionBuildPlanTooltip" />
+                    </li>
+                </ul>
             </div>
-            <hr class="pt-0 pb-0 mt-1 mb-1" />
-            <ul>
-                <li>
-                    <code class="text-white badge bg-primary label-preview">{{ getCourseShortName()?.toUpperCase() }}{{ programmingExercise.shortName.toUpperCase() }}-BASE</code>
-                    <jhi-help-icon text="artemisApp.programmingExercise.preview.templateBuildPlanTooltip" />
-                </li>
-                <li>
-                    <code class="text-white badge bg-primary label-preview"
-                        >{{ getCourseShortName()?.toUpperCase() }}{{ programmingExercise.shortName.toUpperCase() }}-SOLUTION</code
-                    >
-                    <jhi-help-icon text="artemisApp.programmingExercise.preview.solutionBuildPlanTooltip" />
-                </li>
-            </ul>
-        </div>
+        }
     </div>
 }

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-plans-and-repositories-preview.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-plans-and-repositories-preview.component.ts
@@ -9,6 +9,7 @@ import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 })
 export class ProgrammingExercisePlansAndRepositoriesPreviewComponent {
     @Input() programmingExercise: ProgrammingExercise | null;
+    @Input() isLocal: boolean;
 
     getCourseShortName(): string | undefined {
         if (!this.programmingExercise) {

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -17,6 +17,7 @@
                 [programmingExerciseCreationConfig]="getProgrammingExerciseCreationConfig()"
                 [isExamMode]="isExamMode"
                 [isImport]="isImportFromExistingExercise || isImportFromFile"
+                [isLocal]="isLocal"
             />
             <jhi-programming-exercise-difficulty [programmingExercise]="programmingExercise" [programmingExerciseCreationConfig]="getProgrammingExerciseCreationConfig()" />
             <jhi-programming-exercise-language [programmingExercise]="programmingExercise" [programmingExerciseCreationConfig]="getProgrammingExerciseCreationConfig()" />

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -73,6 +73,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
     isImportFromFile: boolean;
     isEdit: boolean;
     isExamMode: boolean;
+    isLocal: boolean;
     hasUnsavedChanges = false;
     programmingExercise: ProgrammingExercise;
     backupExercise: ProgrammingExercise;
@@ -464,6 +465,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
         this.profileService.getProfileInfo().subscribe((profileInfo) => {
             if (profileInfo?.activeProfiles.includes(PROFILE_LOCALCI)) {
                 this.customBuildPlansSupported = PROFILE_LOCALCI;
+                this.isLocal = true;
             }
             if (profileInfo?.activeProfiles.includes(PROFILE_AEOLUS)) {
                 this.customBuildPlansSupported = PROFILE_AEOLUS;

--- a/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.html
@@ -56,7 +56,7 @@
                 <label class="label-narrow" jhiTranslate="artemisApp.programmingExercise.preview.label"></label>
                 <jhi-help-icon text="artemisApp.programmingExercise.preview.tooltip" />
             </div>
-            <jhi-programming-exercise-plans-and-repositories-preview [programmingExercise]="programmingExercise" />
+            <jhi-programming-exercise-plans-and-repositories-preview [programmingExercise]="programmingExercise" [isLocal]="isLocal" />
             @if (!programmingExerciseCreationConfig.isImportFromExistingExercise && programmingExerciseCreationConfig.auxiliaryRepositoriesSupported) {
                 <div class="form-group">
                     @if (programmingExercise.auxiliaryRepositories && programmingExercise.auxiliaryRepositories.length > 0) {
@@ -122,7 +122,7 @@
                             }
                         </ngb-alert>
                     }
-                    @if (programmingExerciseCreationConfig) {
+                    @if (programmingExerciseCreationConfig && !isLocal) {
                         <ngb-alert [dismissible]="false" [type]="'info'">
                             <span>{{ 'artemisApp.programmingExercise.auxiliaryRepository.warning' | artemisTranslate }}</span>
                         </ngb-alert>

--- a/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.ts
@@ -17,6 +17,7 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
     @Input() isExamMode: boolean;
     @Input() programmingExercise: ProgrammingExercise;
     @Input() programmingExerciseCreationConfig: ProgrammingExerciseCreationConfig;
+    @Input() isLocal: boolean;
 
     @ViewChild(ExerciseTitleChannelNameComponent) exerciseTitleChannelComponent: ExerciseTitleChannelNameComponent;
     @ViewChildren(TableEditableFieldComponent) tableEditableFields?: QueryList<TableEditableFieldComponent>;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
This removes build plan preview and a warning about external vcs auxiliary repositories for the localVSC localCI.

### Steps for Testing
*On TS3 or TS6*
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Open Programming Edit View
3. Verify that there is no build plan in the preview and no alert shown regarding external repositories.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
![image](https://github.com/ls1intum/Artemis/assets/78978542/ba6b78ec-dcc9-4a5b-b6dc-6f56c87aeacc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced conditional rendering for build plans in programming exercises, enhancing the interface based on the user's local environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->