### PR TITLE
`Development`: Migrate Bamboo to LocalCI (release 6.8.5)

### DIFF
--- a/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI___Atlassian.xml
+++ b/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI___Atlassian.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artemis (Server, LocalVC &amp; LocalCI &amp; Atlassian)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="bamboo,bitbucket,jira,dev,localci,localvc,artemis,scheduling,local" />
+    <option name="ACTIVE_PROFILES" value="bamboo,bitbucket,jira,dev,localci,localvc,artemis,scheduling,local,aeolus" />
     <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <module name="Artemis.main" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Refer to [Using JHipster in production](http://www.jhipster.tech/production) for
 The following command can automate the deployment to a server. The example shows the deployment to the main Artemis test server (which runs a virtual machine):
 
 ```shell
-./artemis-server-cli deploy username@artemistest.ase.in.tum.de -w build/libs/Artemis-6.8.4.war
+./artemis-server-cli deploy username@artemistest.ase.in.tum.de -w build/libs/Artemis-6.8.5.war
 ```
 
 ## Architecture

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
 }
 
 group = "de.tum.in.www1.artemis"
-version = "6.8.4"
+version = "6.8.5"
 description = "Interactive Learning with Individual Feedback"
 
 java {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "artemis",
-    "version": "6.8.4",
+    "version": "6.8.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "artemis",
-            "version": "6.8.4",
+            "version": "6.8.5",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/MigrationRegistry.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/MigrationRegistry.java
@@ -29,7 +29,8 @@ public class MigrationRegistry {
         this.migrationEntryMap.put(2, MigrationEntry20230810_150000.class);
         this.migrationEntryMap.put(3, MigrationEntry20230920_181600.class);
         this.migrationEntryMap.put(4, MigrationEntry20231206_163000.class);
-        this.migrationEntryMap.put(5, MigrationEntry20240103_143700.class);
+        // this.migrationEntryMap.put(5, MigrationEntry20240103_143700.class); // to make this PR testable, we disable this migration
+        this.migrationEntryMap.put(6, MigrationEntry20240104_195600.class);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20240104_195600.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20240104_195600.java
@@ -1,0 +1,222 @@
+package de.tum.in.www1.artemis.config.migration.entries;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import com.google.gson.Gson;
+
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+import de.tum.in.www1.artemis.repository.SolutionProgrammingExerciseParticipationRepository;
+import de.tum.in.www1.artemis.repository.TemplateProgrammingExerciseParticipationRepository;
+import de.tum.in.www1.artemis.service.connectors.aeolus.Action;
+import de.tum.in.www1.artemis.service.connectors.aeolus.AeolusBuildScriptGenerationService;
+import de.tum.in.www1.artemis.service.connectors.aeolus.ScriptAction;
+import de.tum.in.www1.artemis.service.connectors.aeolus.Windfile;
+
+@Component
+public class MigrationEntry20240104_195600 extends ProgrammingExerciseMigrationEntry {
+
+    private static final int BATCH_SIZE = 100;
+
+    private static final int MAX_THREAD_COUNT = 32;
+
+    private static final String ERROR_MESSAGE = "Failed to migrate programming exercises within nine hours. Aborting migration.";
+
+    private static final int TIMEOUT_IN_HOURS = 9;
+
+    private static final List<String> MIGRATABLE_PROFILES = List.of("bamboo", "localci", "aeolus");
+
+    private static final Logger log = LoggerFactory.getLogger(MigrationEntry20240104_195600.class);
+
+    private final ProgrammingExerciseRepository programmingExerciseRepository;
+
+    private final SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository;
+
+    private final TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository;
+
+    private final Optional<AeolusBuildScriptGenerationService> aeolusBuildScriptGenerationService;
+
+    private final Environment environment;
+
+    private final CopyOnWriteArraySet<String> noDockerImageExercises = new CopyOnWriteArraySet<>();
+
+    public MigrationEntry20240104_195600(ProgrammingExerciseRepository programmingExerciseRepository, Environment environment,
+            SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository,
+            Optional<AeolusBuildScriptGenerationService> aeolusBuildScriptGenerationService,
+            TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository) {
+        this.programmingExerciseRepository = programmingExerciseRepository;
+        this.environment = environment;
+        this.solutionProgrammingExerciseParticipationRepository = solutionProgrammingExerciseParticipationRepository;
+        this.aeolusBuildScriptGenerationService = aeolusBuildScriptGenerationService;
+        this.templateProgrammingExerciseParticipationRepository = templateProgrammingExerciseParticipationRepository;
+    }
+
+    @Override
+    public void execute() {
+        List<String> activeProfiles = List.of(environment.getActiveProfiles());
+        if (!new HashSet<>(activeProfiles).containsAll(MIGRATABLE_PROFILES)) {
+            log.info("Migration will be skipped and marked run because the system does not support a tech-stack that requires this migration: {}",
+                    List.of(environment.getActiveProfiles()));
+            return;
+        }
+
+        var programmingExerciseCount = programmingExerciseRepository.count();
+
+        if (programmingExerciseCount == 0) {
+            // no exercises to change, migration complete
+            return;
+        }
+
+        log.info("Will migrate {} programming exercises now. This might take a while", programmingExerciseCount);
+        // Number of full batches. The last batch might be smaller
+        long totalFullBatchCount = programmingExerciseCount / BATCH_SIZE;
+        int threadCount = (int) Math.max(1, Math.min(totalFullBatchCount, MAX_THREAD_COUNT));
+
+        // Use fixed thread pool to prevent loading too many exercises into memory at once
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        /*
+         * migrate the solution participations, we don't care about template or
+         */
+        var solutionCount = solutionProgrammingExerciseParticipationRepository.count();
+        AtomicInteger counter = new AtomicInteger(0);
+        log.info("Found {} solution participations to migrate.", solutionCount);
+        for (int currentPageStart = 0; currentPageStart < solutionCount; currentPageStart += BATCH_SIZE) {
+            Pageable pageable = PageRequest.of(currentPageStart / BATCH_SIZE, BATCH_SIZE);
+            var solutionParticipationPage = solutionProgrammingExerciseParticipationRepository.findAllWithBuildPlanIdNotNull(pageable);
+            log.info("Will migrate {} solution participations in batch.", solutionParticipationPage.getNumberOfElements());
+            executorService.submit(() -> {
+                migrateSolutions(solutionParticipationPage.toList());
+                log.info("Migrated {}/{} solution participations so far.", counter.addAndGet(solutionParticipationPage.getNumberOfElements()), solutionCount);
+            });
+        }
+
+        log.info("Submitted all solution participations to thread pool for migration.");
+
+        shutdown(executorService, TIMEOUT_IN_HOURS, ERROR_MESSAGE);
+        log.info("Finished migrating programming exercises and student participations");
+        evaluateErrorList(programmingExerciseRepository);
+
+        if (!noDockerImageExercises.isEmpty()) {
+            log.info("The following exercises have no docker image set and need to be fixed manually: {}", noDockerImageExercises);
+        }
+    }
+
+    /**
+     * We only need to migrate the solution build plan, as the student build plans and template ones are not used in the new tech stack.
+     *
+     * @param solutionParticipations the solution participations to migrate
+     */
+    private void migrateSolutions(List<SolutionProgrammingExerciseParticipation> solutionParticipations) {
+        if (aeolusBuildScriptGenerationService.isEmpty()) {
+            log.error("Failed to migrate solutions because the AeolusBuildScriptGenerationService is not present.");
+            return;
+        }
+        for (var solutionParticipation : solutionParticipations) {
+            try {
+                ProgrammingExercise exercise = programmingExerciseRepository.getProgrammingExerciseFromParticipation(solutionParticipation);
+                String exerciseId = exercise != null ? exercise.getId().toString() : "unknown";
+                Windfile windfile = aeolusBuildScriptGenerationService.get().translateBuildPlan(solutionParticipation.getBuildPlanId());
+                if (windfile == null) {
+                    log.error("Failed to migrate solution participation with id {} of exercise {}, because the windfile is null", solutionParticipation.getId(), exerciseId);
+                    if (exercise != null) {
+                        var template = templateProgrammingExerciseParticipationRepository.findByProgrammingExerciseId(exercise.getId());
+                        if (template.isPresent()) {
+                            windfile = aeolusBuildScriptGenerationService.get().translateBuildPlan(template.get().getBuildPlanId());
+                            if (windfile != null) {
+                                log.info("Migrating template participation with id {} of exercise {} using the template build plan", template.get().getId(), exerciseId);
+                            }
+                            else {
+                                log.error("Failed to migrate template participation with id {} of exercise {}, because the windfile is null", template.get().getId(), exerciseId);
+                                errorList.add(solutionParticipation);
+                                continue;
+                            }
+                        }
+                    }
+                    else {
+                        errorList.add(solutionParticipation);
+                        continue;
+                    }
+                }
+                if (windfile == null) {
+                    log.error("Failed to migrate solution participation with id {}", solutionParticipation.getId());
+                    errorList.add(solutionParticipation);
+                    continue;
+                }
+                if (windfile.getMetadata().getDocker() == null) {
+                    noDockerImageExercises.add(exerciseId);
+                    log.info(
+                            "Migrating solution participation with id {} of exercise {} but the docker image is null, the build plan will be translated but not be functional as an instructor needs to add a docker image",
+                            solutionParticipation.getId(), exerciseId);
+                }
+                // we don't need the following fields in the windfile
+                windfile.setRepositories(null);
+                windfile.setId(null);
+                windfile.setName(null);
+                windfile.setAuthor(null);
+                windfile.setGitCredentials(null);
+                windfile.setDescription(null);
+                this.makeWindfileLocalCIOptimized(windfile);
+                // TODO: should we modify the docker parameters here? e.g. remove stuff like --net=host? -> this is more a question for after
+                // the migration is done as localci does not respect the docker parameters anyway at the moment
+                var programmingExercise = solutionParticipation.getProgrammingExercise();
+                programmingExercise.setBuildPlanConfiguration(new Gson().toJson(windfile));
+                programmingExerciseRepository.save(programmingExercise);
+                var buildScript = aeolusBuildScriptGenerationService.get().getScript(programmingExercise);
+                if (buildScript == null) {
+                    throw new RuntimeException("Failed to migrate solution participation because the build script is null.");
+                }
+                programmingExercise.setBuildScript(buildScript);
+                programmingExerciseRepository.save(programmingExercise);
+            }
+            catch (Exception e) {
+                log.error("Failed to migrate solution participation with id {}", solutionParticipation.getId(), e);
+                errorList.add(solutionParticipation);
+            }
+        }
+    }
+
+    /**
+     * LocalCI needs some special treatment for some exercises. This method modifies the windfile to make it work flawlessly with LocalCI.
+     *
+     * @param windfile the windfile to modify
+     */
+    private void makeWindfileLocalCIOptimized(Windfile windfile) {
+        var actions = windfile.getActions();
+        for (Action action : actions) {
+            if (action instanceof ScriptAction scriptAction) {
+                var script = scriptAction.getScript();
+                if (script.trim().contains("./gradlew clean test")) {
+                    scriptAction.setScript(script.replace("./gradlew clean test", "chmod +x ./gradlew\n./gradlew clean test"));
+                }
+                else if (script.trim().contains("chmod -R 777 ${WORKDIR}")) {
+                    scriptAction.setPlatform("bamboo");
+                }
+            }
+        }
+    }
+
+    @Override
+    public String author() {
+        return "reschandreas";
+    }
+
+    @Override
+    public String date() {
+        return "20240104_195600";
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/repository/SolutionProgrammingExerciseParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SolutionProgrammingExerciseParticipationRepository.java
@@ -4,6 +4,8 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -43,6 +45,13 @@ public interface SolutionProgrammingExerciseParticipationRepository extends JpaR
     Optional<SolutionProgrammingExerciseParticipation> findWithEagerSubmissionsByProgrammingExerciseId(long exerciseId);
 
     Optional<SolutionProgrammingExerciseParticipation> findByProgrammingExerciseId(long programmingExerciseId);
+
+    @Query("""
+            SELECT p
+            FROM SolutionProgrammingExerciseParticipation p
+            WHERE p.buildPlanId IS NOT NULL
+            """)
+    Page<SolutionProgrammingExerciseParticipation> findAllWithBuildPlanIdNotNull(Pageable pageable);
 
     default SolutionProgrammingExerciseParticipation findByProgrammingExerciseIdElseThrow(long programmingExerciseId) {
         var optional = findByProgrammingExerciseId(programmingExerciseId);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/AeolusBuildScriptGenerationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/AeolusBuildScriptGenerationService.java
@@ -55,4 +55,14 @@ public class AeolusBuildScriptGenerationService extends BuildScriptGenerationSer
         }
         return null;
     }
+
+    /**
+     * Translates the given Bamboo build plan (identified by {@code buildPlanKey}) into a Windfile.
+     *
+     * @param buildPlanKey the build plan key in Bamboo
+     * @return the Windfile
+     */
+    public Windfile translateBuildPlan(String buildPlanKey) {
+        return aeolusBuildPlanService.translateBuildPlan(AeolusTarget.BAMBOO, buildPlanKey);
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/Windfile.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/aeolus/Windfile.java
@@ -118,6 +118,16 @@ public class Windfile {
         this.metadata.setResultHook(resultHook);
     }
 
+    /**
+     * Sets the author for the windfile.
+     *
+     * @param author the author for the windfile.
+     */
+    public void setAuthor(String author) {
+        checkMetadata();
+        this.metadata.setAuthor(author);
+    }
+
     public void setRepositories(Map<String, AeolusRepository> repositories) {
         this.repositories = repositories;
     }


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR can not be reviewed by deploying it to a testserver, review the code and if you have an atlassian setup, try it out or reach out to me. Also this migration is not intended to be merged into develop but used to migrate our production environment with roughly 3-4k exercises and +800k repositories.

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The TUM Artemis instance currently uses the Atlassian software stack to provide programming exercises to its students, this PR adds a partial automatic migration away from it. With this change, we migrate all build plans of existing exercises from Bamboo to LocalCI using Aeolus, generate bash script and store them within Artemis.

### Description
<!-- Describe your changes in detail -->
The Migration will run once, if all required profiles (`bamboo` and `localci` and `aeolus`) are active and directly migrate all solution buld plans during startup of Artemis. The migration of this PR is expected to be executed after #8122 and is a stacked PR.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Artemis Setup with Bamboo configured
- 1 Aeolus container running, see step 3 on how to set it up

1. Backup your database
2.  Start Aeolus with `docker compose -f docker/aeolus.yml up -d`
4. Add the following lines to your `application-local.yml` to let Artemis know where to find Aeolus
```
aeolus:
  url: http://localhost:8090
```
3. Start Artemis with the profiles `bamboo`, `localci` and `aeolus`, you can also use the new run configuration in this PR that includes all necessary profiles. 
4. Wait for all build plans to be migrated and for Artemis to run
5. Stop Artemis and check if build plans are stored in the database  `select build_script from programming_exercise_details\G`
7. Start Artemis with the normal localvc and localci setup, you have to deactivate bamboo profile for the following to work.
8. Check if the builds of programming exercises still work as expected

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new run configuration named "Artemis" for Spring Boot applications.
	- Added migration services for transitioning from Bitbucket to a local version control system.
	- Implemented new migration entries for programming exercises, including efficient batch processing and error handling.
	- Enhanced build plan translation and script generation for programming exercises using Aeolus.
- **Enhancements**
	- Improved ordering of results in `ProgrammingExerciseStudentParticipationRepository`.
	- Added method to check if the profile is active for Bitbucket in `ProfileService`.
	- Enhanced `GitService` with a new condition check and method for clearing cached repositories.
	- Introduced a method to set the author for windfiles, updating metadata accordingly.
- **Bug Fixes**
	- Corrected annotations for local CI and VC services to support bamboo to local CI migration more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->