### PR TITLE
`Integrated code lifecycle`: Regularly clean up stranded build job containers

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/LocalCIDockerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/LocalCIDockerService.java
@@ -56,11 +56,13 @@ public class LocalCIDockerService {
     @Value("${artemis.continuous-integration.build-container-prefix:local-ci-}")
     private String buildContainerPrefix;
 
+    // with the default value, containers running for longer than 5 minutes when the cleanup starts
     @Value("${artemis.continuous-integration.container-cleanup.expiry-minutes:5}")
     private int containerExpiryMinutes;
 
+    // With the default value, the cleanup is triggered every 60 minutes
     @Value("${artemis.continuous-integration.container-cleanup.cleanup-schedule-minutes:60}")
-    private int containerCleanupScheduleHour;
+    private int containerCleanupScheduleMinutes;
 
     public LocalCIDockerService(DockerClient dockerClient, HazelcastInstance hazelcastInstance) {
         this.dockerClient = dockerClient;
@@ -71,7 +73,7 @@ public class LocalCIDockerService {
     public void applicationReady() {
         // Schedule the cleanup of stranded build containers once 10 seconds after the application has started and then every containerCleanupScheduleHour hours
         ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
-        scheduledExecutorService.scheduleAtFixedRate(this::cleanUpContainers, 10, containerCleanupScheduleHour * 60L, TimeUnit.SECONDS);
+        scheduledExecutorService.scheduleAtFixedRate(this::cleanUpContainers, 10, containerCleanupScheduleMinutes * 60L, TimeUnit.SECONDS);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/LocalCIDockerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/LocalCIDockerService.java
@@ -81,14 +81,12 @@ public class LocalCIDockerService {
         List<Container> buildContainers;
         log.info("Start cleanup stranded build containers");
         if (isFirstCleanup) {
-            log.info("kula");
             // Cleanup all stranded build containers after the application has started
             buildContainers = dockerClient.listContainersCmd().withShowAll(true).exec().stream().filter(container -> container.getNames()[0].startsWith("/" + buildContainerPrefix))
                     .toList();
             isFirstCleanup = false;
         }
         else {
-            log.info("hubi");
             // Cleanup all containers that are older than 5 minutes for all subsequent cleanups
             // Get current time in milliseconds
             long now = Instant.now().toEpochMilli();

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/LocalCIDockerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/LocalCIDockerService.java
@@ -59,7 +59,7 @@ public class LocalCIDockerService {
     @Value("${artemis.continuous-integration.container-cleanup.expiry-minutes:5}")
     private int containerExpiryMinutes;
 
-    @Value("${artemis.continuous-integration.container-cleanup.cleanup-schedule-hours:1}")
+    @Value("${artemis.continuous-integration.container-cleanup.cleanup-schedule-minutes:60}")
     private int containerCleanupScheduleHour;
 
     public LocalCIDockerService(DockerClient dockerClient, HazelcastInstance hazelcastInstance) {
@@ -71,7 +71,7 @@ public class LocalCIDockerService {
     private void scheduleTask() {
         // Schedule the cleanup of stranded build containers once 10 seconds after the application has started and then every containerCleanupScheduleHour hours
         ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
-        scheduledExecutorService.scheduleAtFixedRate(this::cleanUpContainers, 10, containerCleanupScheduleHour * 60L * 60L, TimeUnit.SECONDS);
+        scheduledExecutorService.scheduleAtFixedRate(this::cleanUpContainers, 10, containerCleanupScheduleHour * 60L, TimeUnit.SECONDS);
     }
 
     /**

--- a/src/main/resources/config/application-buildagent.yml
+++ b/src/main/resources/config/application-buildagent.yml
@@ -29,7 +29,7 @@ artemis:
             cleanup-schedule-time: 0 0 3 * * *
         container-cleanup:
             expiry-minutes: 5
-            cleanup-schedule-hours: 1
+            cleanup-schedule-minutes: 60
     git:
         name: Artemis
         email: artemis@xcit.tum.de

--- a/src/main/resources/config/application-buildagent.yml
+++ b/src/main/resources/config/application-buildagent.yml
@@ -27,6 +27,9 @@ artemis:
             enabled: false
             expiry-days: 2
             cleanup-schedule-time: 0 0 3 * * *
+        container-cleanup:
+            expiry-minutes: 5
+            cleanup-schedule-hours: 1
     git:
         name: Artemis
         email: artemis@xcit.tum.de

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCIDockerServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCIDockerServiceTest.java
@@ -95,13 +95,14 @@ class LocalCIDockerServiceTest extends AbstractSpringIntegrationLocalCILocalVCTe
 
         // Mocks
         ListContainersCmd listContainersCmd = mock(ListContainersCmd.class);
+        doReturn(listContainersCmd).when(dockerClient).listContainersCmd();
+        doReturn(listContainersCmd).when(listContainersCmd).withShowAll(true);
 
         Container mockContainer = mock(Container.class);
         doReturn(List.of(mockContainer)).when(listContainersCmd).exec();
         doReturn(new String[] { "/local-ci-dummycontainer" }).when(mockContainer).getNames();
         // Mock container creation time to be older than 5 minutes
-        doReturn(System.currentTimeMillis() - (300001)).when(mockContainer).getCreated();
-
+        doReturn(System.currentTimeMillis() - (6 * 60 * 1000)).when(mockContainer).getCreated();
         doReturn("dummy-container-id").when(mockContainer).getId();
 
         localCIDockerService.cleanUpContainers();

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCITestConfiguration.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCITestConfiguration.java
@@ -127,6 +127,11 @@ public class LocalCITestConfiguration {
         doReturn(removeImageCmd).when(dockerClient).removeImageCmd(anyString());
         doNothing().when(removeImageCmd).exec();
 
+        // Mock removeContainerCmd
+        RemoveContainerCmd removeContainerCmd = mock(RemoveContainerCmd.class);
+        doReturn(removeContainerCmd).when(dockerClient).removeContainerCmd(anyString());
+        doReturn(removeContainerCmd).when(removeContainerCmd).withForce(true);
+
         return dockerClient;
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.




#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In rare cases build job docker containers do not get removed and are left hanging. They are removed when the server is restarted but should also be removed regularly while the server is running.


### Description
<!-- Describe your changes in detail -->
This PR extends the scheduled container clean up to regularly check for stranded containers while the server is running. How often this is done (default: every 60 min) and at what point a container is considered stranded (default: after 5 min), can be configured with the config variables `artemis.continuous-integration.container-cleanup.cleanup-schedule-minutes` and `...expiry-minutes`


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
**Test locally**
Prerequisites:

1. Set `cleanup-schedule-minutes` to 10
2. Create a docker container with the name "local-ci-blabla"
3. Start you Artemis Server (Buildagent is enough)
4. Verify your container gets removed after startup
5. Start another container with the same name
6. Wait for 10 min, it should remove the container again

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Implemented a scheduled task for automated container cleanup to enhance system efficiency.
- **Refactor**
	- Improved container cleanup logic by considering container age.
- **Tests**
	- Added a test for verifying the removal of stranded containers based on their creation time.
- **Chores**
	- Updated dependencies and configurations for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->