### PR TITLE
`Development`: Improve client test coverage

### DIFF
--- a/src/test/javascript/spec/component/detail-overview-list.component.spec.ts
+++ b/src/test/javascript/spec/component/detail-overview-list.component.spec.ts
@@ -92,6 +92,12 @@ describe('DetailOverviewList', () => {
         expect(modalSpy).toHaveBeenCalledOnce();
     });
 
+    it('should not open git diff modal', () => {
+        const modalSpy = jest.spyOn(modalService, 'open');
+        component.showGitDiff(undefined);
+        expect(modalSpy).not.toHaveBeenCalled();
+    });
+
     it('should download apollon Diagram', () => {
         const downloadSpy = jest.spyOn(modelingService, 'convertToPdf').mockReturnValue(of(new HttpResponse({ body: new Blob() })));
         component.downloadApollonDiagramAsPDf({} as UMLModel, 'title');

--- a/src/test/javascript/spec/component/exam/manage/exam-mode-picker.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-mode-picker.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ExamModePickerComponent } from 'app/exam/manage/exams/exam-mode-picker/exam-mode-picker.component';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { MockPipe } from 'ng-mocks';
+import { ArtemisTestModule } from '../../../test.module';
+
+const exam = {
+    id: 2,
+};
+describe('ExamModePickerComponent', () => {
+    let component: ExamModePickerComponent;
+    let fixture: ComponentFixture<ExamModePickerComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [ExamModePickerComponent, MockPipe(ArtemisTranslatePipe)],
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(ExamModePickerComponent);
+                component = fixture.componentInstance;
+                component.exam = exam;
+            });
+    });
+
+    it('should be in readonly mode', () => {
+        const examCopy = { ...exam };
+        component.disableInput = true;
+        fixture.detectChanges();
+        component.setExamMode(true);
+        expect(component.exam).toEqual(examCopy);
+    });
+
+    it('should set exam mode test', () => {
+        fixture.detectChanges();
+        component.setExamMode(true);
+        expect(component.exam.testExam).toBeTrue();
+        expect(component.exam.numberOfCorrectionRoundsInExam).toBe(0);
+    });
+
+    it('should set exam mode test false', () => {
+        fixture.detectChanges();
+        component.setExamMode(false);
+        expect(component.exam.testExam).toBeFalse();
+        expect(component.exam.numberOfCorrectionRoundsInExam).toBe(1);
+    });
+});

--- a/src/test/javascript/spec/core/post-hog-analytics.service.spec.ts
+++ b/src/test/javascript/spec/core/post-hog-analytics.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { AnalyticsService } from 'app/core/posthog/analytics.service';
 import { posthog } from 'posthog-js';
+import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
 
 describe('AnalyticsService', () => {
     let analyticsService: AnalyticsService;
@@ -19,13 +20,13 @@ describe('AnalyticsService', () => {
 
     it('should init posthog', async () => {
         const initSpy = jest.spyOn(posthog, 'init');
-        await analyticsService.initAnalytics({ postHog: { token: 'token', host: 'host' } });
+        await analyticsService.initAnalytics({ postHog: { token: 'token', host: 'host' } } as any as ProfileInfo);
         expect(initSpy).toHaveBeenCalledOnce();
     });
 
     it('should not init posthog', async () => {
         const initSpy = jest.spyOn(posthog, 'init');
-        await analyticsService.initAnalytics({});
+        await analyticsService.initAnalytics({} as any as ProfileInfo);
         expect(initSpy).not.toHaveBeenCalled();
     });
 });

--- a/src/test/javascript/spec/core/post-hog-analytics.service.spec.ts
+++ b/src/test/javascript/spec/core/post-hog-analytics.service.spec.ts
@@ -1,0 +1,31 @@
+import { TestBed } from '@angular/core/testing';
+import { AnalyticsService } from 'app/core/posthog/analytics.service';
+import { posthog } from 'posthog-js';
+
+describe('AnalyticsService', () => {
+    let analyticsService: AnalyticsService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [],
+            providers: [],
+        });
+        analyticsService = TestBed.inject(AnalyticsService);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should init posthog', async () => {
+        const initSpy = jest.spyOn(posthog, 'init');
+        await analyticsService.initAnalytics({ postHog: { token: 'token', host: 'host' } });
+        expect(initSpy).toHaveBeenCalledOnce();
+    });
+
+    it('should not init posthog', async () => {
+        const initSpy = jest.spyOn(posthog, 'init');
+        await analyticsService.initAnalytics({});
+        expect(initSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
client branch coverage too low

### Description
added tests for files without or less branch coverage

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Added a test case to verify the `showGitDiff` function's behavior in detail overview lists.
	- Introduced tests for the `ExamModePickerComponent` covering various modes and behaviors.
	- Implemented tests for initializing PostHog analytics in the `AnalyticsService`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->