### PR TITLE
`Development`: Add architecture test to prevent RestControllers from being dependencies of other classes

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupSessionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupSessionResource.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.tutorialgroups;
 
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
+import static de.tum.in.www1.artemis.service.tutorialgroups.TutorialGroupScheduleService.updateTutorialGroupSession;
 import static de.tum.in.www1.artemis.web.rest.util.DateUtil.interpretInTimeZone;
 
 import java.net.URI;
@@ -22,13 +23,26 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.in.www1.artemis.domain.enumeration.TutorialGroupSessionStatus;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupFreePeriod;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupSession;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupsConfiguration;
-import de.tum.in.www1.artemis.repository.tutorialgroups.*;
+import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupFreePeriodRepository;
+import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupRepository;
+import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupScheduleRepository;
+import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupSessionRepository;
+import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupsConfigurationRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastStudent;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastTutor;
@@ -216,26 +230,6 @@ public class TutorialGroupSessionResource {
 
         return ResponseEntity.created(URI.create("/api/courses/" + courseId + "/tutorial-groups/" + tutorialGroupId + "/sessions/" + newSession.getId()))
                 .body(TutorialGroupSession.preventCircularJsonConversion(newSession));
-    }
-
-    /**
-     * Updates the status and associated free period of a tutorial group session based on the presence of an overlapping free period.
-     *
-     * @param newSession        the tutorial group session to be updated.
-     * @param overlappingPeriod an Optional that may contain a TutorialGroupFreePeriod if there is an overlapping free period.
-     */
-    public static void updateTutorialGroupSession(TutorialGroupSession newSession, Optional<TutorialGroupFreePeriod> overlappingPeriod) {
-        if (overlappingPeriod.isPresent()) {
-            newSession.setStatus(TutorialGroupSessionStatus.CANCELLED);
-            // the status explanation is set to null, as it is specified in the TutorialGroupFreePeriod
-            newSession.setStatusExplanation(null);
-            newSession.setTutorialGroupFreePeriod(overlappingPeriod.get());
-        }
-        else {
-            newSession.setStatus(TutorialGroupSessionStatus.ACTIVE);
-            newSession.setStatusExplanation(null);
-            newSession.setTutorialGroupFreePeriod(null);
-        }
     }
 
     private TutorialGroupsConfiguration validateTutorialGroupConfiguration(@PathVariable Long courseId) {

--- a/src/test/java/de/tum/in/www1/artemis/architecture/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/architecture/ArchitectureTest.java
@@ -528,7 +528,7 @@ class ArchitectureTest extends AbstractArchitectureTest {
         classesExcept(exceptions).should(IMPORT_RESTCONTROLLER).check(allClasses);
     }
 
-    private static final ArchCondition<JavaClass> IMPORT_RESTCONTROLLER = new ArchCondition<>("import RestController") {
+    private static final ArchCondition<JavaClass> IMPORT_RESTCONTROLLER = new ArchCondition<>("not import RestController") {
 
         @Override
         public void check(JavaClass item, ConditionEvents events) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.




### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In general Domain Objects, Services, etc. should not depend on RestControllers.

### Description
<!-- Describe your changes in detail -->
- Adds an architecture test to enforce this rule.
- Moves a method from the TutorialGroupSessionResource to the TutorialGroupScheduleService to pass the architecture test.

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
