### PR TITLE
`Development`: Fix flaky ExerciseLifecycleServiceTest

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
@@ -6,6 +6,7 @@ import static org.awaitility.Awaitility.await;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,7 @@ class ExerciseLifecycleServiceTest extends AbstractSpringIntegrationIndependentT
         assertThat(dueFuture.isDone()).isFalse();
         assertThat(assessmentDueFuture.isDone()).isFalse();
 
-        await().untilAsserted(() -> {
+        await().pollInterval(50, TimeUnit.MILLISECONDS).untilAsserted(() -> {
             assertEqual(releaseTrigger, true);
             assertEqual(dueTrigger, false);
             assertEqual(assessmentDueTrigger, false);
@@ -53,7 +54,7 @@ class ExerciseLifecycleServiceTest extends AbstractSpringIntegrationIndependentT
         assertThat(dueFuture.isDone()).isFalse();
         assertThat(assessmentDueFuture.isDone()).isFalse();
 
-        await().untilAsserted(() -> {
+        await().pollInterval(50, TimeUnit.MILLISECONDS).untilAsserted(() -> {
             assertEqual(releaseTrigger, true);
             assertEqual(dueTrigger, true);
             assertEqual(assessmentDueTrigger, false);
@@ -63,7 +64,7 @@ class ExerciseLifecycleServiceTest extends AbstractSpringIntegrationIndependentT
         assertThat(dueFuture.isDone()).isTrue();
         assertThat(assessmentDueFuture.isDone()).isFalse();
 
-        await().untilAsserted(() -> {
+        await().pollInterval(50, TimeUnit.MILLISECONDS).untilAsserted(() -> {
             assertEqual(releaseTrigger, true);
             assertEqual(dueTrigger, true);
             assertEqual(assessmentDueTrigger, true);


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


### Motivation and Context
The test `testScheduleExerciseOnReleaseTask()` is currently flaky. This is caused by the assertion `assertEqual(assessmentDueTrigger, false);`  which checks that the due date action got executed, but the assessment due date action has not yet run. However it can happen that between the checks both actions were completed already, leading to a test failure. By doubling the poll interval this should no longer happen.


### Steps for Testing
code review

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved the exercise lifecycle service tests by refining waiting assertions with specific time units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->