### PR TITLE
`General`: Fix sticky navigation bar header offset

### DIFF
--- a/src/main/webapp/app/forms/form-status-bar/form-status-bar.component.html
+++ b/src/main/webapp/app/forms/form-status-bar/form-status-bar.component.html
@@ -1,4 +1,4 @@
-<div class="form-status-bar-container py-3">
+<div class="form-status-bar-container py-3" [style]="{ top: (headerHeight ?? 0) - 2 + 'px' }">
     <hr class="form-status-line" />
     <div class="d-flex justify-content-between">
         @for (formStatusSection of formStatusSections; track formStatusSection.title) {

--- a/src/main/webapp/app/forms/form-status-bar/form-status-bar.component.ts
+++ b/src/main/webapp/app/forms/form-status-bar/form-status-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { AfterViewInit, Component, HostListener, Input } from '@angular/core';
 
 export type FormSectionStatus = {
     title: string;
@@ -11,9 +11,20 @@ export type FormSectionStatus = {
     templateUrl: './form-status-bar.component.html',
     styleUrl: './form-status-bar.component.scss',
 })
-export class FormStatusBarComponent {
+export class FormStatusBarComponent implements AfterViewInit {
     @Input()
     formStatusSections: FormSectionStatus[];
+
+    headerHeight? = 0;
+
+    @HostListener('window:resize')
+    onResize() {
+        setTimeout(() => (this.headerHeight = (document.querySelector('jhi-navbar') as HTMLElement).offsetHeight));
+    }
+
+    ngAfterViewInit() {
+        this.onResize();
+    }
 
     scrollToHeadline(id: string) {
         const element = document.getElementById(id);

--- a/src/main/webapp/app/shared/detail-overview-navigation-bar/detail-overview-navigation-bar.component.html
+++ b/src/main/webapp/app/shared/detail-overview-navigation-bar/detail-overview-navigation-bar.component.html
@@ -1,4 +1,4 @@
-<nav class="mt-3">
+<nav class="mt-3" [style]="{ top: headerHeight - 2 + 'px' }">
     <div class="nav-link-container">
         @for (headline of sectionHeadlines; track headline) {
             <a (click)="scrollToView(headline.id)">

--- a/src/main/webapp/app/shared/detail-overview-navigation-bar/detail-overview-navigation-bar.component.ts
+++ b/src/main/webapp/app/shared/detail-overview-navigation-bar/detail-overview-navigation-bar.component.ts
@@ -1,13 +1,24 @@
-import { Component, Input } from '@angular/core';
+import { AfterViewInit, Component, HostListener, Input } from '@angular/core';
 
 @Component({
     selector: 'jhi-detail-overview-navigation-bar',
     templateUrl: './detail-overview-navigation-bar.component.html',
     styleUrls: ['./detail-overview-navigation-bar.scss'],
 })
-export class DetailOverviewNavigationBarComponent {
+export class DetailOverviewNavigationBarComponent implements AfterViewInit {
     @Input()
     sectionHeadlines: { id: string; translationKey: string }[];
+
+    headerHeight = 0;
+
+    @HostListener('window:resize')
+    onResize() {
+        setTimeout(() => (this.headerHeight = (document.querySelector('jhi-navbar') as HTMLElement).offsetHeight));
+    }
+
+    ngAfterViewInit() {
+        this.onResize();
+    }
 
     scrollToView(id: string) {
         document.getElementById(id)?.scrollIntoView();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).



#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
Since the header is sticky, the offset 0 for navigation bar and validation bar on exercise management pages was not correct anymore. This PR fixes this issue


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise 

1. Log in to Artemis
2. Create/Edit Exercise
3. Verify that the validation bar is correctly positioned
4. Go to detail page
5. Verify that the section navigation is correctly positioned

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


