### PR TITLE
`Programming exercises`: Fix template upgrade for maven exercises

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,8 @@ spotless {
                     "**/build/**",
                     "**/src/main/generated/**",
                     "**/src/main/resources/templates/**",
-                    "/docker/**"
+                    "/docker/**",
+                    "checked-out-repos/**"
                 )
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/JavaTemplateUpgradeService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/JavaTemplateUpgradeService.java
@@ -95,7 +95,7 @@ public class JavaTemplateUpgradeService implements TemplateUpgradeService {
             return;
         }
         try {
-            String templatePomDir = repositoryType == RepositoryType.TESTS ? "test/projectTemplate" : repositoryType.getName();
+            String templatePomDir = repositoryType == RepositoryType.TESTS ? "test/maven/projectTemplate" : repositoryType.getName();
             Resource[] templatePoms = getTemplateResources(exercise, templatePomDir + "/**/" + POM_FILE);
             Repository repository = gitService.getOrCheckoutRepository(exercise.getRepositoryURL(repositoryType), true);
             List<File> repositoryPoms = gitService.listFiles(repository).stream().filter(file -> Objects.equals(file.getName(), POM_FILE)).toList();

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -18,7 +18,7 @@
                 [isExamMode]="isExamMode"
                 [isImport]="isImportFromExistingExercise || isImportFromFile"
                 [isLocal]="isLocal"
-                [importConfigs]="importConfigs"
+                [importOptions]="importOptions"
             />
             <hr class="mb-5" />
             <jhi-programming-exercise-difficulty [programmingExercise]="programmingExercise" [programmingExerciseCreationConfig]="getProgrammingExerciseCreationConfig()" />

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -18,6 +18,7 @@
                 [isExamMode]="isExamMode"
                 [isImport]="isImportFromExistingExercise || isImportFromFile"
                 [isLocal]="isLocal"
+                [importConfigs]="importConfigs"
             />
             <hr class="mb-5" />
             <jhi-programming-exercise-difficulty [programmingExercise]="programmingExercise" [programmingExerciseCreationConfig]="getProgrammingExerciseCreationConfig()" />

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -39,6 +39,11 @@ import { ProgrammingExerciseLanguageComponent } from 'app/exercises/programming/
 import { ProgrammingExerciseGradingComponent } from 'app/exercises/programming/manage/update/update-components/programming-exercise-grading.component';
 import { ExerciseUpdatePlagiarismComponent } from 'app/exercises/shared/plagiarism/exercise-update-plagiarism/exercise-update-plagiarism.component';
 
+export interface ImportConfigs {
+    recreateBuildPlans: boolean;
+    updateTemplate: boolean;
+}
+
 @Component({
     selector: 'jhi-programming-exercise-update',
     templateUrl: './programming-exercise-update.component.html',
@@ -139,8 +144,11 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
     public customBuildPlansSupported: string = '';
 
     // Additional options for import
-    public recreateBuildPlans = false;
-    public updateTemplate = false;
+    // This is a wrapper to allow modifications from the other subcomponents
+    public readonly importConfigs: ImportConfigs = {
+        recreateBuildPlans: false,
+        updateTemplate: false,
+    };
     public originalStaticCodeAnalysisEnabled: boolean | undefined;
 
     public projectTypes: ProjectType[] = [];
@@ -626,7 +634,9 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
         if (this.isImportFromFile) {
             this.subscribeToSaveResponse(this.programmingExerciseService.importFromFile(this.programmingExercise, this.courseId));
         } else if (this.isImportFromExistingExercise) {
-            this.subscribeToSaveResponse(this.programmingExerciseService.importExercise(this.programmingExercise, this.recreateBuildPlans, this.updateTemplate));
+            this.subscribeToSaveResponse(
+                this.programmingExerciseService.importExercise(this.programmingExercise, this.importConfigs.recreateBuildPlans, this.importConfigs.updateTemplate),
+            );
         } else if (this.programmingExercise.id !== undefined) {
             const requestOptions = {} as any;
             if (this.notificationText) {
@@ -742,8 +752,8 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
     onStaticCodeAnalysisChanged() {
         // On import: If SCA mode changed, activate recreation of build plans and update of the template
         if (this.isImportFromExistingExercise && this.programmingExercise.staticCodeAnalysisEnabled !== this.originalStaticCodeAnalysisEnabled) {
-            this.recreateBuildPlans = true;
-            this.updateTemplate = true;
+            this.importConfigs.recreateBuildPlans = true;
+            this.importConfigs.updateTemplate = true;
         }
 
         if (!this.programmingExercise.staticCodeAnalysisEnabled) {
@@ -752,7 +762,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
     }
 
     onRecreateBuildPlanOrUpdateTemplateChange() {
-        if (!this.recreateBuildPlans || !this.updateTemplate) {
+        if (!this.importConfigs.recreateBuildPlans || !this.importConfigs.updateTemplate) {
             this.programmingExercise.staticCodeAnalysisEnabled = this.originalStaticCodeAnalysisEnabled;
         }
 
@@ -1075,9 +1085,9 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
             rerenderSubject: this.rerenderSubject.asObservable(),
             validIdeSelection: this.validIdeSelection,
             inProductionEnvironment: this.inProductionEnvironment,
-            recreateBuildPlans: this.recreateBuildPlans,
+            recreateBuildPlans: this.importConfigs.recreateBuildPlans,
             onRecreateBuildPlanOrUpdateTemplateChange: this.onRecreateBuildPlanOrUpdateTemplateChange,
-            updateTemplate: this.updateTemplate,
+            updateTemplate: this.importConfigs.updateTemplate,
             publishBuildPlanUrlAllowed: this.publishBuildPlanUrlAllowed,
             recreateBuildPlanOrUpdateTemplateChange: this.onRecreateBuildPlanOrUpdateTemplateChange,
             buildPlanLoaded: this.buildPlanLoaded,

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -39,7 +39,7 @@ import { ProgrammingExerciseLanguageComponent } from 'app/exercises/programming/
 import { ProgrammingExerciseGradingComponent } from 'app/exercises/programming/manage/update/update-components/programming-exercise-grading.component';
 import { ExerciseUpdatePlagiarismComponent } from 'app/exercises/shared/plagiarism/exercise-update-plagiarism/exercise-update-plagiarism.component';
 
-export interface ImportConfigs {
+export interface ImportOptions {
     recreateBuildPlans: boolean;
     updateTemplate: boolean;
 }
@@ -145,7 +145,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
 
     // Additional options for import
     // This is a wrapper to allow modifications from the other subcomponents
-    public readonly importConfigs: ImportConfigs = {
+    public readonly importOptions: ImportOptions = {
         recreateBuildPlans: false,
         updateTemplate: false,
     };
@@ -635,7 +635,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
             this.subscribeToSaveResponse(this.programmingExerciseService.importFromFile(this.programmingExercise, this.courseId));
         } else if (this.isImportFromExistingExercise) {
             this.subscribeToSaveResponse(
-                this.programmingExerciseService.importExercise(this.programmingExercise, this.importConfigs.recreateBuildPlans, this.importConfigs.updateTemplate),
+                this.programmingExerciseService.importExercise(this.programmingExercise, this.importOptions.recreateBuildPlans, this.importOptions.updateTemplate),
             );
         } else if (this.programmingExercise.id !== undefined) {
             const requestOptions = {} as any;
@@ -752,8 +752,8 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
     onStaticCodeAnalysisChanged() {
         // On import: If SCA mode changed, activate recreation of build plans and update of the template
         if (this.isImportFromExistingExercise && this.programmingExercise.staticCodeAnalysisEnabled !== this.originalStaticCodeAnalysisEnabled) {
-            this.importConfigs.recreateBuildPlans = true;
-            this.importConfigs.updateTemplate = true;
+            this.importOptions.recreateBuildPlans = true;
+            this.importOptions.updateTemplate = true;
         }
 
         if (!this.programmingExercise.staticCodeAnalysisEnabled) {
@@ -762,7 +762,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
     }
 
     onRecreateBuildPlanOrUpdateTemplateChange() {
-        if (!this.importConfigs.recreateBuildPlans || !this.importConfigs.updateTemplate) {
+        if (!this.importOptions.recreateBuildPlans || !this.importOptions.updateTemplate) {
             this.programmingExercise.staticCodeAnalysisEnabled = this.originalStaticCodeAnalysisEnabled;
         }
 
@@ -1085,9 +1085,9 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
             rerenderSubject: this.rerenderSubject.asObservable(),
             validIdeSelection: this.validIdeSelection,
             inProductionEnvironment: this.inProductionEnvironment,
-            recreateBuildPlans: this.importConfigs.recreateBuildPlans,
+            recreateBuildPlans: this.importOptions.recreateBuildPlans,
             onRecreateBuildPlanOrUpdateTemplateChange: this.onRecreateBuildPlanOrUpdateTemplateChange,
-            updateTemplate: this.importConfigs.updateTemplate,
+            updateTemplate: this.importOptions.updateTemplate,
             publishBuildPlanUrlAllowed: this.publishBuildPlanUrlAllowed,
             recreateBuildPlanOrUpdateTemplateChange: this.onRecreateBuildPlanOrUpdateTemplateChange,
             buildPlanLoaded: this.buildPlanLoaded,

--- a/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.html
@@ -158,7 +158,7 @@
                         type="checkbox"
                         name="recreateBuildPlans"
                         id="field_recreateBuildPlans"
-                        [(ngModel)]="importConfigs.recreateBuildPlans"
+                        [(ngModel)]="importOptions.recreateBuildPlans"
                         (change)="programmingExerciseCreationConfig.recreateBuildPlanOrUpdateTemplateChange()"
                     />
                     <span jhiTranslate="artemisApp.programmingExercise.recreateBuildPlans.title"></span>
@@ -179,7 +179,7 @@
                         type="checkbox"
                         name="updateTemplateFiles"
                         id="field_updateTemplateFiles"
-                        [(ngModel)]="importConfigs.updateTemplate"
+                        [(ngModel)]="importOptions.updateTemplate"
                         (change)="programmingExerciseCreationConfig.recreateBuildPlanOrUpdateTemplateChange()"
                     />
                     <span jhiTranslate="artemisApp.programmingExercise.updateTemplate.title"></span>

--- a/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.html
@@ -158,7 +158,7 @@
                         type="checkbox"
                         name="recreateBuildPlans"
                         id="field_recreateBuildPlans"
-                        [(ngModel)]="programmingExerciseCreationConfig.recreateBuildPlans"
+                        [(ngModel)]="importConfigs.recreateBuildPlans"
                         (change)="programmingExerciseCreationConfig.recreateBuildPlanOrUpdateTemplateChange()"
                     />
                     <span jhiTranslate="artemisApp.programmingExercise.recreateBuildPlans.title"></span>
@@ -179,7 +179,7 @@
                         type="checkbox"
                         name="updateTemplateFiles"
                         id="field_updateTemplateFiles"
-                        [(ngModel)]="programmingExerciseCreationConfig.updateTemplate"
+                        [(ngModel)]="importConfigs.updateTemplate"
                         (change)="programmingExerciseCreationConfig.recreateBuildPlanOrUpdateTemplateChange()"
                     />
                     <span jhiTranslate="artemisApp.programmingExercise.updateTemplate.title"></span>

--- a/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, Input, OnDestroy, QueryList, ViewChild, ViewC
 import { NgModel } from '@angular/forms';
 import { ProgrammingExercise, ProjectType } from 'app/entities/programming-exercise.model';
 import { ProgrammingExerciseCreationConfig } from 'app/exercises/programming/manage/update/programming-exercise-creation-config';
-import { ImportConfigs } from 'app/exercises/programming/manage/update/programming-exercise-update.component';
+import { ImportOptions } from 'app/exercises/programming/manage/update/programming-exercise-update.component';
 import { ExerciseTitleChannelNameComponent } from 'app/exercises/shared/exercise-title-channel-name/exercise-title-channel-name.component';
 import { Subject, Subscription } from 'rxjs';
 import { TableEditableFieldComponent } from 'app/shared/table/table-editable-field.component';
@@ -19,7 +19,7 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
     @Input() programmingExercise: ProgrammingExercise;
     @Input() programmingExerciseCreationConfig: ProgrammingExerciseCreationConfig;
     @Input() isLocal: boolean;
-    @Input() importConfigs: ImportConfigs;
+    @Input() importOptions: ImportOptions;
 
     @ViewChild(ExerciseTitleChannelNameComponent) exerciseTitleChannelComponent: ExerciseTitleChannelNameComponent;
     @ViewChildren(TableEditableFieldComponent) tableEditableFields?: QueryList<TableEditableFieldComponent>;

--- a/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-information.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, Input, OnDestroy, QueryList, ViewChild, ViewC
 import { NgModel } from '@angular/forms';
 import { ProgrammingExercise, ProjectType } from 'app/entities/programming-exercise.model';
 import { ProgrammingExerciseCreationConfig } from 'app/exercises/programming/manage/update/programming-exercise-creation-config';
+import { ImportConfigs } from 'app/exercises/programming/manage/update/programming-exercise-update.component';
 import { ExerciseTitleChannelNameComponent } from 'app/exercises/shared/exercise-title-channel-name/exercise-title-channel-name.component';
 import { Subject, Subscription } from 'rxjs';
 import { TableEditableFieldComponent } from 'app/shared/table/table-editable-field.component';
@@ -18,11 +19,11 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
     @Input() programmingExercise: ProgrammingExercise;
     @Input() programmingExerciseCreationConfig: ProgrammingExerciseCreationConfig;
     @Input() isLocal: boolean;
+    @Input() importConfigs: ImportConfigs;
 
     @ViewChild(ExerciseTitleChannelNameComponent) exerciseTitleChannelComponent: ExerciseTitleChannelNameComponent;
     @ViewChildren(TableEditableFieldComponent) tableEditableFields?: QueryList<TableEditableFieldComponent>;
-    @ViewChild('shortName')
-    shortNameField: NgModel;
+    @ViewChild('shortName') shortNameField: NgModel;
     @ViewChild('checkoutSolutionRepository') checkoutSolutionRepositoryField?: NgModel;
     @ViewChild('recreateBuildPlans') recreateBuildPlansField?: NgModel;
     @ViewChild('updateTemplateFiles') updateTemplateFilesField?: NgModel;
@@ -45,7 +46,7 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
         });
     }
 
-    ngOnDestroy() {
+    ngOnDestroy(): void {
         for (const subscription of this.inputFieldSubscriptions) {
             subscription?.unsubscribe();
         }

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -527,7 +527,7 @@ describe('ProgrammingExerciseUpdateComponent', () => {
                     comp.programmingExercise.staticCodeAnalysisEnabled = !scaActivatedOriginal;
                     comp.onStaticCodeAnalysisChanged();
 
-                    expect(comp.updateTemplate).toBeTrue();
+                    expect(comp.importOptions.updateTemplate).toBeTrue();
 
                     comp.programmingExercise.staticCodeAnalysisEnabled = !scaActivatedOriginal;
                     comp.onStaticCodeAnalysisChanged();
@@ -543,10 +543,10 @@ describe('ProgrammingExerciseUpdateComponent', () => {
                 // Recreate build plan and template update should be automatically selected
                 expect(comp.programmingExercise.staticCodeAnalysisEnabled).toBe(!scaActivatedOriginal);
                 expect(comp.programmingExercise.maxStaticCodeAnalysisPenalty).toBe(scaActivatedOriginal ? undefined : newMaxPenalty);
-                expect(comp.recreateBuildPlans).toBeTrue();
-                expect(comp.updateTemplate).toBeTrue();
+                expect(comp.importOptions.recreateBuildPlans).toBeTrue();
+                expect(comp.importOptions.updateTemplate).toBeTrue();
 
-                comp.recreateBuildPlans = !comp.recreateBuildPlans;
+                comp.importOptions.recreateBuildPlans = !comp.importOptions.recreateBuildPlans;
                 comp.onRecreateBuildPlanOrUpdateTemplateChange();
                 tick();
 


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
For Java-Maven exercises we offer the option to upgrade the templates, updating the configuration files and dependency versions. However, this did not work correctly, leading to issues like #8186.

Fixes #8186 (the root cause of the issue).

### Description
This PR fixes two issues:

1) The client did not correctly set the `upgradeTemplate` option to true if the checkbox was activated. This was caused by passing direct booleans to the sub-components, where the updated value did not get populated to the API call. I fixed that by addding a small wrapper object.

2) The server did not upgrade the test repository since the Path to the template repository was not set correctly.


### Steps for Testing

1. Import a older maven exercise into a course
2. Activate the "Upgrade Template" option during the import
3. Check that after importing a "Template upgraded by Artemis commit" is present in the Repository. Check that Ares version `1.13.0` and a new version of the `maven-surefire-plugin` is present.
4. Check that running the tests still works after the import. Check that failed tests come with test feedback (detailText).

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
unchanged
(Sadly the `JavaTemplateUpgradeService` seems to be completely untested, we should add server tests here in a followup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added exclusion of the "checked-out-repos/**" directory from code formatting to enhance developer experience.
	- Introduced additional configuration options for importing exercises in the programming exercise management UI.
- **Enhancements**
	- Updated the directory structure for Maven projects in Java templates to improve project organization.
	- Refactored import options in the `ProgrammingExerciseUpdateComponent` for better structure and readability.
- **Bug Fixes**
	- Fixed bindings for checkboxes related to build plans and template updates in the programming exercise information component.
- **Tests**
	- Updated unit tests to reflect changes in the handling of import options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->