### PR TITLE
`Development`: Extend exam user tests

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -427,9 +427,6 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
 
     List<ProgrammingExercise> findAllByCourse_TeachingAssistantGroupNameIn(Set<String> groupNames);
 
-    @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation" })
-    List<ProgrammingExercise> findAllWithTemplateAndSolutionParticipationByIdIn(Set<Long> exerciseIds);
-
     // Note: we have to use left join here to avoid issues in the where clause, there can be at most one indirection (e.g. c1.editorGroupName) in the WHERE clause when using "OR"
     // Multiple different indirection in the WHERE clause (e.g. pe.course.instructorGroupName and ex.course.instructorGroupName) would not work
     @Query("""
@@ -829,5 +826,4 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
             save(exercise);
         }
     }
-
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -427,6 +427,9 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
 
     List<ProgrammingExercise> findAllByCourse_TeachingAssistantGroupNameIn(Set<String> groupNames);
 
+    @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation" })
+    List<ProgrammingExercise> findAllWithTemplateAndSolutionParticipationByIdIn(Set<Long> exerciseIds);
+
     // Note: we have to use left join here to avoid issues in the where clause, there can be at most one indirection (e.g. c1.editorGroupName) in the WHERE clause when using "OR"
     // Multiple different indirection in the WHERE clause (e.g. pe.course.instructorGroupName and ex.course.instructorGroupName) would not work
     @Query("""
@@ -826,4 +829,5 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
             save(exercise);
         }
     }
+
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamUserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamUserService.java
@@ -132,7 +132,7 @@ public class ExamUserService {
             examUserRepository.save(examUser);
 
             if (oldPathString != null) {
-                Path oldPath = FilePathService.actualPathForPublicPath(URI.create(examUser.getStudentImagePath()));
+                Path oldPath = FilePathService.actualPathForPublicPath(URI.create(oldPathString));
                 fileService.schedulePathForDeletion(oldPath, 0);
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
@@ -17,7 +17,6 @@ import jakarta.validation.constraints.NotNull;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -213,12 +212,11 @@ class ExamUserIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest
         assertThat(examUser.getSigningImagePath()).isNotNull();
     }
 
-    // TODO: enable this test (Issue - https://github.com/ls1intum/Artemis/issues/8289)
-    @Disabled
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testVerifyExamUserAttendance() throws Exception {
         List<StudentExam> studentExams = prepareStudentExamsForConduction(false, true);
+        long examId = studentExams.get(0).getExam().getId();
 
         final HttpHeaders headers = new HttpHeaders();
         headers.set("User-Agent", "foo");
@@ -253,9 +251,36 @@ class ExamUserIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest
                 HttpStatus.OK, ExamUserAttendanceCheckDTO.class);
         // one student (student1) signed, the other 3 did not
         assertThat(examUsersWhoDidNotSign).hasSize(3);
+        List<Long> unsignedExamUserIds = new ArrayList<>();
         for (var examUserAttendanceCheckDTO : examUsersWhoDidNotSign) {
+            unsignedExamUserIds.add(examUserAttendanceCheckDTO.id());
             assertThat(examUserAttendanceCheckDTO.started()).isTrue();
             assertThat(examUserAttendanceCheckDTO.login()).isNotEqualTo(TEST_PREFIX + "student1");
+            assertThat(examUserAttendanceCheckDTO.signingImagePath()).isNull();
+        }
+
+        verifySignedExamUsersHaveSignature(examId, unsignedExamUserIds);
+
+        // update exam user attendance to override signature
+        ExamUserDTO examUserUpdateDTO = new ExamUserDTO(TEST_PREFIX + "student1", "", "", "", "", "", "", "", true, true, true, true, "");
+        var examUserUpdateResponse = request.performMvcRequest(buildUpdateExamUser(examUserUpdateDTO, true, course2.getId(), exam2.getId())).andExpect(status().isOk()).andReturn();
+        ExamUser updatedExamUser = mapper.readValue(examUserUpdateResponse.getResponse().getContentAsString(), ExamUser.class);
+        assertThat(updatedExamUser.getDidCheckRegistrationNumber()).isTrue();
+        assertThat(updatedExamUser.getDidCheckImage()).isTrue();
+        assertThat(updatedExamUser.getDidCheckName()).isTrue();
+        assertThat(updatedExamUser.getDidCheckLogin()).isTrue();
+
+        verifySignedExamUsersHaveSignature(examId, unsignedExamUserIds);
+    }
+
+    private void verifySignedExamUsersHaveSignature(long examId, List<Long> unsignedExamUserIds) throws Exception {
+        Exam exam = examRepository.findByIdWithExamUsersElseThrow(examId);
+        assertThat(exam.getExamUsers()).hasSize(4);
+        List<ExamUser> signedUsers = exam.getExamUsers().stream().filter(eu -> !unsignedExamUserIds.contains(eu.getId())).toList();
+        assertThat(signedUsers).hasSize(1);
+        for (var user : signedUsers) {
+            assertThat(user.getSigningImagePath()).isNotNull();
+            assertThat(request.getFile(user.getSigningImagePath(), HttpStatus.OK)).isNotEmpty();
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
@@ -121,6 +121,7 @@ import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationTestRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
 import de.tum.in.www1.artemis.repository.StaticCodeAnalysisCategoryRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
@@ -312,6 +313,9 @@ public class ProgrammingExerciseTestService {
     private MockDelegate mockDelegate;
 
     private String userPrefix;
+
+    @Autowired
+    private ProgrammingExerciseTestRepository programmingExerciseTestRepository;
 
     public void setupTestUsers(String userPrefix, int additionalStudents, int additionalTutors, int additionalEditors, int additionalInstructors) {
         this.userPrefix = userPrefix;
@@ -1931,7 +1935,7 @@ public class ProgrammingExerciseTestService {
 
         // start exercises
         Set<Long> peIds = exam.getExerciseGroups().get(6).getExercises().stream().map(Exercise::getId).collect(Collectors.toSet());
-        List<ProgrammingExercise> programmingExercises = programmingExerciseRepository.findAllWithTemplateAndSolutionParticipationByIdIn(peIds);
+        List<ProgrammingExercise> programmingExercises = programmingExerciseTestRepository.findAllWithTemplateAndSolutionParticipationByIdIn(peIds);
         exam.getExerciseGroups().get(6).setExercises(new HashSet<>(programmingExercises));
         for (var exercise : programmingExercises) {
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
@@ -1930,16 +1930,16 @@ public class ProgrammingExerciseTestService {
         assertThat(studentExamRepository.findByExamId(exam.getId())).hasSize(registeredStudents.size());
 
         // start exercises
-        List<ProgrammingExercise> programmingExercises = new ArrayList<>();
-        for (var exercise : exam.getExerciseGroups().get(6).getExercises()) {
-            var programmingExercise = (ProgrammingExercise) exercise;
-            programmingExercises.add(programmingExercise);
+        Set<Long> peIds = exam.getExerciseGroups().get(6).getExercises().stream().map(Exercise::getId).collect(Collectors.toSet());
+        List<ProgrammingExercise> programmingExercises = programmingExerciseRepository.findAllWithTemplateAndSolutionParticipationByIdIn(peIds);
+        exam.getExerciseGroups().get(6).setExercises(new HashSet<>(programmingExercises));
+        for (var exercise : programmingExercises) {
 
-            setupRepositoryMocks(programmingExercise);
+            setupRepositoryMocks(exercise);
             for (var examUser : exam.getExamUsers()) {
                 var repo = new LocalRepository(defaultBranch);
                 repo.configureRepos("studentRepo", "studentOriginRepo");
-                setupRepositoryMocksParticipant(programmingExercise, examUser.getUser().getLogin(), repo);
+                setupRepositoryMocksParticipant(exercise, examUser.getUser().getLogin(), repo);
                 studentRepos.add(repo);
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseTestRepository.java
+++ b/src/test/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseTestRepository.java
@@ -1,8 +1,12 @@
 package de.tum.in.www1.artemis.repository;
 
+import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphType.LOAD;
+
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Set;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -68,4 +72,7 @@ public interface ProgrammingExerciseTestRepository extends JpaRepository<Program
     default List<ProgrammingExercise> findAllWithBuildAndTestAfterDueDateInFuture() {
         return findAllByBuildAndTestStudentSubmissionsAfterDueDateAfterDate(ZonedDateTime.now());
     }
+
+    @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation" })
+    List<ProgrammingExercise> findAllWithTemplateAndSolutionParticipationByIdIn(Set<Long> exerciseIds);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [X] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [X] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#8207 exposed gaps in the exam user test.

### Description
<!-- Describe your changes in detail -->
For the exam user image upload and the signature collection I added the use cases to update the corresponding files.
To do this, I reactivated and fixed a recently deactivated test. Additionally, I found out that the one issue we found in the PR did also occur for the exam user images, hence I fixed this issue.

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->
Upload the images for the exam user twice, make sure nothing changes, and all images are where they belong after the second upload.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Exam Mode Test
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExamUserRessource.java | 100% | ✅                           |
