### PR TITLE
`Development`: Fix failing cypress tests that use sidebar

### DIFF
--- a/src/test/cypress/e2e/course/CourseExercise.cy.ts
+++ b/src/test/cypress/e2e/course/CourseExercise.cy.ts
@@ -35,13 +35,13 @@ describe('Course Exercise', () => {
 
         it('should filter exercises based on title', () => {
             cy.visit(`/courses/${course.id}/exercises`);
-            courseOverview.getExercise(exercise1.id!).should('be.visible');
-            courseOverview.getExercise(exercise2.id!).should('be.visible');
-            courseOverview.getExercise(exercise3.id!).should('be.visible');
+            courseOverview.getExercise(exercise1.title!).should('be.visible');
+            courseOverview.getExercise(exercise2.title!).should('be.visible');
+            courseOverview.getExercise(exercise3.title!).should('be.visible');
             courseOverview.search('Course Exercise Quiz');
-            courseOverview.getExercise(exercise1.id!).should('be.visible');
-            courseOverview.getExercise(exercise2.id!).should('be.visible');
-            courseOverview.getExercise(exercise3.id!).should('not.exist');
+            courseOverview.getExercise(exercise1.title!).should('be.visible');
+            courseOverview.getExercise(exercise2.title!).should('be.visible');
+            courseOverview.getExercise(exercise3.title!).should('not.exist');
         });
 
         after('Delete Exercises', () => {

--- a/src/test/cypress/e2e/exercises/ExerciseImport.cy.ts
+++ b/src/test/cypress/e2e/exercises/ExerciseImport.cy.ts
@@ -79,6 +79,7 @@ describe('Import exercises', { scrollBehavior: 'center' }, () => {
         textExerciseCreation.import().then((request: Interception) => {
             const exercise = request.response!.body;
             cy.login(studentOne, `/courses/${secondCourse.id}`);
+            courseOverview.openExerciseOverview(exercise.title!);
             courseOverview.startExercise(exercise.id!);
             courseOverview.openRunningExercise(exercise.id!);
             cy.fixture('loremIpsum-short.txt').then((submission) => {
@@ -112,6 +113,7 @@ describe('Import exercises', { scrollBehavior: 'center' }, () => {
             const exercise = request.response!.body;
             courseManagementExercises.startQuiz(exercise.id!);
             cy.login(studentOne, `/courses/${secondCourse.id}`);
+            courseOverview.openExerciseOverview(exercise.title!);
             courseOverview.startExercise(exercise.id!);
             quizExerciseMultipleChoice.tickAnswerOption(exercise.id!, 0);
             quizExerciseMultipleChoice.tickAnswerOption(exercise.id!, 2);
@@ -137,6 +139,7 @@ describe('Import exercises', { scrollBehavior: 'center' }, () => {
         modelingExerciseCreation.import().then((request: Interception) => {
             const exercise = request.response!.body;
             cy.login(studentOne, `/courses/${secondCourse.id}`);
+            courseOverview.openExerciseOverview(exercise.title!);
             courseOverview.startExercise(exercise.id!);
             courseOverview.openRunningExercise(exercise.id!);
             modelingExerciseEditor.addComponentToModel(exercise.id!, 1);
@@ -163,6 +166,7 @@ describe('Import exercises', { scrollBehavior: 'center' }, () => {
         programmingExerciseCreation.import().then((request: Interception) => {
             const exercise = request.response!.body;
             cy.login(studentOne, `/courses/${secondCourse.id}`);
+            courseOverview.openExerciseOverview(exercise.title!);
             courseOverview.startExercise(exercise.id!);
             courseOverview.openRunningExercise(exercise.id!);
             programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, javaPartiallySuccessfulSubmission, () => {

--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseManagement.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseManagement.cy.ts
@@ -8,6 +8,7 @@ import {
     courseManagement,
     courseManagementAPIRequest,
     courseManagementExercises,
+    courseOverview,
     exerciseAPIRequest,
     modelingExerciseAssessment,
     modelingExerciseCreation,
@@ -135,7 +136,7 @@ describe('Modeling Exercise Management', () => {
             });
             cy.login(studentOne, '/courses');
             cy.contains(course.title!).click({ force: true });
-            cy.contains('No exercises available for the course.').should('be.visible');
+            courseOverview.getExercises().should('have.length', 0);
         });
 
         it('Student can see released Modeling Exercise', () => {

--- a/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/quiz-exercise/QuizExerciseParticipation.cy.ts
@@ -28,7 +28,7 @@ describe('Quiz Exercise Participation', () => {
 
         it('Student cannot see hidden quiz', () => {
             cy.login(studentOne, '/courses/' + course.id);
-            cy.contains('No exercises available for the course.').should('be.visible');
+            courseOverview.getExercises().should('have.length', 0);
         });
 
         it('Student can see a visible quiz', () => {

--- a/src/test/cypress/support/pageobjects/course/CourseCommunication.ts
+++ b/src/test/cypress/support/pageobjects/course/CourseCommunication.ts
@@ -36,7 +36,7 @@ export class CourseCommunicationPage {
     }
 
     searchForMessage(search: string) {
-        cy.get('#search').type(search);
+        cy.get('input[name="searchText"]').type(search);
         cy.get('#search-submit').click();
     }
 

--- a/src/test/cypress/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/cypress/support/pageobjects/course/CourseOverviewPage.ts
@@ -7,8 +7,7 @@ export class CourseOverviewPage {
     readonly participationRequestId = 'participateInExerciseQuery';
 
     search(term: string): void {
-        cy.get('#exercise-search-input').type(term);
-        cy.get('#exercise-search-button').click();
+        cy.get('input[formcontrolname="searchFilter"]').type(term);
     }
 
     startExercise(exerciseId: number) {
@@ -21,8 +20,16 @@ export class CourseOverviewPage {
         cy.get('#open-exercise-' + exerciseId).click();
     }
 
-    getExercise(exerciseID: number) {
-        return cy.get(`#exercise-card-${exerciseID}`);
+    getExercise(exerciseTitle: string) {
+        return cy.contains('#test-sidebar-card', exerciseTitle);
+    }
+
+    openExerciseOverview(exerciseTitle: string) {
+        this.getExercise(exerciseTitle).click();
+    }
+
+    getExercises() {
+        return cy.get('#test-sidebar-card');
     }
 
     openRunningProgrammingExercise(exerciseID: number) {

--- a/src/test/cypress/support/pageobjects/exercises/ExerciseResultPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/ExerciseResultPage.ts
@@ -14,7 +14,7 @@ export class ExerciseResultPage {
 
     shouldShowScore(percentage: number) {
         cy.reloadUntilFound('#submission-result-graded');
-        cy.contains(`${percentage}%`).should('be.visible');
+        cy.contains('.tab-bar-exercise-details', `${percentage}%`).should('be.visible');
     }
 
     clickOpenExercise(exerciseId: number) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some tests fail after sidebar was introduced for exercise and lecture views.

### Description
<!-- Describe your changes in detail -->
This PR adapts cypress e2e tests to new UI changes.

### Steps for Testing
Run all cypress tests and confirm they pass.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
