### PR TITLE
`Development`: Fix null pointer exception when fetching student participation

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseParticipationResource.java
@@ -313,10 +313,13 @@ public class ProgrammingExerciseParticipationResource {
      */
     private void hasAccessToParticipationElseThrow(ProgrammingExerciseStudentParticipation participation) {
         participationAuthCheckService.checkCanAccessParticipationElseThrow(participation);
-        boolean exerciseHasStarted = participation.getExercise().getParticipationStartDate().isBefore(ZonedDateTime.now());
-        boolean isStudent = authCheckService.isOnlyStudentInCourse(participation.getExercise().getCourseViaExerciseGroupOrCourseMember(), null);
-        if (!exerciseHasStarted && isStudent) {
-            throw new AccessForbiddenException("Participation not yet started");
+        ZonedDateTime exerciseStartDate = participation.getExercise().getParticipationStartDate();
+        if (exerciseStartDate != null) {
+            boolean isStudent = authCheckService.isOnlyStudentInCourse(participation.getExercise().getCourseViaExerciseGroupOrCourseMember(), null);
+            boolean exerciseNotStarted = exerciseStartDate.isAfter(ZonedDateTime.now());
+            if (isStudent && exerciseNotStarted) {
+                throw new AccessForbiddenException("Participation not yet started");
+            }
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseParticipationIntegrationTest.java
@@ -84,31 +84,37 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     private static Stream<Arguments> argumentsForGetParticipationResults() {
         ZonedDateTime startDate = ZonedDateTime.now().minusDays(3);
+        ZonedDateTime releaseDate = ZonedDateTime.now().minusDays(4);
         ZonedDateTime someDate = ZonedDateTime.now();
         ZonedDateTime futureDate = ZonedDateTime.now().plusDays(3);
         ZonedDateTime pastDate = ZonedDateTime.now().minusDays(1);
         return Stream.of(
                 // No assessmentType and no completionDate -> notFound
-                Arguments.of(startDate, null, null, null, false),
+                Arguments.of(null, null, null, null, null, false),
                 // Automatic result is always returned
-                Arguments.of(startDate, AssessmentType.AUTOMATIC, null, null, true), Arguments.of(startDate, AssessmentType.AUTOMATIC, someDate, null, true),
-                Arguments.of(startDate, AssessmentType.AUTOMATIC, someDate, futureDate, true), Arguments.of(startDate, AssessmentType.AUTOMATIC, someDate, pastDate, true),
-                Arguments.of(startDate, AssessmentType.AUTOMATIC, null, futureDate, true), Arguments.of(startDate, AssessmentType.AUTOMATIC, null, pastDate, true),
+                Arguments.of(startDate, releaseDate, AssessmentType.AUTOMATIC, null, null, true),
+                Arguments.of(startDate, releaseDate, AssessmentType.AUTOMATIC, someDate, null, true),
+                Arguments.of(startDate, releaseDate, AssessmentType.AUTOMATIC, someDate, futureDate, true),
+                Arguments.of(startDate, releaseDate, AssessmentType.AUTOMATIC, someDate, pastDate, true),
+                Arguments.of(startDate, releaseDate, AssessmentType.AUTOMATIC, null, futureDate, true),
+                Arguments.of(startDate, releaseDate, AssessmentType.AUTOMATIC, null, pastDate, true),
                 // Manual result without completion date (assessment was only saved but no submitted) is not returned
-                Arguments.of(startDate, AssessmentType.SEMI_AUTOMATIC, null, null, false), Arguments.of(startDate, AssessmentType.SEMI_AUTOMATIC, null, futureDate, false),
-                Arguments.of(startDate, AssessmentType.SEMI_AUTOMATIC, null, pastDate, false),
+                Arguments.of(startDate, releaseDate, AssessmentType.SEMI_AUTOMATIC, null, null, false),
+                Arguments.of(startDate, releaseDate, AssessmentType.SEMI_AUTOMATIC, null, futureDate, false),
+                Arguments.of(startDate, releaseDate, AssessmentType.SEMI_AUTOMATIC, null, pastDate, false),
                 // Manual result is not returned if completed and assessment due date has not passed
-                Arguments.of(startDate, AssessmentType.SEMI_AUTOMATIC, someDate, futureDate, false),
+                Arguments.of(startDate, releaseDate, AssessmentType.SEMI_AUTOMATIC, someDate, futureDate, false),
                 // Manual result is returned if completed and assessmentDue date has passed
-                Arguments.of(startDate, AssessmentType.SEMI_AUTOMATIC, someDate, pastDate, true));
+                Arguments.of(startDate, releaseDate, AssessmentType.SEMI_AUTOMATIC, someDate, pastDate, true));
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @MethodSource("argumentsForGetParticipationResults")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetParticipationWithLatestResultAsAStudent(ZonedDateTime startDate, AssessmentType assessmentType, ZonedDateTime completionDate, ZonedDateTime assessmentDueDate,
-            boolean expectLastCreatedResult) throws Exception {
+    void testGetParticipationWithLatestResultAsAStudent(ZonedDateTime startDate, ZonedDateTime releaseDate, AssessmentType assessmentType, ZonedDateTime completionDate,
+            ZonedDateTime assessmentDueDate, boolean expectLastCreatedResult) throws Exception {
         programmingExercise.setStartDate(startDate);
+        programmingExercise.setReleaseDate(releaseDate);
         programmingExercise.setAssessmentDueDate(assessmentDueDate);
         programmingExerciseRepository.save(programmingExercise);
         var result = addStudentParticipationWithResult(assessmentType, completionDate);
@@ -127,9 +133,10 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @MethodSource("argumentsForGetParticipationResults")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetParticipationWithLatestResult_multipleResultsAvailable(ZonedDateTime startDate, AssessmentType assessmentType, ZonedDateTime completionDate,
-            ZonedDateTime assessmentDueDate, boolean expectLastCreatedResult) throws Exception {
+    void testGetParticipationWithLatestResult_multipleResultsAvailable(ZonedDateTime startDate, ZonedDateTime releaseDate, AssessmentType assessmentType,
+            ZonedDateTime completionDate, ZonedDateTime assessmentDueDate, boolean expectLastCreatedResult) throws Exception {
         programmingExercise.setStartDate(startDate);
+        programmingExercise.setReleaseDate(releaseDate);
         // Add an automatic result first
         var firstResult = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, null);
         programmingExercise.setAssessmentDueDate(assessmentDueDate);
@@ -207,9 +214,10 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @MethodSource("argumentsForGetParticipationResults")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetParticipationWithAllResults(ZonedDateTime startDate, AssessmentType assessmentType, ZonedDateTime completionDate, ZonedDateTime assessmentDueDate,
-            boolean expectLastCreatedResult) throws Exception {
+    void testGetParticipationWithAllResults(ZonedDateTime startDate, ZonedDateTime releaseDate, AssessmentType assessmentType, ZonedDateTime completionDate,
+            ZonedDateTime assessmentDueDate, boolean expectLastCreatedResult) throws Exception {
         programmingExercise.setStartDate(startDate);
+        programmingExercise.setReleaseDate(releaseDate);
         // Add an automatic result first
         var firstResult = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, null);
         programmingExercise.setAssessmentDueDate(assessmentDueDate);
@@ -295,6 +303,17 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
         ProgrammingExerciseStudentParticipation participation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise,
                 TEST_PREFIX + "student1");
         request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-all-results", HttpStatus.FORBIDDEN, ProgrammingExerciseStudentParticipation.class);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetParticipationAllResults_studentCanAccessIfNoStartDateSet() throws Exception {
+        programmingExercise.setStartDate(null);
+        programmingExercise.setReleaseDate(null);
+        programmingExerciseRepository.save(programmingExercise);
+        ProgrammingExerciseStudentParticipation participation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise,
+                TEST_PREFIX + "student1");
+        request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-all-results", HttpStatus.OK, ProgrammingExerciseStudentParticipation.class);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, Code Editor and Repositories can't be opened if the exercise doesn't have a start or release date. 

### Description
<!-- Describe your changes in detail -->
When fetching a participation, it is first checked if a start date exists before continuing with the checks.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:

Test that everything works as expected when opening code editor and repositories for programming exercises without start or release date




### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted access control logic for students to participate in programming exercises, ensuring they can only access the exercises after the start date.
- **Tests**
	- Updated programming exercise participation tests to include a `releaseDate` parameter, enhancing the accuracy of test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->