### PR TITLE
`Adaptive learning`: Improve user interface for competency generation

### DIFF
--- a/src/main/webapp/app/course/competencies/generate-competencies/competency-recommendation-detail.component.html
+++ b/src/main/webapp/app/course/competencies/generate-competencies/competency-recommendation-detail.component.html
@@ -2,7 +2,7 @@
     <div class="card-header">
         <div class="d-flex align-items-center mw-100 clickable" (click)="toggle()">
             <div class="icon-container me-3">
-                <fa-icon [icon]="faChevronRight" class="rotate-icon chevron-position" [class.rotated]="isCollapsed" />
+                <fa-icon [icon]="faChevronRight" class="rotate-icon chevron-position" [class.rotated]="!isCollapsed" />
             </div>
             <h6 class="mb-0 text-nowrap text-truncate overflow-hidden">{{ titleControl.value ?? '' }}</h6>
         </div>
@@ -18,12 +18,13 @@
                     [btnType]="ButtonType.WARNING"
                     [btnSize]="ButtonSize.SMALL"
                     [title]="'entity.action.edit'"
-                    [icon]="faEdit"
+                    [icon]="faPencilAlt"
                     (onClick)="edit()"
                     [shouldSubmit]="false"
                 />
             } @else {
                 <jhi-button
+                    class="me-1"
                     id="saveButton-{{ index }}"
                     [btnType]="ButtonType.SUCCESS"
                     [btnSize]="ButtonSize.SMALL"
@@ -75,7 +76,12 @@
                     [enableFileUpload]="false"
                 />
             } @else {
-                <div id="description-{{ index }}" disabled="true" class="markdown-preview border rounded p-1" [innerHTML]="descriptionControl.value | htmlForMarkdown"></div>
+                <div
+                    id="description-{{ index }}"
+                    disabled="true"
+                    class="markdown-preview border rounded p-1"
+                    [innerHTML]="descriptionControl.value || '&nbsp;' | htmlForMarkdown"
+                ></div>
             }
             @if (descriptionControl.invalid && descriptionControl.dirty) {
                 <div class="alert alert-danger">

--- a/src/main/webapp/app/course/competencies/generate-competencies/competency-recommendation-detail.component.ts
+++ b/src/main/webapp/app/course/competencies/generate-competencies/competency-recommendation-detail.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CompetencyValidators } from 'app/entities/competency.model';
-import { faChevronRight, faEdit, faSave, faTrash, faWrench } from '@fortawesome/free-solid-svg-icons';
+import { faChevronRight, faPencilAlt, faSave, faTrash, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { ButtonSize, ButtonType } from 'app/shared/components/button.component';
 import { FormGroup, Validators } from '@angular/forms';
 import { CompetencyFormControlsWithViewed } from 'app/course/competencies/generate-competencies/generate-competencies.component';
@@ -23,7 +23,7 @@ export class CompetencyRecommendationDetailComponent implements OnInit {
     protected readonly faTrash = faTrash;
     protected readonly faWrench = faWrench;
     protected readonly faSave = faSave;
-    protected readonly faEdit = faEdit;
+    protected readonly faPencilAlt = faPencilAlt;
 
     //Other constants for html
     protected readonly competencyValidators = CompetencyValidators;

--- a/src/main/webapp/app/course/competencies/generate-competencies/course-description-form.component.html
+++ b/src/main/webapp/app/course/competencies/generate-competencies/course-description-form.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form" (ngSubmit)="submitForm()">
     <div class="d-flex align-items-center">
-        <h3 class="me-1">{{ 'artemisApp.competency.generate.courseDescription.title' | artemisTranslate }}</h3>
+        <label class="me-1 form-control-label" jhiTranslate="artemisApp.competency.generate.courseDescription.title" for="courseDescription"></label>
         <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.competency.generate.courseDescription.infoTooltip' | artemisTranslate }}" />
     </div>
     <div class="form-group mb-2">
@@ -12,7 +12,7 @@
             [placeholder]="'artemisApp.competency.generate.courseDescription.placeholder' | artemisTranslate"
         ></textarea>
         @if (courseDescriptionControl.invalid && (courseDescriptionControl.dirty || courseDescriptionControl.touched)) {
-            <div class="alert alert-danger">
+            <div class="alert alert-danger mb-0">
                 @if (courseDescriptionControl.errors?.required) {
                     <div>
                         {{ 'artemisApp.competency.generate.courseDescription.requiredValidationError' | artemisTranslate }}

--- a/src/main/webapp/app/course/competencies/generate-competencies/generate-competencies.component.html
+++ b/src/main/webapp/app/course/competencies/generate-competencies/generate-competencies.component.html
@@ -1,6 +1,7 @@
 <div class="container">
+    <h2 id="page-heading" jhiTranslate="artemisApp.competency.generate.title"></h2>
     <jhi-course-description-form (formSubmitted)="getCompetencyRecommendations($event)" [isLoading]="isLoading" />
-    <h3 class="mt-2">{{ 'artemisApp.competency.generate.listTitle' | artemisTranslate }}</h3>
+    <h3 jhiTranslate="artemisApp.competency.generate.listTitle" class="mt-2"></h3>
     @if (isLoading) {
         <div class="d-flex flex-column align-items-center mb-1">
             <div class="spinner-border" role="status">


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Description
Improves the following things in the UI:
- Adds a page heading ("Generate Competency Recommendations")
- Changed "Enter Description" text to label -> better for screenreaders
- Changed the chevrons for recommendations to be oriented correctly
- Some other small fixes

![image](https://github.com/ls1intum/Artemis/assets/118574504/83bd6732-b2b1-4529-a615-ed6bebef77f7)

### Steps for Testing
Prerequisites:
- 1 Instructor
- Only test on ts9!

1. Go to course management -> competencies -> generate
2. See that the UI looks as expected.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
unchanged

### Screenshots
see description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added translation support for titles in the competencies generation section.
- **Style**
	- Updated icons and styling across various components within the competencies feature.
	- Enhanced visual feedback for collapsed states and empty descriptions.
	- Improved form alert styling in course description components.
- **Refactor**
	- Updated icon usage to `faPencilAlt` for a more intuitive editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->