### PR TITLE
`Quiz exercises`: Fix an issue with drag and drop positioning

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
@@ -220,13 +220,15 @@ function computeDropLocation(
     elementLocation: { x: number; y: number; width: number; height: number },
     totalSize: { x?: number; y?: number; width: number; height: number },
 ): DropLocation {
+    console.log('elementLocation', elementLocation);
+    console.log('totalSize', totalSize);
     const dropLocation = new DropLocation();
     // on quiz exercise generation, svg exports adds 15px padding
     elementLocation.x += 15;
     elementLocation.y += 15;
     // round to second decimal
-    dropLocation.posX = round((((elementLocation.x ?? 0) - (totalSize.x ?? 0)) / totalSize.width) * MAX_SIZE_UNIT, 2);
-    dropLocation.posY = round((((elementLocation.y ?? 0) - (totalSize.y ?? 0)) / totalSize.height) * MAX_SIZE_UNIT, 2);
+    dropLocation.posX = round(((elementLocation.x - (totalSize.x ?? 0)) / totalSize.width) * MAX_SIZE_UNIT, 2);
+    dropLocation.posY = round(((elementLocation.y - (totalSize.y ?? 0)) / totalSize.height) * MAX_SIZE_UNIT, 2);
     dropLocation.width = round((elementLocation.width / totalSize.width) * MAX_SIZE_UNIT, 2);
     dropLocation.height = round((elementLocation.height / totalSize.height) * MAX_SIZE_UNIT, 2);
     return dropLocation;

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
@@ -218,15 +218,15 @@ async function generateDragAndDropItemForRelationship(
  */
 function computeDropLocation(
     elementLocation: { x: number; y: number; width: number; height: number },
-    totalSize: { x: number; y: number; width: number; height: number },
+    totalSize: { x?: number; y?: number; width: number; height: number },
 ): DropLocation {
     const dropLocation = new DropLocation();
     // on quiz exercise generation, svg exports adds 15px padding
     elementLocation.x += 15;
     elementLocation.y += 15;
     // round to second decimal
-    dropLocation.posX = round(((elementLocation.x - totalSize.x) / totalSize.width) * MAX_SIZE_UNIT, 2);
-    dropLocation.posY = round(((elementLocation.y - totalSize.y) / totalSize.height) * MAX_SIZE_UNIT, 2);
+    dropLocation.posX = round((((elementLocation.x ?? 0) - (totalSize.x ?? 0)) / totalSize.width) * MAX_SIZE_UNIT, 2);
+    dropLocation.posY = round((((elementLocation.y ?? 0) - (totalSize.y ?? 0)) / totalSize.height) * MAX_SIZE_UNIT, 2);
     dropLocation.width = round((elementLocation.width / totalSize.width) * MAX_SIZE_UNIT, 2);
     dropLocation.height = round((elementLocation.height / totalSize.height) * MAX_SIZE_UNIT, 2);
     return dropLocation;

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
@@ -216,14 +216,17 @@ async function generateDragAndDropItemForRelationship(
  *
  * @return {DropLocation} A Drag and Drop Quiz Exercise `DropLocation`.
  */
-function computeDropLocation(elementLocation: { x: number; y: number; width: number; height: number }, totalSize: { width: number; height: number }): DropLocation {
+function computeDropLocation(
+    elementLocation: { x: number; y: number; width: number; height: number },
+    totalSize: { x: number; y: number; width: number; height: number },
+): DropLocation {
     const dropLocation = new DropLocation();
     // on quiz exercise generation, svg exports adds 15px padding
     elementLocation.x += 15;
     elementLocation.y += 15;
     // round to second decimal
-    dropLocation.posX = round((elementLocation.x / totalSize.width) * MAX_SIZE_UNIT, 2);
-    dropLocation.posY = round((elementLocation.y / totalSize.height) * MAX_SIZE_UNIT, 2);
+    dropLocation.posX = round(((elementLocation.x - totalSize.x) / totalSize.width) * MAX_SIZE_UNIT, 2);
+    dropLocation.posY = round(((elementLocation.y - totalSize.y) / totalSize.height) * MAX_SIZE_UNIT, 2);
     dropLocation.width = round((elementLocation.width / totalSize.width) * MAX_SIZE_UNIT, 2);
     dropLocation.height = round((elementLocation.height / totalSize.height) * MAX_SIZE_UNIT, 2);
     return dropLocation;


### PR DESCRIPTION
This PR hotfixes the positioning of elements when dragging and dropping elements in Quiz exercises.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
At the moment, elements dragged for quiz exercises and positioned incorrectly. This PR fixes this behavior.


### Description
The `computeDropLocation` function in `quiz-exercise-generator.ts` wrongly assumes all SVGs start from {x: 0, y: 0}, which is not the case. it calculates drop location positions as a percentage of the total width, but because of not offsetting the starting position of the SVG clip. This PR fixes this issue by offsetting the calculation by the `totalSize's` x and y coordinates. 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student
- 1 Quiz exercise

1. Log in to Artemis
2. Navigate to a Quiz exercise
3. Move answering options via drag-and-drop
4. The answering options should now be correctly placed relative to the mouse cursor

#### Exam Mode Testing

Prerequisites:
- 1 Student
- 1 Exam with a Quiz Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Move answering options via drag-and-drop
4. The answering options should now be correctly placed relative to the mouse cursor

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Enhanced element positioning calculation in quiz exercise generation for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->