### PR TITLE
`Development`: Fix failing communication server test

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/metis/ConversationMessagingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/ConversationMessagingService.java
@@ -103,8 +103,10 @@ public class ConversationMessagingService extends PostingService {
         newMessage.setAuthor(author);
         newMessage.setDisplayPriority(DisplayPriority.NONE);
 
-        var conversation = conversationService.isMemberOrCreateForCourseWideElseThrow(newMessage.getConversation().getId(), author, Optional.empty())
-                .orElse(conversationRepository.findWithParticipantsById(newMessage.getConversation().getId()).orElseThrow());
+        var conversationId = newMessage.getConversation().getId();
+
+        var conversation = conversationService.isMemberOrCreateForCourseWideElseThrow(conversationId, author, Optional.empty())
+                .orElse(conversationService.loadConversationWithParticipantsIfGroupChat(conversationId));
         log.debug("      createMessage:conversationService.isMemberOrCreateForCourseWideElseThrow DONE");
 
         var course = preCheckUserAndCourseForMessaging(author, courseId);

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -144,6 +144,9 @@ public class ConversationService {
 
     /**
      * In certain use cases, we need the conversation participants to generate the human-readable name for a group chat.
+     *
+     * @param conversationId the id of the conversation
+     * @return the conversation that has been loaded
      */
     public Conversation loadConversationWithParticipantsIfGroupChat(Long conversationId) {
         var conversation = conversationRepository.findByIdElseThrow(conversationId);

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -127,7 +127,7 @@ public class ConversationService {
             return Optional.empty();
         }
 
-        Conversation conversation = conversationRepository.findByIdElseThrow(conversationId);
+        Conversation conversation = loadConversationWithParticipantsIfGroupChat(conversationId);
 
         if (conversation instanceof Channel channel && channel.getIsCourseWide()) {
             ConversationParticipant conversationParticipant = ConversationParticipant.createWithDefaultValues(user, channel);
@@ -140,6 +140,17 @@ public class ConversationService {
         }
 
         return Optional.of(conversation);
+    }
+
+    /**
+     * In certain use cases, we need the conversation participants to generate the human-readable name for a group chat.
+     */
+    public Conversation loadConversationWithParticipantsIfGroupChat(Long conversationId) {
+        var conversation = conversationRepository.findByIdElseThrow(conversationId);
+        if (conversation instanceof GroupChat) {
+            return conversationRepository.findWithParticipantsById(conversationId).orElseThrow();
+        }
+        return conversation;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We have a failing test on develop. 

### Description
<!-- Describe your changes in detail -->
Improved the loading logic to only load conversation participants if it is a group chat. Therefore, the participants are no longer loaded in case of channels.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Enhanced readability and separation of concerns in conversation service by delegating conversation loading for group chats to a new method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->