### PR TITLE
`Exam mode`: Fix spacing in quiz navigation

### DIFF
--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
@@ -44,7 +44,7 @@
         </div>
     }
     @if (quizConfiguration.quizQuestions) {
-        <div class="quiz-content ms-5">
+        <div class="ms-5">
             <h4 class="exercise-title">
                 {{ examTimeline ? quizConfiguration.title : quizConfiguration?.exerciseGroup?.title ?? '-' }}
                 <span

--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
@@ -1,10 +1,10 @@
-<div class="row">
+<div class="w-auto m-0 pb-5">
     @if (quizConfiguration.quizQuestions && !examTimeline) {
-        <div class="quiz-navigation sticky-top">
-            <div class="quiz-navigation-content">
-                <div class="stepwizardquiz">
+        <div class="position-fixed d-flex align-items-center justify-content-center">
+            <div class="p-0 col-md-auto quiz-navigation sticky-top">
+                <div class="stepwizardquiz col-6">
                     @for (question of quizConfiguration.quizQuestions; track question; let i = $index) {
-                        <div class="stepwizardquiz__step">
+                        <div class="stepwizardquiz__step mb-3">
                             @if (question.type === DRAG_AND_DROP) {
                                 <span
                                     class="btn btn-light btn-circle stepbutton stepwizardquiz-circle draganddropcolor-question"
@@ -35,8 +35,8 @@
                                     <b class="fa">SA</b>
                                 </span>
                             }
-                            <ng-template #tooltipExplanationTranslate>{{ 'artemisApp.quizExercise.explanationAnswered' | artemisTranslate }}</ng-template>
-                            <ng-template #tooltipNotExplanationTranslate>{{ 'artemisApp.quizExercise.explanationNotAnswered' | artemisTranslate }}</ng-template>
+                            <ng-template #tooltipExplanationTranslate>{{ 'artemisApp.quizExercise.explanationAnswered' | artemisTranslate }} </ng-template>
+                            <ng-template #tooltipNotExplanationTranslate>{{ 'artemisApp.quizExercise.explanationNotAnswered' | artemisTranslate }} </ng-template>
                         </div>
                     }
                 </div>
@@ -44,7 +44,7 @@
         </div>
     }
     @if (quizConfiguration.quizQuestions) {
-        <div class="quiz-content container">
+        <div class="quiz-content ms-5">
             <h4 class="exercise-title">
                 {{ examTimeline ? quizConfiguration.title : quizConfiguration?.exerciseGroup?.title ?? '-' }}
                 <span

--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.scss
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.scss
@@ -1,9 +1,3 @@
-.quiz-content {
-    .question-index {
-        padding: 2px 6px;
-    }
-}
-
 .quiz-navigation {
     .draganddropcolor-question {
         background-color: var(--quiz-participation-footer-dnd-background) !important;
@@ -19,67 +13,6 @@
     }
 }
 
-.quiz-content,
-.quiz-navigation-content-content {
-    font-size: 16px;
-}
-
-.quiz-navigation-content {
-    .form-control,
-    .input-group-btn {
-        width: auto;
-    }
-
-    .form-group {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-
-        > * {
-            margin: 0 4px;
-        }
-    }
-
-    .invalid-reasons-tooltip .tooltip-inner {
-        text-align: left;
-        max-width: 300px;
-
-        p {
-            margin: 4px 0;
-            padding: 4px;
-        }
-    }
-
-    @media (max-width: 767.98px) {
-        font-size: 12px;
-    }
-}
-
-.in-parentheses:before {
-    content: '(';
-}
-
-.in-parentheses:after {
-    content: ')';
-}
-
-.align-text {
-    max-height: 22px;
-    white-space: nowrap;
-}
-
-.hide-mobile {
-    @media (max-width: 699px) {
-        display: none;
-    }
-}
-.show-mobile {
-    @media (min-width: 700px) {
-        display: none;
-    }
-}
-
 .stepwizardquiz {
     &__step {
         .fa {
@@ -87,13 +20,13 @@
         }
 
         .btn {
-            cursor: pointer;
+            cursor: help;
             opacity: 1 !important;
         }
     }
 }
 
-.btn-circle.btn-circle {
+.btn-circle {
     width: 30px;
     height: 30px;
     text-align: center;
@@ -125,19 +58,6 @@
         align-items: center;
         .fa {
             font-size: 6px;
-        }
-    }
-}
-
-@media (max-width: 990px) {
-    .btn-circle.btn-circle {
-        width: 23px;
-        height: 23px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        .fa {
-            font-size: 10px;
         }
     }
 }

--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.scss
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.scss
@@ -1,25 +1,10 @@
 .quiz-content {
-    margin-top: 6px;
-    margin-bottom: 110px;
-    min-height: calc(100vh - 400px);
-    padding-left: 40px;
-
     .question-index {
         padding: 2px 6px;
     }
 }
 
 .quiz-navigation {
-    width: 45px;
-    height: 100%;
-    position: absolute;
-    padding: 0 10px;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 8;
-    background: var(--quiz-navigation-background);
-
     .draganddropcolor-question {
         background-color: var(--quiz-participation-footer-dnd-background) !important;
     }
@@ -40,12 +25,6 @@
 }
 
 .quiz-navigation-content {
-    height: 300px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-
     .form-control,
     .input-group-btn {
         width: auto;
@@ -102,20 +81,7 @@
 }
 
 .stepwizardquiz {
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    overflow: visible;
-    position: fixed;
-    height: 90vh;
-    top: 45%;
-
     &__step {
-        display: inline-block;
-        text-align: center;
-        position: relative;
-        margin-bottom: 15px;
-
         .fa {
             vertical-align: initial;
         }

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
@@ -1,5 +1,5 @@
 @if (quizParticipation.quizQuestions && quizParticipation.quizQuestions.length > 0) {
-    <div class="quiz-content container">
+    <div class="container">
         @if (showMissingResultsNotice) {
             <div class="alert alert-info mb-2">
                 {{ 'artemisApp.exam.examSummary.missingResultNotice' | artemisTranslate }}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The quiz navigation sizes was 100% covering the exercise header. --> see [Testing session 7.0.0](https://confluence.ase.in.tum.de/display/ArTEMiS/Testing+7.0.0+Milestone+08.04.2024)

### Description
<!-- Describe your changes in detail -->
Replaced custom css with bootstrap built in styling

### Screenshots
#### Before
The quiz navigation has been implemented with much custom css which led to an overlap of the left hand quiz navigation (left bubbles showing the response status of the quiz questions) and the different headers
<img width="806" alt="Screenshot 2024-04-09 at 21 30 22" src="https://github.com/ls1intum/Artemis/assets/29427964/54c0d022-dbf4-49c2-be6e-5646a53e0123">

#### After
The custom css has been replaced with using default css classes of bootstrap. 
<img width="823" alt="Screenshot 2024-04-09 at 21 32 23" src="https://github.com/ls1intum/Artemis/assets/29427964/b9811c9f-eb73-409e-8c3b-80b368f1e33b">


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 exam with quiz exercises

1. Log in to Artemis
2. Navigate to Course Administration
3. Do a test run
4. Open the quiz exercise

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
unchanged