### PR TITLE
`Development`: Use Stringbuilder instead of + for Strings

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/structural/StructuralAttribute.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/structural/StructuralAttribute.java
@@ -21,59 +21,50 @@ class StructuralAttribute implements StructuralElement {
     @JsonProperty(required = true)
     private String type;
 
-    private List<String> modifiers = new ArrayList<>();
+    private final List<String> modifiers = new ArrayList<>();
 
-    private List<String> annotations = new ArrayList<>();
+    private final List<String> annotations = new ArrayList<>();
 
     @Override
     public String getSourceCode(StructuralClassElements structuralClassElements, JavaClass solutionClass) {
         JavaField solutionAttribute = getSolutionAttribute(solutionClass);
-        String attributeCode = "";
+        StringBuilder attributeCode = new StringBuilder();
         if (!this.getAnnotations().isEmpty()) {
-            attributeCode += getAnnotationsString(this.getAnnotations(), solutionAttribute);
+            attributeCode.append(getAnnotationsString(this.getAnnotations(), solutionAttribute));
         }
         if (!this.getModifiers().isEmpty()) {
-            attributeCode += formatModifiers(this.getModifiers()) + " ";
+            attributeCode.append(formatModifiers(this.getModifiers())).append(" ");
         }
-        attributeCode += (solutionAttribute == null ? this.getType() : solutionAttribute.getType().getGenericValue()) + " ";
-        attributeCode += this.getName();
-        attributeCode += ";";
-        return attributeCode;
+        if (solutionAttribute != null) {
+            attributeCode.append(solutionAttribute.getType().getGenericValue());
+        }
+        else {
+            attributeCode.append(this.getType());
+        }
+        attributeCode.append(" ").append(this.getName()).append(";");
+        return attributeCode.toString();
     }
 
     private JavaField getSolutionAttribute(JavaClass solutionClass) {
-        return solutionClass == null ? null : solutionClass.getFields().stream().filter(field -> field.getName().equals(this.getName())).findFirst().orElse(null);
+        if (solutionClass == null) {
+            return null;
+        }
+        return solutionClass.getFields().stream().filter(field -> field.getName().equals(this.getName())).findFirst().orElse(null);
     }
 
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
     public List<String> getModifiers() {
         return modifiers;
-    }
-
-    public void setModifiers(List<String> modifiers) {
-        this.modifiers = modifiers;
     }
 
     public String getType() {
         return type;
     }
 
-    public void setType(String type) {
-        this.type = type;
-    }
-
     public List<String> getAnnotations() {
         return annotations;
-    }
-
-    public void setAnnotations(List<String> annotations) {
-        this.annotations = annotations;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/structural/StructuralClass.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/structural/StructuralClass.java
@@ -22,7 +22,7 @@ class StructuralClass implements StructuralElement {
 
     private String superclass;
 
-    private List<String> modifiers = new ArrayList<>();
+    private final List<String> modifiers = new ArrayList<>();
 
     @JsonProperty(defaultValue = "false")
     private boolean isInterface;
@@ -30,116 +30,91 @@ class StructuralClass implements StructuralElement {
     @JsonProperty(defaultValue = "false")
     private boolean isEnum;
 
-    private List<String> interfaces = new ArrayList<>();
+    private final List<String> interfaces = new ArrayList<>();
 
-    private List<String> annotations = new ArrayList<>();
+    private final List<String> annotations = new ArrayList<>();
 
     @Override
     public String getSourceCode(StructuralClassElements structuralClassElements, JavaClass solutionClass) {
-        String classSolutionCode = "package " + this.getPackageName() + ";\n\n";
+        StringBuilder classSolutionCode = new StringBuilder("package ").append(this.getPackageName()).append(";\n\n");
 
         if (!this.getAnnotations().isEmpty()) {
-            classSolutionCode += getAnnotationsString(this.getAnnotations(), solutionClass);
+            classSolutionCode.append(getAnnotationsString(this.getAnnotations(), solutionClass));
         }
-        classSolutionCode += getClassHeaderCode(solutionClass);
-        // Class Body
-        classSolutionCode += "{\n";
-        classSolutionCode += SINGLE_INDENTATION;
+        classSolutionCode.append(getClassHeaderCode(solutionClass)).append("{\n").append(SINGLE_INDENTATION);  // Class Body
         if (this.isEnum()) {
-            classSolutionCode += String.join(", ", structuralClassElements.getEnumValues());
+            classSolutionCode.append(String.join(", ", structuralClassElements.getEnumValues()));
         }
-        classSolutionCode += "\n}";
+        classSolutionCode.append("\n}");
 
-        return classSolutionCode;
+        return classSolutionCode.toString();
     }
 
     private String getClassHeaderCode(JavaClass solutionClass) {
-        String classHeaderCode = "";
+        StringBuilder classHeaderCode = new StringBuilder();
         if (!this.getModifiers().isEmpty()) {
-            classHeaderCode += formatModifiers(this.getModifiers()) + " ";
+            classHeaderCode.append(formatModifiers(this.getModifiers())).append(" ");
         }
-        classHeaderCode += (this.isInterface() ? "interface" : (this.isEnum() ? "enum" : "class")) + " ";
-        classHeaderCode += this.getName();
+
+        if (this.isInterface) {
+            classHeaderCode.append("interface ");
+        }
+        else if (this.isEnum) {
+            classHeaderCode.append("enum ");
+        }
+        else {
+            classHeaderCode.append("class ");
+        }
+        classHeaderCode.append(this.getName());
+
         if (solutionClass != null && !solutionClass.getTypeParameters().isEmpty()) {
-            classHeaderCode += getGenericTypesString(solutionClass.getTypeParameters());
+            classHeaderCode.append(getGenericTypesString(solutionClass.getTypeParameters()));
         }
-        classHeaderCode += " ";
-        classHeaderCode += getInheritanceCode();
-        return classHeaderCode;
+        classHeaderCode.append(" ");
+        classHeaderCode.append(getInheritanceCode());
+        return classHeaderCode.toString();
     }
 
     private String getInheritanceCode() {
-        String inheritanceCode = "";
+        StringBuilder inheritanceCode = new StringBuilder();
         if (this.getSuperclass() != null) {
-            inheritanceCode += "extends " + this.getSuperclass() + " ";
+            inheritanceCode.append("extends ").append(this.getSuperclass()).append(" ");
         }
         if (!this.getInterfaces().isEmpty()) {
-            inheritanceCode += "implements " + String.join(", ", this.getInterfaces()) + " ";
+            inheritanceCode.append("implements ").append(String.join(", ", this.getInterfaces())).append(" ");
         }
-        return inheritanceCode;
+        return inheritanceCode.toString();
     }
 
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public String getSuperclass() {
+        return superclass;
     }
 
     public String getPackageName() {
         return packageName;
     }
 
-    public void setPackageName(String packageName) {
-        this.packageName = packageName;
-    }
-
-    public String getSuperclass() {
-        return superclass;
-    }
-
-    public void setSuperclass(String superclass) {
-        this.superclass = superclass;
-    }
-
     public boolean isInterface() {
         return isInterface;
-    }
-
-    public void setIsInterface(boolean anInterface) {
-        isInterface = anInterface;
     }
 
     public boolean isEnum() {
         return isEnum;
     }
 
-    public void setIsEnum(boolean anEnum) {
-        isEnum = anEnum;
-    }
-
     public List<String> getInterfaces() {
         return interfaces;
-    }
-
-    public void setInterfaces(List<String> interfaces) {
-        this.interfaces = interfaces;
     }
 
     public List<String> getModifiers() {
         return modifiers;
     }
 
-    public void setModifiers(List<String> modifiers) {
-        this.modifiers = modifiers;
-    }
-
     public List<String> getAnnotations() {
         return annotations;
-    }
-
-    public void setAnnotations(List<String> annotations) {
-        this.annotations = annotations;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/structural/StructuralConstructor.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/structural/StructuralConstructor.java
@@ -14,26 +14,25 @@ import com.thoughtworks.qdox.model.JavaConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 class StructuralConstructor implements StructuralElement {
 
-    private List<String> modifiers = new ArrayList<>();
+    private final List<String> modifiers = new ArrayList<>();
 
-    private List<String> parameters = new ArrayList<>();
+    private final List<String> parameters = new ArrayList<>();
 
-    private List<String> annotations = new ArrayList<>();
+    private final List<String> annotations = new ArrayList<>();
 
     @Override
     public String getSourceCode(StructuralClassElements structuralClassElements, JavaClass solutionClass) {
         JavaConstructor solutionConstructor = getSolutionConstructor(solutionClass);
-        String constructorSolutionCode = "";
+        StringBuilder constructorSolutionCode = new StringBuilder();
         if (!this.getAnnotations().isEmpty()) {
-            constructorSolutionCode += getAnnotationsString(this.getAnnotations(), solutionConstructor);
+            constructorSolutionCode.append(getAnnotationsString(this.getAnnotations(), solutionConstructor));
         }
         if (!this.getModifiers().isEmpty()) {
-            constructorSolutionCode += formatModifiers(this.getModifiers()) + " ";
+            constructorSolutionCode.append(formatModifiers(this.getModifiers())).append(" ");
         }
-        constructorSolutionCode += structuralClassElements.getStructuralClass().getName();
-        constructorSolutionCode += generateParametersString(this.getParameters(), solutionConstructor) + " ";
-        constructorSolutionCode += "{\n" + SINGLE_INDENTATION + "\n}";
-        return constructorSolutionCode;
+        constructorSolutionCode.append(structuralClassElements.getStructuralClass().getName()).append(generateParametersString(this.getParameters(), solutionConstructor))
+                .append(" {\n").append(SINGLE_INDENTATION).append("\n}");
+        return constructorSolutionCode.toString();
     }
 
     /**
@@ -55,23 +54,11 @@ class StructuralConstructor implements StructuralElement {
         return modifiers;
     }
 
-    public void setModifiers(List<String> modifiers) {
-        this.modifiers = modifiers;
-    }
-
     public List<String> getParameters() {
         return parameters;
     }
 
-    public void setParameters(List<String> parameters) {
-        this.parameters = parameters;
-    }
-
     public List<String> getAnnotations() {
         return annotations;
-    }
-
-    public void setAnnotations(List<String> annotations) {
-        this.annotations = annotations;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/structural/StructuralElement.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/structural/StructuralElement.java
@@ -105,8 +105,14 @@ public interface StructuralElement {
      * @return The parameter source code
      */
     default String generateParametersString(List<String> parameterTypes, JavaExecutable javaExecutable) {
-        List<JavaParameter> solutionParameters = javaExecutable != null ? javaExecutable.getParameters() : Collections.emptyList();
-        String result = "(";
+        List<JavaParameter> solutionParameters;
+        if (javaExecutable != null) {
+            solutionParameters = javaExecutable.getParameters();
+        }
+        else {
+            solutionParameters = Collections.emptyList();
+        }
+        final StringBuilder result = new StringBuilder("(");
         if (parameterTypes != null) {
             for (int i = 0; i < parameterTypes.size(); i++) {
                 if (solutionParameters.size() > i) {
@@ -118,9 +124,10 @@ public interface StructuralElement {
                     parameterTypes.set(i, parameterTypes.get(i) + " var" + i);
                 }
             }
-            result += String.join(", ", parameterTypes);
+
+            result.append(String.join(", ", parameterTypes));
         }
-        result += ")";
-        return result;
+        result.append(")");
+        return result.toString();
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/structural/StructuralMethod.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/structural/StructuralMethod.java
@@ -31,30 +31,39 @@ class StructuralMethod implements StructuralElement {
     @Override
     public String getSourceCode(StructuralClassElements structuralClassElements, JavaClass solutionClass) {
         JavaMethod solutionMethod = getSolutionMethod(solutionClass);
-        String methodSolutionCode = "";
+        StringBuilder methodSolutionCode = new StringBuilder();
         boolean isAbstract = this.getModifiers().contains("abstract");
 
         if (!this.getAnnotations().isEmpty()) {
-            methodSolutionCode += getAnnotationsString(this.getAnnotations(), solutionMethod);
+            methodSolutionCode.append(getAnnotationsString(this.getAnnotations(), solutionMethod));
         }
 
-        methodSolutionCode += formatModifiers(structuralClassElements, isAbstract);
+        methodSolutionCode.append(formatModifiers(structuralClassElements, isAbstract));
 
         // Generics
         if (solutionMethod != null && !solutionMethod.getTypeParameters().isEmpty()) {
-            methodSolutionCode += getGenericTypesString(solutionMethod.getTypeParameters()) + " ";
+            methodSolutionCode.append(getGenericTypesString(solutionMethod.getTypeParameters())).append(" ");
         }
 
         // Return type
-        methodSolutionCode += solutionMethod != null ? solutionMethod.getReturnType().getGenericValue() + " " : this.getReturnType() + " ";
-        // Name
-        methodSolutionCode += this.getName();
-        // Parameters
-        methodSolutionCode += generateParametersString(this.getParameters(), solutionMethod);
-        // Body
-        methodSolutionCode += isAbstract ? ";" : " {\n" + SINGLE_INDENTATION + "\n}";
+        if (solutionMethod != null) {
+            methodSolutionCode.append(solutionMethod.getReturnType().getGenericValue());
+        }
+        else {
+            methodSolutionCode.append(this.getReturnType());
+        }
+        methodSolutionCode.append(" ").append(this.getName()) // Name
+                .append(generateParametersString(this.getParameters(), solutionMethod)); // Parameters
 
-        return methodSolutionCode;
+        // Body
+        if (isAbstract) {
+            methodSolutionCode.append(";");
+        }
+        else {
+            methodSolutionCode.append(" {\n").append(SINGLE_INDENTATION).append("\n}");
+        }
+
+        return methodSolutionCode.toString();
     }
 
     /**
@@ -102,39 +111,19 @@ class StructuralMethod implements StructuralElement {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
     public List<String> getModifiers() {
         return modifiers;
-    }
-
-    public void setModifiers(List<String> modifiers) {
-        this.modifiers = modifiers;
     }
 
     public List<String> getParameters() {
         return parameters;
     }
 
-    public void setParameters(List<String> parameters) {
-        this.parameters = parameters;
-    }
-
     public List<String> getAnnotations() {
         return annotations;
     }
 
-    public void setAnnotations(List<String> annotations) {
-        this.annotations = annotations;
-    }
-
     public String getReturnType() {
         return returnType;
-    }
-
-    public void setReturnType(String returnType) {
-        this.returnType = returnType;
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We concat a lot of strings using the + operator, 


### Description
<!-- Describe your changes in detail -->
StrinBuilder is more efficient than using the + operator, this PR cleans up a bit.


### Steps for Testing

Prerequisites:
- code review

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved efficiency and clarity in code generation for structural elements by utilizing `StringBuilder` and finalizing lists.
	- Removed unnecessary setter methods across several classes to enhance code immutability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->