### PR TITLE
`Development`: Fix executing server tests with MySQL and Postgres

### DIFF
--- a/src/test/resources/config/application-mysql.yml
+++ b/src/test/resources/config/application-mysql.yml
@@ -2,6 +2,7 @@
 # It can be activated e.g. by setting the environment variable SPRING_PROFILES_INCLUDE=mysql
 spring:
     jpa:
+        database-platform: org.hibernate.dialect.MySQLDialect
         database: MYSQL
 
 zonky:

--- a/src/test/resources/config/application-postgres.yml
+++ b/src/test/resources/config/application-postgres.yml
@@ -2,6 +2,7 @@
 # It can be activated e.g. by setting the environment variable SPRING_PROFILES_INCLUDE=postgres
 spring:
     jpa:
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: POSTGRESQL
 
 zonky:


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
#8282 removed the `database-platform` property, as the dialect can now be inferred from the JDBC URL. However, this is not the case in the server tests, as we don't provide a JDBC URL there as we don't use an external database. Hence, JDBC can't infer the correct dialect and generates wrong SQL queries.

### Description
re-added these configuration attributes.


### Steps for Testing
see that MySQL and Postgres tests run again.