### PR TITLE
`Development`: Fix potential null pointer exception during server tests

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/quiz/QuizScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/quiz/QuizScheduleService.java
@@ -273,14 +273,14 @@ public class QuizScheduleService {
      * stop scheduler
      */
     public void stopSchedule() {
-        if (!scheduledProcessQuizSubmissions.isNull()) {
+        var savedHandler = scheduledProcessQuizSubmissions.getAndSet(null);
+        if (savedHandler != null) {
             log.info("Try to stop quiz schedule service");
-            var scheduledFuture = threadPoolTaskScheduler.getScheduledFuture(scheduledProcessQuizSubmissions.get());
+            var scheduledFuture = threadPoolTaskScheduler.getScheduledFuture(savedHandler);
             try {
                 // if the task has been disposed, this will throw a StaleTaskException
                 boolean cancelSuccess = scheduledFuture.cancel(false);
                 scheduledFuture.dispose();
-                scheduledProcessQuizSubmissions.set(null);
                 log.info("Stop Quiz Schedule Service was successful: {}", cancelSuccess);
             }
             catch (@SuppressWarnings("unused") StaleTaskException e) {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/quiz/QuizScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/quiz/QuizScheduleService.java
@@ -273,7 +273,7 @@ public class QuizScheduleService {
      * stop scheduler
      */
     public void stopSchedule() {
-        var savedHandler = scheduledProcessQuizSubmissions.getAndSet(null);
+        var savedHandler = scheduledProcessQuizSubmissions.get();
         if (savedHandler != null) {
             log.info("Try to stop quiz schedule service");
             var scheduledFuture = threadPoolTaskScheduler.getScheduledFuture(savedHandler);
@@ -281,6 +281,7 @@ public class QuizScheduleService {
                 // if the task has been disposed, this will throw a StaleTaskException
                 boolean cancelSuccess = scheduledFuture.cancel(false);
                 scheduledFuture.dispose();
+                scheduledProcessQuizSubmissions.set(null);
                 log.info("Stop Quiz Schedule Service was successful: {}", cancelSuccess);
             }
             catch (@SuppressWarnings("unused") StaleTaskException e) {


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


### Motivation and Context
Sometimes the server tests fail due to a NullPointerException in the `QuizScheduleService#stopSchedule()` method:

![grafik](https://github.com/ls1intum/Artemis/assets/26540346/567cada7-0a72-4c9c-966e-2d857b4f6f5e)

### Description
There is a concurrency issue in this method. We first call `isNull()` and afterwards `get()`, assuming that the value returned by `get()` cannot be null. However with parallel server tests, the value can get set to null between these calls, leading to this exception.


### Steps for Testing
code review

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the scheduler stopping logic in the quiz feature for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->