### PR TITLE
`Development`: Fix flaky server tests

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ParticipantScoreScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ParticipantScoreScheduleService.java
@@ -442,6 +442,9 @@ public class ParticipantScoreScheduleService {
 
     /**
      * Get hash code for the given exercise and participant to identify tasks during scheduling.
+     * <p>
+     * Required, as calculating the hash code out of a record causes too many collisions. The separator char is used to avoid unnecessary collisions by certain number combinations
+     * (e.g. 155,13 and 15,513 resulting in the same string and hence the same hash code).
      *
      * @param exerciseId    the id of the exercise
      * @param participantId the id of the participant (user or team, depending on the exercise's setting)

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ParticipantScoreScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ParticipantScoreScheduleService.java
@@ -205,7 +205,7 @@ public class ParticipantScoreScheduleService {
      * @param resultIdToBeDeleted the id of the result that is about to be deleted (or null, if result is created/updated)
      */
     private void scheduleTask(Long exerciseId, Long participantId, Instant resultLastModified, Long resultIdToBeDeleted) {
-        final int participantScoreHash = new ParticipantScoreId(exerciseId, participantId).hashCode();
+        final int participantScoreHash = hashCode(exerciseId, participantId);
         var task = scheduledTasks.get(participantScoreHash);
         if (task != null) {
             // If a task is already scheduled, cancel it and reschedule it with the latest result
@@ -320,7 +320,7 @@ public class ParticipantScoreScheduleService {
             log.error("Exception while processing participant score for exercise {} and participant {} for participant scores:", exerciseId, participantId, e);
         }
         finally {
-            scheduledTasks.remove(new ParticipantScoreId(exerciseId, participantId).hashCode());
+            scheduledTasks.remove(hashCode(exerciseId, participantId));
         }
         long end = System.currentTimeMillis();
         log.info("Updating the participant score for exercise {} and participant {} took {} ms.", exerciseId, participantId, end - start);
@@ -441,11 +441,12 @@ public class ParticipantScoreScheduleService {
     }
 
     /**
-     * Each participant score can be uniquely identified by the combination of exercise id and participant id.
+     * Get hash code for the given exercise and participant to identify tasks during scheduling.
      *
      * @param exerciseId    the id of the exercise
      * @param participantId the id of the participant (user or team, depending on the exercise's setting)
      */
-    public record ParticipantScoreId(Long exerciseId, Long participantId) {
+    private int hashCode(Long exerciseId, Long participantId) {
+        return (exerciseId + "|" + participantId).hashCode();
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
@@ -9,7 +9,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -23,7 +22,7 @@ class ExerciseLifecycleServiceTest extends AbstractSpringIntegrationIndependentT
     @Autowired
     private ExerciseLifecycleService exerciseLifecycleService;
 
-    @RepeatedTest(1000)
+    @Test
     void testScheduleExerciseOnReleaseTask() {
         final ZonedDateTime now = ZonedDateTime.now();
 

--- a/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -22,7 +23,7 @@ class ExerciseLifecycleServiceTest extends AbstractSpringIntegrationIndependentT
     @Autowired
     private ExerciseLifecycleService exerciseLifecycleService;
 
-    @Test
+    @RepeatedTest(1000)
     void testScheduleExerciseOnReleaseTask() {
         final ZonedDateTime now = ZonedDateTime.now();
 

--- a/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
@@ -43,24 +43,27 @@ class ExerciseLifecycleServiceTest extends AbstractSpringIntegrationIndependentT
         assertThat(releaseFuture.isDone()).isFalse();
         assertThat(dueFuture.isDone()).isFalse();
         assertThat(assessmentDueFuture.isDone()).isFalse();
+        assertThat(releaseTrigger.booleanValue()).isFalse();
+        assertThat(dueTrigger.booleanValue()).isFalse();
+        assertThat(assessmentDueTrigger.booleanValue()).isFalse();
 
-        await().pollInterval(50, TimeUnit.MILLISECONDS).until(() -> releaseTrigger.booleanValue() && !dueTrigger.booleanValue() && !assessmentDueTrigger.booleanValue());
+        await().pollInterval(50, TimeUnit.MILLISECONDS).until(releaseFuture::isDone);
 
-        assertThat(releaseFuture.isDone()).isTrue();
-        assertThat(dueFuture.isDone()).isFalse();
-        assertThat(assessmentDueFuture.isDone()).isFalse();
+        assertThat(releaseTrigger.booleanValue()).isTrue();
+        assertThat(dueTrigger.booleanValue()).isFalse();
+        assertThat(assessmentDueTrigger.booleanValue()).isFalse();
 
-        await().pollInterval(50, TimeUnit.MILLISECONDS).until(() -> releaseTrigger.booleanValue() && dueTrigger.booleanValue() && !assessmentDueTrigger.booleanValue());
+        await().pollInterval(50, TimeUnit.MILLISECONDS).until(dueFuture::isDone);
 
-        assertThat(releaseFuture.isDone()).isTrue();
-        assertThat(dueFuture.isDone()).isTrue();
-        assertThat(assessmentDueFuture.isDone()).isFalse();
+        assertThat(releaseTrigger.booleanValue()).isTrue();
+        assertThat(dueTrigger.booleanValue()).isTrue();
+        assertThat(assessmentDueTrigger.booleanValue()).isFalse();
 
-        await().pollInterval(50, TimeUnit.MILLISECONDS).until(() -> releaseTrigger.booleanValue() && dueTrigger.booleanValue() && assessmentDueTrigger.booleanValue());
+        await().pollInterval(50, TimeUnit.MILLISECONDS).until(assessmentDueFuture::isDone);
 
-        assertThat(releaseFuture.isDone()).isTrue();
-        assertThat(dueFuture.isDone()).isTrue();
-        assertThat(assessmentDueFuture.isDone()).isTrue();
+        assertThat(releaseTrigger.booleanValue()).isTrue();
+        assertThat(dueTrigger.booleanValue()).isTrue();
+        assertThat(assessmentDueTrigger.booleanValue()).isTrue();
 
         assertThat(releaseFuture.isCancelled()).isFalse();
         assertThat(dueFuture.isCancelled()).isFalse();

--- a/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
@@ -29,8 +29,8 @@ class ExerciseLifecycleServiceTest extends AbstractSpringIntegrationIndependentT
         Exercise exercise = new TextExercise();
         exercise.setTitle("ExerciseLifecycleServiceTest:testScheduleExerciseOnReleaseTask");
         exercise.setReleaseDate(now.plus(200, ChronoUnit.MILLIS));
-        exercise.setDueDate(now.plus(400, ChronoUnit.MILLIS));
-        exercise.setAssessmentDueDate(now.plus(600, ChronoUnit.MILLIS));
+        exercise.setDueDate(now.plus(500, ChronoUnit.MILLIS));
+        exercise.setAssessmentDueDate(now.plus(1000, ChronoUnit.MILLIS));
 
         MutableBoolean releaseTrigger = new MutableBoolean(false);
         MutableBoolean dueTrigger = new MutableBoolean(false);
@@ -47,19 +47,19 @@ class ExerciseLifecycleServiceTest extends AbstractSpringIntegrationIndependentT
         assertThat(dueTrigger.booleanValue()).isFalse();
         assertThat(assessmentDueTrigger.booleanValue()).isFalse();
 
-        await().pollInterval(50, TimeUnit.MILLISECONDS).until(releaseFuture::isDone);
+        await().pollInterval(20, TimeUnit.MILLISECONDS).until(releaseFuture::isDone);
 
         assertThat(releaseTrigger.booleanValue()).isTrue();
         assertThat(dueTrigger.booleanValue()).isFalse();
         assertThat(assessmentDueTrigger.booleanValue()).isFalse();
 
-        await().pollInterval(50, TimeUnit.MILLISECONDS).until(dueFuture::isDone);
+        await().pollInterval(20, TimeUnit.MILLISECONDS).until(dueFuture::isDone);
 
         assertThat(releaseTrigger.booleanValue()).isTrue();
         assertThat(dueTrigger.booleanValue()).isTrue();
         assertThat(assessmentDueTrigger.booleanValue()).isFalse();
 
-        await().pollInterval(50, TimeUnit.MILLISECONDS).until(assessmentDueFuture::isDone);
+        await().pollInterval(20, TimeUnit.MILLISECONDS).until(assessmentDueFuture::isDone);
 
         assertThat(releaseTrigger.booleanValue()).isTrue();
         assertThat(dueTrigger.booleanValue()).isTrue();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
These two flaky tests are annoying as hell. One more than the other. Succeeds, fails, succeeds, fails, succeeds, fails. Enough motivation for me :)

### Description
<!-- Describe your changes in detail -->
**ExerciseLifecycleServiceTest**
The test is structured according to the logic of "once the values are set correctly, check if the futures are resolved." This logic is odd and apparently doesn't work very reliably. I inverted the logic to "once the expected future is resolved, check if the values are set correctly.", which works consistently.
I additionally removed the usage of the unnecessary helper method.

**ParticipantScoreIntegrationTest:**
For distinct combinations of `exerciseId` and `participantId` within the record, the hash sums are the same, resulting in overrides in the map and a chance not all scores are generated. Using the hashCode method in the `String` class is a different implementation and improves the situation.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
    - Improved the readability and simplicity of assertions in exercise lifecycle tests by using lambda expressions.
    - Replaced `ParticipantScoreId` record with a private method for task identification during scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->