### PR TITLE
`Development`: Migrate Bitbucket to LocalVC (release 6.8.4)

### DIFF
--- a/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI___Atlassian.xml
+++ b/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI___Atlassian.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Artemis (Server, LocalVC &amp; LocalCI &amp; Atlassian)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ACTIVE_PROFILES" value="bamboo,bitbucket,jira,dev,localci,localvc,artemis,scheduling,local" />
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
+    <module name="Artemis.main" />
+    <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.tum.in.www1.artemis.ArtemisApp" />
+    <option name="VM_PARAMETERS" value="-XX:+ShowCodeDetailsInExceptionMessages -Duser.country=US -Duser.language=en" />
+    <method v="2">
+      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessCheck -x checkstyleMain -x checkstyleTest" />
+    </method>
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Refer to [Using JHipster in production](http://www.jhipster.tech/production) for
 The following command can automate the deployment to a server. The example shows the deployment to the main Artemis test server (which runs a virtual machine):
 
 ```shell
-./artemis-server-cli deploy username@artemistest.ase.in.tum.de -w build/libs/Artemis-6.8.3.war
+./artemis-server-cli deploy username@artemistest.ase.in.tum.de -w build/libs/Artemis-6.8.4.war
 ```
 
 ## Architecture

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
 }
 
 group = "de.tum.in.www1.artemis"
-version = "6.8.3"
+version = "6.8.4"
 description = "Interactive Learning with Individual Feedback"
 
 java {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "artemis",
-    "version": "6.8.3",
+    "version": "6.8.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "artemis",
-            "version": "6.8.3",
+            "version": "6.8.4",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "artemis",
-    "version": "6.8.3",
+    "version": "6.8.4",
     "description": "Interactive Learning with Individual Feedback",
     "private": true,
     "license": "MIT",

--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -305,6 +305,11 @@ public final class Constants {
     public static final int SIZE_OF_UNSIGNED_TINYINT = 255;
 
     /**
+     * The name of the Spring profile used for Artemis core functionality.
+     */
+    public static final String PROFILE_CORE = "core";
+
+    /**
      * The maximum length of a group conversation human-readable name before it is truncated if no name is specified.
      */
     public static final int GROUP_CONVERSATION_HUMAN_READABLE_NAME_LIMIT = 100;

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/MigrationEntry.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/MigrationEntry.java
@@ -1,6 +1,14 @@
 package de.tum.in.www1.artemis.config.migration;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public abstract class MigrationEntry {
+
+    private static final Logger log = LoggerFactory.getLogger(MigrationEntry.class);
 
     public abstract void execute();
 
@@ -15,4 +23,26 @@ public abstract class MigrationEntry {
      * @return Current time in given format
      */
     public abstract String date();
+
+    protected static void shutdown(ExecutorService executorService, int timeoutInHours, String errorMessage) {
+        // Wait for all threads to finish
+        executorService.shutdown();
+
+        try {
+            boolean finished = executorService.awaitTermination(timeoutInHours, TimeUnit.HOURS);
+            if (!finished) {
+                log.error(errorMessage);
+                if (executorService.awaitTermination(1, TimeUnit.MINUTES)) {
+                    log.error("Failed to cancel all migration threads. Some threads are still running.");
+                }
+                throw new RuntimeException(errorMessage);
+            }
+        }
+        catch (InterruptedException e) {
+            log.error(errorMessage);
+            executorService.shutdownNow();
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/MigrationRegistry.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/MigrationRegistry.java
@@ -6,7 +6,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +15,6 @@ import de.tum.in.www1.artemis.config.migration.entries.*;
  * This component allows registering certain entries containing functionality that gets executed on application startup. The entries must extend {@link MigrationEntry}.
  */
 @Component
-@Profile("scheduling")
 public class MigrationRegistry {
 
     // Using SortedMap to allow sorting. I'm using a map because with a list entries could accidentally be switched.
@@ -31,6 +29,7 @@ public class MigrationRegistry {
         this.migrationEntryMap.put(2, MigrationEntry20230810_150000.class);
         this.migrationEntryMap.put(3, MigrationEntry20230920_181600.class);
         this.migrationEntryMap.put(4, MigrationEntry20231206_163000.class);
+        this.migrationEntryMap.put(5, MigrationEntry20240103_143700.class);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/MigrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/MigrationService.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -26,7 +25,6 @@ import de.tum.in.www1.artemis.repository.MigrationChangeRepository;
  * This service contains utility functionality that verifies a changelog to prevent corruption and executes a given changelog.
  */
 @Service
-@Profile("scheduling")
 public class MigrationService {
 
     private static final Logger log = LoggerFactory.getLogger(MigrationService.class);

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/BitbucketLocalVCMigrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/BitbucketLocalVCMigrationService.java
@@ -1,0 +1,36 @@
+package de.tum.in.www1.artemis.config.migration.entries;
+
+import java.net.URL;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * Services for executing migration tasks for bitbucket to local vc, needed for the value injection
+ */
+@Service
+@Profile("bitbucket & localvc")
+public class BitbucketLocalVCMigrationService {
+
+    @Value("${artemis.version-control.default-branch:main}")
+    private String defaultBranch;
+
+    @Value("${migration.base-url:http://0.0.0.0}")
+    private URL localVCBaseUrl;
+
+    @Value("${migration.local-vcs-repo-path:null}")
+    private String localVCBasePath;
+
+    public String getDefaultBranch() {
+        return defaultBranch;
+    }
+
+    public URL getLocalVCBaseUrl() {
+        return localVCBaseUrl;
+    }
+
+    public String getLocalVCBasePath() {
+        return localVCBasePath;
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20230808_203400.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20230808_203400.java
@@ -1,20 +1,21 @@
 package de.tum.in.www1.artemis.config.migration.entries;
 
-import static de.tum.in.www1.artemis.config.Constants.*;
+import static de.tum.in.www1.artemis.config.Constants.ASSIGNMENT_REPO_NAME;
+import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
+import static de.tum.in.www1.artemis.config.Constants.SOLUTION_REPO_NAME;
+import static de.tum.in.www1.artemis.config.Constants.TEST_REPO_NAME;
 import static de.tum.in.www1.artemis.service.util.TimeLogUtil.formatDuration;
 
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,18 +24,25 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
 
-import de.tum.in.www1.artemis.config.migration.MigrationEntry;
 import de.tum.in.www1.artemis.domain.AuxiliaryRepository;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUri;
-import de.tum.in.www1.artemis.domain.participation.*;
+import de.tum.in.www1.artemis.domain.participation.AbstractBaseProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
+import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.domain.participation.TemplateProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.exception.ContinuousIntegrationException;
-import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.repository.AuxiliaryRepositoryRepository;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
+import de.tum.in.www1.artemis.repository.SolutionProgrammingExerciseParticipationRepository;
+import de.tum.in.www1.artemis.repository.TemplateProgrammingExerciseParticipationRepository;
 import de.tum.in.www1.artemis.service.UriService;
 import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlService;
 
+@Profile(PROFILE_CORE)
 @Component
-public class MigrationEntry20230808_203400 extends MigrationEntry {
+public class MigrationEntry20230808_203400 extends ProgrammingExerciseMigrationEntry {
 
     private static final int BATCH_SIZE = 100;
 
@@ -62,9 +70,7 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
 
     private final Environment environment;
 
-    private final UriService uriService = new UriService();
-
-    private final CopyOnWriteArrayList<ProgrammingExerciseParticipation> errorList = new CopyOnWriteArrayList<>();
+    private final UriService uriService;
 
     private static final List<String> MIGRATABLE_PROFILES = List.of("bamboo", "gitlab", "jenkins");
 
@@ -72,7 +78,7 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
             SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository,
             TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository,
             ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository, AuxiliaryRepositoryRepository auxiliaryRepositoryRepository,
-            Optional<CIVCSMigrationService> ciMigrationService, Optional<VersionControlService> versionControlService, Environment environment) {
+            Optional<CIVCSMigrationService> ciMigrationService, Optional<VersionControlService> versionControlService, Environment environment, UriService uriService) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.solutionProgrammingExerciseParticipationRepository = solutionProgrammingExerciseParticipationRepository;
         this.templateProgrammingExerciseParticipationRepository = templateProgrammingExerciseParticipationRepository;
@@ -81,6 +87,7 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
         this.ciMigrationService = ciMigrationService;
         this.versionControlService = versionControlService;
         this.environment = environment;
+        this.uriService = uriService;
     }
 
     @Override
@@ -162,28 +169,9 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
             }
         }
 
-        // Wait for all threads to finish
-        executorService.shutdown();
-
-        try {
-            boolean finished = executorService.awaitTermination(TIMEOUT_IN_HOURS, TimeUnit.HOURS);
-            if (!finished) {
-                log.error(ERROR_MESSAGE);
-                if (executorService.awaitTermination(1, TimeUnit.MINUTES)) {
-                    log.error("Failed to cancel all migration threads. Some threads are still running.");
-                }
-                throw new RuntimeException(ERROR_MESSAGE);
-            }
-        }
-        catch (InterruptedException e) {
-            log.error(ERROR_MESSAGE);
-            executorService.shutdownNow();
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        }
-
+        shutdown(executorService, TIMEOUT_IN_HOURS, ERROR_MESSAGE);
         log.info("Finished migrating programming exercises and student participations");
-        evaluateErrorList();
+        evaluateErrorList(programmingExerciseRepository);
     }
 
     /**
@@ -580,33 +568,6 @@ public class MigrationEntry20230808_203400 extends MigrationEntry {
             log.error("Failed to replace repositories in template build plan for exercise {} with buildPlanId {}", exercise.getId(), exercise.getTemplateBuildPlanId(), e);
             errorList.add(participation);
         }
-    }
-
-    /**
-     * Evaluates the error map and prints the errors to the log.
-     */
-    private void evaluateErrorList() {
-        if (errorList.isEmpty()) {
-            log.info("Successfully migrated all programming exercises");
-            return;
-        }
-
-        List<Long> failedTemplateExercises = errorList.stream().filter(participation -> participation instanceof TemplateProgrammingExerciseParticipation)
-                .map(participation -> participation.getProgrammingExercise().getId()).toList();
-        List<Long> failedSolutionExercises = errorList.stream().filter(participation -> participation instanceof SolutionProgrammingExerciseParticipation)
-                .map(participation -> participation.getProgrammingExercise().getId()).toList();
-        List<Long> failedStudentParticipations = errorList.stream().filter(participation -> participation instanceof ProgrammingExerciseStudentParticipation)
-                .map(ParticipationInterface::getId).toList();
-
-        log.error("{} failures during migration", errorList.size());
-        // print each participation in a single line in the long to simplify reviewing the issues
-        log.error("Errors occurred for the following participations: \n{}", errorList.stream().map(Object::toString).collect(Collectors.joining("\n")));
-        log.error("Failed to migrate template build plan for exercises: {}", failedTemplateExercises);
-        log.error("Failed to migrate solution build plan for exercises: {}", failedSolutionExercises);
-        log.error("Failed to migrate students participations: {}", failedStudentParticipations);
-        log.warn("Please check the logs for more information. If the issues are related to the external VCS/CI system, fix the issues and rerun the migration. or "
-                + "fix the build plans yourself and mark the migration as run. The migration can be rerun by deleting the migration entry in the database table containing "
-                + "the migration with author: {} and date_string: {} and then restarting Artemis.", author(), date());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20230920_181600.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20230920_181600.java
@@ -1,16 +1,16 @@
 package de.tum.in.www1.artemis.config.migration.entries;
 
+import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
+
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,15 +19,21 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
 
-import de.tum.in.www1.artemis.config.migration.MigrationEntry;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUri;
-import de.tum.in.www1.artemis.domain.participation.*;
-import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.domain.participation.AbstractBaseProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
+import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.domain.participation.TemplateProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
+import de.tum.in.www1.artemis.repository.SolutionProgrammingExerciseParticipationRepository;
+import de.tum.in.www1.artemis.repository.TemplateProgrammingExerciseParticipationRepository;
 import de.tum.in.www1.artemis.service.UriService;
 
+@Profile(PROFILE_CORE)
 @Component
-public class MigrationEntry20230920_181600 extends MigrationEntry {
+public class MigrationEntry20230920_181600 extends ProgrammingExerciseMigrationEntry {
 
     private static final int BATCH_SIZE = 100;
 
@@ -51,9 +57,7 @@ public class MigrationEntry20230920_181600 extends MigrationEntry {
 
     private final Environment environment;
 
-    private final UriService uriService = new UriService();
-
-    private final CopyOnWriteArrayList<ProgrammingExerciseParticipation> errorList = new CopyOnWriteArrayList<>();
+    private final UriService uriService;
 
     private static final List<String> MIGRATABLE_PROFILES = List.of("bamboo");
 
@@ -61,13 +65,14 @@ public class MigrationEntry20230920_181600 extends MigrationEntry {
             SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository,
             TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository,
             ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository, Optional<CIVCSMigrationService> ciMigrationService,
-            Environment environment) {
+            Environment environment, UriService uriService) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.solutionProgrammingExerciseParticipationRepository = solutionProgrammingExerciseParticipationRepository;
         this.templateProgrammingExerciseParticipationRepository = templateProgrammingExerciseParticipationRepository;
         this.programmingExerciseStudentParticipationRepository = programmingExerciseStudentParticipationRepository;
         this.ciMigrationService = ciMigrationService;
         this.environment = environment;
+        this.uriService = uriService;
     }
 
     @Override
@@ -138,28 +143,9 @@ public class MigrationEntry20230920_181600 extends MigrationEntry {
             }
         }
 
-        // Wait for all threads to finish
-        executorService.shutdown();
-
-        try {
-            boolean finished = executorService.awaitTermination(TIMEOUT_IN_HOURS, TimeUnit.HOURS);
-            if (!finished) {
-                log.error(ERROR_MESSAGE);
-                if (executorService.awaitTermination(1, TimeUnit.MINUTES)) {
-                    log.error("Failed to cancel all migration threads. Some threads are still running.");
-                }
-                throw new RuntimeException(ERROR_MESSAGE);
-            }
-        }
-        catch (InterruptedException e) {
-            log.error(ERROR_MESSAGE);
-            executorService.shutdownNow();
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        }
-
+        shutdown(executorService, TIMEOUT_IN_HOURS, ERROR_MESSAGE);
         log.info("Finished migrating programming exercises and student participations");
-        evaluateErrorList();
+        evaluateErrorList(programmingExerciseRepository);
     }
 
     /**
@@ -314,33 +300,6 @@ public class MigrationEntry20230920_181600 extends MigrationEntry {
             log.warn("Failed to migrate template build plan for exercise {} with buildPlanId {}", exercise.getId(), exercise.getTemplateBuildPlanId(), e);
             errorList.add(participation);
         }
-    }
-
-    /**
-     * Evaluates the error map and prints the errors to the log.
-     */
-    private void evaluateErrorList() {
-        if (errorList.isEmpty()) {
-            log.info("Successfully migrated all programming exercises");
-            return;
-        }
-
-        List<Long> failedTemplateExercises = errorList.stream().filter(participation -> participation instanceof TemplateProgrammingExerciseParticipation)
-                .map(participation -> participation.getProgrammingExercise().getId()).toList();
-        List<Long> failedSolutionExercises = errorList.stream().filter(participation -> participation instanceof SolutionProgrammingExerciseParticipation)
-                .map(participation -> participation.getProgrammingExercise().getId()).toList();
-        List<Long> failedStudentParticipations = errorList.stream().filter(participation -> participation instanceof ProgrammingExerciseStudentParticipation)
-                .map(ParticipationInterface::getId).toList();
-
-        log.error("{} failures during migration", errorList.size());
-        // print each participation in a single line in the long to simplify reviewing the issues
-        log.error("Errors occurred for the following participations: \n{}", errorList.stream().map(Object::toString).collect(Collectors.joining("\n")));
-        log.error("Failed to migrate template build plan for exercises: {}", failedTemplateExercises);
-        log.error("Failed to migrate solution build plan for exercises: {}", failedSolutionExercises);
-        log.error("Failed to migrate students participations: {}", failedStudentParticipations);
-        log.warn("Please check the logs for more information. If the issues are related to the external VCS/CI system, fix the issues and rerun the migration. or "
-                + "fix the build plans yourself and mark the migration as run. The migration can be rerun by deleting the migration entry in the database table containing "
-                + "the migration with author: {} and date_string: {} and then restarting Artemis.", author(), date());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20240103_143700.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20240103_143700.java
@@ -1,0 +1,500 @@
+package de.tum.in.www1.artemis.config.migration.entries;
+
+import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jgit.api.Git;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import de.tum.in.www1.artemis.domain.AuxiliaryRepository;
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.VcsRepositoryUri;
+import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
+import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.domain.participation.TemplateProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.exception.localvc.LocalVCInternalException;
+import de.tum.in.www1.artemis.repository.AuxiliaryRepositoryRepository;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
+import de.tum.in.www1.artemis.repository.SolutionProgrammingExerciseParticipationRepository;
+import de.tum.in.www1.artemis.repository.TemplateProgrammingExerciseParticipationRepository;
+import de.tum.in.www1.artemis.service.UriService;
+import de.tum.in.www1.artemis.service.connectors.bitbucket.BitbucketService;
+import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCRepositoryUri;
+import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCService;
+import de.tum.in.www1.artemis.service.util.TimeLogUtil;
+
+@Profile(PROFILE_CORE)
+@Component
+public class MigrationEntry20240103_143700 extends ProgrammingExerciseMigrationEntry {
+
+    private static final int BATCH_SIZE = 100;
+
+    private static final int MAX_THREAD_COUNT = 32;
+
+    private static final int TIMEOUT_IN_HOURS = 48;
+
+    private static final long ESTIMATED_TIME_PER_REPOSITORY = 2; // 2s per repository
+
+    private static final String ERROR_MESSAGE = "Failed to migrate programming exercises within " + TIMEOUT_IN_HOURS + " hours. Aborting migration.";
+
+    private static final List<String> MIGRATABLE_PROFILES = List.of("bitbucket", "localvc");
+
+    private final static Logger log = LoggerFactory.getLogger(MigrationEntry20240103_143700.class);
+
+    private final ProgrammingExerciseRepository programmingExerciseRepository;
+
+    private final SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository;
+
+    private final TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository;
+
+    private final ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository;
+
+    private final AuxiliaryRepositoryRepository auxiliaryRepositoryRepository;
+
+    private final UriService uriService;
+
+    private final Environment environment;
+
+    private final Optional<LocalVCService> localVCService;
+
+    private final Optional<BitbucketService> bitbucketService;
+
+    private final Optional<BitbucketLocalVCMigrationService> bitbucketLocalVCMigrationService;
+
+    public MigrationEntry20240103_143700(ProgrammingExerciseRepository programmingExerciseRepository, Environment environment,
+            SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository,
+            TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository,
+            ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository, Optional<LocalVCService> localVCService,
+            AuxiliaryRepositoryRepository auxiliaryRepositoryRepository, Optional<BitbucketService> bitbucketService, UriService uriService,
+            Optional<BitbucketLocalVCMigrationService> bitbucketLocalVCMigrationService) {
+        this.programmingExerciseRepository = programmingExerciseRepository;
+        this.environment = environment;
+        this.solutionProgrammingExerciseParticipationRepository = solutionProgrammingExerciseParticipationRepository;
+        this.templateProgrammingExerciseParticipationRepository = templateProgrammingExerciseParticipationRepository;
+        this.programmingExerciseStudentParticipationRepository = programmingExerciseStudentParticipationRepository;
+        this.localVCService = localVCService;
+        this.auxiliaryRepositoryRepository = auxiliaryRepositoryRepository;
+        this.bitbucketService = bitbucketService;
+        this.uriService = uriService;
+        this.bitbucketLocalVCMigrationService = bitbucketLocalVCMigrationService;
+    }
+
+    @Override
+    public void execute() {
+        List<String> activeProfiles = List.of(environment.getActiveProfiles());
+        if (!new HashSet<>(activeProfiles).containsAll(MIGRATABLE_PROFILES)) {
+            log.info("Migration will be skipped and marked run because the system does not support a tech-stack that requires this migration: {}",
+                    List.of(environment.getActiveProfiles()));
+            return;
+        }
+
+        if (bitbucketLocalVCMigrationService.isEmpty()) {
+            log.error("Migration will be skipped and marked run because the BitbucketLocalVCMigrationService is not available.");
+            return;
+        }
+
+        if (bitbucketLocalVCMigrationService.get().getLocalVCBasePath() == null) {
+            log.error("Migration will be skipped and marked run because the local VC base path is not configured.");
+            return;
+        }
+
+        if (bitbucketLocalVCMigrationService.get().getLocalVCBaseUrl() == null || bitbucketLocalVCMigrationService.get().getLocalVCBaseUrl().toString().equals("http://0.0.0.0")) {
+            log.error("Migration will be skipped and marked run because the local VC base URL is not configured.");
+            return;
+        }
+
+        if (bitbucketLocalVCMigrationService.get().getDefaultBranch() == null) {
+            log.error("Migration will be skipped and marked run because the default branch is not configured.");
+            return;
+        }
+
+        var programmingExerciseCount = programmingExerciseRepository.count();
+        var studentCount = programmingExerciseStudentParticipationRepository.findAllWithRepositoryUri(Pageable.unpaged()).getTotalElements();
+
+        if (programmingExerciseCount == 0) {
+            // no exercises to change, migration complete
+            return;
+        }
+
+        log.info("Will migrate {} programming exercises and {} student repositories now. This might take a while", programmingExerciseCount, studentCount);
+
+        final long totalFullBatchCount = programmingExerciseCount / BATCH_SIZE;
+        final long threadCount = Math.max(1, Math.min(totalFullBatchCount, MAX_THREAD_COUNT));
+        final long estimatedTimeExercise = getRestDurationInSeconds(0, programmingExerciseCount, 3, threadCount);
+        final long estimatedTimeStudents = getRestDurationInSeconds(0, studentCount, 1, threadCount);
+
+        final long estimatedTime = (estimatedTimeExercise + estimatedTimeStudents);
+        log.info("Using {} threads for migration, and assuming {}s per repository, the migration should take around {}", threadCount, ESTIMATED_TIME_PER_REPOSITORY,
+                TimeLogUtil.formatDuration(estimatedTime));
+
+        // Use fixed thread pool to prevent loading too many exercises into memory at once
+        ExecutorService executorService = Executors.newFixedThreadPool((int) threadCount);
+
+        /*
+         * migrate the solution participations first, then the template participations, then the student participations
+         */
+        AtomicInteger solutionCounter = new AtomicInteger(0);
+        final var totalNumberOfSolutions = solutionProgrammingExerciseParticipationRepository.count();
+        log.info("Found {} solution participations to migrate.", totalNumberOfSolutions);
+        for (int currentPageStart = 0; currentPageStart < totalNumberOfSolutions; currentPageStart += BATCH_SIZE) {
+            Pageable pageable = PageRequest.of(currentPageStart / BATCH_SIZE, BATCH_SIZE);
+            var solutionParticipationPage = solutionProgrammingExerciseParticipationRepository.findAll(pageable);
+            log.info("Will migrate {} solution participations in batch.", solutionParticipationPage.getNumberOfElements());
+            executorService.submit(() -> {
+                migrateSolutions(solutionParticipationPage.toList());
+                solutionCounter.addAndGet(solutionParticipationPage.getNumberOfElements());
+                logProgress(solutionCounter.get(), totalNumberOfSolutions, threadCount, 2, "solution");
+            });
+        }
+
+        log.info("Submitted all solution participations to thread pool for migration.");
+        /*
+         * migrate the template participations
+         */
+        AtomicInteger templateCounter = new AtomicInteger(0);
+        var templateCount = templateProgrammingExerciseParticipationRepository.count();
+        log.info("Found {} template participations to migrate", templateCount);
+        for (int currentPageStart = 0; currentPageStart < templateCount; currentPageStart += BATCH_SIZE) {
+            Pageable pageable = PageRequest.of(currentPageStart / BATCH_SIZE, BATCH_SIZE);
+            var templateParticipationPage = templateProgrammingExerciseParticipationRepository.findAll(pageable);
+            log.info("Will migrate {} template programming exercises in batch.", templateParticipationPage.getNumberOfElements());
+            executorService.submit(() -> {
+                migrateTemplates(templateParticipationPage.toList());
+                templateCounter.addAndGet(templateParticipationPage.getNumberOfElements());
+                logProgress(templateCounter.get(), templateCount, threadCount, 1, "template");
+            });
+        }
+
+        log.info("Submitted all template participations to thread pool for migration.");
+        /*
+         * migrate the student participations
+         */
+        AtomicInteger studentCounter = new AtomicInteger(0);
+        log.info("Found {} student programming exercise participations with build plans to migrate.", studentCount);
+        for (int currentPageStart = 0; currentPageStart < studentCount; currentPageStart += BATCH_SIZE) {
+            Pageable pageable = PageRequest.of(currentPageStart / BATCH_SIZE, BATCH_SIZE);
+            Page<ProgrammingExerciseStudentParticipation> studentParticipationPage = programmingExerciseStudentParticipationRepository.findAllWithRepositoryUri(pageable);
+            log.info("Will migrate {} student programming exercise participations in batch.", studentParticipationPage.getNumberOfElements());
+            executorService.submit(() -> {
+                migrateStudents(studentParticipationPage.toList());
+                studentCounter.addAndGet(studentParticipationPage.getNumberOfElements());
+                logProgress(studentCounter.get(), studentCount, threadCount, 1, "student");
+            });
+        }
+
+        log.info("Submitted all student participations to thread pool for migration.");
+
+        shutdown(executorService, TIMEOUT_IN_HOURS, ERROR_MESSAGE);
+        log.info("Finished migrating programming exercises and student participations");
+        evaluateErrorList(programmingExerciseRepository);
+    }
+
+    private void logProgress(long doneCount, long totalCount, long threadCount, long reposPerEntry, String migrationType) {
+        final double percentage = ((double) doneCount / totalCount) * 100;
+        log.info("Migrated {}/{} {} participations ({}%)", doneCount, totalCount, migrationType, String.format("%.2f", percentage));
+        log.info("Estimated time remaining: {} for {} repositories", TimeLogUtil.formatDuration(getRestDurationInSeconds(doneCount, totalCount, reposPerEntry, threadCount)),
+                migrationType);
+    }
+
+    private long getRestDurationInSeconds(final long done, final long total, final long reposPerEntry, final long threads) {
+        final long stillTodo = total - done;
+        final long timePerEntry = ESTIMATED_TIME_PER_REPOSITORY * reposPerEntry;
+        return (stillTodo * timePerEntry) / threads;
+    }
+
+    private String migrateTestRepo(ProgrammingExercise programmingExercise) throws URISyntaxException {
+        return cloneRepositoryFromBitbucketAndMoveToLocalVCS(programmingExercise, programmingExercise.getTestRepositoryUri(), programmingExercise.getBranch());
+    }
+
+    /**
+     * Migrate auxiliary repositories of the given programming exercise.
+     *
+     * @param solutionParticipation the solution participation to migrate the auxiliary repositories for
+     * @param programmingExercise   the programming exercise to migrate the auxiliary repositories for
+     * @param oldBranch             the old branch of the programming exercise
+     */
+    private void migrateAuxiliaryRepositories(SolutionProgrammingExerciseParticipation solutionParticipation, ProgrammingExercise programmingExercise, String oldBranch) {
+        for (var repo : getAuxiliaryRepositories(programmingExercise.getId())) {
+            try {
+                if (repo.getRepositoryUri() == null) {
+                    log.error("Repository URI is null for auxiliary repository with id {}, cant migrate", repo.getId());
+                    continue;
+                }
+                var url = cloneRepositoryFromBitbucketAndMoveToLocalVCS(programmingExercise, repo.getRepositoryUri(), oldBranch);
+                if (url == null) {
+                    errorList.add(solutionParticipation);
+                    log.error("Failed to migrate auxiliary repository for programming exercise with id {}, keeping the url in the database", programmingExercise.getId());
+                }
+                else {
+                    log.debug("Migrated auxiliary repository with id {} to {}", repo.getId(), url);
+                }
+                repo.setRepositoryUri(url);
+                auxiliaryRepositoryRepository.save(repo);
+            }
+            catch (Exception e) {
+                log.error("Failed to migrate auxiliary repository with id {}", repo.getId(), e);
+            }
+        }
+    }
+
+    /**
+     * Returns a list of auxiliary repositories for the given exercise.
+     *
+     * @param exerciseId The id of the exercise
+     * @return A list of auxiliary repositories, or an empty list if the migration service does not support auxiliary repositories
+     */
+    private List<AuxiliaryRepository> getAuxiliaryRepositories(Long exerciseId) {
+        return auxiliaryRepositoryRepository.findByExerciseId(exerciseId);
+    }
+
+    /**
+     * Migrate the solution participations. Also Migrates the test and aux repository of the programming exercise since we have it
+     * in the solution participation already loaded from the database.
+     *
+     * @param solutionParticipations the solution participations to migrate
+     */
+    private void migrateSolutions(List<SolutionProgrammingExerciseParticipation> solutionParticipations) {
+        if (bitbucketLocalVCMigrationService.isEmpty()) {
+            log.error("Failed to migrate solution participations because the Bitbucket migration service is not available.");
+            return;
+        }
+        for (var solutionParticipation : solutionParticipations) {
+            try {
+                if (solutionParticipation.getRepositoryUri() == null) {
+                    log.error("Repository URI is null for solution participation with id {}, cant migrate", solutionParticipation.getId());
+                    errorList.add(solutionParticipation);
+                    continue;
+                }
+                var programmingExercise = solutionParticipation.getProgrammingExercise();
+                var url = cloneRepositoryFromBitbucketAndMoveToLocalVCS(solutionParticipation.getProgrammingExercise(), solutionParticipation.getRepositoryUri(),
+                        programmingExercise.getBranch());
+                if (url == null) {
+                    log.error("Failed to migrate solution repository for solution participation with id {}, keeping the url in the database", solutionParticipation.getId());
+                    errorList.add(solutionParticipation);
+                }
+                else {
+                    log.debug("Migrated solution participation with id {} to {}", solutionParticipation.getId(), url);
+                }
+                solutionParticipation.setRepositoryUri(url);
+                solutionProgrammingExerciseParticipationRepository.save(solutionParticipation);
+                url = migrateTestRepo(solutionParticipation.getProgrammingExercise());
+                var oldBranch = programmingExercise.getBranch();
+                if (url == null) {
+                    log.error("Failed to migrate test repository for solution participation with id {}, keeping the url in the database", solutionParticipation.getId());
+                    errorList.add(solutionParticipation);
+                }
+                else {
+                    log.debug("Migrated test repository for solution participation with id {} to {}", solutionParticipation.getId(), url);
+                    if (!bitbucketLocalVCMigrationService.get().getDefaultBranch().equals(programmingExercise.getBranch())) {
+                        programmingExercise.setBranch(bitbucketLocalVCMigrationService.get().getDefaultBranch());
+                        log.debug("Changed branch of programming exercise with id {} to {}", programmingExercise.getId(), programmingExercise.getBranch());
+                    }
+                }
+                programmingExercise.setTestRepositoryUri(url);
+                programmingExerciseRepository.save(programmingExercise);
+                migrateAuxiliaryRepositories(solutionParticipation, programmingExercise, oldBranch);
+            }
+            catch (Exception e) {
+                log.error("Failed to migrate solution participation with id {}", solutionParticipation.getId(), e);
+                errorList.add(solutionParticipation);
+            }
+        }
+    }
+
+    /**
+     * Migrate the template participations.
+     *
+     * @param templateParticipations list of template participations to migrate
+     */
+    private void migrateTemplates(List<TemplateProgrammingExerciseParticipation> templateParticipations) {
+        for (var templateParticipation : templateParticipations) {
+            try {
+                if (templateParticipation.getRepositoryUri() == null) {
+                    log.error("Repository URI is null for template participation with id {}, cant migrate", templateParticipation.getId());
+                    errorList.add(templateParticipation);
+                    continue;
+                }
+                var url = cloneRepositoryFromBitbucketAndMoveToLocalVCS(templateParticipation.getProgrammingExercise(), templateParticipation.getRepositoryUri(),
+                        templateParticipation.getProgrammingExercise().getBranch());
+                if (url == null) {
+                    log.error("Failed to migrate template repository for template participation with id {}, keeping the url in the database", templateParticipation.getId());
+                    errorList.add(templateParticipation);
+                }
+                else {
+                    log.debug("Migrated template participation with id {} to {}", templateParticipation.getId(), url);
+                }
+                templateParticipation.setRepositoryUri(url);
+                templateProgrammingExerciseParticipationRepository.save(templateParticipation);
+            }
+            catch (Exception e) {
+                log.error("Failed to migrate template participation with id {}", templateParticipation.getId(), e);
+                errorList.add(templateParticipation);
+            }
+        }
+    }
+
+    /**
+     * Migrate the student participations. This is the most time-consuming part of the migration as we have
+     * to clone the repository for each student.
+     *
+     * @param participations list of student participations to migrate
+     */
+    private void migrateStudents(List<ProgrammingExerciseStudentParticipation> participations) {
+        if (bitbucketLocalVCMigrationService.isEmpty()) {
+            log.error("Failed to migrate student participations because the Bitbucket migration service is not available.");
+            return;
+        }
+        for (var participation : participations) {
+            try {
+                if (participation.getRepositoryUri() == null) {
+                    log.error("Repository URI is null for student participation with id {}, cant migrate", participation.getId());
+                    errorList.add(participation);
+                    continue;
+                }
+                var url = cloneRepositoryFromBitbucketAndMoveToLocalVCS(participation.getProgrammingExercise(), participation.getRepositoryUri(), participation.getBranch());
+                if (url == null) {
+                    log.error("Failed to migrate student repository for student participation with id {}, keeping the url in the database", participation.getId());
+                    errorList.add(participation);
+                }
+                else {
+                    log.debug("Migrated student participation with id {} to {}", participation.getId(), url);
+                    if (participation.getBranch() != null) {
+                        participation.setBranch(bitbucketLocalVCMigrationService.get().getDefaultBranch());
+                        log.debug("Changed branch of student participation with id {} to {}", participation.getId(), participation.getBranch());
+                    }
+                }
+                participation.setRepositoryUri(url);
+                programmingExerciseStudentParticipationRepository.save(participation);
+            }
+            catch (Exception e) {
+                log.error("Failed to migrate student participation with id {}", participation.getId(), e);
+                errorList.add(participation);
+            }
+        }
+    }
+
+    /**
+     * Clones the repository from Bitbucket and moves it to the local VCS.
+     * This is done by cloning the repository from Bitbucket and then creating a bare repository in the local VCS.
+     *
+     * @param exercise      the programming exercise
+     * @param repositoryUri the repository URI
+     * @param oldBranch     the old branch of the programming exercise
+     * @return the URI of the repository in the local VCS
+     * @throws URISyntaxException if the repository URL is invalid
+     */
+    private String cloneRepositoryFromBitbucketAndMoveToLocalVCS(ProgrammingExercise exercise, String repositoryUri, String oldBranch) throws URISyntaxException {
+        if (localVCService.isEmpty() || bitbucketService.isEmpty() || bitbucketLocalVCMigrationService.isEmpty()) {
+            log.error("Failed to clone repository from Bitbucket: {}", repositoryUri);
+            if (localVCService.isEmpty()) {
+                log.error("Local VC service is not available");
+            }
+            if (bitbucketService.isEmpty()) {
+                log.error("Bitbucket service is not available");
+            }
+            if (bitbucketLocalVCMigrationService.isEmpty()) {
+                log.error("BitbucketLocalVCMigrationService is not available");
+            }
+            return null;
+        }
+        // repo is already migrated -> return
+        if (repositoryUri.startsWith(bitbucketLocalVCMigrationService.get().getLocalVCBaseUrl().toString())) {
+            log.info("Repository {} is already in local VC", repositoryUri);
+            return repositoryUri;
+        }
+        // check if the repo exists in Bitbucket, if not -> return
+        if (!bitbucketService.get().repositoryUriIsValid(new VcsRepositoryUri(repositoryUri))) {
+            log.info("Repository {} is not available in Bitbucket, removing the reference in the database", repositoryUri);
+            return null;
+        }
+        try {
+            var repositoryName = uriService.getRepositorySlugFromRepositoryUriString(repositoryUri);
+            var projectKey = exercise.getProjectKey();
+
+            localVCService.get().createProjectForExercise(exercise);
+            log.info("Cloning repository {} from Bitbucket and moving it to local VCS", repositoryUri);
+            copyRepoToLocalVC(projectKey, repositoryName, repositoryUri, oldBranch);
+            log.info("Successfully cloned repository {} from Bitbucket and moved it to local VCS", repositoryUri);
+            var uri = new LocalVCRepositoryUri(projectKey, repositoryName, bitbucketLocalVCMigrationService.get().getLocalVCBaseUrl());
+            return uri.toString();
+        }
+        catch (LocalVCInternalException e) {
+            /*
+             * By returning null here, we indicate that the repository does not exist anymore
+             */
+            log.error("Failed to clone repository from Bitbucket: {}, the repository is unavailable.", repositoryUri, e);
+            return null;
+        }
+    }
+
+    /**
+     * Clones the repository from the old origin and creates a bare repository in the local VCS, just as a normal local VC repository would be created
+     * by Artemis.
+     *
+     * @param projectKey     the project key
+     * @param repositorySlug the repository slug
+     * @param oldOrigin      the old origin of the repository
+     */
+    private void copyRepoToLocalVC(String projectKey, String repositorySlug, String oldOrigin, String branch) {
+        if (bitbucketLocalVCMigrationService.isEmpty()) {
+            log.error("Failed to clone repository from Bitbucket: {}", repositorySlug);
+            log.error("BitbucketLocalVCMigrationService is not available");
+            return;
+        }
+        LocalVCRepositoryUri localVCRepositoryUri = new LocalVCRepositoryUri(projectKey, repositorySlug, bitbucketLocalVCMigrationService.get().getLocalVCBaseUrl());
+
+        Path repositoryPath = localVCRepositoryUri.getLocalRepositoryPath(bitbucketLocalVCMigrationService.get().getLocalVCBasePath());
+
+        try {
+            Files.createDirectories(repositoryPath);
+            log.debug("Created local git repository folder {}", repositoryPath);
+
+            // Create a bare local repository with JGit.
+            try (Git git = Git.cloneRepository().setBranch(branch).setDirectory(repositoryPath.toFile()).setBare(true).setURI(oldOrigin).call()) {
+                if (!git.getRepository().getBranch().equals(bitbucketLocalVCMigrationService.get().getDefaultBranch())) {
+                    // Rename the default branch to the configured default branch. Old exercises might have a different default branch.
+                    git.branchRename().setNewName(bitbucketLocalVCMigrationService.get().getDefaultBranch()).call();
+                    log.debug("Renamed default branch of local git repository {} to {}", repositorySlug, bitbucketLocalVCMigrationService.get().getDefaultBranch());
+                }
+            }
+            catch (Exception e) {
+                log.error("Failed to clone repository from Bitbucket: {}", repositorySlug, e);
+                throw new LocalVCInternalException("Error while cloning repository from Bitbucket.", e);
+            }
+
+            log.debug("Created local git repository {} in directory {}", repositorySlug, repositoryPath);
+        }
+        catch (IOException e) {
+            log.error("Could not create local git repo {} at location {}", repositorySlug, repositoryPath, e);
+            throw new LocalVCInternalException("Error while creating local git project.", e);
+        }
+    }
+
+    @Override
+    public String author() {
+        return "reschandreas";
+    }
+
+    @Override
+    public String date() {
+        return "20240103_143700";
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/ProgrammingExerciseMigrationEntry.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/ProgrammingExerciseMigrationEntry.java
@@ -1,0 +1,71 @@
+package de.tum.in.www1.artemis.config.migration.entries;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.tum.in.www1.artemis.config.migration.MigrationEntry;
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.participation.ParticipationInterface;
+import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
+import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.domain.participation.TemplateProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+
+public abstract class ProgrammingExerciseMigrationEntry extends MigrationEntry {
+
+    private static final Logger log = LoggerFactory.getLogger(ProgrammingExerciseMigrationEntry.class);
+
+    protected final CopyOnWriteArrayList<ProgrammingExerciseParticipation> errorList = new CopyOnWriteArrayList<>();
+
+    /**
+     * Evaluates the error map and prints the errors to the log.
+     */
+    protected void evaluateErrorList(ProgrammingExerciseRepository programmingExerciseRepository) {
+        if (errorList.isEmpty()) {
+            log.info("Successfully migrated all programming exercises");
+            return;
+        }
+
+        List<Long> failedTemplateExercises = errorList.stream().filter(participation -> participation instanceof TemplateProgrammingExerciseParticipation)
+                .map(participation -> getProgrammingExerciseId(programmingExerciseRepository, participation)).filter(Objects::nonNull).toList();
+        List<Long> failedSolutionExercises = errorList.stream().filter(participation -> participation instanceof SolutionProgrammingExerciseParticipation)
+                .map(participation -> getProgrammingExerciseId(programmingExerciseRepository, participation)).filter(Objects::nonNull).toList();
+        List<Long> failedStudentParticipations = errorList.stream().filter(participation -> participation instanceof ProgrammingExerciseStudentParticipation)
+                .map(ParticipationInterface::getId).toList();
+
+        log.error("{} failures during migration", errorList.size());
+        // print each participation in a single line in the long to simplify reviewing the issues
+        log.error("Errors occurred for the following participations: \n{}", errorList.stream().map(Object::toString).collect(Collectors.joining("\n")));
+        log.error("Failed to migrate template build plan for exercises: {}", failedTemplateExercises);
+        log.error("Failed to migrate solution build plan for exercises: {}", failedSolutionExercises);
+        log.error("Failed to migrate students participations: {}", failedStudentParticipations);
+        log.warn("Please check the logs for more information. If the issues are related to the external VCS/CI system, fix the issues and rerun the migration. or "
+                + "fix the build plans yourself and mark the migration as run. The migration can be rerun by deleting the migration entry in the database table containing "
+                + "the migration with author: {} and date_string: {} and then restarting Artemis.", author(), date());
+    }
+
+    /**
+     * Sometimes the programming exercise is not set in the participation, so we need to get it from the repository
+     *
+     * @param repository    the repository to get the programming exercise from
+     * @param participation the participation to get the programming exercise from
+     * @return the id of the programming exercise
+     */
+    private Long getProgrammingExerciseId(ProgrammingExerciseRepository repository, ProgrammingExerciseParticipation participation) {
+        ProgrammingExercise programmingExercise = participation.getProgrammingExercise();
+
+        if (programmingExercise == null) {
+            programmingExercise = repository.getProgrammingExerciseFromParticipation(participation);
+            if (programmingExercise == null) {
+                return null;
+            }
+        }
+        return programmingExercise.getId();
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseStudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseStudentParticipationRepository.java
@@ -57,7 +57,7 @@ public interface ProgrammingExerciseStudentParticipationRepository extends JpaRe
             WHERE p.id = :participationId AND ((pr.assessmentType = 'AUTOMATIC'
                         OR (pr.completionDate IS NOT NULL
                             AND (p.exercise.assessmentDueDate IS NULL
-                                OR p.exercise.assessmentDueDate < :#{#dateTime}))) OR pr.id IS NULL)
+                                OR p.exercise.assessmentDueDate < :dateTime))) OR pr.id IS NULL)
              """)
     Optional<ProgrammingExerciseStudentParticipation> findByIdWithAllResultsAndRelatedSubmissions(@Param("participationId") long participationId,
             @Param("dateTime") ZonedDateTime dateTime);
@@ -201,6 +201,7 @@ public interface ProgrammingExerciseStudentParticipationRepository extends JpaRe
             SELECT DISTINCT p
             FROM ProgrammingExerciseStudentParticipation p
             WHERE p.buildPlanId IS NOT NULL
+            ORDER BY p.id DESC
             """)
     Page<ProgrammingExerciseStudentParticipation> findAllWithBuildPlanId(Pageable pageable);
 
@@ -211,6 +212,14 @@ public interface ProgrammingExerciseStudentParticipationRepository extends JpaRe
                 OR p.repositoryUri IS NOT NULL
             """)
     Page<ProgrammingExerciseStudentParticipation> findAllWithRepositoryUriOrBuildPlanId(Pageable pageable);
+
+    @Query("""
+            SELECT DISTINCT p
+            FROM ProgrammingExerciseStudentParticipation p
+            WHERE p.repositoryUri IS NOT NULL
+            ORDER BY p.id DESC
+            """)
+    Page<ProgrammingExerciseStudentParticipation> findAllWithRepositoryUri(Pageable pageable);
 
     /**
      * Remove the build plan id from all participations of the given exercise.
@@ -225,7 +234,7 @@ public interface ProgrammingExerciseStudentParticipationRepository extends JpaRe
     @Query("""
             UPDATE ProgrammingExerciseStudentParticipation p
             SET p.buildPlanId = NULL
-            WHERE p.exercise.id = :#{#exerciseId}
+            WHERE p.exercise.id = :exerciseId
             """)
     void unsetBuildPlanIdForExercise(@Param("exerciseId") Long exerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProfileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProfileService.java
@@ -33,6 +33,10 @@ public class ProfileService {
         return isProfileActive("gitlabci") || isJenkins();
     }
 
+    public boolean isBitbucket() {
+        return isProfileActive("bitbucket");
+    }
+
     /**
      * Checks if the local CI profile is active
      *

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -270,7 +270,7 @@ public class GitService {
      * @throws URISyntaxException if SSH is used and the SSH URI could not be retrieved.
      */
     private URI getGitUri(VcsRepositoryUri vcsRepositoryUri) throws URISyntaxException {
-        if (profileService.isLocalVcsCi()) {
+        if (profileService.isLocalVcsCi() && !profileService.isBitbucket()) {
             // Create less generic LocalVCRepositoryUri out of VcsRepositoryUri.
             LocalVCRepositoryUri localVCRepositoryUri = new LocalVCRepositoryUri(vcsRepositoryUri.toString(), gitUrl);
             String localVCBasePath = environment.getProperty("artemis.version-control.local-vcs-repo-path");

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIProgrammingLanguageFeatureService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIProgrammingLanguageFeatureService.java
@@ -5,6 +5,7 @@ import static de.tum.in.www1.artemis.domain.enumeration.ProjectType.*;
 
 import java.util.List;
 
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,7 @@ import de.tum.in.www1.artemis.service.programming.ProgrammingLanguageFeatureServ
  * Sets the features provided for the different programming languages when using the local CI system.
  */
 @Service
+@Primary // only needed for the bamboo to local ci migration
 @Profile("localci")
 public class LocalCIProgrammingLanguageFeatureService extends ProgrammingLanguageFeatureService {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIResultService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIResultService.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.service.connectors.localci;
 
 import java.util.List;
 
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +23,7 @@ import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseFeedbackCre
  * Service implementation for integrated CI.
  */
 @Service
+@Primary // only needed for the bamboo to local ci migration
 @Profile("localci")
 public class LocalCIResultService extends AbstractContinuousIntegrationResultService {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,7 @@ import de.tum.in.www1.artemis.service.hestia.TestwiseCoverageService;
  * needed and thus contain an empty implementation.
  */
 @Service
+@Primary // only needed for the bamboo to local ci migration
 @Profile("localci")
 public class LocalCIService extends AbstractContinuousIntegrationService {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -12,6 +12,7 @@ import javax.annotation.PostConstruct;
 import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -42,6 +43,7 @@ import de.tum.in.www1.artemis.service.programming.ProgrammingLanguageFeature;
  * Service for triggering builds on the local CI system.
  */
 @Service
+@Primary // only needed for the bamboo to local ci migration
 @Profile("localci")
 public class LocalCITriggerService implements ContinuousIntegrationTriggerService {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCService.java
@@ -22,6 +22,7 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -42,6 +43,7 @@ import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPer
  * Implementation of VersionControlService for the local VC server.
  */
 @Service
+@Primary // only needed for the bamboo to local ci migration
 @Profile("localvc")
 public class LocalVCService extends AbstractVersionControlService {
 


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR can not be reviewed by deploying it to a testserver, review the code and if you have an atlassian setup, try it out or reach out to me. Also this migration is not intended to be merged into develop but used to migrate our production environment with roughly 3-4k exercises and +800k repositories.

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The TUM Artemis instance currently uses the Atlassian software stack to provide programming exercises to its students, this PR adds an automatic migration away from it. With this change we migrate all repositories of existing exercises from Bitbucket to LocalVC, storing them within Artemis and change the URI in the database.

### Description
<!-- Describe your changes in detail -->
The Migration will run once if all required profiles (`bitbucket` and `localvc`) are active and directly migrate all repos during startup of Artemis. As LocalVC is not compatible with Bamboo, the migration effectively makes Artemis unusable for programming exercises without the Migration in #8124. 
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Artemis Setup with Bitbucket configured

1. Backup your database
2. Set `migration.base-url` to your artemis url in `application-local.yml`
3. Set `migration.local-vcs-repo-path` to where you want to store the new repositories in `application-local.yml`
the new lines should look like this if you have a default artemis clone of this project
```
migration:
  local-vcs-repo-path: ./local-vcs-repos
  base-url: http://localhost:8080
```
4. Start Artemis with the profiles `bitbucket`, `localvc`, you can also use the new run configuration within this PR, as it contains all required profiles.
5. Wait for all repositories to be migrated and for Artemis to run.
6. Stop Artemis and check if the repositories have content in them in `local-vcs-repos`
7. Artemis with LocalVC expects the contents of `local-vcs-repos` in a subdirectory called `git` and not directly in it, please move all the content into a new subdirectory: `mv repos git && mkdir repos && mv git repos/`
8. Check the database if the URIs for all programming exercises have been changed to your Artemis FQDN: `select repository_url from participation\G`
9. Artemis is now not operational without the migration of #8124 so please follow the steps there to migrate completely to the new CI/VCS solution or restore the backup of your database.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new run configuration for the Artemis Spring Boot application, enhancing development and testing workflows.
	- Added support for migrations from Bitbucket to a local version control system, including efficient handling of programming exercises and participations.
	- Implemented new methods and services to facilitate the transition from Bitbucket and Bamboo to local version control and continuous integration systems.
- **Improvements**
	- Improved the ordering of SQL query results in the Programming Exercise Student Participation Repository for better data management.
	- Enhanced the Git and Bitbucket services with new functionalities like checking active profiles and clearing cached repositories.
- **Refactor**
	- Modified several classes to improve code quality and maintainability, including changes to constructors, method extractions, and the addition of annotations for primary service selection during migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->