### PR TITLE
`Integrated code lifecycle`: Reduce build agent payload size 

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/Participation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/Participation.java
@@ -314,15 +314,6 @@ public abstract class Participation extends DomainObject implements Participatio
                 + results + ", submissions=" + submissions + ", submissionCount=" + submissionCountTransient + "}";
     }
 
-    /**
-     * NOTE: do not use this in a transactional context and do not save the returned object to the database
-     * This method is useful when we want to cut off attributes while sending entities to the client and we are only interested in the id of the object
-     * We use polymorphism here, so subclasses should implement / override this method to create the correct object type
-     *
-     * @return an empty participation just including the id of the object
-     */
-    public abstract Participation copyParticipationId();
-
     public abstract void filterSensitiveInformation();
 
     @JsonIgnore

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/ParticipationInterface.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/ParticipationInterface.java
@@ -31,8 +31,6 @@ public interface ParticipationInterface {
 
     void addSubmission(Submission submission);
 
-    Participation copyParticipationId();
-
     Exercise getExercise();
 
     void setExercise(Exercise exercise);

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/ProgrammingExerciseStudentParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/ProgrammingExerciseStudentParticipation.java
@@ -120,10 +120,4 @@ public class ProgrammingExerciseStudentParticipation extends StudentParticipatio
                 + getIndividualDueDate() + "'" + ", presentationScore=" + getPresentationScore() + "}";
     }
 
-    @Override
-    public Participation copyParticipationId() {
-        var participation = new ProgrammingExerciseStudentParticipation();
-        participation.setId(getId());
-        return participation;
-    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/SolutionProgrammingExerciseParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/SolutionProgrammingExerciseParticipation.java
@@ -33,10 +33,4 @@ public class SolutionProgrammingExerciseParticipation extends AbstractBaseProgra
         return "solution";
     }
 
-    @Override
-    public Participation copyParticipationId() {
-        var participation = new SolutionProgrammingExerciseParticipation();
-        participation.setId(getId());
-        return participation;
-    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/StudentParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/StudentParticipation.java
@@ -130,10 +130,4 @@ public class StudentParticipation extends Participation {
         return getClass().getSimpleName() + "{" + "id=" + getId() + ", presentationScore=" + presentationScore + ", " + participantString + "}";
     }
 
-    @Override
-    public Participation copyParticipationId() {
-        var participation = new StudentParticipation();
-        participation.setId(getId());
-        return participation;
-    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/TemplateProgrammingExerciseParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/TemplateProgrammingExerciseParticipation.java
@@ -33,10 +33,4 @@ public class TemplateProgrammingExerciseParticipation extends AbstractBaseProgra
         return "template";
     }
 
-    @Override
-    public Participation copyParticipationId() {
-        var participation = new TemplateProgrammingExerciseParticipation();
-        participation.setId(getId());
-        return participation;
-    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIResultProcessingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCIResultProcessingService.java
@@ -37,6 +37,7 @@ import de.tum.in.www1.artemis.service.connectors.localci.dto.ResultQueueItem;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseGradingService;
 import de.tum.in.www1.artemis.service.programming.ProgrammingMessagingService;
 import de.tum.in.www1.artemis.service.programming.ProgrammingTriggerService;
+import de.tum.in.www1.artemis.web.rest.dto.ResultDTO;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 import de.tum.in.www1.artemis.web.websocket.programmingSubmission.BuildTriggerWebsocketError;
 
@@ -199,7 +200,7 @@ public class LocalCIResultProcessingService {
                 List<LocalCIBuildJobQueueItem> recentBuildJobs = buildAgent.recentBuildJobs();
                 for (int i = 0; i < recentBuildJobs.size(); i++) {
                     if (recentBuildJobs.get(i).id().equals(buildJob.id())) {
-                        recentBuildJobs.set(i, new LocalCIBuildJobQueueItem(buildJob, result));
+                        recentBuildJobs.set(i, new LocalCIBuildJobQueueItem(buildJob, ResultDTO.of(result)));
                         break;
                     }
                 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/BuildConfig.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/BuildConfig.java
@@ -3,9 +3,14 @@ package de.tum.in.www1.artemis.service.connectors.localci.dto;
 import java.io.Serializable;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 import de.tum.in.www1.artemis.domain.enumeration.ProjectType;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record BuildConfig(String buildScript, String dockerImage, String commitHash, String branch, ProgrammingLanguage programmingLanguage, ProjectType projectType,
         boolean scaEnabled, boolean sequentialTestRunsEnabled, boolean testwiseCoverageEnabled, List<String> resultPaths) implements Serializable {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/DockerImageBuild.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/DockerImageBuild.java
@@ -2,5 +2,10 @@ package de.tum.in.www1.artemis.service.connectors.localci.dto;
 
 import java.time.ZonedDateTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record DockerImageBuild(String dockerImage, ZonedDateTime lastBuildCompletionDate) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/JobTimingInfo.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/JobTimingInfo.java
@@ -3,5 +3,10 @@ package de.tum.in.www1.artemis.service.connectors.localci.dto;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record JobTimingInfo(ZonedDateTime submissionDate, ZonedDateTime buildStartDate, ZonedDateTime buildCompletionDate) implements Serializable {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/LocalCIBuildAgentInformation.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/LocalCIBuildAgentInformation.java
@@ -4,6 +4,11 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record LocalCIBuildAgentInformation(String name, int maxNumberOfConcurrentBuildJobs, int numberOfCurrentBuildJobs, List<LocalCIBuildJobQueueItem> runningBuildJobs,
         boolean status, List<LocalCIBuildJobQueueItem> recentBuildJobs) implements Serializable {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/LocalCIBuildJobQueueItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/LocalCIBuildJobQueueItem.java
@@ -4,11 +4,11 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 
-import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.enumeration.BuildStatus;
+import de.tum.in.www1.artemis.web.rest.dto.ResultDTO;
 
 public record LocalCIBuildJobQueueItem(String id, String name, String buildAgentAddress, long participationId, long courseId, long exerciseId, int retryCount, int priority,
-        BuildStatus status, RepositoryInfo repositoryInfo, JobTimingInfo jobTimingInfo, BuildConfig buildConfig, Result submissionResult) implements Serializable {
+        BuildStatus status, RepositoryInfo repositoryInfo, JobTimingInfo jobTimingInfo, BuildConfig buildConfig, ResultDTO submissionResult) implements Serializable {
 
     @Serial
     private static final long serialVersionUID = 1L;
@@ -38,7 +38,7 @@ public record LocalCIBuildJobQueueItem(String id, String name, String buildAgent
                 queueItem.buildConfig(), null);
     }
 
-    public LocalCIBuildJobQueueItem(LocalCIBuildJobQueueItem queueItem, Result submissionResult) {
+    public LocalCIBuildJobQueueItem(LocalCIBuildJobQueueItem queueItem, ResultDTO submissionResult) {
         this(queueItem.id(), queueItem.name(), queueItem.buildAgentAddress(), queueItem.participationId(), queueItem.courseId(), queueItem.exerciseId(), queueItem.retryCount(),
                 queueItem.priority(), queueItem.status(), queueItem.repositoryInfo(), queueItem.jobTimingInfo(), queueItem.buildConfig(), submissionResult);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/LocalCIBuildJobQueueItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/LocalCIBuildJobQueueItem.java
@@ -4,9 +4,14 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.enumeration.BuildStatus;
 import de.tum.in.www1.artemis.web.rest.dto.ResultDTO;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record LocalCIBuildJobQueueItem(String id, String name, String buildAgentAddress, long participationId, long courseId, long exerciseId, int retryCount, int priority,
         BuildStatus status, RepositoryInfo repositoryInfo, JobTimingInfo jobTimingInfo, BuildConfig buildConfig, ResultDTO submissionResult) implements Serializable {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/LocalCIBuildResult.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/LocalCIBuildResult.java
@@ -8,6 +8,9 @@ import java.util.List;
 
 import org.springframework.util.ObjectUtils;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.BuildLogEntry;
 import de.tum.in.www1.artemis.service.connectors.bamboo.dto.TestwiseCoverageReportDTO;
 import de.tum.in.www1.artemis.service.dto.AbstractBuildResultNotificationDTO;
@@ -19,6 +22,8 @@ import de.tum.in.www1.artemis.service.dto.TestCaseDTOInterface;
  * Represents all the information returned by the local CI system about a build.
  * Note: due to limitations with inheritance, we cannot declare this as a record, but we can use it in a similar way with final fields.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class LocalCIBuildResult extends AbstractBuildResultNotificationDTO implements Serializable {
 
     private final String assignmentRepoBranchName;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/RepositoryInfo.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/RepositoryInfo.java
@@ -2,8 +2,13 @@ package de.tum.in.www1.artemis.service.connectors.localci.dto;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.enumeration.RepositoryType;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record RepositoryInfo(String repositoryName, RepositoryType repositoryType, RepositoryType triggeredByPushTo, String assignmentRepositoryUri, String testRepositoryUri,
         String solutionRepositoryUri, String[] auxiliaryRepositoryUris, String[] auxiliaryRepositoryCheckoutDirectories) implements Serializable {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/ResultQueueItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/ResultQueueItem.java
@@ -2,5 +2,8 @@ package de.tum.in.www1.artemis.service.connectors.localci.dto;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ResultQueueItem(LocalCIBuildResult buildResult, LocalCIBuildJobQueueItem buildJobQueueItem, Throwable exception) implements Serializable {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminBuildJobQueueResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/admin/AdminBuildJobQueueResource.java
@@ -62,6 +62,7 @@ public class AdminBuildJobQueueResource {
     public ResponseEntity<List<LocalCIBuildAgentInformation>> getBuildAgentInformation() {
         log.debug("REST request to get information on available build agents");
         List<LocalCIBuildAgentInformation> buildAgentInfo = localCIBuildJobQueueService.getBuildAgentInformation();
+        // TODO: convert into a proper DTO and strip unnecessary information, e.g. build config, because it's not shown in the client and contains too much information
         return ResponseEntity.ok(buildAgentInfo);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ParticipationDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ParticipationDTO.java
@@ -1,14 +1,19 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.in.www1.artemis.domain.participation.Participation;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record ParticipationDTO(Long id, boolean testRun, String type, Integer submissionCount) {
+public record ParticipationDTO(Long id, boolean testRun, String type, Integer submissionCount) implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public static ParticipationDTO of(Participation participation) {
         return new ParticipationDTO(participation.getId(), participation.isTestRun(), participation.getType(), participation.getSubmissionCount());
     }
-
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ParticipationDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ParticipationDTO.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -9,9 +8,6 @@ import de.tum.in.www1.artemis.domain.participation.Participation;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ParticipationDTO(Long id, boolean testRun, String type, Integer submissionCount) implements Serializable {
-
-    @Serial
-    private static final long serialVersionUID = 1L;
 
     public static ParticipationDTO of(Participation participation) {
         return new ParticipationDTO(participation.getId(), participation.isTestRun(), participation.getType(), participation.getSubmissionCount());

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ParticipationDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ParticipationDTO.java
@@ -1,15 +1,44 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
 import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import jakarta.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.in.www1.artemis.domain.Course;
+import de.tum.in.www1.artemis.domain.Exercise;
+import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
+import de.tum.in.www1.artemis.domain.enumeration.ExerciseType;
 import de.tum.in.www1.artemis.domain.participation.Participation;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record ParticipationDTO(Long id, boolean testRun, String type, Integer submissionCount) implements Serializable {
+public record ParticipationDTO(Long id, boolean testRun, String type, Integer submissionCount, ParticipationExerciseDTO exercise) implements Serializable {
 
     public static ParticipationDTO of(Participation participation) {
-        return new ParticipationDTO(participation.getId(), participation.isTestRun(), participation.getType(), participation.getSubmissionCount());
+        return Optional.ofNullable(participation)
+                .map(p -> new ParticipationDTO(p.getId(), p.isTestRun(), p.getType(), p.getSubmissionCount(), ParticipationExerciseDTO.of(p.getExercise()))).orElse(null);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public record ParticipationExerciseDTO(Long id, ExerciseType exerciseType, String type, AssessmentType assessmentType, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate,
+            Double maxPoints, CourseDTO course) implements Serializable {
+
+        @Nullable
+        public static ParticipationExerciseDTO of(Exercise exercise) {
+            return Optional.ofNullable(exercise).map(e -> new ParticipationExerciseDTO(e.getId(), e.getExerciseType(), e.getType(), e.getAssessmentType(), e.getDueDate(),
+                    e.getAssessmentDueDate(), e.getMaxPoints(), CourseDTO.of(e.getCourseViaExerciseGroupOrCourseMember()))).orElse(null);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public record CourseDTO(Long id, Integer accuracyOfScores) implements Serializable {
+
+        @Nullable
+        public static CourseDTO of(Course course) {
+            return Optional.ofNullable(course).map(c -> new CourseDTO(c.getId(), c.getAccuracyOfScores())).orElse(null);
+        }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ResultDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ResultDTO.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -23,28 +22,18 @@ public record ResultDTO(Long id, ZonedDateTime completionDate, Boolean successfu
         List<FeedbackDTO> feedbacks, AssessmentType assessmentType, Boolean hasComplaint, Boolean exampleResult, Integer testCaseCount, Integer passedTestCaseCount,
         Integer codeIssueCount) implements Serializable {
 
-    @Serial
-    private static final long serialVersionUID = 1L;
-
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record FeedbackDTO(Long id, String text, String detailText, boolean hasLongFeedbackText, String reference, Double credits, Boolean positive, FeedbackType type,
             Visibility visibility, TestCaseDTO testCase) implements Serializable {
 
-        @Serial
-        private static final long serialVersionUID = 1L;
-
         public static FeedbackDTO of(Feedback feedback) {
             return new FeedbackDTO(feedback.getId(), feedback.getText(), feedback.getDetailText(), feedback.getHasLongFeedbackText(), feedback.getReference(),
                     feedback.getCredits(), feedback.isPositive(), feedback.getType(), feedback.getVisibility(), TestCaseDTO.of(feedback.getTestCase()));
-
         }
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record TestCaseDTO(String testName, Long id) implements Serializable {
-
-        @Serial
-        private static final long serialVersionUID = 1L;
 
         public static TestCaseDTO of(ProgrammingExerciseTestCase testCase) {
             if (testCase == null) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ResultDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ResultDTO.java
@@ -1,5 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -19,11 +21,17 @@ import de.tum.in.www1.artemis.domain.enumeration.*;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ResultDTO(Long id, ZonedDateTime completionDate, Boolean successful, Double score, Boolean rated, SubmissionDTO submission, ParticipationDTO participation,
         List<FeedbackDTO> feedbacks, AssessmentType assessmentType, Boolean hasComplaint, Boolean exampleResult, Integer testCaseCount, Integer passedTestCaseCount,
-        Integer codeIssueCount) {
+        Integer codeIssueCount) implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record FeedbackDTO(Long id, String text, String detailText, boolean hasLongFeedbackText, String reference, Double credits, Boolean positive, FeedbackType type,
-            Visibility visibility, TestCaseDTO testCase) {
+            Visibility visibility, TestCaseDTO testCase) implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         public static FeedbackDTO of(Feedback feedback) {
             return new FeedbackDTO(feedback.getId(), feedback.getText(), feedback.getDetailText(), feedback.getHasLongFeedbackText(), feedback.getReference(),
@@ -33,7 +41,10 @@ public record ResultDTO(Long id, ZonedDateTime completionDate, Boolean successfu
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public record TestCaseDTO(String testName, Long id) {
+    public record TestCaseDTO(String testName, Long id) implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         public static TestCaseDTO of(ProgrammingExerciseTestCase testCase) {
             if (testCase == null) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ResultDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ResultDTO.java
@@ -17,6 +17,8 @@ import de.tum.in.www1.artemis.domain.enumeration.*;
  * DTO containing {@link Result} information.
  * This does not include large reference attributes in order to send minimal data to the client.
  */
+// TODO: the result should include an actual string calculated and rounded on server side (based on exercise and course settings), this should not be done on the client side
+// this would also simplify the logic in result.component.ts and and result.service.ts and make the experience more consistent among different clients (webapp, ios, android)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ResultDTO(Long id, ZonedDateTime completionDate, Boolean successful, Double score, Boolean rated, SubmissionDTO submission, ParticipationDTO participation,
         List<FeedbackDTO> feedbacks, AssessmentType assessmentType, Boolean hasComplaint, Boolean exampleResult, Integer testCaseCount, Integer passedTestCaseCount,

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/SubmissionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/SubmissionDTO.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 
@@ -17,9 +16,6 @@ import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record SubmissionDTO(Long id, Boolean submitted, SubmissionType type, Boolean exampleSubmission, ZonedDateTime submissionDate, String commitHash, Boolean buildFailed,
         Boolean buildArtifact, ParticipationDTO participation, String submissionExerciseType) implements Serializable {
-
-    @Serial
-    private static final long serialVersionUID = 1L;
 
     /**
      * Converts a Submission into a SubmissionDTO.

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/SubmissionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/SubmissionDTO.java
@@ -1,5 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -14,7 +16,10 @@ import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record SubmissionDTO(Long id, Boolean submitted, SubmissionType type, Boolean exampleSubmission, ZonedDateTime submissionDate, String commitHash, Boolean buildFailed,
-        Boolean buildArtifact, ParticipationDTO participation, String submissionExerciseType) {
+        Boolean buildArtifact, ParticipationDTO participation, String submissionExerciseType) implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     /**
      * Converts a Submission into a SubmissionDTO.

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/localci/LocalCIWebsocketMessagingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/localci/LocalCIWebsocketMessagingService.java
@@ -93,6 +93,7 @@ public class LocalCIWebsocketMessagingService {
     public void sendBuildAgentInformation(List<LocalCIBuildAgentInformation> buildAgentInfo) {
         String channel = "/topic/admin/build-agents";
         log.debug("Sending message on topic {}: {}", channel, buildAgentInfo);
+        // TODO: convert into a proper DTO and strip unnecessary information, e.g. build config, because it's not shown in the client and contains too much information
         websocketMessagingService.sendMessage(channel, buildAgentInfo);
     }
 

--- a/src/main/webapp/app/entities/participation/participation.model.ts
+++ b/src/main/webapp/app/entities/participation/participation.model.ts
@@ -68,10 +68,10 @@ export const getExercise = (participation: Participation): Exercise | undefined 
                 return (participation as ProgrammingExerciseStudentParticipation).exercise;
             case ParticipationType.STUDENT:
                 return (participation as StudentParticipation).exercise;
-            case ParticipationType.SOLUTION:
-                return (participation as SolutionProgrammingExerciseParticipation).programmingExercise;
-            case ParticipationType.TEMPLATE:
-                return (participation as TemplateProgrammingExerciseParticipation).programmingExercise;
+            case ParticipationType.SOLUTION: // it could be stored in both programmingExercise or exercise
+                return (participation as SolutionProgrammingExerciseParticipation).programmingExercise ?? (participation as SolutionProgrammingExerciseParticipation).exercise;
+            case ParticipationType.TEMPLATE: // it could be stored in both programmingExercise or exercise
+                return (participation as TemplateProgrammingExerciseParticipation).programmingExercise ?? (participation as TemplateProgrammingExerciseParticipation).exercise;
         }
     }
 };

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
@@ -220,8 +220,6 @@ function computeDropLocation(
     elementLocation: { x: number; y: number; width: number; height: number },
     totalSize: { x?: number; y?: number; width: number; height: number },
 ): DropLocation {
-    console.log('elementLocation', elementLocation);
-    console.log('totalSize', totalSize);
     const dropLocation = new DropLocation();
     // on quiz exercise generation, svg exports adds 15px padding
     elementLocation.x += 15;

--- a/src/main/webapp/app/exercises/shared/result/result.service.ts
+++ b/src/main/webapp/app/exercises/shared/result/result.service.ts
@@ -35,7 +35,8 @@ export interface IResultService {
     find: (resultId: number) => Observable<EntityResponseType>;
     getResultsForExerciseWithPointsPerGradingCriterion: (exerciseId: number, req?: any) => Observable<ResultsWithPointsArrayResponseType>;
     getFeedbackDetailsForResult: (participationId: number, result: Result) => Observable<HttpResponse<Feedback[]>>;
-    delete: (participationId: number, resultId: number) => Observable<HttpResponse<void>>;
+    getResultsWithPointsPerGradingCriterion: (exercise: Exercise) => Observable<ResultsWithPointsArrayResponseType>;
+    triggerDownloadCSV: (rows: string[], csvFileName: string) => void;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -195,10 +196,6 @@ export class ResultService implements IResultService {
                 return res;
             }),
         );
-    }
-
-    delete(participationId: number, resultId: number): Observable<HttpResponse<void>> {
-        return this.http.delete<void>(`${this.resultResourceUrl}/${resultId}`, { observe: 'response' });
     }
 
     public convertResultDatesFromClient(result: Result): Result {

--- a/src/main/webapp/app/localci/build-agents/build-agents.component.html
+++ b/src/main/webapp/app/localci/build-agents/build-agents.component.html
@@ -1,5 +1,6 @@
 <div style="padding-bottom: 60px">
     <h3 id="build-agents-heading" jhiTranslate="artemisApp.buildAgents.title"></h3>
+    <p>{{ buildAgents.length }} online agent(s): {{ currentBuilds }} of {{ buildCapacity }} build jobs running</p>
     <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-3"></div>
     <jhi-data-table [showPageSizeDropdown]="false" [showSearchField]="false" entityType="buildAgent" [allEntities]="buildAgents!">
         <ng-template let-settings="settings" let-controls="controls">
@@ -41,7 +42,7 @@
                         }
                     </ng-template>
                 </ngx-datatable-column>
-                <ngx-datatable-column prop="maxNumberOfConcurrentBuildJobs" [minWidth]="150">
+                <ngx-datatable-column prop="maxNumberOfConcurrentBuildJobs" [minWidth]="100">
                     <ng-template ngx-datatable-header-template>
                         <span class="datatable-header-cell-wrapper" (click)="controls.onSort('maxNumberOfConcurrentBuildJobs')">
                             <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.maxNumberOfConcurrentBuildJobs"></span>
@@ -52,7 +53,7 @@
                         <span>{{ value }}</span>
                     </ng-template>
                 </ngx-datatable-column>
-                <ngx-datatable-column prop="numberOfCurrentBuildJobs" [minWidth]="150">
+                <ngx-datatable-column prop="numberOfCurrentBuildJobs" [minWidth]="100">
                     <ng-template ngx-datatable-header-template>
                         <span class="datatable-header-cell-wrapper" (click)="controls.onSort('numberOfCurrentBuildJobs')">
                             <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.numberOfCurrentBuildJobs"></span>
@@ -69,7 +70,7 @@
                         }
                     </ng-template>
                 </ngx-datatable-column>
-                <ngx-datatable-column prop="runningBuildJobs" [minWidth]="180">
+                <ngx-datatable-column prop="runningBuildJobs" [minWidth]="250">
                     <ng-template ngx-datatable-header-template>
                         <span class="datatable-header-cell-wrapper" (click)="controls.onSort('runningBuildJobs')">
                             <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.runningBuildJobs"></span>
@@ -80,7 +81,7 @@
                         <div>
                             @for (job of value; track job.id) {
                                 <div style="display: flex; align-items: center">
-                                    <span style="width: 120px; margin-right: 10px; text-align: left">{{ job.id }}</span>
+                                    <span style="width: 200px; margin-right: 10px; text-align: left">{{ job.id }}</span>
                                     <button style="margin-bottom: 2px" class="btn btn-danger btn-sm" (click)="cancelBuildJob(job.id)">
                                         <fa-icon [icon]="faTimes" />
                                     </button>

--- a/src/main/webapp/app/localci/build-agents/build-agents.component.html
+++ b/src/main/webapp/app/localci/build-agents/build-agents.component.html
@@ -1,110 +1,14 @@
 <div style="padding-bottom: 60px">
     <h3 id="build-agents-heading" jhiTranslate="artemisApp.buildAgents.title"></h3>
-    <p>{{ buildAgents.length }} online agent(s): {{ currentBuilds }} of {{ buildCapacity }} build jobs running</p>
-    <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-3"></div>
-    <jhi-data-table [showPageSizeDropdown]="false" [showSearchField]="false" entityType="buildAgent" [allEntities]="buildAgents!">
-        <ng-template let-settings="settings" let-controls="controls">
-            <ngx-datatable
-                class="bootstrap"
-                [limit]="settings.limit"
-                [sortType]="settings.sortType"
-                [columnMode]="settings.columnMode"
-                [headerHeight]="settings.headerHeight"
-                [footerHeight]="settings.footerHeight"
-                [rowHeight]="settings.rowHeight"
-                [rows]="settings.rows"
-                [rowClass]="settings.rowClass"
-                [scrollbarH]="settings.scrollbarH"
-            >
-                <ngx-datatable-column prop="name" [minWidth]="150">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('name')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.name"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('name')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="status" [minWidth]="150">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('status')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.status"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('status')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        @if (value) {
-                            <span jhiTranslate="artemisApp.buildAgents.running"></span>
-                        } @else {
-                            <span jhiTranslate="artemisApp.buildAgents.idle"></span>
-                        }
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="maxNumberOfConcurrentBuildJobs" [minWidth]="100">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('maxNumberOfConcurrentBuildJobs')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.maxNumberOfConcurrentBuildJobs"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('maxNumberOfConcurrentBuildJobs')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="numberOfCurrentBuildJobs" [minWidth]="100">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('numberOfCurrentBuildJobs')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.numberOfCurrentBuildJobs"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('numberOfCurrentBuildJobs')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                        <span style="margin-right: 20px">{{ value }}</span>
-                        @if (value > 0) {
-                            <button class="btn btn-danger btn-sm" (click)="cancelAllBuildJobs(row.name)">
-                                <fa-icon [icon]="faTimes" />
-                                <span jhiTranslate="artemisApp.buildQueue.cancelAll"></span>
-                            </button>
-                        }
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="runningBuildJobs" [minWidth]="250">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('runningBuildJobs')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.runningBuildJobs"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('runningBuildJobs')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <div>
-                            @for (job of value; track job.id) {
-                                <div style="display: flex; align-items: center">
-                                    <span style="width: 200px; margin-right: 10px; text-align: left">{{ job.id }}</span>
-                                    <button style="margin-bottom: 2px" class="btn btn-danger btn-sm" (click)="cancelBuildJob(job.id)">
-                                        <fa-icon [icon]="faTimes" />
-                                    </button>
-                                </div>
-                            }
-                        </div>
-                    </ng-template>
-                </ngx-datatable-column>
-            </ngx-datatable>
-        </ng-template>
-    </jhi-data-table>
-</div>
-<div style="padding-bottom: 60px">
-    <h3 id="build-agents-recent-builds-heading" jhiTranslate="artemisApp.buildAgents.recentBuildJobs"></h3>
-    @for (agent of buildAgents; track agent.id) {
-        <h5 id="build-agent-recent-builds-heading" style="padding-top: 30px">{{ agent.name }}</h5>
+    @if (buildAgents) {
+        <p>{{ buildAgents.length }} online agent(s): {{ currentBuilds }} of {{ buildCapacity }} build jobs running</p>
         <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-3"></div>
-        <jhi-data-table [showPageSizeDropdown]="false" [showSearchField]="false" entityType="build" [allEntities]="agent.recentBuildJobs!">
+        <jhi-data-table [showPageSizeDropdown]="false" [showSearchField]="false" entityType="buildAgent" [allEntities]="buildAgents!">
             <ng-template let-settings="settings" let-controls="controls">
                 <ngx-datatable
                     class="bootstrap"
                     [limit]="settings.limit"
-                    [sorts]="settings.sorts"
+                    [sortType]="settings.sortType"
                     [columnMode]="settings.columnMode"
                     [headerHeight]="settings.headerHeight"
                     [footerHeight]="settings.footerHeight"
@@ -113,206 +17,306 @@
                     [rowClass]="settings.rowClass"
                     [scrollbarH]="settings.scrollbarH"
                 >
-                    <ngx-datatable-column [minWidth]="30" [maxWidth]="30">
-                        <ng-template ngx-datatable-header-template />
-                        <ng-template ngx-datatable-cell-template let-row="row">
-                            <span
-                                [ngClass]="{
-                                    'text-success': row.status === 'SUCCESSFUL',
-                                    'text-warning': row.status === 'CANCELLED',
-                                    'text-danger': row.status === 'FAILED' || row.status === 'ERROR'
-                                }"
-                            >
-                                <fa-icon [icon]="row.status === 'SUCCESSFUL' ? faCircleCheck : row.status === 'CANCELLED' ? faExclamationTriangle : faExclamationCircle" />
-                            </span>
-                        </ng-template>
-                    </ngx-datatable-column>
-                    <ngx-datatable-column prop="name" [minWidth]="100">
+                    <ngx-datatable-column prop="name" [minWidth]="150">
                         <ng-template ngx-datatable-header-template>
                             <span class="datatable-header-cell-wrapper" (click)="controls.onSort('name')">
-                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.name"></span>
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.name"></span>
                                 <fa-icon [icon]="controls.iconForSortPropField('name')" />
                             </span>
                         </ng-template>
-                        <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                            <span
-                                [ngClass]="{
-                                    'text-success': row.status === 'SUCCESSFUL',
-                                    'text-warning': row.status === 'CANCELLED',
-                                    'text-danger': row.status === 'FAILED' || row.status === 'ERROR'
-                                }"
-                                >{{ value }}</span
-                            >
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
                         </ng-template>
                     </ngx-datatable-column>
-                    <ngx-datatable-column prop="status" [minWidth]="100">
+                    <ngx-datatable-column prop="status" [minWidth]="150">
                         <ng-template ngx-datatable-header-template>
                             <span class="datatable-header-cell-wrapper" (click)="controls.onSort('status')">
-                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.status"></span>
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.status"></span>
                                 <fa-icon [icon]="controls.iconForSortPropField('status')" />
                             </span>
                         </ng-template>
-                        <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                            @if (value === 'SUCCESSFUL') {
-                                <jhi-result [result]="row.submissionResult" [showUngradedResults]="true" [showBadge]="true" />
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            @if (value) {
+                                <span jhiTranslate="artemisApp.buildAgents.running"></span>
                             } @else {
-                                <span
-                                    [ngClass]="{
-                                        'text-warning': row.status === 'CANCELLED',
-                                        'text-danger': row.status === 'FAILED' || row.status === 'ERROR'
-                                    }"
-                                    >{{ value }}
-                                </span>
+                                <span jhiTranslate="artemisApp.buildAgents.idle"></span>
                             }
                         </ng-template>
                     </ngx-datatable-column>
-                    <ngx-datatable-column prop="participationId" [minWidth]="100">
+                    <ngx-datatable-column prop="maxNumberOfConcurrentBuildJobs" [minWidth]="100">
                         <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('participationId')">
-                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.participationId"></span>
-                                <fa-icon [icon]="controls.iconForSortPropField('participationId')" />
-                            </span>
-                        </ng-template>
-                        <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                            @if (
-                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
-                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
-                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
-                            ) {
-                                <a
-                                    [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']"
-                                    [queryParams]="{ isTmpOrSolutionProgrParticipation: true }"
-                                    >{{ value }}</a
-                                >
-                            } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
-                                <a [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']">{{
-                                    value
-                                }}</a>
-                            } @else {
-                                {{ value }}
-                            }
-                        </ng-template>
-                    </ngx-datatable-column>
-                    <ngx-datatable-column prop="repositoryInfo.repositoryName" [minWidth]="100">
-                        <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryName')">
-                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryName"></span>
-                                <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryName')" />
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('maxNumberOfConcurrentBuildJobs')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.maxNumberOfConcurrentBuildJobs"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('maxNumberOfConcurrentBuildJobs')" />
                             </span>
                         </ng-template>
                         <ng-template ngx-datatable-cell-template let-value="value">
                             <span>{{ value }}</span>
                         </ng-template>
                     </ngx-datatable-column>
-                    <ngx-datatable-column prop="repositoryInfo.repositoryType" [minWidth]="100">
+                    <ngx-datatable-column prop="numberOfCurrentBuildJobs" [minWidth]="100">
                         <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryType')">
-                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryType"></span>
-                                <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryType')" />
-                            </span>
-                        </ng-template>
-                        <ng-template ngx-datatable-cell-template let-value="value">
-                            <span>{{ value }}</span>
-                        </ng-template>
-                    </ngx-datatable-column>
-                    <ngx-datatable-column prop="buildConfig.commitHash" [minWidth]="100">
-                        <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('buildConfig.commitHash')">
-                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.commitHash"></span>
-                                <fa-icon [icon]="controls.iconForSortPropField('buildConfig.commitHash')" />
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('numberOfCurrentBuildJobs')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.numberOfCurrentBuildJobs"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('numberOfCurrentBuildJobs')" />
                             </span>
                         </ng-template>
                         <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                            @if (
-                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
-                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
-                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
-                            ) {
-                                <a
-                                    class="wrap-long-text"
-                                    [routerLink]="[
-                                        '/course-management',
-                                        row.courseId,
-                                        'programming-exercises',
-                                        row.exerciseId,
-                                        'repository',
-                                        row.repositoryInfo.triggeredByPushTo,
-                                        'commit-history',
-                                        value
-                                    ]"
-                                    >{{ value }}</a
-                                >
-                            } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
-                                <a
-                                    class="wrap-long-text"
-                                    [routerLink]="[
-                                        '/course-management',
-                                        row.courseId,
-                                        'programming-exercises',
-                                        row.exerciseId,
-                                        'participations',
-                                        row.participationId,
-                                        'repository',
-                                        'commit-history',
-                                        value
-                                    ]"
-                                    >{{ value }}</a
-                                >
-                            } @else {
-                                <span class="wrap-long-text">{{ value }}</span>
+                            <span style="margin-right: 20px">{{ value }}</span>
+                            @if (value > 0) {
+                                <button class="btn btn-danger btn-sm" (click)="cancelAllBuildJobs(row.name)">
+                                    <fa-icon [icon]="faTimes" />
+                                    <span jhiTranslate="artemisApp.buildQueue.cancelAll"></span>
+                                </button>
                             }
                         </ng-template>
                     </ngx-datatable-column>
-                    <ngx-datatable-column prop="courseId" [minWidth]="100">
+                    <ngx-datatable-column prop="runningBuildJobs" [minWidth]="250">
                         <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('courseId')">
-                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.courseId"></span>
-                                <fa-icon [icon]="controls.iconForSortPropField('courseId')" />
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('runningBuildJobs')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildAgents.runningBuildJobs"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('runningBuildJobs')" />
                             </span>
                         </ng-template>
                         <ng-template ngx-datatable-cell-template let-value="value">
-                            <a [routerLink]="['/course-management', value]">{{ value }}</a>
-                        </ng-template>
-                    </ngx-datatable-column>
-                    <ngx-datatable-column prop="priority" [minWidth]="100">
-                        <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('priority')">
-                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.priority"></span>
-                                <fa-icon [icon]="controls.iconForSortPropField('priority')" />
-                            </span>
-                        </ng-template>
-                        <ng-template ngx-datatable-cell-template let-value="value">
-                            <span>{{ value }}</span>
-                        </ng-template>
-                    </ngx-datatable-column>
-                    <ngx-datatable-column prop="jobTimingInfo.submissionDate" [minWidth]="100">
-                        <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('jobTimingInfo.submissionDate')">
-                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.submissionDate"></span>
-                                <fa-icon [icon]="controls.iconForSortPropField('jobTimingInfo.submissionDate')" />
-                            </span>
-                        </ng-template>
-                        <ng-template ngx-datatable-cell-template let-value="value">
-                            <span>{{ value | artemisDate: 'long' : true }}</span>
-                        </ng-template>
-                    </ngx-datatable-column>
-                    <ngx-datatable-column prop="jobTimingInfo.buildDuration" [minWidth]="250">
-                        <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('jobTimingInfo.buildDuration')">
-                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.buildDuration"></span>
-                                <fa-icon [icon]="controls.iconForSortPropField('jobTimingInfo.buildDuration')" />
-                            </span>
-                        </ng-template>
-                        <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                            <span>
-                                <strong>Start:</strong> {{ row.jobTimingInfo?.buildStartDate | artemisDate: 'long' : true }},<br />
-                                <strong>Completion:</strong> {{ row.jobTimingInfo?.buildCompletionDate | artemisDate: 'long' : true }},<br />
-                                <strong>Duration:</strong> {{ value | artemisDurationFromSeconds: false }}
-                            </span>
+                            <div>
+                                @for (job of value; track job.id) {
+                                    <div style="display: flex; align-items: center">
+                                        <span style="width: 200px; margin-right: 10px; text-align: left">{{ job.id }}</span>
+                                        <button style="margin-bottom: 2px" class="btn btn-danger btn-sm" (click)="cancelBuildJob(job.id)">
+                                            <fa-icon [icon]="faTimes" />
+                                        </button>
+                                    </div>
+                                }
+                            </div>
                         </ng-template>
                     </ngx-datatable-column>
                 </ngx-datatable>
             </ng-template>
         </jhi-data-table>
+    }
+</div>
+<div style="padding-bottom: 60px">
+    <h3 id="build-agents-recent-builds-heading" jhiTranslate="artemisApp.buildAgents.recentBuildJobs"></h3>
+    @for (agent of buildAgents; track agent.id) {
+        <h5 id="build-agent-recent-builds-heading" style="padding-top: 30px">{{ agent.name }}</h5>
+        <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-3"></div>
+        @if (agent.recentBuildJobs) {
+            <jhi-data-table [showPageSizeDropdown]="false" [showSearchField]="false" entityType="build" [allEntities]="agent.recentBuildJobs!">
+                <ng-template let-settings="settings" let-controls="controls">
+                    <ngx-datatable
+                        class="bootstrap"
+                        [limit]="settings.limit"
+                        [sorts]="settings.sorts"
+                        [columnMode]="settings.columnMode"
+                        [headerHeight]="settings.headerHeight"
+                        [footerHeight]="settings.footerHeight"
+                        [rowHeight]="settings.rowHeight"
+                        [rows]="settings.rows"
+                        [rowClass]="settings.rowClass"
+                        [scrollbarH]="settings.scrollbarH"
+                    >
+                        <ngx-datatable-column [minWidth]="30" [maxWidth]="30">
+                            <ng-template ngx-datatable-header-template />
+                            <ng-template ngx-datatable-cell-template let-row="row">
+                                <span
+                                    [ngClass]="{
+                                        'text-success': row.status === 'SUCCESSFUL',
+                                        'text-warning': row.status === 'CANCELLED',
+                                        'text-danger': row.status === 'FAILED' || row.status === 'ERROR'
+                                    }"
+                                >
+                                    <fa-icon [icon]="row.status === 'SUCCESSFUL' ? faCircleCheck : row.status === 'CANCELLED' ? faExclamationTriangle : faExclamationCircle" />
+                                </span>
+                            </ng-template>
+                        </ngx-datatable-column>
+                        <ngx-datatable-column prop="name" [minWidth]="100">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper" (click)="controls.onSort('name')">
+                                    <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.name"></span>
+                                    <fa-icon [icon]="controls.iconForSortPropField('name')" />
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                                <span
+                                    [ngClass]="{
+                                        'text-success': row.status === 'SUCCESSFUL',
+                                        'text-warning': row.status === 'CANCELLED',
+                                        'text-danger': row.status === 'FAILED' || row.status === 'ERROR'
+                                    }"
+                                    >{{ value }}</span
+                                >
+                            </ng-template>
+                        </ngx-datatable-column>
+                        <ngx-datatable-column prop="status" [minWidth]="100">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper" (click)="controls.onSort('status')">
+                                    <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.status"></span>
+                                    <fa-icon [icon]="controls.iconForSortPropField('status')" />
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                                @if (value === 'SUCCESSFUL') {
+                                    <jhi-result [result]="row.submissionResult" [showUngradedResults]="true" [showBadge]="true" />
+                                } @else {
+                                    <span
+                                        [ngClass]="{
+                                            'text-warning': row.status === 'CANCELLED',
+                                            'text-danger': row.status === 'FAILED' || row.status === 'ERROR'
+                                        }"
+                                        >{{ value }}
+                                    </span>
+                                }
+                            </ng-template>
+                        </ngx-datatable-column>
+                        <ngx-datatable-column prop="participationId" [minWidth]="100">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper" (click)="controls.onSort('participationId')">
+                                    <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.participationId"></span>
+                                    <fa-icon [icon]="controls.iconForSortPropField('participationId')" />
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                                @if (
+                                    row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
+                                    row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
+                                    row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
+                                ) {
+                                    <a
+                                        [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']"
+                                        [queryParams]="{ isTmpOrSolutionProgrParticipation: true }"
+                                        >{{ value }}</a
+                                    >
+                                } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
+                                    <a [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']">{{
+                                        value
+                                    }}</a>
+                                } @else {
+                                    {{ value }}
+                                }
+                            </ng-template>
+                        </ngx-datatable-column>
+                        <ngx-datatable-column prop="repositoryInfo.repositoryName" [minWidth]="100">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryName')">
+                                    <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryName"></span>
+                                    <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryName')" />
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value">
+                                <span>{{ value }}</span>
+                            </ng-template>
+                        </ngx-datatable-column>
+                        <ngx-datatable-column prop="repositoryInfo.repositoryType" [minWidth]="100">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryType')">
+                                    <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryType"></span>
+                                    <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryType')" />
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value">
+                                <span>{{ value }}</span>
+                            </ng-template>
+                        </ngx-datatable-column>
+                        <ngx-datatable-column prop="buildConfig.commitHash" [minWidth]="100">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper" (click)="controls.onSort('buildConfig.commitHash')">
+                                    <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.commitHash"></span>
+                                    <fa-icon [icon]="controls.iconForSortPropField('buildConfig.commitHash')" />
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                                @if (
+                                    row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
+                                    row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
+                                    row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
+                                ) {
+                                    <a
+                                        class="wrap-long-text"
+                                        [routerLink]="[
+                                            '/course-management',
+                                            row.courseId,
+                                            'programming-exercises',
+                                            row.exerciseId,
+                                            'repository',
+                                            row.repositoryInfo.triggeredByPushTo,
+                                            'commit-history',
+                                            value
+                                        ]"
+                                        >{{ value }}</a
+                                    >
+                                } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
+                                    <a
+                                        class="wrap-long-text"
+                                        [routerLink]="[
+                                            '/course-management',
+                                            row.courseId,
+                                            'programming-exercises',
+                                            row.exerciseId,
+                                            'participations',
+                                            row.participationId,
+                                            'repository',
+                                            'commit-history',
+                                            value
+                                        ]"
+                                        >{{ value }}</a
+                                    >
+                                } @else {
+                                    <span class="wrap-long-text">{{ value }}</span>
+                                }
+                            </ng-template>
+                        </ngx-datatable-column>
+                        <ngx-datatable-column prop="courseId" [minWidth]="100">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper" (click)="controls.onSort('courseId')">
+                                    <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.courseId"></span>
+                                    <fa-icon [icon]="controls.iconForSortPropField('courseId')" />
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value">
+                                <a [routerLink]="['/course-management', value]">{{ value }}</a>
+                            </ng-template>
+                        </ngx-datatable-column>
+                        <ngx-datatable-column prop="priority" [minWidth]="100">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper" (click)="controls.onSort('priority')">
+                                    <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.priority"></span>
+                                    <fa-icon [icon]="controls.iconForSortPropField('priority')" />
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value">
+                                <span>{{ value }}</span>
+                            </ng-template>
+                        </ngx-datatable-column>
+                        <ngx-datatable-column prop="jobTimingInfo.submissionDate" [minWidth]="100">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper" (click)="controls.onSort('jobTimingInfo.submissionDate')">
+                                    <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.submissionDate"></span>
+                                    <fa-icon [icon]="controls.iconForSortPropField('jobTimingInfo.submissionDate')" />
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value">
+                                <span>{{ value | artemisDate: 'long' : true }}</span>
+                            </ng-template>
+                        </ngx-datatable-column>
+                        <ngx-datatable-column prop="jobTimingInfo.buildDuration" [minWidth]="250">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper" (click)="controls.onSort('jobTimingInfo.buildDuration')">
+                                    <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.buildDuration"></span>
+                                    <fa-icon [icon]="controls.iconForSortPropField('jobTimingInfo.buildDuration')" />
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                                <span>
+                                    <strong>Start:</strong> {{ row.jobTimingInfo?.buildStartDate | artemisDate: 'long' : true }},<br />
+                                    <strong>Completion:</strong> {{ row.jobTimingInfo?.buildCompletionDate | artemisDate: 'long' : true }},<br />
+                                    <strong>Duration:</strong> {{ value | artemisDurationFromSeconds: false }}
+                                </span>
+                            </ng-template>
+                        </ngx-datatable-column>
+                    </ngx-datatable>
+                </ng-template>
+            </jhi-data-table>
+        }
     }
 </div>

--- a/src/main/webapp/app/localci/build-queue/build-queue.component.html
+++ b/src/main/webapp/app/localci/build-queue/build-queue.component.html
@@ -1,383 +1,391 @@
 <div style="padding-bottom: 60px">
     <h3 id="build-queue-running-heading" jhiTranslate="artemisApp.buildAgents.runningBuildJobs"></h3>
     <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-3"></div>
-    <jhi-data-table [showPageSizeDropdown]="false" [showSearchField]="false" entityType="buildJob" [allEntities]="runningBuildJobs!">
-        <ng-template let-settings="settings" let-controls="controls">
-            <ngx-datatable
-                class="bootstrap"
-                [limit]="settings.limit"
-                [sorts]="runningJobsSorts"
-                [columnMode]="settings.columnMode"
-                [headerHeight]="settings.headerHeight"
-                [footerHeight]="settings.footerHeight"
-                [rowHeight]="settings.rowHeight"
-                [rows]="settings.rows"
-                [rowClass]="settings.rowClass"
-                [scrollbarH]="settings.scrollbarH"
-            >
-                <ngx-datatable-column prop="id" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('id')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.id"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('id')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="buildAgentAddress" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('buildAgentAddress')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.buildAgent"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('buildAgentAddress')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="name" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('name')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.name"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('name')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="participationId" [minWidth]="150" [width]="150">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('participationId')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.participationId"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('participationId')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                        @if (
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
-                        ) {
-                            <a
-                                [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']"
-                                [queryParams]="{ isTmpOrSolutionProgrParticipation: true }"
-                                >{{ value }}</a
-                            >
-                        } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
-                            <a [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']">{{ value }}</a>
-                        }
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="repositoryInfo.repositoryName" [minWidth]="150" [width]="150">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryName')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryName"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryName')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="repositoryInfo.repositoryType" [minWidth]="150" [width]="150">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryType')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryType"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryType')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="buildConfig.commitHash" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('buildConfig.commitHash')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.commitHash"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('buildConfig.commitHash')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                        @if (
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
-                        ) {
-                            <a
-                                class="wrap-long-text"
-                                [routerLink]="[
-                                    '/course-management',
-                                    row.courseId,
-                                    'programming-exercises',
-                                    row.exerciseId,
-                                    'repository',
-                                    row.repositoryInfo.triggeredByPushTo,
-                                    'commit-history',
-                                    value
-                                ]"
-                                >{{ value }}</a
-                            >
-                        } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
-                            <a
-                                class="wrap-long-text"
-                                [routerLink]="[
-                                    '/course-management',
-                                    row.courseId,
-                                    'programming-exercises',
-                                    row.exerciseId,
-                                    'participations',
-                                    row.participationId,
-                                    'repository',
-                                    'commit-history',
-                                    value
-                                ]"
-                                >{{ value }}</a
-                            >
-                        } @else {
-                            <span class="wrap-long-text">{{ value }}</span>
-                        }
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="jobTimingInfo.submissionDate" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('jobTimingInfo.submissionDate')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.submissionDate"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('jobTimingInfo.submissionDate')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value | artemisDate: 'long' : true }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="jobTimingInfo.buildStartDate" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('jobTimingInfo.buildStartDate')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.buildStartDate"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('jobTimingInfo.buildStartDate')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value | artemisDate: 'long' : true }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="courseId" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('courseId')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.courseId"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('courseId')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <a [routerLink]="['/course-management', value]">{{ value }}</a>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="priority" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('priority')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.priority"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('priority')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="cancel" [minWidth]="150" [width]="100">
-                    <div class="d-flex justify-content-center align-items-center">
+    @if (runningBuildJobs) {
+        <jhi-data-table [showPageSizeDropdown]="false" [showSearchField]="false" entityType="buildJob" [allEntities]="runningBuildJobs!">
+            <ng-template let-settings="settings" let-controls="controls">
+                <ngx-datatable
+                    class="bootstrap"
+                    [limit]="settings.limit"
+                    [sorts]="runningJobsSorts"
+                    [columnMode]="settings.columnMode"
+                    [headerHeight]="settings.headerHeight"
+                    [footerHeight]="settings.footerHeight"
+                    [rowHeight]="settings.rowHeight"
+                    [rows]="settings.rows"
+                    [rowClass]="settings.rowClass"
+                    [scrollbarH]="settings.scrollbarH"
+                >
+                    <ngx-datatable-column prop="id" [minWidth]="150" [width]="200">
                         <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper">
-                                <button class="btn btn-danger btn-sm" (click)="cancelAllRunningBuildJobs()">
-                                    <fa-icon [icon]="faTimes" />
-                                    <span jhiTranslate="artemisApp.buildQueue.cancelAll"></span>
-                                </button>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('id')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.id"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('id')" />
                             </span>
                         </ng-template>
-                        <ng-template ngx-datatable-cell-template let-row="row">
-                            <button class="btn btn-danger btn-sm" (click)="cancelBuildJob(row.id)">
-                                <fa-icon [icon]="faTimes" />
-                            </button>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
                         </ng-template>
-                    </div>
-                </ngx-datatable-column>
-            </ngx-datatable>
-        </ng-template>
-    </jhi-data-table>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="buildAgentAddress" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('buildAgentAddress')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.buildAgent"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('buildAgentAddress')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="name" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('name')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.name"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('name')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="participationId" [minWidth]="150" [width]="150">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('participationId')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.participationId"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('participationId')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                            @if (
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
+                            ) {
+                                <a
+                                    [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']"
+                                    [queryParams]="{ isTmpOrSolutionProgrParticipation: true }"
+                                    >{{ value }}</a
+                                >
+                            } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
+                                <a [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']">{{
+                                    value
+                                }}</a>
+                            }
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="repositoryInfo.repositoryName" [minWidth]="150" [width]="150">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryName')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryName"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryName')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="repositoryInfo.repositoryType" [minWidth]="150" [width]="150">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryType')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryType"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryType')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="buildConfig.commitHash" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('buildConfig.commitHash')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.commitHash"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('buildConfig.commitHash')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                            @if (
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
+                            ) {
+                                <a
+                                    class="wrap-long-text"
+                                    [routerLink]="[
+                                        '/course-management',
+                                        row.courseId,
+                                        'programming-exercises',
+                                        row.exerciseId,
+                                        'repository',
+                                        row.repositoryInfo.triggeredByPushTo,
+                                        'commit-history',
+                                        value
+                                    ]"
+                                    >{{ value }}</a
+                                >
+                            } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
+                                <a
+                                    class="wrap-long-text"
+                                    [routerLink]="[
+                                        '/course-management',
+                                        row.courseId,
+                                        'programming-exercises',
+                                        row.exerciseId,
+                                        'participations',
+                                        row.participationId,
+                                        'repository',
+                                        'commit-history',
+                                        value
+                                    ]"
+                                    >{{ value }}</a
+                                >
+                            } @else {
+                                <span class="wrap-long-text">{{ value }}</span>
+                            }
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="jobTimingInfo.submissionDate" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('jobTimingInfo.submissionDate')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.submissionDate"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('jobTimingInfo.submissionDate')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value | artemisDate: 'long' : true }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="jobTimingInfo.buildStartDate" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('jobTimingInfo.buildStartDate')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.buildStartDate"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('jobTimingInfo.buildStartDate')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value | artemisDate: 'long' : true }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="courseId" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('courseId')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.courseId"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('courseId')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <a [routerLink]="['/course-management', value]">{{ value }}</a>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="priority" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('priority')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.priority"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('priority')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="cancel" [minWidth]="150" [width]="100">
+                        <div class="d-flex justify-content-center align-items-center">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper">
+                                    <button class="btn btn-danger btn-sm" (click)="cancelAllRunningBuildJobs()">
+                                        <fa-icon [icon]="faTimes" />
+                                        <span jhiTranslate="artemisApp.buildQueue.cancelAll"></span>
+                                    </button>
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-row="row">
+                                <button class="btn btn-danger btn-sm" (click)="cancelBuildJob(row.id)">
+                                    <fa-icon [icon]="faTimes" />
+                                </button>
+                            </ng-template>
+                        </div>
+                    </ngx-datatable-column>
+                </ngx-datatable>
+            </ng-template>
+        </jhi-data-table>
+    }
 </div>
 <div>
     <h3 id="build-queue-queued-heading" jhiTranslate="artemisApp.buildQueue.queuedBuildJobs"></h3>
     <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-3"></div>
-    <jhi-data-table [showPageSizeDropdown]="false" [showSearchField]="false" entityType="buildJob" [allEntities]="queuedBuildJobs!">
-        <ng-template let-settings="settings" let-controls="controls">
-            <ngx-datatable
-                class="bootstrap"
-                [limit]="settings.limit"
-                [sorts]="queuedJobsSorts"
-                [columnMode]="settings.columnMode"
-                [headerHeight]="settings.headerHeight"
-                [footerHeight]="settings.footerHeight"
-                [rowHeight]="settings.rowHeight"
-                [rows]="settings.rows"
-                [rowClass]="settings.rowClass"
-                [scrollbarH]="settings.scrollbarH"
-            >
-                <ngx-datatable-column prop="name" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('name')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.name"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('name')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="participationId" [minWidth]="150" [width]="150">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('participationId')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.participationId"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('participationId')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                        @if (
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
-                        ) {
-                            <a
-                                [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']"
-                                [queryParams]="{ isTmpOrSolutionProgrParticipation: true }"
-                                >{{ value }}</a
-                            >
-                        } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
-                            <a [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']">{{ value }}</a>
-                        }
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="repositoryInfo.repositoryName" [minWidth]="150" [width]="150">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryName')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryName"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryName')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="repositoryInfo.repositoryType" [minWidth]="150" [width]="150">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryType')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryType"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryType')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="buildConfig.commitHash" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('buildConfig.commitHash')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.commitHash"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('buildConfig.commitHash')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                        @if (
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
-                            row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
-                        ) {
-                            <a
-                                class="wrap-long-text"
-                                [routerLink]="[
-                                    '/course-management',
-                                    row.courseId,
-                                    'programming-exercises',
-                                    row.exerciseId,
-                                    'repository',
-                                    row.repositoryInfo.triggeredByPushTo,
-                                    'commit-history',
-                                    value
-                                ]"
-                                >{{ value }}</a
-                            >
-                        } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
-                            <a
-                                class="wrap-long-text"
-                                [routerLink]="[
-                                    '/course-management',
-                                    row.courseId,
-                                    'programming-exercises',
-                                    row.exerciseId,
-                                    'participations',
-                                    row.participationId,
-                                    'repository',
-                                    'commit-history',
-                                    value
-                                ]"
-                                >{{ value }}</a
-                            >
-                        } @else {
-                            <span class="wrap-long-text">{{ value }}</span>
-                        }
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="jobTimingInfo.submissionDate" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('jobTimingInfo.submissionDate')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.submissionDate"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('jobTimingInfo.submissionDate')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value | artemisDate: 'long' : true }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="courseId" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('courseId')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.courseId"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('courseId')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <a [routerLink]="['/course-management', value]">{{ value }}</a>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="priority" [minWidth]="150" [width]="200">
-                    <ng-template ngx-datatable-header-template>
-                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('priority')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.priority"></span>
-                            <fa-icon [icon]="controls.iconForSortPropField('priority')" />
-                        </span>
-                    </ng-template>
-                    <ng-template ngx-datatable-cell-template let-value="value">
-                        <span>{{ value }}</span>
-                    </ng-template>
-                </ngx-datatable-column>
-                <ngx-datatable-column prop="cancel" [minWidth]="150" [width]="100">
-                    <div class="d-flex justify-content-center align-items-center">
+    @if (queuedBuildJobs) {
+        <jhi-data-table [showPageSizeDropdown]="false" [showSearchField]="false" entityType="buildJob" [allEntities]="queuedBuildJobs!">
+            <ng-template let-settings="settings" let-controls="controls">
+                <ngx-datatable
+                    class="bootstrap"
+                    [limit]="settings.limit"
+                    [sorts]="queuedJobsSorts"
+                    [columnMode]="settings.columnMode"
+                    [headerHeight]="settings.headerHeight"
+                    [footerHeight]="settings.footerHeight"
+                    [rowHeight]="settings.rowHeight"
+                    [rows]="settings.rows"
+                    [rowClass]="settings.rowClass"
+                    [scrollbarH]="settings.scrollbarH"
+                >
+                    <ngx-datatable-column prop="name" [minWidth]="150" [width]="200">
                         <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper">
-                                <button class="btn btn-danger btn-sm" (click)="cancelAllQueuedBuildJobs()">
-                                    <fa-icon [icon]="faTimes" />
-                                    <span jhiTranslate="artemisApp.buildQueue.cancelAll"></span>
-                                </button>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('name')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.name"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('name')" />
                             </span>
                         </ng-template>
-                        <ng-template ngx-datatable-cell-template let-row="row">
-                            <button class="btn btn-danger btn-sm" (click)="cancelBuildJob(row.id)">
-                                <fa-icon [icon]="faTimes" />
-                            </button>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
                         </ng-template>
-                    </div>
-                </ngx-datatable-column>
-            </ngx-datatable>
-        </ng-template>
-    </jhi-data-table>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="participationId" [minWidth]="150" [width]="150">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('participationId')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.participationId"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('participationId')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                            @if (
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
+                            ) {
+                                <a
+                                    [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']"
+                                    [queryParams]="{ isTmpOrSolutionProgrParticipation: true }"
+                                    >{{ value }}</a
+                                >
+                            } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
+                                <a [routerLink]="['/course-management', row.courseId, 'programming-exercises', row.exerciseId, 'participations', value, 'submissions']">{{
+                                    value
+                                }}</a>
+                            }
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="repositoryInfo.repositoryName" [minWidth]="150" [width]="150">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryName')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryName"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryName')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="repositoryInfo.repositoryType" [minWidth]="150" [width]="150">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('repositoryInfo.repositoryType')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.repositoryType"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('repositoryInfo.repositoryType')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="buildConfig.commitHash" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('buildConfig.commitHash')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.commitHash"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('buildConfig.commitHash')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                            @if (
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TEMPLATE ||
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.SOLUTION ||
+                                row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.TESTS
+                            ) {
+                                <a
+                                    class="wrap-long-text"
+                                    [routerLink]="[
+                                        '/course-management',
+                                        row.courseId,
+                                        'programming-exercises',
+                                        row.exerciseId,
+                                        'repository',
+                                        row.repositoryInfo.triggeredByPushTo,
+                                        'commit-history',
+                                        value
+                                    ]"
+                                    >{{ value }}</a
+                                >
+                            } @else if (row.repositoryInfo.triggeredByPushTo === TriggeredByPushTo.USER) {
+                                <a
+                                    class="wrap-long-text"
+                                    [routerLink]="[
+                                        '/course-management',
+                                        row.courseId,
+                                        'programming-exercises',
+                                        row.exerciseId,
+                                        'participations',
+                                        row.participationId,
+                                        'repository',
+                                        'commit-history',
+                                        value
+                                    ]"
+                                    >{{ value }}</a
+                                >
+                            } @else {
+                                <span class="wrap-long-text">{{ value }}</span>
+                            }
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="jobTimingInfo.submissionDate" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('jobTimingInfo.submissionDate')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.submissionDate"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('jobTimingInfo.submissionDate')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value | artemisDate: 'long' : true }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="courseId" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('courseId')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.courseId"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('courseId')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <a [routerLink]="['/course-management', value]">{{ value }}</a>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="priority" [minWidth]="150" [width]="200">
+                        <ng-template ngx-datatable-header-template>
+                            <span class="datatable-header-cell-wrapper" (click)="controls.onSort('priority')">
+                                <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.buildQueue.buildJob.priority"></span>
+                                <fa-icon [icon]="controls.iconForSortPropField('priority')" />
+                            </span>
+                        </ng-template>
+                        <ng-template ngx-datatable-cell-template let-value="value">
+                            <span>{{ value }}</span>
+                        </ng-template>
+                    </ngx-datatable-column>
+                    <ngx-datatable-column prop="cancel" [minWidth]="150" [width]="100">
+                        <div class="d-flex justify-content-center align-items-center">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper">
+                                    <button class="btn btn-danger btn-sm" (click)="cancelAllQueuedBuildJobs()">
+                                        <fa-icon [icon]="faTimes" />
+                                        <span jhiTranslate="artemisApp.buildQueue.cancelAll"></span>
+                                    </button>
+                                </span>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-row="row">
+                                <button class="btn btn-danger btn-sm" (click)="cancelBuildJob(row.id)">
+                                    <fa-icon [icon]="faTimes" />
+                                </button>
+                            </ng-template>
+                        </div>
+                    </ngx-datatable-column>
+                </ngx-datatable>
+            </ng-template>
+        </jhi-data-table>
+    }
 </div>

--- a/src/main/webapp/app/localci/build-queue/build-queue.component.ts
+++ b/src/main/webapp/app/localci/build-queue/build-queue.component.ts
@@ -14,8 +14,8 @@ import { TriggeredByPushTo } from 'app/entities/repository-info.model';
 })
 export class BuildQueueComponent implements OnInit, OnDestroy {
     protected readonly TriggeredByPushTo = TriggeredByPushTo;
-    queuedBuildJobs: BuildJob[];
-    runningBuildJobs: BuildJob[];
+    queuedBuildJobs: BuildJob[] = [];
+    runningBuildJobs: BuildJob[] = [];
     courseChannels: string[] = [];
 
     //icons

--- a/src/test/javascript/spec/helpers/mocks/service/mock-result.service.ts
+++ b/src/test/javascript/spec/helpers/mocks/service/mock-result.service.ts
@@ -4,13 +4,9 @@ import { Result } from 'app/entities/result.model';
 import { Exercise } from 'app/entities/exercise.model';
 
 export class MockResultService implements IResultService {
-    create = (result: Result) => of();
-    delete = (participationId: number, resultId: number) => EMPTY;
     find = (resultId: number) => EMPTY;
     getFeedbackDetailsForResult = (participationId: number, result: Result) => EMPTY;
     getResultsForExerciseWithPointsPerGradingCriterion = (exerciseId: number, req: any) => EMPTY;
     getResultsWithPointsPerGradingCriterion = (exercise: Exercise): Observable<ResultsWithPointsArrayResponseType> => EMPTY;
-    update = (result: Result) => of();
-    getResults = (exercise: Exercise) => of();
     triggerDownloadCSV = (rows: string[], csvFileName: string) => EMPTY;
 }

--- a/src/test/javascript/spec/jest-test-setup.ts
+++ b/src/test/javascript/spec/jest-test-setup.ts
@@ -8,6 +8,8 @@ import failOnConsole from 'jest-fail-on-console';
 
 failOnConsole({
     shouldFailOnWarn: true,
+    shouldFailOnLog: true,
+    shouldFailOnInfo: true,
 });
 
 const noop = () => {};


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
The payload size over REST and web socket is too large when navigating to the build agent view

### Description
* We want to reduce the size to avoid issues
* This PR also adds display of current builds and max build capacity
* Fix a TypeScript issue
* Improve DTO annotations
* Unrelated changes
  1. Remove unused code
  2. Fix the console log settings for jest  


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise

1. Participate in programming exercises (using push and online code editor) in a course and in an exam
3. Make sure the result display is correct
4. Navigate to the build agent view (LocalCI), check that the result display is correct and double check the payload size for the REST call and for any web socket updates (in messages). Those should be reasonable and as small as possible without sending unnecessary information

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://docs.artemis.cit.tum.de/user/exam_mode/) as reference.
5. ...

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [x] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `getExercise` function in `participation.model.ts` to retrieve exercises from `programmingExercise` and `exercise` properties.
- **Refactor**
	- Removed the `copyParticipationId` method from various participation classes for improved handling.
- **Documentation**
	- No changes.
- **Style**
	- No changes.
- **Tests**
	- No changes.
- **Bug Fixes**
	- No changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->