### PR TITLE
`Programming exercises`: Don't show participation buttons if repository is not available

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -240,10 +240,15 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
      * - the participation is initialized (build plan exists, this is always the case during an exam), or
      * - the participation is inactive (build plan cleaned up), but can not be resumed (e.g. because we're after the due date)
      *
+     * for all conditions it is important that the repository is set
+     *
      * For course exercises, an initialized practice participation should only be displayed if it's not possible to start a new graded participation.
      * For exam exercises, only one active participation can exist, so this should be shown.
      */
     public shouldDisplayIDEButtons(): boolean {
+        if (!this.isRepositoryUriSet()) {
+            return false;
+        }
         const shouldPreferPractice = this.participationService.shouldPreferPractice(this.exercise);
         const activePracticeParticipation = this.practiceParticipation?.initializationState === InitializationState.INITIALIZED && (shouldPreferPractice || this.examMode);
         const activeGradedParticipation = this.gradedParticipation?.initializationState === InitializationState.INITIALIZED;
@@ -253,6 +258,16 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
             !isStartExerciseAvailable(this.exercise, this.gradedParticipation);
 
         return activePracticeParticipation || activeGradedParticipation || inactiveGradedParticipation;
+    }
+
+    /**
+     * Returns true if the repository uri of the active participation is set
+     * We don't want to show buttons that would interact with the repository if the repository is not set
+     */
+    private isRepositoryUriSet(): boolean {
+        const participations = this.exercise.studentParticipations ?? [];
+        const activeParticipation: ProgrammingExerciseStudentParticipation = this.participationService.getSpecificStudentParticipation(participations, false) ?? participations[0];
+        return !!activeParticipation?.repositoryUri;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
After our migration from Bitbucket to LocalVC it could happen that some participations have no `repositoryUri`, to counter this and prevent confusion in the UI for students, we don't show buttons related to repositories, if the participation has no repo.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise

1. Log in to Artemis as a student
2. Open a participation of a programming exercise
3. Open your database and find your participation, remove the uri with `update participation set repository_url = NULL where id = <your-participation-id>;`
4. Reload the page, the buttons should be gone, the participation is now also not working anymore, so delete it to have a consistent state of your dev environment.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="610" alt="correct_with_buttons" src="https://github.com/ls1intum/Artemis/assets/16179620/e9ef0ae9-7875-489f-a237-bdb25b8a62c6">
<img width="617" alt="no_buttons" src="https://github.com/ls1intum/Artemis/assets/16179620/65b78e5b-fc9f-4fca-a186-672675da44d3">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the display logic for certain buttons in the exercise details, ensuring they are shown only when relevant information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->