### PR TITLE
`Development`: Fix exam participation e2e tests

### DIFF
--- a/src/test/cypress/support/pageobjects/exam/ExamStartEndPage.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamStartEndPage.ts
@@ -47,7 +47,7 @@ export class ExamStartEndPage {
     }
 
     pressShowSummary() {
-        cy.intercept(GET, COURSE_BASE + '*/exams/*/student-exams/*/summary').as('examSummaryDownload');
+        cy.intercept(GET, COURSE_BASE + '/*/exams/*/student-exams/*/summary').as('examSummaryDownload');
         cy.get('#showExamSummaryButton').should('be.visible').should('not.have.attr', 'disabled', { timeout: 15000 }).click();
         cy.wait('@examSummaryDownload');
     }

--- a/src/test/cypress/support/pageobjects/exam/ExamStartEndPage.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamStartEndPage.ts
@@ -47,7 +47,7 @@ export class ExamStartEndPage {
     }
 
     pressShowSummary() {
-        cy.intercept(GET, COURSE_BASE + '/*/exams/*/student-exams/*/summary').as('examSummaryDownload');
+        cy.intercept(GET, `${COURSE_BASE}/*/exams/*/student-exams/*/summary`).as('examSummaryDownload');
         cy.get('#showExamSummaryButton').should('be.visible').should('not.have.attr', 'disabled', { timeout: 15000 }).click();
         cy.wait('@examSummaryDownload');
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Apparently, I missed a slash when fixing the URL paths resulting in 5 failing tests. For some reason neither I nor anyone else found the tests failing at the time.

### Description
<!-- Describe your changes in detail -->
I added the slash and the tets succeed again :)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Corrected URL pattern in exam summary feature to ensure proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->