### PR TITLE
`Integrated code lifecycle`: Fix open edge in clone repo component

### DIFF
--- a/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
+++ b/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
@@ -38,13 +38,11 @@
                     </div>
                 </div>
             }
-            <!-- ngStyle: sshEnabled -> Remove round edges and edge on the left side (due to dropdown to select ssh or https)
-      || useSsh -> Remove round edges and edge on the right side (as ssh repo-links can't be open in the browser)-->
+            <!-- 'url-box-remove-line-left': Remove round edges and edge on the left side (due to dropdown to select ssh or https)
+           `url-box-remove-line-right`: Remove round edges and edge on the right side (not available for LocalVC) -->
             <pre
                 class="clone-url"
-                [ngClass]="
-                    sshEnabled && !useSsh ? 'url-box-remove-line-left url-box-remove-line-right' : sshEnabled && useSsh ? 'url-box-remove-line-left' : 'url-box-remove-line-right'
-                "
+                [ngClass]="sshEnabled && ((useSsh && !localVCEnabled) || !useSsh) ? 'url-box-remove-line-left' : !localVCEnabled ? 'url-box-remove-line-right' : ''"
                 [cdkCopyToClipboard]="getHttpOrSshRepositoryUri(false)"
                 (cdkCopyToClipboardCopied)="onCopyFinished($event)"
                 >{{ getHttpOrSshRepositoryUri() }} </pre

--- a/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
+++ b/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
@@ -42,7 +42,7 @@
            `url-box-remove-line-right`: Remove round edges and edge on the right side (not available for LocalVC) -->
             <pre
                 class="clone-url"
-                [ngClass]="sshEnabled && ((useSsh && !localVCEnabled) || !useSsh) ? 'url-box-remove-line-left' : !localVCEnabled ? 'url-box-remove-line-right' : ''"
+                [ngClass]="{'url-box-remove-line-left': sshEnabled && ((useSsh && !localVCEnabled) || !useSsh), 'url-box-remove-line-right': !localVCEnabled && !(sshEnabled && ((useSsh && !localVCEnabled) || !useSsh))}"
                 [cdkCopyToClipboard]="getHttpOrSshRepositoryUri(false)"
                 (cdkCopyToClipboardCopied)="onCopyFinished($event)"
                 >{{ getHttpOrSshRepositoryUri() }} </pre

--- a/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
+++ b/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
@@ -42,7 +42,10 @@
            `url-box-remove-line-right`: Remove round edges and edge on the right side (not available for LocalVC) -->
             <pre
                 class="clone-url"
-                [ngClass]="{'url-box-remove-line-left': sshEnabled && ((useSsh && !localVCEnabled) || !useSsh), 'url-box-remove-line-right': !localVCEnabled && !(sshEnabled && ((useSsh && !localVCEnabled) || !useSsh))}"
+                [ngClass]="{
+                    'url-box-remove-line-left': sshEnabled && ((useSsh && !localVCEnabled) || !useSsh),
+                    'url-box-remove-line-right': !localVCEnabled && !(sshEnabled && ((useSsh && !localVCEnabled) || !useSsh))
+                }"
                 [cdkCopyToClipboard]="getHttpOrSshRepositoryUri(false)"
                 (cdkCopyToClipboardCopied)="onCopyFinished($event)"
                 >{{ getHttpOrSshRepositoryUri() }} </pre


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
With the new LocalVC Setup, the button to open the repository in the VC (introduced with #4746 ) is no longer available. Currently, the styling has not been adapted, so the text field of the URL is open on the right side.
![image](https://github.com/ls1intum/Artemis/assets/94070506/149285a2-7c08-46ab-9436-cab0a786e2b1)

### Description
This PR fixes the styling by taking the localVC into account.
The following conditions are passed in a compressed manner to the ngClass:

sshEnabled && useSsh && localVCEnabled: url-box-remove-line-left
sshEnabled && useSsh && !localVCEnabled: url-box-remove-line-left
sshEnabled && !useSsh && localVCEnabled: url-box-remove-line-left
sshEnabled && !useSsh && !localVCEnabled: url-box-remove-line-left url-box-remove-line-right
!sshEnabled && !useSsh && !localVCEnabled: url-box-remove-line-left url-box-remove-line-right

If sshEnabled, the dropdown to select ssh or https is shown on the left -> url-box-remove-line-left
If !useSsh and !localVCEnabled, the button to open the repository in a browser window is shown -> url-box-remove-line-right


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise 

1. Log in to Artemis
2. Navigate to Course Administration
3. Create or reuse a programming exercise
4. Open the clone repro component and verify, that the edges for the text field are displayed accordingly. 


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
![image](https://github.com/ls1intum/Artemis/assets/94070506/a35b5583-774f-41cf-a252-d57b94268e25)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
	- Enhanced conditional styling for the clone repository button based on SSH and version control settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->