### PR TITLE
`Development`: Unify nullability annotations

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/PublicResourcesConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/PublicResourcesConfiguration.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
@@ -31,7 +31,7 @@ public class PublicResourcesConfiguration implements WebMvcConfigurer {
     private JHipsterProperties jHipsterProperties;
 
     @Override
-    public void addResourceHandlers(@NotNull ResourceHandlerRegistry registry) {
+    public void addResourceHandlers(@Nonnull ResourceHandlerRegistry registry) {
         // Enable static resource serving in general from "/public" from both classpath and hosts filesystem
         addResourceHandlerForPath(registry);
 

--- a/src/main/java/de/tum/in/www1/artemis/config/RestTemplateConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/RestTemplateConfiguration.java
@@ -4,7 +4,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.util.ArrayList;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -136,7 +136,7 @@ public class RestTemplateConfiguration {
         return createShortTimeoutRestTemplate();
     }
 
-    @NotNull
+    @Nonnull
     private RestTemplate initializeRestTemplateWithInterceptors(ClientHttpRequestInterceptor interceptor, RestTemplate restTemplate) {
         var interceptors = restTemplate.getInterceptors();
         if (interceptors.isEmpty()) {

--- a/src/main/java/de/tum/in/www1/artemis/config/auth/AthenaAuthorizationInterceptor.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/auth/AthenaAuthorizationInterceptor.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.config.auth;
 
 import java.io.IOException;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -20,7 +20,7 @@ public class AthenaAuthorizationInterceptor implements ClientHttpRequestIntercep
     @Value("${artemis.athena.secret}")
     private String secret;
 
-    @NotNull
+    @Nonnull
     @Override
     public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
         request.getHeaders().set(HttpHeaders.AUTHORIZATION, secret);

--- a/src/main/java/de/tum/in/www1/artemis/config/auth/IrisAuthorizationInterceptor.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/auth/IrisAuthorizationInterceptor.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.config.auth;
 
 import java.io.IOException;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -20,7 +20,7 @@ public class IrisAuthorizationInterceptor implements ClientHttpRequestIntercepto
     @Value("${artemis.iris.secret-token}")
     private String secret;
 
-    @NotNull
+    @Nonnull
     @Override
     public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
         request.getHeaders().set(HttpHeaders.AUTHORIZATION, secret);

--- a/src/main/java/de/tum/in/www1/artemis/config/websocket/WebsocketConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/websocket/WebsocketConfiguration.java
@@ -16,8 +16,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.http.Cookie;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,7 +119,7 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
     }
 
     @Override
-    protected void configureMessageBroker(@NotNull MessageBrokerRegistry config) {
+    protected void configureMessageBroker(@Nonnull MessageBrokerRegistry config) {
         // Try to create a TCP client that will connect to the message broker (or the message brokers if multiple exists).
         // If tcpClient is null, there is no valid address specified in the config. This could be due to a development setup or a mistake in the config.
         TcpOperations<byte[]> tcpClient = createTcpClient();
@@ -182,7 +182,7 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
         registration.interceptors(new TopicSubscriptionInterceptor());
     }
 
-    @NotNull
+    @Nonnull
     @Override
     protected MappingJackson2MessageConverter createJacksonConverter() {
         // NOTE: We need to adapt the default messageConverter for WebSocket messages
@@ -201,8 +201,8 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
         return new HandshakeInterceptor() {
 
             @Override
-            public boolean beforeHandshake(@NotNull ServerHttpRequest request, @NotNull ServerHttpResponse response, @NotNull WebSocketHandler wsHandler,
-                    @NotNull Map<String, Object> attributes) {
+            public boolean beforeHandshake(@Nonnull ServerHttpRequest request, @Nonnull ServerHttpResponse response, @Nonnull WebSocketHandler wsHandler,
+                    @Nonnull Map<String, Object> attributes) {
                 if (request instanceof ServletServerHttpRequest servletRequest) {
                     attributes.put(IP_ADDRESS, servletRequest.getRemoteAddress());
                     Cookie jwtCookie = WebUtils.getCookie(servletRequest.getServletRequest(), JWTFilter.JWT_COOKIE_NAME);
@@ -212,7 +212,7 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
             }
 
             @Override
-            public void afterHandshake(@NotNull ServerHttpRequest request, @NotNull ServerHttpResponse response, @NotNull WebSocketHandler wsHandler, Exception exception) {
+            public void afterHandshake(@Nonnull ServerHttpRequest request, @Nonnull ServerHttpResponse response, @Nonnull WebSocketHandler wsHandler, Exception exception) {
                 if (exception != null) {
                     log.warn("Exception occurred in WS.afterHandshake", exception);
                 }
@@ -224,7 +224,7 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
         return new DefaultHandshakeHandler() {
 
             @Override
-            protected Principal determineUser(@NotNull ServerHttpRequest request, @NotNull WebSocketHandler wsHandler, @NotNull Map<String, Object> attributes) {
+            protected Principal determineUser(@Nonnull ServerHttpRequest request, @Nonnull WebSocketHandler wsHandler, @Nonnull Map<String, Object> attributes) {
                 Principal principal = request.getPrincipal();
                 if (principal == null) {
                     Collection<SimpleGrantedAuthority> authorities = new ArrayList<>();
@@ -247,7 +247,7 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
          * @return message that gets sent along further
          */
         @Override
-        public Message<?> preSend(@NotNull Message<?> message, @NotNull MessageChannel channel) {
+        public Message<?> preSend(@Nonnull Message<?> message, @Nonnull MessageChannel channel) {
             StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(message);
             Principal principal = headerAccessor.getUser();
             String destination = headerAccessor.getDestination();

--- a/src/main/java/de/tum/in/www1/artemis/domain/Authority.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Authority.java
@@ -4,8 +4,8 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import org.hibernate.annotations.Cache;
@@ -37,7 +37,7 @@ public class Authority implements Serializable {
 
     public static final Authority USER_AUTHORITY = new Authority(Role.STUDENT.getAuthority());
 
-    @NotNull
+    @Nonnull
     @Size(max = 50)
     @Id
     @Column(length = 50)

--- a/src/main/java/de/tum/in/www1/artemis/domain/GradingScale.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/GradingScale.java
@@ -4,9 +4,9 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import org.hibernate.annotations.Cache;
@@ -210,7 +210,7 @@ public class GradingScale extends DomainObject {
     }
 
     @JsonIgnore
-    @NotNull
+    @Nonnull
     public String getPlagiarismGradeOrDefault() {
         return Objects.requireNonNullElse(plagiarismGrade, DEFAULT_PLAGIARISM_GRADE);
     }
@@ -224,7 +224,7 @@ public class GradingScale extends DomainObject {
     }
 
     @JsonIgnore
-    @NotNull
+    @Nonnull
     public String getNoParticipationGradeOrDefault() {
         return Objects.requireNonNullElse(noParticipationGrade, DEFAULT_NO_PARTICIPATION_GRADE);
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/LtiPlatformConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/LtiPlatformConfiguration.java
@@ -3,9 +3,9 @@ package de.tum.in.www1.artemis.domain;
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
@@ -27,11 +27,11 @@ public class LtiPlatformConfiguration extends DomainObject {
     /** Entity name for LTI platform configuration. */
     public static final String ENTITY_NAME = "ltiPlatformConfiguration";
 
-    @NotNull
+    @Nonnull
     @Column(name = "registration_id", nullable = false)
     private String registrationId;
 
-    @NotNull
+    @Nonnull
     @Column(name = "client_id", nullable = false)
     private String clientId;
 
@@ -43,15 +43,15 @@ public class LtiPlatformConfiguration extends DomainObject {
     @Column(name = "custom_name")
     private String customName;
 
-    @NotNull
+    @Nonnull
     @Column(name = "authorization_uri", nullable = false)
     private String authorizationUri;
 
-    @NotNull
+    @Nonnull
     @Column(name = "jwk_set_uri", nullable = false)
     private String jwkSetUri;
 
-    @NotNull
+    @Nonnull
     @Column(name = "token_uri", nullable = false)
     private String tokenUri;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/Organization.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Organization.java
@@ -3,8 +3,8 @@ package de.tum.in.www1.artemis.domain;
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import org.hibernate.annotations.Cache;
@@ -19,12 +19,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Organization extends DomainObject {
 
-    @NotNull
+    @Nonnull
     @Size(max = 100)
     @Column(name = "name", length = 100)
     private String name;
 
-    @NotNull
+    @Nonnull
     @Size(max = 50)
     @Column(name = "shortName", length = 50)
     private String shortName;
@@ -38,7 +38,7 @@ public class Organization extends DomainObject {
     @Column(name = "logoUrl")
     private String logoUrl;
 
-    @NotNull
+    @Nonnull
     @Column(name = "emailPattern")
     private String emailPattern;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/PersistentAuditEvent.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/PersistentAuditEvent.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -34,7 +34,7 @@ public class PersistentAuditEvent implements Serializable {
     @Column(name = "event_id")
     private Long id;
 
-    @NotNull
+    @Nonnull
     @Column(nullable = false)
     private String principal;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
@@ -5,8 +5,8 @@ import static de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseTestCaseTy
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -99,7 +99,7 @@ public class ProgrammingExerciseTestCase extends DomainObject {
         this.weight = weight;
     }
 
-    @NotNull
+    @Nonnull
     public Double getBonusMultiplier() {
         return bonusMultiplier != null ? bonusMultiplier : 1.0;
     }
@@ -113,7 +113,7 @@ public class ProgrammingExerciseTestCase extends DomainObject {
         this.bonusMultiplier = bonusMultiplier;
     }
 
-    @NotNull
+    @Nonnull
     public Double getBonusPoints() {
         return bonusPoints != null ? bonusPoints : 0.0;
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -58,7 +58,7 @@ public class ProgrammingSubmission extends Submission {
      * @param commitHash     the hash of the corresponding commit in the git repository in the version control system
      * @return the newly created programming submission
      */
-    @NotNull
+    @Nonnull
     public static ProgrammingSubmission createFallbackSubmission(ProgrammingExerciseParticipation participation, ZonedDateTime submissionDate, String commitHash) {
         ProgrammingSubmission submission = new ProgrammingSubmission();
         submission.setParticipation((Participation) participation);

--- a/src/main/java/de/tum/in/www1/artemis/domain/Result.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Result.java
@@ -10,8 +10,8 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -215,7 +215,7 @@ public class Result extends DomainObject implements Comparable<Result> {
         this.rated = rated;
     }
 
-    private void setRatedIfNotAfterDueDate(@NotNull Participation participation, @NotNull ZonedDateTime submissionDate) {
+    private void setRatedIfNotAfterDueDate(@Nonnull Participation participation, @Nonnull ZonedDateTime submissionDate) {
         var optionalDueDate = ExerciseDateService.getDueDate(participation);
         if (optionalDueDate.isEmpty()) {
             this.rated = true;

--- a/src/main/java/de/tum/in/www1/artemis/domain/Submission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Submission.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -25,7 +26,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -156,7 +156,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     /**
      * @return an unmodifiable list or all non-automatic results
      */
-    @NotNull
+    @Nonnull
     private List<Result> filterNonAutomaticResults() {
         return results.stream().filter(result -> result == null || !result.isAutomatic()).toList();
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/Team.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Team.java
@@ -4,8 +4,8 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -59,7 +59,7 @@ public class Team extends AbstractAuditingEntity implements Participant {
      *
      * @param team Team which to copy
      */
-    public Team(@NotNull Team team) {
+    public Team(@Nonnull Team team) {
         this.name = team.name;
         this.shortName = team.shortName;
         this.image = team.image;

--- a/src/main/java/de/tum/in/www1/artemis/domain/TeamAssignmentConfig.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TeamAssignmentConfig.java
@@ -1,8 +1,8 @@
 package de.tum.in.www1.artemis.domain;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -27,7 +27,7 @@ public class TeamAssignmentConfig extends DomainObject {
     private Exercise exercise;
 
     @Min(1)
-    @NotNull
+    @Nonnull
     @Column(name = "min_team_size")
     private Integer minTeamSize;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/User.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/User.java
@@ -10,10 +10,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -45,7 +45,7 @@ import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupRegistration;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class User extends AbstractAuditingEntity implements Participant {
 
-    @NotNull
+    @Nonnull
     @Pattern(regexp = Constants.LOGIN_REGEX)
     @Size(min = USERNAME_MIN_LENGTH, max = USERNAME_MAX_LENGTH)
     @Column(length = USERNAME_MAX_LENGTH, unique = true, nullable = false)
@@ -78,11 +78,11 @@ public class User extends AbstractAuditingEntity implements Participant {
     @Column(length = 100)
     private String email;
 
-    @NotNull
+    @Nonnull
     @Column(nullable = false)
     private boolean activated = false;
 
-    @NotNull
+    @Nonnull
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false; // default value
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
@@ -8,9 +8,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -169,30 +169,30 @@ public class Exam extends DomainObject {
         this.testExam = testExam;
     }
 
-    @NotNull
+    @Nonnull
     public ZonedDateTime getVisibleDate() {
         return visibleDate;
     }
 
-    public void setVisibleDate(@NotNull ZonedDateTime visibleDate) {
+    public void setVisibleDate(@Nonnull ZonedDateTime visibleDate) {
         this.visibleDate = visibleDate;
     }
 
-    @NotNull
+    @Nonnull
     public ZonedDateTime getStartDate() {
         return startDate;
     }
 
-    public void setStartDate(@NotNull ZonedDateTime startDate) {
+    public void setStartDate(@Nonnull ZonedDateTime startDate) {
         this.startDate = startDate;
     }
 
-    @NotNull
+    @Nonnull
     public ZonedDateTime getEndDate() {
         return endDate;
     }
 
-    public void setEndDate(@NotNull ZonedDateTime endDate) {
+    public void setEndDate(@Nonnull ZonedDateTime endDate) {
         this.endDate = endDate;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/iris/message/IrisExercisePlanStep.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/iris/message/IrisExercisePlanStep.java
@@ -1,7 +1,7 @@
 package de.tum.in.www1.artemis.domain.iris.message;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -23,12 +23,12 @@ public class IrisExercisePlanStep extends DomainObject {
     @JoinColumn(name = "exercise_plan_id")
     private IrisExercisePlan plan;
 
-    @NotNull
+    @Nonnull
     @Enumerated(EnumType.STRING)
     @Column(name = "exercise_component")
     private ExerciseComponent component;
 
-    @NotNull
+    @Nonnull
     @Column(name = "instructions")
     private String instructions;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/iris/message/IrisJsonMessageContent.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/iris/message/IrisJsonMessageContent.java
@@ -1,7 +1,7 @@
 package de.tum.in.www1.artemis.domain.iris.message;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -17,13 +17,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class IrisJsonMessageContent extends IrisMessageContent {
 
-    @NotNull
+    @Nonnull
     @Column(name = "json_content")
     @JsonRawValue
     @JsonProperty(value = "attributes", required = true)
     private String jsonContent = "{}";
 
-    @NotNull
+    @Nonnull
     @Transient
     @JsonIgnore
     private JsonNode jsonNode = new ObjectMapper().createObjectNode();
@@ -32,7 +32,7 @@ public class IrisJsonMessageContent extends IrisMessageContent {
     public IrisJsonMessageContent() {
     }
 
-    public IrisJsonMessageContent(@NotNull JsonNode jsonNode) {
+    public IrisJsonMessageContent(@Nonnull JsonNode jsonNode) {
         this.jsonNode = jsonNode;
         this.jsonContent = jsonNode.toPrettyString();
     }
@@ -48,7 +48,7 @@ public class IrisJsonMessageContent extends IrisMessageContent {
      *
      * @param jsonContent The JSON string to set as content
      */
-    public void setJsonContent(@NotNull String jsonContent) {
+    public void setJsonContent(@Nonnull String jsonContent) {
         try {
             this.jsonNode = new ObjectMapper().readTree(jsonContent);
             this.jsonContent = jsonContent;
@@ -58,7 +58,7 @@ public class IrisJsonMessageContent extends IrisMessageContent {
         }
     }
 
-    @NotNull
+    @Nonnull
     public JsonNode getJsonNode() {
         return jsonNode;
     }
@@ -69,7 +69,7 @@ public class IrisJsonMessageContent extends IrisMessageContent {
      *
      * @param jsonNode The JsonNode to set as content
      */
-    public void setJsonNode(@NotNull JsonNode jsonNode) {
+    public void setJsonNode(@Nonnull JsonNode jsonNode) {
         this.jsonNode = jsonNode;
         this.jsonContent = jsonNode.toPrettyString();
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/lti/LtiResourceLaunch.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/lti/LtiResourceLaunch.java
@@ -1,9 +1,9 @@
 package de.tum.in.www1.artemis.domain.lti;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 
 import de.tum.in.www1.artemis.domain.*;
 
@@ -14,25 +14,25 @@ import de.tum.in.www1.artemis.domain.*;
 @Table(name = "lti_resource_launch")
 public class LtiResourceLaunch extends DomainObject {
 
-    @NotNull
+    @Nonnull
     private String iss;
 
-    @NotNull
+    @Nonnull
     private String sub;
 
-    @NotNull
+    @Nonnull
     private String deploymentId;
 
-    @NotNull
+    @Nonnull
     private String resourceLinkId;
 
     private String scoreLineItemUrl;
 
-    @NotNull
+    @Nonnull
     @ManyToOne
     private User user;
 
-    @NotNull
+    @Nonnull
     @ManyToOne
     private Exercise exercise;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/ConversationParticipant.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/ConversationParticipant.java
@@ -2,8 +2,8 @@ package de.tum.in.www1.artemis.domain.metis;
 
 import java.time.ZonedDateTime;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -24,7 +24,7 @@ public class ConversationParticipant extends DomainObject {
 
     @ManyToOne
     @JsonIncludeProperties({ "id", "firstName", "lastName" })
-    @NotNull
+    @Nonnull
     private User user;
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Channel.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/conversation/Channel.java
@@ -3,10 +3,10 @@ package de.tum.in.www1.artemis.domain.metis.conversation;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -53,7 +53,7 @@ public class Channel extends Conversation {
      * A channel is either public or private. Users need an invitation to join a private channel. Every user can join a public channel.
      */
     @Column(name = "is_public")
-    @NotNull
+    @Nonnull
     private Boolean isPublic;
 
     /**
@@ -61,7 +61,7 @@ public class Channel extends Conversation {
      * Answer posts are still possible so that students can ask questions concerning the announcement.
      */
     @Column(name = "is_announcement")
-    @NotNull
+    @Nonnull
     private Boolean isAnnouncementChannel;
 
     /**
@@ -70,7 +70,7 @@ public class Channel extends Conversation {
      * The channel can be unarchived at any time.
      */
     @Column(name = "is_archived")
-    @NotNull
+    @Nonnull
     private Boolean isArchived;
 
     /**
@@ -78,7 +78,7 @@ public class Channel extends Conversation {
      * A conversation_participant entry will be created on the fly for these channels as soon as an entry is needed.
      */
     @Column(name = "is_course_wide")
-    @NotNull
+    @Nonnull
     private boolean isCourseWide = false;
 
     @OneToOne

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/SingleUserNotificationFactory.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/SingleUserNotificationFactory.java
@@ -7,7 +7,7 @@ import static de.tum.in.www1.artemis.domain.notification.NotificationTargetFacto
 
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.domain.DataExport;
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -30,7 +30,7 @@ public class SingleUserNotificationFactory {
      * @param recipient        who should be notified
      * @return an instance of SingleUserNotification
      */
-    public static @NotNull SingleUserNotification createNotification(Exercise exercise, NotificationType notificationType, User recipient) {
+    public static @Nonnull SingleUserNotification createNotification(Exercise exercise, NotificationType notificationType, User recipient) {
         String title;
         String notificationText;
         String[] placeholderValues;

--- a/src/main/java/de/tum/in/www1/artemis/domain/plagiarism/PlagiarismComparison.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/plagiarism/PlagiarismComparison.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -158,7 +158,7 @@ public class PlagiarismComparison<E extends PlagiarismSubmissionElement> extends
     }
 
     @Override
-    public int compareTo(@NotNull PlagiarismComparison<E> otherComparison) {
+    public int compareTo(@Nonnull PlagiarismComparison<E> otherComparison) {
         return Double.compare(similarity, otherComparison.similarity);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
@@ -5,9 +5,9 @@ import static de.tum.in.www1.artemis.domain.enumeration.ExerciseType.QUIZ;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
@@ -570,7 +570,7 @@ public class QuizExercise extends Exercise implements QuizConfiguration {
      * @return the view depending on the current state of the quiz
      */
     @JsonIgnore
-    @NotNull
+    @Nonnull
     public Class<?> viewForStudentsInQuizExercise(@Nullable QuizBatch batch) {
         if (isQuizEnded()) {
             return QuizView.After.class;

--- a/src/main/java/de/tum/in/www1/artemis/domain/tutorialgroups/TutorialGroup.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/tutorialgroups/TutorialGroup.java
@@ -2,9 +2,9 @@ package de.tum.in.www1.artemis.domain.tutorialgroups;
 
 import java.util.*;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import org.hibernate.annotations.Cache;
@@ -31,7 +31,7 @@ public class TutorialGroup extends DomainObject {
 
     @Column(name = "title")
     @Size(min = 1, max = 19)
-    @NotNull
+    @Nonnull
     private String title;
 
     @Column(name = "additional_information")
@@ -42,7 +42,7 @@ public class TutorialGroup extends DomainObject {
     private Integer capacity;
 
     @Column(name = "is_online")
-    @NotNull
+    @Nonnull
     private Boolean isOnline = false;
 
     @Column(name = "campus")

--- a/src/main/java/de/tum/in/www1/artemis/domain/tutorialgroups/TutorialGroupRegistration.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/tutorialgroups/TutorialGroupRegistration.java
@@ -1,7 +1,7 @@
 package de.tum.in.www1.artemis.domain.tutorialgroups;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -21,13 +21,13 @@ public class TutorialGroupRegistration extends DomainObject {
 
     @ManyToOne
     @JoinColumn(name = "student_id")
-    @NotNull
+    @Nonnull
     @JsonIgnoreProperties("tutorialGroupRegistrations")
     private User student;
 
     @ManyToOne
     @JoinColumn(name = "tutorial_group_id")
-    @NotNull
+    @Nonnull
     @JsonIgnoreProperties("registrations")
     private TutorialGroup tutorialGroup;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/tutorialgroups/TutorialGroupsConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/tutorialgroups/TutorialGroupsConfiguration.java
@@ -3,8 +3,8 @@ package de.tum.in.www1.artemis.domain.tutorialgroups;
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -29,28 +29,28 @@ public class TutorialGroupsConfiguration extends DomainObject {
      * Note: String to prevent Hibernate from converting it to UTC
      */
     @Column(name = "tutorial_period_start_inclusive")
-    @NotNull
+    @Nonnull
     private String tutorialPeriodStartInclusive;
 
     /**
      * Note: String to prevent Hibernate from converting it to UTC
      */
     @Column(name = "tutorial_period_end_inclusive")
-    @NotNull
+    @Nonnull
     private String tutorialPeriodEndInclusive;
 
     /**
      * If true, tutorial groups channel will be created for each tutorial group. If false, they will not be created.
      */
     @Column(name = "use_tutorial_group_channels")
-    @NotNull
+    @Nonnull
     private Boolean useTutorialGroupChannels;
 
     /**
      * If true, the created tutorial group channels will be public. If false, they will be private.
      */
     @Column(name = "use_public_tutorial_group_channels")
-    @NotNull
+    @Nonnull
     private Boolean usePublicTutorialGroupChannels;
 
     @OneToMany(mappedBy = "tutorialGroupsConfiguration", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)

--- a/src/main/java/de/tum/in/www1/artemis/repository/ApollonDiagramRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ApollonDiagramRepository.java
@@ -4,7 +4,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
@@ -39,7 +39,7 @@ public interface ApollonDiagramRepository extends JpaRepository<ApollonDiagram, 
     @Cacheable(cacheNames = "diagramTitle", key = "#diagramId", unless = "#result == null")
     String getDiagramTitle(@Param("diagramId") Long diagramId);
 
-    @NotNull
+    @Nonnull
     default ApollonDiagram findByIdElseThrow(Long apollonDiagramId) throws EntityNotFoundException {
         return findById(apollonDiagramId).orElseThrow(() -> new EntityNotFoundException("ApollonDiagram", apollonDiagramId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/AttachmentUnitRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/AttachmentUnitRepository.java
@@ -4,7 +4,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -45,7 +45,7 @@ public interface AttachmentUnitRepository extends JpaRepository<AttachmentUnit, 
      * @return the list of all attachment units with the given lecture id and attachment type
      * @throws EntityNotFoundException if no results are found
      */
-    @NotNull
+    @Nonnull
     default List<AttachmentUnit> findAllByLectureIdAndAttachmentTypeElseThrow(Long lectureId, AttachmentType attachmentType) throws EntityNotFoundException {
         List<AttachmentUnit> attachmentUnits = findAllByLectureIdAndAttachmentType(lectureId, attachmentType);
         if (attachmentUnits.isEmpty()) {
@@ -62,7 +62,7 @@ public interface AttachmentUnitRepository extends JpaRepository<AttachmentUnit, 
             """)
     AttachmentUnit findOneWithSlides(@Param("attachmentUnitId") long attachmentUnitId);
 
-    @NotNull
+    @Nonnull
     default AttachmentUnit findByIdElseThrow(Long attachmentUnitId) throws EntityNotFoundException {
         return findById(attachmentUnitId).orElseThrow(() -> new EntityNotFoundException("AttachmentUnit", attachmentUnitId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/CourseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/CourseRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
@@ -346,7 +346,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             """)
     Page<Course> findByTitleInCoursesWhereInstructorOrEditor(@Param("partialTitle") String partialTitle, @Param("groups") Set<String> groups, Pageable pageable);
 
-    @NotNull
+    @Nonnull
     default Course findByIdElseThrow(long courseId) throws EntityNotFoundException {
         return findById(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
@@ -368,12 +368,12 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
         return Optional.ofNullable(findWithEagerTutorialGroupConfigurationsById(courseId)).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
 
-    @NotNull
+    @Nonnull
     default Course findWithEagerOrganizationsElseThrow(long courseId) throws EntityNotFoundException {
         return findWithEagerOrganizations(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
 
-    @NotNull
+    @Nonnull
     default Course findWithEagerOrganizationsAndCompetenciesAndLearningPathsElseThrow(long courseId) throws EntityNotFoundException {
         return findWithEagerOrganizationsAndCompetenciesAndLearningPaths(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
@@ -438,42 +438,42 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
         }
     }
 
-    @NotNull
+    @Nonnull
     default Course findByIdWithExercisesAndLecturesElseThrow(long courseId) {
         return findWithEagerExercisesAndLecturesById(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
 
-    @NotNull
+    @Nonnull
     default Course findByIdWithLecturesElseThrow(long courseId) {
         return findWithEagerLecturesById(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
 
-    @NotNull
+    @Nonnull
     default Course findByIdWithLecturesAndLectureUnitsElseThrow(long courseId) {
         return findWithEagerLecturesAndLectureUnitsById(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
 
-    @NotNull
+    @Nonnull
     default Course findByIdForUpdateElseThrow(long courseId) {
         return findForUpdateById(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
 
-    @NotNull
+    @Nonnull
     default Course findByIdWithExercisesAndLecturesAndLectureUnitsAndCompetenciesElseThrow(long courseId) {
         return findWithEagerExercisesAndLecturesAndLectureUnitsAndCompetenciesById(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
 
-    @NotNull
+    @Nonnull
     default Course findWithEagerCompetenciesByIdElseThrow(long courseId) {
         return findWithEagerCompetenciesById(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
 
-    @NotNull
+    @Nonnull
     default Course findWithEagerLearningPathsByIdElseThrow(long courseId) {
         return findWithEagerLearningPathsById(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }
 
-    @NotNull
+    @Nonnull
     default Course findWithEagerLearningPathsAndCompetenciesByIdElseThrow(long courseId) {
         return findWithEagerLearningPathsAndCompetenciesById(courseId).orElseThrow(() -> new EntityNotFoundException("Course", courseId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -8,7 +8,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
@@ -391,7 +391,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @Cacheable(cacheNames = "examTitle", key = "#examId", unless = "#result == null")
     String getExamTitle(@Param("examId") long examId);
 
-    @NotNull
+    @Nonnull
     default Exam findByIdElseThrow(long examId) throws EntityNotFoundException {
         return findById(examId).orElseThrow(() -> new EntityNotFoundException("Exam", examId));
     }
@@ -402,7 +402,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
      * @param examId the id of the entity
      * @return the exam with exercise groups
      */
-    @NotNull
+    @Nonnull
     default Exam findByIdWithExerciseGroupsElseThrow(long examId) {
         return findWithExerciseGroupsById(examId).orElseThrow(() -> new EntityNotFoundException("Exam", examId));
     }
@@ -428,7 +428,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
      * @param examId the id of the entity
      * @return the exam with registered users
      */
-    @NotNull
+    @Nonnull
     default Exam findByIdWithExamUsersElseThrow(long examId) {
         return findWithExamUsersById(examId).orElseThrow(() -> new EntityNotFoundException("Exam", examId));
     }
@@ -439,7 +439,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
      * @param examId the id of the entity
      * @return the exam with registered users and exercise groups
      */
-    @NotNull
+    @Nonnull
     default Exam findByIdWithExamUsersExerciseGroupsAndExercisesElseThrow(long examId) {
         return findWithExamUsersAndExerciseGroupsAndExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam", examId));
     }
@@ -458,7 +458,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
         return findWithExerciseGroupsAndExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam", examId));
     }
 
-    @NotNull
+    @Nonnull
     default Exam findWithExerciseGroupsAndExercisesAndDetailsByIdOrElseThrow(long examId) {
         return findWithExerciseGroupsAndExercisesAndDetailsById(examId).orElseThrow(() -> new EntityNotFoundException("Exam", examId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExerciseGroupRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExerciseGroupRepository.java
@@ -6,7 +6,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -46,7 +46,7 @@ public interface ExerciseGroupRepository extends JpaRepository<ExerciseGroup, Lo
      * @param exerciseGroupId the id of the entity
      * @return the entity
      */
-    @NotNull
+    @Nonnull
     default ExerciseGroup findByIdElseThrow(long exerciseGroupId) {
         // Note: exam is loaded eagerly anyway
         return findById(exerciseGroupId).orElseThrow(() -> new EntityNotFoundException("ExerciseGroup", exerciseGroupId));
@@ -58,7 +58,7 @@ public interface ExerciseGroupRepository extends JpaRepository<ExerciseGroup, Lo
      * @param exerciseGroupId the id of the entity
      * @return the exercise group with all exercise
      */
-    @NotNull
+    @Nonnull
     default ExerciseGroup findByIdWithExercisesElseThrow(long exerciseGroupId) {
         return findWithExercisesById(exerciseGroupId).orElseThrow(() -> new EntityNotFoundException("ExerciseGroup", exerciseGroupId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExerciseRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
@@ -481,12 +481,12 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
             """)
     Long getTeamParticipationCountById(@Param("exerciseId") Long exerciseId);
 
-    @NotNull
+    @Nonnull
     default Exercise findByIdElseThrow(Long exerciseId) throws EntityNotFoundException {
         return findById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Exercise", exerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default Exercise findWithCompetenciesByIdElseThrow(long exerciseId) throws EntityNotFoundException {
         return findWithCompetenciesById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Exercise", exerciseId));
     }
@@ -497,7 +497,7 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
      * @param exerciseId the exerciseId of the entity
      * @return the entity
      */
-    @NotNull
+    @Nonnull
     default Exercise findByIdWithCategoriesAndTeamAssignmentConfigElseThrow(Long exerciseId) {
         return findWithEagerCategoriesAndTeamAssignmentConfigById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Exercise", exerciseId));
     }
@@ -529,7 +529,7 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
      * @param exerciseId the exerciseId of the exercise entity
      * @return the exercise entity
      */
-    @NotNull
+    @Nonnull
     default Exercise findByIdWithStudentParticipationsElseThrow(Long exerciseId) {
         return findByIdWithEagerParticipations(exerciseId).orElseThrow(() -> new EntityNotFoundException("Exercise", exerciseId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/FileUploadExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/FileUploadExerciseRepository.java
@@ -6,7 +6,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -42,7 +42,7 @@ public interface FileUploadExerciseRepository extends JpaRepository<FileUploadEx
      * @param exerciseId the id of the entity
      * @return the entity
      */
-    @NotNull
+    @Nonnull
     default FileUploadExercise findByIdElseThrow(Long exerciseId) {
         return findById(exerciseId).orElseThrow(() -> new EntityNotFoundException("File Upload Exercise", exerciseId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/FileUploadSubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/FileUploadSubmissionRepository.java
@@ -5,7 +5,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -67,7 +67,7 @@ public interface FileUploadSubmissionRepository extends JpaRepository<FileUpload
      * @param submissionId the id of the submission that should be loaded from the database
      * @return the file upload submission with the given id
      */
-    @NotNull
+    @Nonnull
     default FileUploadSubmission findByIdWithEagerResultAndAssessorAndFeedbackElseThrow(long submissionId) {
         return findByIdWithEagerResultAndAssessorAndFeedback(submissionId).orElseThrow(() -> new EntityNotFoundException("File Upload Submission", submissionId));
     }
@@ -79,7 +79,7 @@ public interface FileUploadSubmissionRepository extends JpaRepository<FileUpload
      * @param submissionId the id of the submission that should be loaded from the database
      * @return the file upload submission with the given id
      */
-    @NotNull
+    @Nonnull
     default FileUploadSubmission findByIdWithEagerResultAndFeedbackAndAssessorAndParticipationResultsElseThrow(long submissionId) {
         return findWithResultsFeedbacksAssessorAndParticipationResultsById(submissionId).orElseThrow(() -> new EntityNotFoundException("File Upload Submission", submissionId));
     }
@@ -90,7 +90,7 @@ public interface FileUploadSubmissionRepository extends JpaRepository<FileUpload
      * @param submissionId the id of the submission that should be loaded from the database
      * @return the file upload submission with the given id
      */
-    @NotNull
+    @Nonnull
     default FileUploadSubmission findByIdElseThrow(long submissionId) {
         return findById(submissionId).orElseThrow(() -> new EntityNotFoundException("File Upload Submission", submissionId));
     }
@@ -103,7 +103,7 @@ public interface FileUploadSubmissionRepository extends JpaRepository<FileUpload
      * @param exerciseId   the id of the exercise that should be loaded from the database
      * @return the file upload submission with the given id
      */
-    @NotNull
+    @Nonnull
     default FileUploadSubmission findWithTeamStudentsAndParticipationAndExerciseByIdAndExerciseIdElseThrow(long submissionId, long exerciseId) {
         return findWithTeamStudentsAndParticipationAndExerciseByIdAndExerciseId(submissionId, exerciseId)
                 .orElseThrow(() -> new EntityNotFoundException("File Upload Submission", submissionId));

--- a/src/main/java/de/tum/in/www1/artemis/repository/GradingScaleRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/GradingScaleRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
@@ -81,7 +81,7 @@ public interface GradingScaleRepository extends JpaRepository<GradingScale, Long
      * @param courseId the course to which the grading scale belongs
      * @return the found grading scale
      */
-    @NotNull
+    @Nonnull
     default GradingScale findByCourseIdOrElseThrow(long courseId) {
         try {
             return findByCourseId(courseId).orElseThrow(() -> new EntityNotFoundException("Grading scale with course ID " + courseId + " doesn't exist"));
@@ -108,7 +108,7 @@ public interface GradingScaleRepository extends JpaRepository<GradingScale, Long
      * @param examId the exam to which the grading scale belongs
      * @return the found grading scale
      */
-    @NotNull
+    @Nonnull
     default GradingScale findByExamIdOrElseThrow(long examId) {
         try {
             return findByExamId(examId).orElseThrow(() -> new EntityNotFoundException("Grading scale with exam ID " + examId + " doesn't exist"));

--- a/src/main/java/de/tum/in/www1/artemis/repository/LectureRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/LectureRepository.java
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
@@ -137,27 +137,27 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
     @Cacheable(cacheNames = "lectureTitle", key = "#lectureId", unless = "#result == null")
     String getLectureTitle(@Param("lectureId") Long lectureId);
 
-    @NotNull
+    @Nonnull
     default Lecture findByIdElseThrow(long lectureId) {
         return findById(lectureId).orElseThrow(() -> new EntityNotFoundException("Lecture", lectureId));
     }
 
-    @NotNull
+    @Nonnull
     default Lecture findByIdWithLectureUnitsAndCompetenciesElseThrow(Long lectureId) {
         return findByIdWithLectureUnitsAndCompetencies(lectureId).orElseThrow(() -> new EntityNotFoundException("Lecture", lectureId));
     }
 
-    @NotNull
+    @Nonnull
     default Lecture findByIdWithAttachmentsAndPostsAndLectureUnitsAndCompetenciesAndCompletionsElseThrow(Long lectureId) {
         return findByIdWithAttachmentsAndPostsAndLectureUnitsAndCompetenciesAndCompletions(lectureId).orElseThrow(() -> new EntityNotFoundException("Lecture", lectureId));
     }
 
-    @NotNull
+    @Nonnull
     default Lecture findByIdWithLectureUnitsAndAttachmentsElseThrow(Long lectureId) {
         return findByIdWithLectureUnitsAndAttachments(lectureId).orElseThrow(() -> new EntityNotFoundException("Lecture", lectureId));
     }
 
-    @NotNull
+    @Nonnull
     default Lecture findByIdWithLectureUnitsAndSlidesAndAttachmentsElseThrow(long lectureId) {
         return findByIdWithLectureUnitsAndSlidesAndAttachments(lectureId).orElseThrow(() -> new EntityNotFoundException("Lecture", lectureId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/Lti13ResourceLaunchRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/Lti13ResourceLaunchRepository.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.repository;
 import java.util.Collection;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,8 +13,8 @@ import de.tum.in.www1.artemis.domain.lti.LtiResourceLaunch;
 
 public interface Lti13ResourceLaunchRepository extends JpaRepository<LtiResourceLaunch, Long> {
 
-    Optional<LtiResourceLaunch> findByIssAndSubAndDeploymentIdAndResourceLinkId(@NotNull String iss, @NotNull String sub, @NotNull String deploymentId,
-            @NotNull String resourceLinkId);
+    Optional<LtiResourceLaunch> findByIssAndSubAndDeploymentIdAndResourceLinkId(@Nonnull String iss, @Nonnull String sub, @Nonnull String deploymentId,
+            @Nonnull String resourceLinkId);
 
     Collection<LtiResourceLaunch> findByUserAndExercise(User user, Exercise exercise);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/LtiPlatformConfigurationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/LtiPlatformConfigurationRepository.java
@@ -5,7 +5,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -37,7 +37,7 @@ public interface LtiPlatformConfigurationRepository extends JpaRepository<LtiPla
      * @return LtiPlatformConfiguration if found.
      * @throws EntityNotFoundException if not found.
      */
-    @NotNull
+    @Nonnull
     default LtiPlatformConfiguration findByIdElseThrow(Long platformId) throws EntityNotFoundException {
         return findById(platformId).orElseThrow(() -> new EntityNotFoundException("LtiPlatformConfiguration", platformId));
     }
@@ -49,7 +49,7 @@ public interface LtiPlatformConfigurationRepository extends JpaRepository<LtiPla
      * @return {@link LtiPlatformConfiguration} with eager-loaded courses, or {@code null} if not found.
      * @throws EntityNotFoundException if no entity with the given ID is found.
      */
-    @NotNull
+    @Nonnull
     default LtiPlatformConfiguration findLtiPlatformConfigurationWithEagerLoadedCoursesByIdElseThrow(long id) throws EntityNotFoundException {
         return Optional.ofNullable(findWithEagerOnlineCourseConfigurationsById(id)).orElseThrow(() -> new EntityNotFoundException("LtiPlatformConfiguration", id));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ModelingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ModelingExerciseRepository.java
@@ -7,7 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -92,28 +92,28 @@ public interface ModelingExerciseRepository extends JpaRepository<ModelingExerci
     @EntityGraph(type = LOAD, attributePaths = { "studentParticipations", "studentParticipations.submissions", "studentParticipations.submissions.results" })
     Optional<ModelingExercise> findWithStudentParticipationsSubmissionsResultsById(Long exerciseId);
 
-    @NotNull
+    @Nonnull
     default ModelingExercise findByIdElseThrow(long exerciseId) {
         return findById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Modeling Exercise", exerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default ModelingExercise findWithEagerExampleSubmissionsAndCompetenciesByIdElseThrow(long exerciseId) {
         return findWithEagerExampleSubmissionsAndCompetenciesById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Modeling Exercise", exerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default ModelingExercise findWithEagerExampleSubmissionsAndCompetenciesAndPlagiarismDetectionConfigByIdElseThrow(long exerciseId) {
         return findWithEagerExampleSubmissionsAndCompetenciesAndPlagiarismDetectionConfigById(exerciseId)
                 .orElseThrow(() -> new EntityNotFoundException("Modeling Exercise", exerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default ModelingExercise findByIdWithExampleSubmissionsAndResultsAndPlagiarismDetectionConfigElseThrow(long exerciseId) {
         return findByIdWithExampleSubmissionsAndResultsAndPlagiarismDetectionConfig(exerciseId).orElseThrow(() -> new EntityNotFoundException("Modeling Exercise", exerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default ModelingExercise findByIdWithStudentParticipationsSubmissionsResultsElseThrow(long exerciseId) {
         return findWithStudentParticipationsSubmissionsResultsById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Modeling Exercise", exerciseId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/NotificationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/NotificationRepository.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
@@ -57,7 +57,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             """)
     // For some reason IntelliJ doesn't parse this JPQL, shows an error and the syntax highlighting is broken in the WHERE clause. However, it compiles and works fine.
     Page<Notification> findAllNotificationsForRecipientWithLogin(@Param("currentGroups") Set<String> currentGroups, @Param("login") String login,
-            @NotNull @Param("hideUntil") ZonedDateTime hideUntil, @Param("tutorialGroupIds") Set<Long> tutorialGroupIds,
+            @Nonnull @Param("hideUntil") ZonedDateTime hideUntil, @Param("tutorialGroupIds") Set<Long> tutorialGroupIds,
             @Param("titlesToNotLoadNotification") Set<String> titlesToNotLoadNotification, Pageable pageable);
 
     @Query("""
@@ -101,6 +101,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             """)
     // For some reason IntelliJ doesn't parse this JPQL, shows an error and the syntax highlighting is broken in the WHERE clause. However, it compiles and works fine.
     Page<Notification> findAllNotificationsFilteredBySettingsForRecipientWithLogin(@Param("currentGroups") Set<String> currentGroups, @Param("login") String login,
-            @NotNull @Param("hideUntil") ZonedDateTime hideUntil, @Param("deactivatedTitles") Set<String> deactivatedTitles, @Param("tutorialGroupIds") Set<Long> tutorialGroupIds,
+            @Nonnull @Param("hideUntil") ZonedDateTime hideUntil, @Param("deactivatedTitles") Set<String> deactivatedTitles, @Param("tutorialGroupIds") Set<Long> tutorialGroupIds,
             @Param("titlesToNotLoadNotification") Set<String> titlesToNotLoadNotification, Pageable pageable);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/OnlineUnitRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/OnlineUnitRepository.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.repository;
 
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,7 +18,7 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 @Repository
 public interface OnlineUnitRepository extends JpaRepository<OnlineUnit, Long> {
 
-    @NotNull
+    @Nonnull
     default OnlineUnit findByIdElseThrow(Long onlineUnitId) throws EntityNotFoundException {
         return findById(onlineUnitId).orElseThrow(() -> new EntityNotFoundException("OnlineUnit", onlineUnitId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/OrganizationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/OrganizationRepository.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
@@ -115,7 +115,7 @@ public interface OrganizationRepository extends JpaRepository<Organization, Long
      * @param userEmail the email of the user to match
      * @return a set of all matching organizations
      */
-    @NotNull
+    @Nonnull
     default Set<Organization> getAllMatchingOrganizationsByUserEmail(String userEmail) {
         Set<Organization> matchingOrganizations = new HashSet<>();
         // TODO: we should avoid findAll() and instead try to filter this directly in the database
@@ -135,7 +135,7 @@ public interface OrganizationRepository extends JpaRepository<Organization, Long
      * @param organizationId the id of the organization to find
      * @return the organization entity, if it exists
      */
-    @NotNull
+    @Nonnull
     default Organization findByIdElseThrow(long organizationId) throws EntityNotFoundException {
         return findById(organizationId).orElseThrow(() -> new EntityNotFoundException("Organization", organizationId));
     }
@@ -146,7 +146,7 @@ public interface OrganizationRepository extends JpaRepository<Organization, Long
      * @param organizationId the id of the organization to retrieve
      * @return the organization with the given id containing eagerly loaded list of users and courses
      */
-    @NotNull
+    @Nonnull
     default Organization findByIdWithEagerUsersAndCoursesElseThrow(long organizationId) throws EntityNotFoundException {
         return findByIdWithEagerUsersAndCourses(organizationId).orElseThrow(() -> new EntityNotFoundException("Organization", organizationId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ParticipantScoreRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ParticipantScoreRepository.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -45,7 +45,7 @@ public interface ParticipantScoreRepository extends JpaRepository<ParticipantSco
             """)
     List<ParticipantScore> findAllOutdated();
 
-    @NotNull
+    @Nonnull
     @Override
     @EntityGraph(type = LOAD, attributePaths = { "exercise", "lastResult", "lastRatedResult" })
     List<ParticipantScore> findAll();

--- a/src/main/java/de/tum/in/www1/artemis/repository/ParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ParticipationRepository.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import java.time.ZonedDateTime;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -63,7 +63,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             """)
     Optional<Participation> findWithEagerLegalSubmissionsById(@Param("participationId") long participationId);
 
-    @NotNull
+    @Nonnull
     default Participation findByIdWithLegalSubmissionsElseThrow(long participationId) {
         return findWithEagerLegalSubmissionsById(participationId).orElseThrow(() -> new EntityNotFoundException("Participation", participationId));
     }
@@ -78,12 +78,12 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             """)
     Optional<Participation> findWithEagerSubmissionsByIdWithTeamStudents(@Param("participationId") Long participationId);
 
-    @NotNull
+    @Nonnull
     default Participation findWithEagerSubmissionsByIdWithTeamStudentsElseThrow(long participationId) {
         return findWithEagerSubmissionsByIdWithTeamStudents(participationId).orElseThrow(() -> new EntityNotFoundException("Participation", participationId));
     }
 
-    @NotNull
+    @Nonnull
     default Participation findByIdElseThrow(long participationId) {
         return findById(participationId).orElseThrow(() -> new EntityNotFoundException("Participation", participationId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/PersistenceAuditEventRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/PersistenceAuditEventRepository.java
@@ -6,7 +6,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,11 +26,11 @@ public interface PersistenceAuditEventRepository extends JpaRepository<Persisten
     @EntityGraph(type = LOAD, attributePaths = { "data" })
     Page<PersistentAuditEvent> findAllByAuditEventDateBetween(Instant fromDate, Instant toDate, Pageable pageable);
 
-    @NotNull
+    @Nonnull
     @EntityGraph(type = LOAD, attributePaths = { "data" })
-    Page<PersistentAuditEvent> findAll(@NotNull Pageable pageable);
+    Page<PersistentAuditEvent> findAll(@Nonnull Pageable pageable);
 
-    @NotNull
+    @Nonnull
     @EntityGraph(type = LOAD, attributePaths = { "data" })
-    Optional<PersistentAuditEvent> findById(@NotNull Long auditEventId);
+    Optional<PersistentAuditEvent> findById(@Nonnull Long auditEventId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -9,9 +9,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.criteria.JoinType;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.Hibernate;
 import org.springframework.context.annotation.Profile;
@@ -487,7 +487,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @param programmingExerciseId of the programming exercise.
      * @return The programming exercise related to the given id
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdElseThrow(long programmingExerciseId) throws EntityNotFoundException {
         return findById(programmingExerciseId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
     }
@@ -531,7 +531,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @param programmingExerciseId of the programming exercise.
      * @return The programming exercise related to the given id
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithPlagiarismDetectionConfigElseThrow(long programmingExerciseId) throws EntityNotFoundException {
         return findWithPlagiarismDetectionConfigById(programmingExerciseId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
     }
@@ -542,7 +542,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @param programmingExerciseId of the programming exercise.
      * @return The programming exercise related to the given id
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithAuxiliaryRepositoriesElseThrow(long programmingExerciseId) throws EntityNotFoundException {
         return findWithAuxiliaryRepositoriesById(programmingExerciseId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
     }
@@ -553,7 +553,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @param programmingExerciseId of the programming exercise.
      * @return The programming exercise related to the given id
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithSubmissionPolicyElseThrow(long programmingExerciseId) throws EntityNotFoundException {
         return findWithSubmissionPolicyById(programmingExerciseId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
     }
@@ -567,7 +567,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @return The programming exercise related to the given id
      * @throws EntityNotFoundException the programming exercise could not be found.
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithTemplateAndSolutionParticipationElseThrow(long programmingExerciseId) throws EntityNotFoundException {
         Optional<ProgrammingExercise> programmingExercise = findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId);
         return programmingExercise.orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
@@ -581,7 +581,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @return The programming exercise related to the given id
      * @throws EntityNotFoundException the programming exercise could not be found.
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithTemplateAndSolutionParticipationAndAuxiliaryRepositoriesElseThrow(long programmingExerciseId) throws EntityNotFoundException {
         Optional<ProgrammingExercise> programmingExercise = findWithTemplateAndSolutionParticipationAndAuxiliaryRepositoriesById(programmingExerciseId);
         return programmingExercise.orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
@@ -594,7 +594,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @return The programming exercise related to the given id
      * @throws EntityNotFoundException the programming exercise could not be found.
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithStudentParticipationsAndLegalSubmissionsElseThrow(long programmingExerciseId) throws EntityNotFoundException {
         Optional<ProgrammingExercise> programmingExercise = findWithEagerStudentParticipationsStudentAndLegalSubmissionsById(programmingExerciseId);
         return programmingExercise.orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
@@ -625,20 +625,20 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @return The programming exercise related to the given id
      * @throws EntityNotFoundException the programming exercise could not be found.
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesElseThrow(long programmingExerciseId) throws EntityNotFoundException {
         Optional<ProgrammingExercise> programmingExercise = findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId);
         return programmingExercise.orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesAndCompetenciesElseThrow(long programmingExerciseId)
             throws EntityNotFoundException {
         Optional<ProgrammingExercise> programmingExercise = findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesAndCompetenciesById(programmingExerciseId);
         return programmingExercise.orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesAndCompetenciesAndPlagiarismDetectionConfigElseThrow(
             long programmingExerciseId) throws EntityNotFoundException {
         Optional<ProgrammingExercise> programmingExercise = findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesAndCompetenciesAndPlagiarismDetectionConfigById(
@@ -654,7 +654,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @return A programming exercise that has the given id.
      * @throws EntityNotFoundException In case no exercise with the given id exists.
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithAuxiliaryRepositoriesTeamAssignmentConfigAndGradingCriteriaElseThrow(long exerciseId, boolean withGradingCriteria)
             throws EntityNotFoundException {
 
@@ -680,7 +680,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @return The programming exercise related to the given id
      * @throws EntityNotFoundException the programming exercise could not be found.
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findForCreationByIdElseThrow(long programmingExerciseId) throws EntityNotFoundException {
         Optional<ProgrammingExercise> programmingExercise = findForCreationById(programmingExerciseId);
         return programmingExercise.orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
@@ -712,7 +712,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @return The programming exercise related to the given id
      * @throws EntityNotFoundException the programming exercise could not be found.
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findByIdWithTemplateAndSolutionParticipationLatestResultFeedbackTestCasesElseThrow(long programmingExerciseId) throws EntityNotFoundException {
         // TODO: This is a dark hack. Move this into a service where we properly load only the solution participation in the second step
         Optional<ProgrammingExercise> programmingExerciseWithTemplate = findWithTemplateParticipationLatestResultFeedbackTestCasesById(programmingExerciseId);
@@ -726,7 +726,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
         return withTemplate;
     }
 
-    @NotNull
+    @Nonnull
     default ProgrammingExercise findWithEagerStudentParticipationsByIdElseThrow(long programmingExerciseId) {
         return findWithEagerStudentParticipationsById(programmingExerciseId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseStudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseStudentParticipationRepository.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
@@ -174,7 +174,7 @@ public interface ProgrammingExerciseStudentParticipationRepository extends JpaRe
     @EntityGraph(type = LOAD, attributePaths = "team.students")
     Optional<ProgrammingExerciseStudentParticipation> findWithTeamStudentsById(long participationId);
 
-    @NotNull
+    @Nonnull
     default ProgrammingExerciseStudentParticipation findByIdElseThrow(long participationId) {
         return findById(participationId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise Student Participation", participationId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingSubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingSubmissionRepository.java
@@ -6,7 +6,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Pageable;
@@ -32,7 +32,7 @@ public interface ProgrammingSubmissionRepository extends JpaRepository<Programmi
      * @param submissionId the submissionId
      * @return programming submission
      */
-    @NotNull
+    @Nonnull
     default ProgrammingSubmission findByIdElseThrow(long submissionId) {
         return findById(submissionId).orElseThrow(() -> new EntityNotFoundException("ProgrammingSubmission", submissionId));
     }
@@ -118,12 +118,12 @@ public interface ProgrammingSubmissionRepository extends JpaRepository<Programmi
      * @param submissionId the id of the submission that should be loaded from the database
      * @return the programming submission with the given id
      */
-    @NotNull
+    @Nonnull
     default ProgrammingSubmission findByIdWithResultsFeedbacksAssessorTestCases(long submissionId) {
         return findWithEagerResultsFeedbacksTestCasesAssessorById(submissionId).orElseThrow(() -> new EntityNotFoundException("Programming Submission", submissionId));
     }
 
-    @NotNull
+    @Nonnull
     default ProgrammingSubmission findByResultIdElseThrow(long resultId) {
         return findByResultId(resultId).orElseThrow(() -> new EntityNotFoundException("Programming Submission for Result", resultId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/QuizBatchRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/QuizBatchRepository.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -49,7 +49,7 @@ public interface QuizBatchRepository extends JpaRepository<QuizBatch, Long> {
             """)
     Set<QuizBatch> findAllByQuizExerciseAndStudentLogin(@Param("quizExercise") QuizExercise quizExercise, @Param("studentLogin") String studentLogin);
 
-    @NotNull
+    @Nonnull
     default QuizBatch findByIdElseThrow(Long quizBatchId) throws EntityNotFoundException {
         return findById(quizBatchId).orElseThrow(() -> new EntityNotFoundException("Quiz Batch", quizBatchId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/QuizExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/QuizExerciseRepository.java
@@ -7,8 +7,8 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -63,12 +63,12 @@ public interface QuizExerciseRepository extends JpaRepository<QuizExercise, Long
     @EntityGraph(type = LOAD, attributePaths = { "quizBatches" })
     Optional<QuizExercise> findWithEagerBatchesById(Long quizExerciseId);
 
-    @NotNull
+    @Nonnull
     default QuizExercise findByIdElseThrow(Long quizExerciseId) throws EntityNotFoundException {
         return findById(quizExerciseId).orElseThrow(() -> new EntityNotFoundException("Quiz Exercise", quizExerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default QuizExercise findWithEagerQuestionsByIdOrElseThrow(Long quizExerciseId) {
         return findWithEagerQuestionsById(quizExerciseId).orElseThrow(() -> new EntityNotFoundException("QuizExercise", quizExerciseId));
     }
@@ -90,7 +90,7 @@ public interface QuizExerciseRepository extends JpaRepository<QuizExercise, Long
      * @param quizExerciseId the id of the entity
      * @return the entity
      */
-    @NotNull
+    @Nonnull
     default QuizExercise findByIdWithQuestionsElseThrow(Long quizExerciseId) {
         return findWithEagerQuestionsById(quizExerciseId).orElseThrow(() -> new EntityNotFoundException("Quiz Exercise", quizExerciseId));
     }
@@ -101,7 +101,7 @@ public interface QuizExerciseRepository extends JpaRepository<QuizExercise, Long
      * @param quizExerciseId the id of the entity
      * @return the entity
      */
-    @NotNull
+    @Nonnull
     default QuizExercise findByIdWithBatchesElseThrow(Long quizExerciseId) {
         return findWithEagerBatchesById(quizExerciseId).orElseThrow(() -> new EntityNotFoundException("Quiz Exercise", quizExerciseId));
     }
@@ -117,12 +117,12 @@ public interface QuizExerciseRepository extends JpaRepository<QuizExercise, Long
         return findWithEagerQuestionsAndStatisticsById(quizExerciseId).orElse(null);
     }
 
-    @NotNull
+    @Nonnull
     default QuizExercise findByIdWithQuestionsAndStatisticsElseThrow(Long quizExerciseId) {
         return findWithEagerQuestionsAndStatisticsById(quizExerciseId).orElseThrow(() -> new EntityNotFoundException("Quiz Exercise", quizExerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default QuizExercise findByIdWithQuestionsAndStatisticsAndCompetenciesElseThrow(Long quizExerciseId) {
         return findWithEagerQuestionsAndStatisticsAndCompetenciesById(quizExerciseId).orElseThrow(() -> new EntityNotFoundException("Quiz Exercise", quizExerciseId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/SourceRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SourceRepository.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.repository;
 
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,7 +18,7 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 @Repository
 public interface SourceRepository extends JpaRepository<Source, Long> {
 
-    @NotNull
+    @Nonnull
     default Source findByIdElseThrow(long sourceId) throws EntityNotFoundException {
         return findById(sourceId).orElseThrow(() -> new EntityNotFoundException("Source", sourceId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -314,7 +314,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             """)
     void startStudentExam(@Param("studentExamId") Long studentExamId, @Param("startedDate") ZonedDateTime startedDate);
 
-    @NotNull
+    @Nonnull
     default StudentExam findByIdElseThrow(Long studentExamId) throws EntityNotFoundException {
         return findById(studentExamId).orElseThrow(() -> new EntityNotFoundException("Student Exam", studentExamId));
     }
@@ -340,7 +340,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
      * @param studentExamId the id of the student exam
      * @return the student exam with exercises
      */
-    @NotNull
+    @Nonnull
     default StudentExam findByIdWithExercisesElseThrow(Long studentExamId) {
         return findWithExercisesById(studentExamId).orElseThrow(() -> new EntityNotFoundException("Student exam", studentExamId));
     }
@@ -351,7 +351,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
      * @param studentExamId the id of the student exam
      * @return the student exam with exercises
      */
-    @NotNull
+    @Nonnull
     default StudentExam findByIdWithExercisesSubmissionPolicyAndSessionsElseThrow(Long studentExamId) {
         return findWithExercisesSubmissionPolicyAndSessionsById(studentExamId).orElseThrow(() -> new EntityNotFoundException("Student exam", studentExamId));
     }
@@ -363,7 +363,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
      * @return the maximum of all student exam working times for the given exam
      * @throws EntityNotFoundException if no student exams could be found
      */
-    @NotNull
+    @Nonnull
     default Integer findMaxWorkingTimeByExamIdElseThrow(Long examId) {
         return findMaxWorkingTimeByExamId(examId).orElseThrow(() -> new EntityNotFoundException("No student exams found for exam id " + examId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
@@ -9,7 +9,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
@@ -836,27 +836,27 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
     List<StudentParticipation> findAllByParticipationExerciseIdAndResultAssessorAndCorrectionRoundIgnoreTestRuns(@Param("exerciseId") long exerciseId,
             @Param("assessor") User assessor);
 
-    @NotNull
+    @Nonnull
     default StudentParticipation findByIdElseThrow(long studentParticipationId) {
         return findById(studentParticipationId).orElseThrow(() -> new EntityNotFoundException("Student Participation", studentParticipationId));
     }
 
-    @NotNull
+    @Nonnull
     default StudentParticipation findByIdWithResultsElseThrow(long participationId) {
         return findWithEagerResultsById(participationId).orElseThrow(() -> new EntityNotFoundException("StudentParticipation", participationId));
     }
 
-    @NotNull
+    @Nonnull
     default StudentParticipation findByIdWithLegalSubmissionsResultsFeedbackElseThrow(long participationId) {
         return findWithEagerLegalSubmissionsResultsFeedbacksById(participationId).orElseThrow(() -> new EntityNotFoundException("StudentParticipation", participationId));
     }
 
-    @NotNull
+    @Nonnull
     default StudentParticipation findByIdWithLegalSubmissionsElseThrow(long participationId) {
         return findWithEagerLegalSubmissionsById(participationId).orElseThrow(() -> new EntityNotFoundException("Participation", participationId));
     }
 
-    @NotNull
+    @Nonnull
     default StudentParticipation findByIdWithEagerTeamStudentsElseThrow(long participationId) {
         return findByIdWithEagerTeamStudents(participationId).orElseThrow(() -> new EntityNotFoundException("Participation", participationId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/TextExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/TextExerciseRepository.java
@@ -6,7 +6,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -57,7 +57,7 @@ public interface TextExerciseRepository extends JpaRepository<TextExercise, Long
     @EntityGraph(type = LOAD, attributePaths = { "studentParticipations", "studentParticipations.submissions", "studentParticipations.submissions.results" })
     Optional<TextExercise> findWithStudentParticipationsAndSubmissionsById(long exerciseId);
 
-    @NotNull
+    @Nonnull
     default TextExercise findByIdElseThrow(long exerciseId) {
         return findById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Text Exercise", exerciseId));
     }
@@ -65,17 +65,17 @@ public interface TextExerciseRepository extends JpaRepository<TextExercise, Long
     @EntityGraph(type = LOAD, attributePaths = { "gradingCriteria" })
     Optional<TextExercise> findWithGradingCriteriaById(long exerciseId);
 
-    @NotNull
+    @Nonnull
     default TextExercise findWithGradingCriteriaByIdElseThrow(long exerciseId) {
         return findWithGradingCriteriaById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Text Exercise", exerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default TextExercise findByIdWithExampleSubmissionsAndResultsElseThrow(long exerciseId) {
         return findWithExampleSubmissionsAndResultsById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Text Exercise", exerciseId));
     }
 
-    @NotNull
+    @Nonnull
     default TextExercise findByIdWithStudentParticipationsAndSubmissionsElseThrow(long exerciseId) {
         return findWithStudentParticipationsAndSubmissionsById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Text Exercise", exerciseId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
@@ -6,7 +6,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -33,7 +33,7 @@ public interface TextSubmissionRepository extends JpaRepository<TextSubmission, 
      * @param submissionId the submissionId
      * @return optional text submission
      */
-    @NotNull
+    @Nonnull
     default TextSubmission findByIdElseThrow(long submissionId) {
         return findById(submissionId).orElseThrow(() -> new EntityNotFoundException("Text Submission", submissionId));
     }
@@ -66,13 +66,13 @@ public interface TextSubmissionRepository extends JpaRepository<TextSubmission, 
     @EntityGraph(type = LOAD, attributePaths = { "blocks" })
     Set<TextSubmission> findByParticipation_ExerciseIdAndSubmittedIsTrue(long exerciseId);
 
-    @NotNull
+    @Nonnull
     default TextSubmission getTextSubmissionWithResultAndTextBlocksAndFeedbackByResultIdElseThrow(long resultId) {
         return findWithEagerResultAndTextBlocksAndFeedbackByResults_Id(resultId) // TODO should be EntityNotFoundException
                 .orElseThrow(() -> new BadRequestAlertException("No text submission found for the given result.", "textSubmission", "textSubmissionNotFound"));
     }
 
-    @NotNull
+    @Nonnull
     default TextSubmission findByIdWithParticipationExerciseResultAssessorElseThrow(long submissionId) {
         return findWithEagerParticipationExerciseResultAssessorById(submissionId).orElseThrow(() -> new EntityNotFoundException("TextSubmission", submissionId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
@@ -599,7 +599,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
     /**
      * @return existing user object by current user login
      */
-    @NotNull
+    @Nonnull
     default User getUser() {
         String currentUserLogin = getCurrentUserLogin();
         Optional<User> user = findOneByLogin(currentUserLogin);
@@ -612,7 +612,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * @param login the login of the user to search
      * @return the user entity if it exists
      */
-    @NotNull
+    @Nonnull
     default User getUserByLoginElseThrow(String login) {
         return findOneByLogin(login).orElseThrow(() -> new EntityNotFoundException("User: " + login));
     }
@@ -622,7 +622,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      *
      * @return currently logged-in user
      */
-    @NotNull
+    @Nonnull
     default User getUserWithGroupsAndAuthorities() {
         String currentUserLogin = getCurrentUserLogin();
         Optional<User> user = findOneWithGroupsAndAuthoritiesByLogin(currentUserLogin);
@@ -634,7 +634,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      *
      * @return currently logged-in user
      */
-    @NotNull
+    @Nonnull
     default User getUserWithGroupsAndAuthoritiesAndOrganizations() {
         String currentUserLogin = getCurrentUserLogin();
         Optional<User> user = findOneWithGroupsAndAuthoritiesAndOrganizationsByLogin(currentUserLogin);
@@ -647,14 +647,14 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      *
      * @return currently logged-in user
      */
-    @NotNull
+    @Nonnull
     default User getUserWithGroupsAuthoritiesAndGuidedTourSettings() {
         String currentUserLogin = getCurrentUserLogin();
         Optional<User> user = findOneWithGroupsAuthoritiesAndGuidedTourSettingsByLogin(currentUserLogin);
         return unwrapOptionalUser(user, currentUserLogin);
     }
 
-    @NotNull
+    @Nonnull
     private User unwrapOptionalUser(Optional<User> optionalUser, String currentUserLogin) {
         return optionalUser.orElseThrow(() -> new EntityNotFoundException("No user found with login: " + currentUserLogin));
     }
@@ -673,8 +673,8 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * @param username the username of the user who should be retrieved from the database
      * @return the user that belongs to the given principal with eagerly loaded groups and authorities
      */
-    @NotNull
-    default User getUserWithGroupsAndAuthorities(@NotNull String username) {
+    @Nonnull
+    default User getUserWithGroupsAndAuthorities(@Nonnull String username) {
         Optional<User> user = findOneWithGroupsAndAuthoritiesByLogin(username);
         return unwrapOptionalUser(user, username);
     }
@@ -685,7 +685,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * @param username the username of the user who should be retrieved from the database
      * @return the user that belongs to the given principal with eagerly loaded authorities
      */
-    default User getUserWithAuthorities(@NotNull String username) {
+    default User getUserWithAuthorities(@Nonnull String username) {
         Optional<User> user = findOneWithAuthoritiesByLogin(username);
         return unwrapOptionalUser(user, username);
     }
@@ -729,7 +729,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
         return findOneWithGroupsAndAuthoritiesByEmail(email);
     }
 
-    @NotNull
+    @Nonnull
     default User findByIdWithGroupsAndAuthoritiesElseThrow(long userId) {
         return findOneWithGroupsAndAuthoritiesById(userId).orElseThrow(() -> new EntityNotFoundException("User", userId));
     }
@@ -740,7 +740,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * @param userId the id of the user to find
      * @return the user with groups, authorities and organizations if it exists, else throw exception
      */
-    @NotNull
+    @Nonnull
     default User findByIdWithGroupsAndAuthoritiesAndOrganizationsElseThrow(long userId) {
         return findOneWithGroupsAndAuthoritiesAndOrganizationsById(userId).orElseThrow(() -> new EntityNotFoundException("User", userId));
     }
@@ -751,7 +751,7 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
      * @param userId the id of the user to find
      * @return the user with learning paths if it exists, else throw exception
      */
-    @NotNull
+    @Nonnull
     default User findWithLearningPathsByIdElseThrow(long userId) {
         return findWithLearningPathsById(userId).orElseThrow(() -> new EntityNotFoundException("User", userId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/VideoUnitRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/VideoUnitRepository.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.repository;
 
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,7 +18,7 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 @Repository
 public interface VideoUnitRepository extends JpaRepository<VideoUnit, Long> {
 
-    @NotNull
+    @Nonnull
     default VideoUnit findByIdElseThrow(Long videoUnitId) throws EntityNotFoundException {
         return findById(videoUnitId).orElseThrow(() -> new EntityNotFoundException("VideoUnit", videoUnitId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/competency/KnowledgeAreaRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/competency/KnowledgeAreaRepository.java
@@ -6,7 +6,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -29,12 +29,12 @@ public interface KnowledgeAreaRepository extends JpaRepository<KnowledgeArea, Lo
     @EntityGraph(type = LOAD, attributePaths = "competencies")
     List<KnowledgeArea> findAllWithCompetenciesByOrderByTitleAsc();
 
-    @NotNull
+    @Nonnull
     default KnowledgeArea findWithChildrenAndCompetenciesByIdElseThrow(long knowledgeAreaId) throws EntityNotFoundException {
         return findWithChildrenAndCompetenciesById(knowledgeAreaId).orElseThrow(() -> new EntityNotFoundException("KnowledgeArea", knowledgeAreaId));
     }
 
-    @NotNull
+    @Nonnull
     default KnowledgeArea findByIdElseThrow(long knowledgeAreaId) throws EntityNotFoundException {
         return findById(knowledgeAreaId).orElseThrow(() -> new EntityNotFoundException("KnowledgeArea", knowledgeAreaId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/competency/StandardizedCompetencyRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/competency/StandardizedCompetencyRepository.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.repository.competency;
 
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,7 +18,7 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 @Repository
 public interface StandardizedCompetencyRepository extends JpaRepository<StandardizedCompetency, Long> {
 
-    @NotNull
+    @Nonnull
     default StandardizedCompetency findByIdElseThrow(long competencyId) throws EntityNotFoundException {
         return findById(competencyId).orElseThrow(() -> new EntityNotFoundException("StandardizedCompetency", competencyId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/hestia/CodeHintRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/hestia/CodeHintRepository.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.repository.hestia;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,12 +19,12 @@ public interface CodeHintRepository extends JpaRepository<CodeHint, Long> {
 
     Set<CodeHint> findByExerciseId(Long exerciseId);
 
-    @NotNull
+    @Nonnull
     default CodeHint findByIdElseThrow(long exerciseHintId) throws EntityNotFoundException {
         return findById(exerciseHintId).orElseThrow(() -> new EntityNotFoundException("Code Hint", exerciseHintId));
     }
 
-    @NotNull
+    @Nonnull
     default CodeHint findByIdWithSolutionEntriesElseThrow(long exerciseHintId) throws EntityNotFoundException {
         return findByIdWithSolutionEntries(exerciseHintId).orElseThrow(() -> new EntityNotFoundException("Code Hint", exerciseHintId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/hestia/ExerciseHintRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/hestia/ExerciseHintRepository.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -31,12 +31,12 @@ public interface ExerciseHintRepository extends JpaRepository<ExerciseHint, Long
             """)
     Optional<ExerciseHint> findByIdWithRelations(@Param("hintId") Long hintId);
 
-    @NotNull
+    @Nonnull
     default ExerciseHint findByIdWithRelationsElseThrow(long hintId) throws EntityNotFoundException {
         return findByIdWithRelations(hintId).orElseThrow(() -> new EntityNotFoundException("Exercise Hint", hintId));
     }
 
-    @NotNull
+    @Nonnull
     default ExerciseHint findByIdElseThrow(long exerciseHintId) throws EntityNotFoundException {
         return findById(exerciseHintId).orElseThrow(() -> new EntityNotFoundException("Exercise Hint", exerciseHintId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/hestia/ProgrammingExerciseSolutionEntryRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/hestia/ProgrammingExerciseSolutionEntryRepository.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.repository.hestia;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,7 +24,7 @@ public interface ProgrammingExerciseSolutionEntryRepository extends JpaRepositor
      * @return The solution entry with the given ID if found
      * @throws EntityNotFoundException If no solution entry with the given ID was found
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExerciseSolutionEntry findByIdWithTestCaseAndProgrammingExerciseElseThrow(long entryId) throws EntityNotFoundException {
         return findByIdWithTestCaseAndProgrammingExercise(entryId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise Solution Entry", entryId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/hestia/ProgrammingExerciseTaskRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/hestia/ProgrammingExerciseTaskRepository.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.repository.hestia;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -26,7 +26,7 @@ public interface ProgrammingExerciseTaskRepository extends JpaRepository<Program
      * @return The task with the given ID if found
      * @throws EntityNotFoundException If no task with the given ID was found
      */
-    @NotNull
+    @Nonnull
     default ProgrammingExerciseTask findByIdWithTestCaseAndSolutionEntriesElseThrow(long entryId) throws EntityNotFoundException {
         return findByIdWithTestCaseAndSolutionEntries(entryId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise Task", entryId));
     }
@@ -53,7 +53,7 @@ public interface ProgrammingExerciseTaskRepository extends JpaRepository<Program
      * @return All tasks with solution entries and associated test cases
      * @throws EntityNotFoundException If the exercise with exerciseId does not exist
      */
-    @NotNull
+    @Nonnull
     default Set<ProgrammingExerciseTask> findByExerciseIdWithTestCaseAndSolutionEntriesElseThrow(long exerciseId) throws EntityNotFoundException {
         return findByExerciseIdWithTestCaseAndSolutionEntries(exerciseId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise Task", exerciseId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/iris/IrisChatSessionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/iris/IrisChatSessionRepository.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.repository.iris;
 
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -42,7 +42,7 @@ public interface IrisChatSessionRepository extends JpaRepository<IrisChatSession
      * @return A list of chat sessions.
      * @throws EntityNotFoundException if no sessions are found.
      */
-    @NotNull
+    @Nonnull
     default List<IrisChatSession> findByExerciseIdAndUserIdElseThrow(long exerciseId, long userId) throws EntityNotFoundException {
         var result = findByExerciseIdAndUserId(exerciseId, userId);
         if (result.isEmpty()) {
@@ -58,7 +58,7 @@ public interface IrisChatSessionRepository extends JpaRepository<IrisChatSession
      * @return The found chat session.
      * @throws EntityNotFoundException if no session is found.
      */
-    @NotNull
+    @Nonnull
     default IrisChatSession findByIdElseThrow(long sessionId) throws EntityNotFoundException {
         return findById(sessionId).orElseThrow(() -> new EntityNotFoundException("Iris Chat Session", sessionId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/iris/IrisCodeEditorSessionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/iris/IrisCodeEditorSessionRepository.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.repository.iris;
 
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -41,7 +41,7 @@ public interface IrisCodeEditorSessionRepository extends JpaRepository<IrisCodeE
      * @return A list of chat sessions.
      * @throws EntityNotFoundException if no sessions are found.
      */
-    @NotNull
+    @Nonnull
     default List<IrisCodeEditorSession> findByExerciseIdAndUserIdElseThrow(long exerciseId, long userId) throws EntityNotFoundException {
         var result = findByExerciseIdAndUserId(exerciseId, userId);
         if (result.isEmpty()) {
@@ -57,7 +57,7 @@ public interface IrisCodeEditorSessionRepository extends JpaRepository<IrisCodeE
      * @return The found chat session.
      * @throws EntityNotFoundException if no session is found.
      */
-    @NotNull
+    @Nonnull
     default IrisCodeEditorSession findByIdElseThrow(long sessionId) throws EntityNotFoundException {
         return findById(sessionId).orElseThrow(() -> new EntityNotFoundException("Iris Code Editor Session", sessionId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/iris/IrisMessageRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/iris/IrisMessageRepository.java
@@ -5,7 +5,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 import java.time.ZonedDateTime;
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -41,11 +41,11 @@ public interface IrisMessageRepository extends JpaRepository<IrisMessage, Long> 
             """)
     int countLlmResponsesOfUserWithinTimeframe(@Param("userId") long userId, @Param("start") ZonedDateTime start, @Param("end") ZonedDateTime end);
 
-    @NotNull
+    @Nonnull
     default IrisMessage findByIdElseThrow(long messageId) throws EntityNotFoundException {
         return findById(messageId).orElseThrow(() -> new EntityNotFoundException("Iris Message", messageId));
     }
 
     @EntityGraph(type = LOAD, attributePaths = { "content" })
-    IrisMessage findFirstWithContentBySessionIdAndSenderOrderBySentAtDesc(long sessionId, @NotNull IrisMessageSender sender);
+    IrisMessage findFirstWithContentBySessionIdAndSenderOrderBySentAtDesc(long sessionId, @Nonnull IrisMessageSender sender);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/iris/IrisSessionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/iris/IrisSessionRepository.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.repository.iris;
 
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -33,12 +33,12 @@ public interface IrisSessionRepository extends JpaRepository<IrisSession, Long> 
             """)
     IrisSession findByIdWithMessagesAndContents(@Param("sessionId") long sessionId);
 
-    @NotNull
+    @Nonnull
     default IrisSession findByIdElseThrow(long sessionId) throws EntityNotFoundException {
         return findById(sessionId).orElseThrow(() -> new EntityNotFoundException("Iris Session", sessionId));
     }
 
-    @NotNull
+    @Nonnull
     default IrisSession findByIdWithMessagesElseThrow(long sessionId) throws EntityNotFoundException {
         return findByIdWithMessages(sessionId).orElseThrow(() -> new EntityNotFoundException("Iris Session", sessionId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/metis/AnswerPostRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metis/AnswerPostRepository.java
@@ -4,7 +4,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,19 +22,19 @@ public interface AnswerPostRepository extends JpaRepository<AnswerPost, Long> {
 
     List<AnswerPost> findAnswerPostsByAuthorId(long authorId);
 
-    @NotNull
+    @Nonnull
     default AnswerPost findAnswerPostByIdElseThrow(Long answerPostId) {
         return findById(answerPostId).filter(answerPost -> answerPost.getPost().getConversation() == null)
                 .orElseThrow(() -> new EntityNotFoundException("Answer Post", answerPostId));
     }
 
-    @NotNull
+    @Nonnull
     default AnswerPost findAnswerMessageByIdElseThrow(Long answerPostId) {
         return findById(answerPostId).filter(answerPost -> answerPost.getPost().getConversation() != null)
                 .orElseThrow(() -> new EntityNotFoundException("Answer Post", answerPostId));
     }
 
-    @NotNull
+    @Nonnull
     default AnswerPost findAnswerPostOrAnswerMessageByIdElseThrow(Long answerPostId) {
         return findById(answerPostId).orElseThrow(() -> new EntityNotFoundException("Answer Post", answerPostId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/tutorialgroups/TutorialGroupRegistrationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/tutorialgroups/TutorialGroupRegistrationRepository.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -36,7 +36,7 @@ public interface TutorialGroupRegistrationRepository extends JpaRepository<Tutor
 
     @Transactional  // ok because of delete
     @Modifying
-    void deleteById(@NotNull Long tutorialGroupRegistrationId);
+    void deleteById(@Nonnull Long tutorialGroupRegistrationId);
 
     @Transactional  // ok because of delete
     @Modifying

--- a/src/main/java/de/tum/in/www1/artemis/security/annotations/AnnotationUtils.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/annotations/AnnotationUtils.java
@@ -6,8 +6,8 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Optional;
 
+import jakarta.annotation.Nonnull;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
@@ -29,8 +29,8 @@ public final class AnnotationUtils {
      * @param <T>       the type of the annotation
      * @return the annotation if it is present, empty otherwise
      */
-    @NotNull
-    public static <T extends Annotation> Optional<T> getAnnotation(@NotNull Class<T> clazz, @NotNull ProceedingJoinPoint joinPoint) {
+    @Nonnull
+    public static <T extends Annotation> Optional<T> getAnnotation(@Nonnull Class<T> clazz, @Nonnull ProceedingJoinPoint joinPoint) {
         final var method = ((MethodSignature) joinPoint.getSignature()).getMethod();
         T annotation = method.getAnnotation(clazz);
         if (annotation != null) {
@@ -65,8 +65,8 @@ public final class AnnotationUtils {
      * @param <V>        the type of the value
      * @return the value if it is present, otherwise an exception is thrown
      */
-    @NotNull
-    public static <T extends Annotation, V> Optional<V> getValue(@NotNull T annotation, @NotBlank String valueName, @NotNull Class<V> valueType) {
+    @Nonnull
+    public static <T extends Annotation, V> Optional<V> getValue(@Nonnull T annotation, @NotBlank String valueName, @Nonnull Class<V> valueType) {
         try {
             Method method = annotation.annotationType().getMethod(valueName);
             Object value = method.invoke(annotation);
@@ -87,8 +87,8 @@ public final class AnnotationUtils {
      * @param fieldName the fieldName
      * @return the id if it is present, empty otherwise
      */
-    @NotNull
-    public static Optional<Long> getIdFromSignature(@NotNull ProceedingJoinPoint joinPoint, @NotBlank String fieldName) {
+    @Nonnull
+    public static Optional<Long> getIdFromSignature(@Nonnull ProceedingJoinPoint joinPoint, @NotBlank String fieldName) {
         final MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         final int indexOfId = Arrays.asList(signature.getParameterNames()).indexOf(fieldName);
         Object[] args = joinPoint.getArgs();

--- a/src/main/java/de/tum/in/www1/artemis/service/AuthorizationCheckService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/AuthorizationCheckService.java
@@ -7,8 +7,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import javax.annotation.CheckReturnValue;
 
@@ -80,7 +80,7 @@ public class AuthorizationCheckService {
      * @return true if the currently logged-in user is at least an editor (also if the user is instructor or admin), false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastEditorForExercise(@NotNull Exercise exercise) {
+    public boolean isAtLeastEditorForExercise(@Nonnull Exercise exercise) {
         return isAtLeastEditorInCourse(exercise.getCourseViaExerciseGroupOrCourseMember(), null);
     }
 
@@ -93,7 +93,7 @@ public class AuthorizationCheckService {
      * @return true if the currently logged-in user is at least an editor, false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastEditorForExercise(@NotNull Exercise exercise, @Nullable User user) {
+    public boolean isAtLeastEditorForExercise(@Nonnull Exercise exercise, @Nullable User user) {
         return isAtLeastEditorInCourse(exercise.getCourseViaExerciseGroupOrCourseMember(), user);
     }
 
@@ -104,7 +104,7 @@ public class AuthorizationCheckService {
      * @param course the course that needs to be checked
      * @param user   the user whose permissions should be checked
      */
-    private void checkIsAtLeastEditorInCourseElseThrow(@NotNull Course course, @Nullable User user) {
+    private void checkIsAtLeastEditorInCourseElseThrow(@Nonnull Course course, @Nullable User user) {
         if (!isAtLeastEditorInCourse(course, user)) {
             throw new AccessForbiddenException("Course", course.getId());
         }
@@ -118,7 +118,7 @@ public class AuthorizationCheckService {
      * @return true if the passed user is at least an editor in the course, false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastEditorInCourse(@NotNull Course course, @Nullable User user) {
+    public boolean isAtLeastEditorInCourse(@Nonnull Course course, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return isEditorInCourse(course, user) || isInstructorInCourse(course, user) || isAdmin(user);
     }
@@ -182,7 +182,7 @@ public class AuthorizationCheckService {
      * @return true if the currently logged-in user is at least a teaching assistant (also if the user is instructor or admin), false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastTeachingAssistantForExercise(@NotNull Exercise exercise) {
+    public boolean isAtLeastTeachingAssistantForExercise(@Nonnull Exercise exercise) {
         return isAtLeastTeachingAssistantInCourse(exercise.getCourseViaExerciseGroupOrCourseMember(), null);
     }
 
@@ -195,7 +195,7 @@ public class AuthorizationCheckService {
      * @return true if the passed user is at least a teaching assistant (also if the user is instructor or admin), false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastTeachingAssistantForExercise(@NotNull Exercise exercise, @Nullable User user) {
+    public boolean isAtLeastTeachingAssistantForExercise(@Nonnull Exercise exercise, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return isAtLeastTeachingAssistantInCourse(exercise.getCourseViaExerciseGroupOrCourseMember(), user);
     }
@@ -207,7 +207,7 @@ public class AuthorizationCheckService {
      * @return true if the currently logged-in user is at least a student (also if the user is teaching assistant, instructor or admin), false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastStudentForExercise(@NotNull Exercise exercise) {
+    public boolean isAtLeastStudentForExercise(@Nonnull Exercise exercise) {
         return isAtLeastStudentForExercise(exercise, null);
     }
 
@@ -219,7 +219,7 @@ public class AuthorizationCheckService {
      * @return true if the currently logged-in user is at least a student (also if the user is teaching assistant, instructor or admin), false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastStudentForExercise(@NotNull Exercise exercise, @Nullable User user) {
+    public boolean isAtLeastStudentForExercise(@Nonnull Exercise exercise, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return isStudentInCourse(exercise.getCourseViaExerciseGroupOrCourseMember(), user) || isAtLeastTeachingAssistantForExercise(exercise, user);
     }
@@ -231,7 +231,7 @@ public class AuthorizationCheckService {
      * @param course the course that needs to be checked
      * @param user   the user whose permissions should be checked
      */
-    private void checkIsAtLeastTeachingAssistantInCourseElseThrow(@NotNull Course course, @Nullable User user) {
+    private void checkIsAtLeastTeachingAssistantInCourseElseThrow(@Nonnull Course course, @Nullable User user) {
         if (!isAtLeastTeachingAssistantInCourse(course, user)) {
             throw new AccessForbiddenException("Course", course.getId());
         }
@@ -245,7 +245,7 @@ public class AuthorizationCheckService {
      * @return true if the passed user is at least a teaching assistant in the course (also if the user is instructor or admin), false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastTeachingAssistantInCourse(@NotNull Course course, @Nullable User user) {
+    public boolean isAtLeastTeachingAssistantInCourse(@Nonnull Course course, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return isTeachingAssistantInCourse(course, user) || isEditorInCourse(course, user) || isInstructorInCourse(course, user) || isAdmin(user);
     }
@@ -293,7 +293,7 @@ public class AuthorizationCheckService {
      * @param course the course that needs to be checked
      * @param user   the user whose permissions should be checked
      */
-    private void checkIsAtLeastStudentInCourseElseThrow(@NotNull Course course, @Nullable User user) {
+    private void checkIsAtLeastStudentInCourseElseThrow(@Nonnull Course course, @Nullable User user) {
         if (!isAtLeastStudentInCourse(course, user)) {
             throw new AccessForbiddenException("Course", course.getId());
         }
@@ -428,7 +428,7 @@ public class AuthorizationCheckService {
      * @return true if the passed user is at least a student in the course (also if the user is teaching assistant, instructor or admin), false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastStudentInCourse(@NotNull Course course, @Nullable User user) {
+    public boolean isAtLeastStudentInCourse(@Nonnull Course course, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return isStudentInCourse(course, user) || isTeachingAssistantInCourse(course, user) || isEditorInCourse(course, user) || isInstructorInCourse(course, user)
                 || isAdmin(user);
@@ -479,7 +479,7 @@ public class AuthorizationCheckService {
      * @return true if the currently logged-in user is at least an instructor (or admin), false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastInstructorForExercise(@NotNull Exercise exercise, @Nullable User user) {
+    public boolean isAtLeastInstructorForExercise(@Nonnull Exercise exercise, @Nullable User user) {
         return isAtLeastInstructorInCourse(exercise.getCourseViaExerciseGroupOrCourseMember(), user);
     }
 
@@ -490,7 +490,7 @@ public class AuthorizationCheckService {
      * @return true if the currently logged-in user is at least an instructor (or admin), false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastInstructorForExercise(@NotNull Exercise exercise) {
+    public boolean isAtLeastInstructorForExercise(@Nonnull Exercise exercise) {
         return isAtLeastInstructorForExercise(exercise, null);
     }
 
@@ -502,7 +502,7 @@ public class AuthorizationCheckService {
      * @param lecture belongs to a course that will be checked for permission rights
      * @param user    the user whose permissions should be checked
      */
-    public void checkHasAtLeastRoleForLectureElseThrow(@NotNull Role role, @NotNull Lecture lecture, @Nullable User user) {
+    public void checkHasAtLeastRoleForLectureElseThrow(@Nonnull Role role, @Nonnull Lecture lecture, @Nullable User user) {
         checkHasAtLeastRoleInCourseElseThrow(role, lecture.getCourse(), user);
     }
 
@@ -514,7 +514,7 @@ public class AuthorizationCheckService {
      * @param exercise belongs to a course that will be checked for permission rights
      * @param user     the user whose permissions should be checked
      */
-    public void checkHasAtLeastRoleForExerciseElseThrow(@NotNull Role role, @NotNull Exercise exercise, @Nullable User user) {
+    public void checkHasAtLeastRoleForExerciseElseThrow(@Nonnull Role role, @Nonnull Exercise exercise, @Nullable User user) {
         checkHasAtLeastRoleInCourseElseThrow(role, exercise.getCourseViaExerciseGroupOrCourseMember(), user);
     }
 
@@ -526,7 +526,7 @@ public class AuthorizationCheckService {
      * @param course the course that needs to be checked
      * @param user   the user whose permissions should be checked
      */
-    public void checkHasAtLeastRoleInCourseElseThrow(@NotNull Role role, @NotNull Course course, @Nullable User user) {
+    public void checkHasAtLeastRoleInCourseElseThrow(@Nonnull Role role, @Nonnull Course course, @Nullable User user) {
         // Note: the consumer is necessary to get an exhaustive check for the switch expression here, also see https://stackoverflow.com/questions/66204407
         Consumer<User> consumer = switch (role) {
             case ADMIN -> this::checkIsAdminElseThrow;
@@ -547,7 +547,7 @@ public class AuthorizationCheckService {
      * @param course the course that needs to be checked
      * @param user   the user whose permissions should be checked
      */
-    private void checkIsAtLeastInstructorInCourseElseThrow(@NotNull Course course, @Nullable User user) {
+    private void checkIsAtLeastInstructorInCourseElseThrow(@Nonnull Course course, @Nullable User user) {
         if (!isAtLeastInstructorInCourse(course, user)) {
             throw new AccessForbiddenException("Course", course.getId());
         }
@@ -561,7 +561,7 @@ public class AuthorizationCheckService {
      * @return true if the passed user is at least instructor in the course (also if the user is admin), false otherwise
      */
     @CheckReturnValue
-    public boolean isAtLeastInstructorInCourse(@NotNull Course course, @Nullable User user) {
+    public boolean isAtLeastInstructorInCourse(@Nonnull Course course, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return user.getGroups().contains(course.getInstructorGroupName()) || isAdmin(user);
     }
@@ -610,7 +610,7 @@ public class AuthorizationCheckService {
      * @return true, if user is instructor of this course, otherwise false
      */
     @CheckReturnValue
-    public boolean isInstructorInCourse(@NotNull Course course, @Nullable User user) {
+    public boolean isInstructorInCourse(@Nonnull Course course, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return user.getGroups().contains(course.getInstructorGroupName());
     }
@@ -623,7 +623,7 @@ public class AuthorizationCheckService {
      * @return true, if user is an editor of this course, otherwise false
      */
     @CheckReturnValue
-    public boolean isEditorInCourse(@NotNull Course course, @Nullable User user) {
+    public boolean isEditorInCourse(@Nonnull Course course, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return user.getGroups().contains(course.getEditorGroupName());
     }
@@ -636,7 +636,7 @@ public class AuthorizationCheckService {
      * @return true, if user is teaching assistant of this course, otherwise false
      */
     @CheckReturnValue
-    public boolean isTeachingAssistantInCourse(@NotNull Course course, @Nullable User user) {
+    public boolean isTeachingAssistantInCourse(@Nonnull Course course, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return user.getGroups().contains(course.getTeachingAssistantGroupName());
     }
@@ -649,7 +649,7 @@ public class AuthorizationCheckService {
      * @return true, if user is only student of this course, otherwise false
      */
     @CheckReturnValue
-    public boolean isOnlyStudentInCourse(@NotNull Course course, @Nullable User user) {
+    public boolean isOnlyStudentInCourse(@Nonnull Course course, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return user.getGroups().contains(course.getStudentGroupName()) && !isAtLeastTeachingAssistantInCourse(course, user);
     }
@@ -662,7 +662,7 @@ public class AuthorizationCheckService {
      * @return true, if user is student of this course, otherwise false
      */
     @CheckReturnValue
-    public boolean isStudentInCourse(@NotNull Course course, @Nullable User user) {
+    public boolean isStudentInCourse(@Nonnull Course course, @Nullable User user) {
         user = loadUserIfNeeded(user);
         return user.getGroups().contains(course.getStudentGroupName());
     }
@@ -674,7 +674,7 @@ public class AuthorizationCheckService {
      * @return true, if user is student is owner of this participation, otherwise false
      */
     @CheckReturnValue
-    public boolean isOwnerOfParticipation(@NotNull StudentParticipation participation) {
+    public boolean isOwnerOfParticipation(@Nonnull StudentParticipation participation) {
         if (participation.getParticipant() == null) {
             return false;
         }
@@ -689,7 +689,7 @@ public class AuthorizationCheckService {
      * @param participation the participation that needs to be checked
      * @throws AccessForbiddenException if active user isn't owner of participation
      */
-    public void isOwnerOfParticipationElseThrow(@NotNull StudentParticipation participation) throws AccessForbiddenException {
+    public void isOwnerOfParticipationElseThrow(@Nonnull StudentParticipation participation) throws AccessForbiddenException {
         if (!isOwnerOfParticipation(participation)) {
             throw new AccessForbiddenException("participation", participation.getId());
         }
@@ -703,7 +703,7 @@ public class AuthorizationCheckService {
      * @return true, if user is student is owner of this participation, otherwise false
      */
     @CheckReturnValue
-    public boolean isOwnerOfParticipation(@NotNull StudentParticipation participation, @Nullable User user) {
+    public boolean isOwnerOfParticipation(@Nonnull StudentParticipation participation, @Nullable User user) {
         user = loadUserIfNeeded(user);
         if (participation.getParticipant() == null) {
             return false;
@@ -724,7 +724,7 @@ public class AuthorizationCheckService {
      * @return true if user is owner of this team, otherwise false
      */
     @CheckReturnValue
-    public boolean isOwnerOfTeam(@NotNull Team team, @NotNull User user) {
+    public boolean isOwnerOfTeam(@Nonnull Team team, @Nonnull User user) {
         return user.equals(team.getOwner());
     }
 
@@ -737,7 +737,7 @@ public class AuthorizationCheckService {
      * @return true, if user is student is owner of this team, otherwise false
      */
     @CheckReturnValue
-    public boolean isStudentInTeam(@NotNull Course course, String teamShortName, @NotNull User user) {
+    public boolean isStudentInTeam(@Nonnull Course course, String teamShortName, @Nonnull User user) {
         return userRepository.findAllInTeam(course.getId(), teamShortName).contains(user);
     }
 
@@ -749,7 +749,7 @@ public class AuthorizationCheckService {
      * @return true, if user is allowed to see this exercise, otherwise false
      */
     @CheckReturnValue
-    public boolean isAllowedToSeeExercise(@NotNull Exercise exercise, @Nullable User user) {
+    public boolean isAllowedToSeeExercise(@Nonnull Exercise exercise, @Nullable User user) {
         user = loadUserIfNeeded(user);
         if (isAdmin(user)) {
             return true;
@@ -764,7 +764,7 @@ public class AuthorizationCheckService {
      * @param lecture the lecture that needs to be checked
      * @param user    the user whose permissions should be checked
      */
-    public void checkIsAllowedToSeeLectureElseThrow(@NotNull Lecture lecture, @Nullable User user) {
+    public void checkIsAllowedToSeeLectureElseThrow(@Nonnull Lecture lecture, @Nullable User user) {
         user = loadUserIfNeeded(user);
         if (isAdmin(user)) {
             return;
@@ -785,7 +785,7 @@ public class AuthorizationCheckService {
      * @return true if the user is allowed, false otherwise
      */
     @CheckReturnValue
-    public boolean isAllowedToSeeLectureUnit(@NotNull LectureUnit lectureUnit, @Nullable User user) {
+    public boolean isAllowedToSeeLectureUnit(@Nonnull LectureUnit lectureUnit, @Nullable User user) {
         user = loadUserIfNeeded(user);
         if (isAdmin(user)) {
             return true;
@@ -828,7 +828,7 @@ public class AuthorizationCheckService {
      * @return true, if user is admin, otherwise false
      */
     @CheckReturnValue
-    public boolean isAdmin(@NotNull String login) {
+    public boolean isAdmin(@Nonnull String login) {
         return userRepository.isAdmin(login);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -30,7 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import jakarta.ws.rs.BadRequestException;
 
 import org.slf4j.Logger;
@@ -928,7 +928,7 @@ public class CourseService {
      * @param groupName the name of the group
      * @return list of users
      */
-    @NotNull
+    @Nonnull
     public ResponseEntity<Set<User>> getAllUsersInGroup(Course course, String groupName) {
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
         var usersInGroup = userRepository.findAllByIsDeletedIsFalseAndGroupsContains(groupName);
@@ -1167,7 +1167,7 @@ public class CourseService {
      *
      * @param course the course to check
      */
-    public void checkLearningPathsEnabledElseThrow(@NotNull Course course) {
+    public void checkLearningPathsEnabledElseThrow(@Nonnull Course course) {
         if (!course.getLearningPathsEnabled()) {
             throw new BadRequestException("Learning paths are not enabled for this course.");
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -7,7 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -743,7 +743,7 @@ public class ExerciseService {
      * @param minScore the minimum score that should be achieved
      * @return true if the user achieved the minimum score, false otherwise
      */
-    public boolean hasScoredAtLeast(@NotNull Exercise exercise, @NotNull User user, double minScore) {
+    public boolean hasScoredAtLeast(@Nonnull Exercise exercise, @Nonnull User user, double minScore) {
         final var score = participantScoreService.getStudentAndTeamParticipationScoresAsDoubleStream(user, Set.of(exercise)).max();
         if (score.isEmpty()) {
             return false;
@@ -757,7 +757,7 @@ public class ExerciseService {
      * @param exercises  set of exercises
      * @param competency competency to remove
      */
-    public void removeCompetency(@NotNull Set<Exercise> exercises, @NotNull Competency competency) {
+    public void removeCompetency(@Nonnull Set<Exercise> exercises, @Nonnull Competency competency) {
         exercises.forEach(exercise -> exercise.getCompetencies().remove(competency));
         exerciseRepository.saveAll(exercises);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -17,8 +17,8 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.disk.DiskFileItem;
@@ -161,7 +161,7 @@ public class FileService implements DisposableBean {
      * @param markdown     boolean which is set to true, when we are uploading a file within the markdown editor
      * @return The API path of the file
      */
-    @NotNull
+    @Nonnull
     public URI handleSaveFile(MultipartFile file, boolean keepFilename, boolean markdown) {
         // check for file type
         String filename = checkAndSanitizeFilename(file.getOriginalFilename());
@@ -188,7 +188,7 @@ public class FileService implements DisposableBean {
      * @param keepFilename whether to keep the original filename or not
      * @return the path where the file was saved
      */
-    @NotNull
+    @Nonnull
     public Path saveFile(MultipartFile file, Path basePath, boolean keepFilename) {
         String sanitizedFilename = checkAndSanitizeFilename(file.getOriginalFilename());
         validateExtension(sanitizedFilename, false);
@@ -204,7 +204,7 @@ public class FileService implements DisposableBean {
      * @param fullSanitizedPath the full path to save the file to
      * @return the path where the file was saved
      */
-    @NotNull
+    @Nonnull
     public Path saveFile(MultipartFile file, Path fullSanitizedPath) {
         copyFile(file, fullSanitizedPath);
         return fullSanitizedPath;
@@ -227,7 +227,7 @@ public class FileService implements DisposableBean {
      * @return the sanitized filename
      * @throws IllegalArgumentException if the filename is null
      */
-    @NotNull
+    @Nonnull
     public String checkAndSanitizeFilename(@Nullable String filename) {
         if (filename == null) {
             throw new IllegalArgumentException("Filename cannot be null");
@@ -298,7 +298,7 @@ public class FileService implements DisposableBean {
      * @param subPath sub-path URI to search for
      * @throws IllegalArgumentException if the provided path does not start with the provided sub-path or the provided legacy-sub-path
      */
-    public static void sanitizeByCheckingIfPathStartsWithSubPathElseThrow(@NotNull URI path, @NotNull URI subPath) {
+    public static void sanitizeByCheckingIfPathStartsWithSubPathElseThrow(@Nonnull URI path, @Nonnull URI subPath) {
         // Removes redundant elements (e.g. ../ or ./) from the path and sub-path
         URI normalisedPath = path.normalize();
         URI normalisedSubPath = subPath.normalize();

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadExerciseImportService.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import java.util.HashMap;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +42,7 @@ public class FileUploadExerciseImportService extends ExerciseImportService {
      * @param importedExercise The new exercise already containing values which should not get copied, i.e. overwritten
      * @return The newly created exercise
      */
-    @NotNull
+    @Nonnull
     public FileUploadExercise importFileUploadExercise(final FileUploadExercise templateExercise, FileUploadExercise importedExercise) {
         log.debug("Creating a new Exercise based on exercise {}", templateExercise);
         FileUploadExercise newExercise = copyFileUploadExerciseBasis(importedExercise);
@@ -61,7 +61,7 @@ public class FileUploadExerciseImportService extends ExerciseImportService {
      * @param importedExercise The exercise from which to copy the basis
      * @return the cloned TextExercise basis
      */
-    @NotNull
+    @Nonnull
     private FileUploadExercise copyFileUploadExerciseBasis(FileUploadExercise importedExercise) {
         log.debug("Copying the exercise basis from {}", importedExercise);
         FileUploadExercise newExercise = new FileUploadExercise();

--- a/src/main/java/de/tum/in/www1/artemis/service/LearningObjectService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LearningObjectService.java
@@ -4,7 +4,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -41,7 +41,7 @@ public class LearningObjectService {
      * @param user           the user for which to check the completion status
      * @return true if the user completed the lecture unit or has at least one result for the exercise, false otherwise
      */
-    public boolean isCompletedByUser(@NotNull LearningObject learningObject, @NotNull User user) {
+    public boolean isCompletedByUser(@Nonnull LearningObject learningObject, @Nonnull User user) {
         if (learningObject instanceof LectureUnit lectureUnit) {
             return lectureUnit.getCompletedUsers().stream().map(LectureUnitCompletion::getUser).anyMatch(user1 -> user1.getId().equals(user.getId()));
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureUnitProcessingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureUnitProcessingService.java
@@ -7,7 +7,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -281,7 +281,7 @@ public class LectureUnitProcessingService {
      * @param outlineMap   Outline map with unit information
      * @param index        index that shows current page
      */
-    private void updatePreviousUnitEndPage(int outlineCount, @NotNull Map<Integer, LectureUnitSplit> outlineMap, int index) {
+    private void updatePreviousUnitEndPage(int outlineCount, @Nonnull Map<Integer, LectureUnitSplit> outlineMap, int index) {
         if (outlineCount > 1) {
             int previousOutlineCount = outlineCount - 1;
             int previousStart = outlineMap.get(previousOutlineCount).startPage;

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureUnitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureUnitService.java
@@ -11,7 +11,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -61,7 +61,7 @@ public class LectureUnitService {
      * @param user        The user that completed/uncompleted the lecture unit
      * @param completed   True if the lecture unit was completed, false otherwise
      */
-    public void setLectureUnitCompletion(@NotNull LectureUnit lectureUnit, @NotNull User user, boolean completed) {
+    public void setLectureUnitCompletion(@Nonnull LectureUnit lectureUnit, @Nonnull User user, boolean completed) {
         Optional<LectureUnitCompletion> existingCompletion = lectureUnitCompletionRepository.findByLectureUnitIdAndUserId(lectureUnit.getId(), user.getId());
         if (completed) {
             if (existingCompletion.isEmpty()) {
@@ -89,7 +89,7 @@ public class LectureUnitService {
      * @param user         The user that completed/uncompleted the lecture unit
      * @param completed    True if the lecture unit was completed, false otherwise
      */
-    public void setCompletedForAllLectureUnits(List<? extends LectureUnit> lectureUnits, @NotNull User user, boolean completed) {
+    public void setCompletedForAllLectureUnits(List<? extends LectureUnit> lectureUnits, @Nonnull User user, boolean completed) {
         var existingCompletion = lectureUnitCompletionRepository.findByLectureUnitsAndUserId(lectureUnits, user.getId());
         if (!completed) {
             lectureUnitCompletionRepository.deleteAll(existingCompletion);
@@ -129,7 +129,7 @@ public class LectureUnitService {
      *
      * @param lectureUnit lecture unit to delete
      */
-    public void removeLectureUnit(@NotNull LectureUnit lectureUnit) {
+    public void removeLectureUnit(@Nonnull LectureUnit lectureUnit) {
         LectureUnit lectureUnitToDelete = lectureUnitRepository.findByIdWithCompetenciesAndSlidesElseThrow(lectureUnit.getId());
 
         if (!(lectureUnitToDelete instanceof ExerciseUnit)) {

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingExerciseImportService.java
@@ -4,7 +4,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +44,7 @@ public class ModelingExerciseImportService extends ExerciseImportService {
      * @param importedExercise The new exercise already containing values which should not get copied, i.e. overwritten
      * @return The newly created exercise
      */
-    @NotNull
+    @Nonnull
     public ModelingExercise importModelingExercise(ModelingExercise templateExercise, ModelingExercise importedExercise) {
         log.debug("Creating a new Exercise based on exercise {}", templateExercise.getId());
         Map<Long, GradingInstruction> gradingInstructionCopyTracker = new HashMap<>();
@@ -66,7 +66,7 @@ public class ModelingExerciseImportService extends ExerciseImportService {
      * @param gradingInstructionCopyTracker The mapping from original GradingInstruction Ids to new GradingInstruction instances.
      * @return the cloned TextExercise basis
      */
-    @NotNull
+    @Nonnull
     private ModelingExercise copyModelingExerciseBasis(Exercise importedExercise, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
         log.debug("Copying the exercise basis from {}", importedExercise);
         ModelingExercise newExercise = new ModelingExercise();

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,7 +233,7 @@ public class ModelingSubmissionService extends SubmissionService {
      *
      * @param submission Result for the Submission acting as a reference for the modeling submission to be searched.
      */
-    public void setNumberOfAffectedSubmissionsPerElement(@NotNull ModelingSubmission submission) {
+    public void setNumberOfAffectedSubmissionsPerElement(@Nonnull ModelingSubmission submission) {
         List<ModelElementRepository.ModelElementCount> elementCounts = modelElementRepository.countOtherElementsInSameClusterForSubmissionId(submission.getId());
         submission.setSimilarElements(elementCounts.stream().map(modelElementCount -> {
             SimilarElementCount similarElementCount = new SimilarElementCount();

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationAuthorizationCheckService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationAuthorizationCheckService.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.service;
 
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +61,7 @@ public class ParticipationAuthorizationCheckService {
      * @param participation Some participation.
      * @return True, if the current user is allowed to access the participation; false otherwise.
      */
-    public boolean canAccessParticipation(@NotNull final ParticipationInterface participation) {
+    public boolean canAccessParticipation(@Nonnull final ParticipationInterface participation) {
         final User user = userRepository.getUserWithGroupsAndAuthorities();
         return canAccessParticipation(participation, user);
     }
@@ -73,7 +73,7 @@ public class ParticipationAuthorizationCheckService {
      * @param user          The user that wants to access the participation.
      * @return True, if the user is allowed to access the participation; false otherwise.
      */
-    public boolean canAccessParticipation(@NotNull final ParticipationInterface participation, final User user) {
+    public boolean canAccessParticipation(@Nonnull final ParticipationInterface participation, final User user) {
         if (participation instanceof StudentParticipation studentParticipation && studentParticipation.getParticipant() instanceof Team team) {
             // eager load the team with students so their information can be used for the access check below
             studentParticipation.setParticipant(teamRepository.findWithStudentsByIdElseThrow(team.getId()));

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseImportService.java
@@ -6,7 +6,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +49,7 @@ public class QuizExerciseImportService extends ExerciseImportService {
      * @param importedExercise The new exercise already containing values which should not get copied, i.e. overwritten
      * @return The newly created exercise
      */
-    @NotNull
+    @Nonnull
     public QuizExercise importQuizExercise(final QuizExercise templateExercise, QuizExercise importedExercise) {
         log.debug("Creating a new Exercise based on exercise {}", templateExercise);
         QuizExercise newExercise = copyQuizExerciseBasis(importedExercise);
@@ -69,7 +69,7 @@ public class QuizExerciseImportService extends ExerciseImportService {
      * @param importedExercise The exercise from which to copy the basis
      * @return the cloned QuizExercise basis
      */
-    @NotNull
+    @Nonnull
     private QuizExercise copyQuizExerciseBasis(QuizExercise importedExercise) {
         log.debug("Copying the exercise basis from {}", importedExercise);
         QuizExercise newExercise = new QuizExercise();

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
@@ -12,8 +12,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -123,7 +123,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
      * @param files                the files that were uploaded
      * @return the updated quiz exercise with the changed statistics
      */
-    public QuizExercise reEvaluate(QuizExercise quizExercise, QuizExercise originalQuizExercise, @NotNull List<MultipartFile> files) throws IOException {
+    public QuizExercise reEvaluate(QuizExercise quizExercise, QuizExercise originalQuizExercise, @Nonnull List<MultipartFile> files) throws IOException {
         quizExercise.undoUnallowedChanges(originalQuizExercise);
         validateQuizExerciseFiles(quizExercise, files, false);
 
@@ -318,7 +318,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
      * @param providedFiles the provided files to validate
      * @param isCreate      On create all files get validated, on update only changed files get validated
      */
-    public void validateQuizExerciseFiles(QuizExercise quizExercise, @NotNull List<MultipartFile> providedFiles, boolean isCreate) {
+    public void validateQuizExerciseFiles(QuizExercise quizExercise, @Nonnull List<MultipartFile> providedFiles, boolean isCreate) {
         long fileCount = providedFiles.size();
         Set<String> exerciseFileNames = getAllPathsFromDragAndDropQuestionsOfExercise(quizExercise);
         Set<String> newFileNames = isCreate ? exerciseFileNames : exerciseFileNames.stream().filter(fileNameOrUri -> {

--- a/src/main/java/de/tum/in/www1/artemis/service/ResourceLoaderService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ResourceLoaderService.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -89,7 +89,7 @@ public class ResourceLoaderService {
      * @param basePath A relative path pattern to a resource.
      * @return The resources located by the specified pathPattern.
      */
-    @NotNull
+    @Nonnull
     public Resource[] getResources(final Path basePath) {
         return getResources(basePath, ALL_FILES_GLOB);
     }
@@ -105,7 +105,7 @@ public class ResourceLoaderService {
      * @param pattern  A pattern that limits which files in the directory of the base path are matched.
      * @return The resources located by the specified pathPattern.
      */
-    @NotNull
+    @Nonnull
     public Resource[] getResources(final Path basePath, final String pattern) {
         checkValidPathElseThrow(basePath);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ResultService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ResultService.java
@@ -6,8 +6,8 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.Hibernate;
 import org.slf4j.Logger;
@@ -180,7 +180,7 @@ public class ResultService {
      * @param shouldSave   whether the result should be saved or not
      * @return the updated (and potentially saved) result
      */
-    public Result storeFeedbackInResult(@NotNull Result result, List<Feedback> feedbackList, boolean shouldSave) {
+    public Result storeFeedbackInResult(@Nonnull Result result, List<Feedback> feedbackList, boolean shouldSave) {
         var savedFeedbacks = saveFeedbackWithHibernateWorkaround(result, feedbackList);
         result.setFeedbacks(savedFeedbacks);
         return shouldSaveResult(result, shouldSave);
@@ -199,8 +199,8 @@ public class ResultService {
      * @param shouldSave   whether the result should be saved or not
      * @return the updated (and potentially saved) result
      */
-    @NotNull
-    public Result addFeedbackToResult(@NotNull Result result, List<Feedback> feedbackList, boolean shouldSave) {
+    @Nonnull
+    public Result addFeedbackToResult(@Nonnull Result result, List<Feedback> feedbackList, boolean shouldSave) {
         List<Feedback> savedFeedbacks = saveFeedbackWithHibernateWorkaround(result, feedbackList);
         result.addFeedbacks(savedFeedbacks);
         return shouldSaveResult(result, shouldSave);
@@ -425,8 +425,8 @@ public class ResultService {
         return logsAvailability;
     }
 
-    @NotNull
-    private List<Feedback> saveFeedbackWithHibernateWorkaround(@NotNull Result result, List<Feedback> feedbackList) {
+    @Nonnull
+    private List<Feedback> saveFeedbackWithHibernateWorkaround(@Nonnull Result result, List<Feedback> feedbackList) {
         // Avoid hibernate exception
         List<Feedback> savedFeedbacks = new ArrayList<>();
         // Collect ids of feedbacks that have long feedback.
@@ -463,8 +463,8 @@ public class ResultService {
         return savedFeedbacks;
     }
 
-    @NotNull
-    private Result shouldSaveResult(@NotNull Result result, boolean shouldSave) {
+    @Nonnull
+    private Result shouldSaveResult(@Nonnull Result result, boolean shouldSave) {
         if (shouldSave) {
             // Note: This also saves the feedback objects in the database because of the 'cascade = CascadeType.ALL' option.
             return resultRepository.save(result);

--- a/src/main/java/de/tum/in/www1/artemis/service/TextExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextExerciseImportService.java
@@ -6,7 +6,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +54,7 @@ public class TextExerciseImportService extends ExerciseImportService {
      * @param importedExercise The new exercise already containing values which should not get copied, i.e. overwritten
      * @return The newly created exercise
      */
-    @NotNull
+    @Nonnull
     public TextExercise importTextExercise(final TextExercise templateExercise, TextExercise importedExercise) {
         log.debug("Creating a new Exercise based on exercise {}", templateExercise);
         Map<Long, GradingInstruction> gradingInstructionCopyTracker = new HashMap<>();
@@ -79,7 +79,7 @@ public class TextExerciseImportService extends ExerciseImportService {
      * @param gradingInstructionCopyTracker The mapping from original GradingInstruction Ids to new GradingInstruction instances.
      * @return the cloned TextExercise basis
      */
-    @NotNull
+    @Nonnull
     private TextExercise copyTextExerciseBasis(TextExercise importedExercise, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
         log.debug("Copying the exercise basis from {}", importedExercise);
         TextExercise newExercise = new TextExercise();

--- a/src/main/java/de/tum/in/www1/artemis/service/TutorLeaderboardService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TutorLeaderboardService.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -89,7 +89,7 @@ public class TutorLeaderboardService {
                 tutorLeaderboardComplaintResponses, tutorLeaderboardAnsweredMoreFeedbackRequests, exercise.isExamExercise());
     }
 
-    @NotNull
+    @Nonnull
     private List<TutorLeaderboardDTO> aggregateTutorLeaderboardData(Set<User> tutors, List<TutorLeaderboardAssessments> assessments, List<TutorLeaderboardComplaints> complaints,
             List<TutorLeaderboardMoreFeedbackRequests> feedbackRequests, List<TutorLeaderboardComplaintResponses> complaintResponses,
             List<TutorLeaderboardAnsweredMoreFeedbackRequests> answeredFeedbackRequests, boolean isExam) {

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLAttribute.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLAttribute.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.service.compass.umlmodel.classdiagram;
 import java.io.Serializable;
 import java.util.Objects;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.service.compass.strategy.NameSimilarity;
 import de.tum.in.www1.artemis.service.compass.umlmodel.Similarity;
@@ -39,7 +39,7 @@ public class UMLAttribute extends UMLElement implements Serializable {
      *
      * @return the UML element that contains this attribute
      */
-    @NotNull
+    @Nonnull
     public UMLElement getParentElement() {
         return parentElement;
     }
@@ -49,7 +49,7 @@ public class UMLAttribute extends UMLElement implements Serializable {
      *
      * @param parentElement the UML element that contains this attribute
      */
-    public void setParentElement(@NotNull UMLElement parentElement) {
+    public void setParentElement(@Nonnull UMLElement parentElement) {
         this.parentElement = parentElement;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLMethod.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLMethod.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.service.compass.strategy.NameSimilarity;
 import de.tum.in.www1.artemis.service.compass.umlmodel.Similarity;
@@ -47,7 +47,7 @@ public class UMLMethod extends UMLElement implements Serializable {
      *
      * @return the UML class that contains this method
      */
-    @NotNull
+    @Nonnull
     public UMLElement getParentElement() {
         return parentElement;
     }
@@ -57,7 +57,7 @@ public class UMLMethod extends UMLElement implements Serializable {
      *
      * @param parentElement the UML class that contains this method
      */
-    public void setParentElement(@NotNull UMLElement parentElement) {
+    public void setParentElement(@Nonnull UMLElement parentElement) {
         this.parentElement = parentElement;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/parsers/v2/ClassDiagramParser.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/parsers/v2/ClassDiagramParser.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.service.compass.utils.JSONMapping.*;
 import java.io.IOException;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.lang3.EnumUtils;
 
@@ -165,7 +165,7 @@ public class ClassDiagramParser {
      * @param jsonElementMap map of element ids and elements in the model
      * @return the list of UMLAttribute java objects
      */
-    @NotNull
+    @Nonnull
     protected static List<UMLAttribute> parseUmlAttributes(JsonObject classJson, Map<String, JsonObject> jsonElementMap) {
         List<UMLAttribute> umlAttributesList = new ArrayList<>();
         for (JsonElement attributeId : classJson.getAsJsonArray(ELEMENT_ATTRIBUTES)) {
@@ -182,7 +182,7 @@ public class ClassDiagramParser {
      * @param jsonElementMap map of element ids and elements in the model
      * @return the list of UMLMethod Java objects
      */
-    @NotNull
+    @Nonnull
     protected static List<UMLMethod> parseUmlMethods(JsonObject objectJson, Map<String, JsonObject> jsonElementMap) {
         List<UMLMethod> umlMethodList = new ArrayList<>();
         for (JsonElement methodId : objectJson.getAsJsonArray(ELEMENT_METHODS)) {

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/parsers/v2/ObjectDiagramParser.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/parsers/v2/ObjectDiagramParser.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.service.compass.utils.JSONMapping.*;
 import java.io.IOException;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -47,7 +47,7 @@ public class ObjectDiagramParser {
      * @param modelElements a JSON array containing all the model elements of the corresponding UML object diagram as JSON objects
      * @return the UMLObject map parsed from the JSON array
      */
-    @NotNull
+    @Nonnull
     public static Map<String, UMLObject> parseUMLObjects(JsonArray modelElements) {
         Map<String, UMLObject> umlObjectMap = new HashMap<>();
         // loop over all JSON elements and create the UML objects
@@ -106,7 +106,7 @@ public class ObjectDiagramParser {
      * @param jsonElementMap a map containing all the model elements and their ids of the corresponding UML object diagram as JSON objects
      * @return the list of UMLObjectAttribute parsed from the JSON object map
      */
-    @NotNull
+    @Nonnull
     protected static List<UMLObjectAttribute> parseUmlAttributes(JsonObject objectJson, Map<String, JsonObject> jsonElementMap) {
         List<UMLObjectAttribute> umlAttributesList = new ArrayList<>();
         for (JsonElement attributeId : objectJson.getAsJsonArray(ELEMENT_ATTRIBUTES)) {
@@ -123,7 +123,7 @@ public class ObjectDiagramParser {
      * @param jsonElementMap a map containing all the model elements and their ids of the corresponding UML object diagram as JSON objects
      * @return the list of UMLObjectMethod parsed from the JSON object map
      */
-    @NotNull
+    @Nonnull
     protected static List<UMLObjectMethod> parseUmlMethods(JsonObject objectJson, Map<String, JsonObject> jsonElementMap) {
         List<UMLObjectMethod> umlMethodList = new ArrayList<>();
         for (JsonElement methodId : objectJson.getAsJsonArray(ELEMENT_METHODS)) {

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/parsers/v3/ClassDiagramParser.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/parsers/v3/ClassDiagramParser.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.service.compass.utils.JSONMapping.*;
 import java.io.IOException;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.lang3.EnumUtils;
 
@@ -166,7 +166,7 @@ public class ClassDiagramParser {
      * @param jsonElementMap map of element ids and elements in the model
      * @return the list of UMLAttribute java objects
      */
-    @NotNull
+    @Nonnull
     protected static List<UMLAttribute> parseUmlAttributes(JsonObject classJson, Map<String, JsonObject> jsonElementMap) {
         List<UMLAttribute> umlAttributesList = new ArrayList<>();
         for (JsonElement attributeId : classJson.getAsJsonArray(ELEMENT_ATTRIBUTES)) {
@@ -183,7 +183,7 @@ public class ClassDiagramParser {
      * @param jsonElementMap map of element ids and elements in the model
      * @return the list of UMLMethod Java objects
      */
-    @NotNull
+    @Nonnull
     protected static List<UMLMethod> parseUmlMethods(JsonObject objectJson, Map<String, JsonObject> jsonElementMap) {
         List<UMLMethod> umlMethodList = new ArrayList<>();
         for (JsonElement methodId : objectJson.getAsJsonArray(ELEMENT_METHODS)) {

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/parsers/v3/ObjectDiagramParser.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/parsers/v3/ObjectDiagramParser.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.service.compass.utils.JSONMapping.*;
 import java.io.IOException;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -46,7 +46,7 @@ public class ObjectDiagramParser {
      * @param modelElements a JSON object containing all the model elements of the corresponding UML object diagram as JSON objects
      * @return the UMLObject map parsed from the JSON array
      */
-    @NotNull
+    @Nonnull
     public static Map<String, UMLObject> parseUMLObjects(JsonObject modelElements) {
         Map<String, UMLObject> umlObjectMap = new HashMap<>();
         // loop over all JSON elements and create the UML objects
@@ -107,7 +107,7 @@ public class ObjectDiagramParser {
      * @param jsonElementMap a map containing all the model elements and their ids of the corresponding UML object diagram as JSON objects
      * @return the list of UMLObjectAttribute parsed from the JSON object map
      */
-    @NotNull
+    @Nonnull
     protected static List<UMLObjectAttribute> parseUmlAttributes(JsonObject objectJson, Map<String, JsonObject> jsonElementMap) {
         List<UMLObjectAttribute> umlAttributesList = new ArrayList<>();
         for (JsonElement attributeId : objectJson.getAsJsonArray(ELEMENT_ATTRIBUTES)) {
@@ -124,7 +124,7 @@ public class ObjectDiagramParser {
      * @param jsonElementMap a map containing all the model elements and their ids of the corresponding UML object diagram as JSON objects
      * @return the list of UMLObjectMethod parsed from the JSON object map
      */
-    @NotNull
+    @Nonnull
     protected static List<UMLObjectMethod> parseUmlMethods(JsonObject objectJson, Map<String, JsonObject> jsonElementMap) {
         List<UMLObjectMethod> umlMethodList = new ArrayList<>();
         for (JsonElement methodId : objectJson.getAsJsonArray(ELEMENT_METHODS)) {

--- a/src/main/java/de/tum/in/www1/artemis/service/competency/CompetencyProgressService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/competency/CompetencyProgressService.java
@@ -6,7 +6,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +74,7 @@ public class CompetencyProgressService {
      * @param participant    The participant (user or team) for which to update the progress
      */
     @Async
-    public void updateProgressByLearningObjectAsync(LearningObject learningObject, @NotNull Participant participant) {
+    public void updateProgressByLearningObjectAsync(LearningObject learningObject, @Nonnull Participant participant) {
         SecurityUtils.setAuthorizationObject(); // required for async
         updateProgressByLearningObject(learningObject, participant.getParticipants());
     }
@@ -118,7 +118,7 @@ public class CompetencyProgressService {
      * @param learningObject The learning object for which to fetch the competencies
      * @param users          A list of users for which to update the progress
      */
-    public void updateProgressByLearningObject(LearningObject learningObject, @NotNull Set<User> users) {
+    public void updateProgressByLearningObject(LearningObject learningObject, @Nonnull Set<User> users) {
         log.debug("Updating competency progress for {} users.", users.size());
         try {
             Set<Competency> competencies;
@@ -215,7 +215,7 @@ public class CompetencyProgressService {
      * @param user            The user for which the progress should be calculated
      * @return The percentage of completed learning objects by the user
      */
-    private double calculateProgress(@NotNull Set<LearningObject> learningObjects, @NotNull User user) {
+    private double calculateProgress(@Nonnull Set<LearningObject> learningObjects, @Nonnull User user) {
         return learningObjects.stream().map(learningObject -> learningObjectService.isCompletedByUser(learningObject, user)).mapToInt(completed -> completed ? 100 : 0).average()
                 .orElse(0.);
     }
@@ -227,7 +227,7 @@ public class CompetencyProgressService {
      * @param user      The user for which the confidence score should be calculated
      * @return The average score of the user in all exercises linked to the competency
      */
-    private double calculateConfidence(@NotNull Set<Exercise> exercises, @NotNull User user) {
+    private double calculateConfidence(@Nonnull Set<Exercise> exercises, @Nonnull User user) {
         return participantScoreService.getStudentAndTeamParticipationScoresAsDoubleStream(user, exercises).summaryStatistics().getAverage();
     }
 
@@ -237,7 +237,7 @@ public class CompetencyProgressService {
      * @param competencyProgress The user's progress
      * @return The mastery level
      */
-    public static double getMastery(@NotNull CompetencyProgress competencyProgress) {
+    public static double getMastery(@Nonnull CompetencyProgress competencyProgress) {
         // mastery as a weighted function of progress and confidence (consistent with client)
         final double weight = 2.0 / 3.0;
         return (1 - weight) * competencyProgress.getProgress() + weight * competencyProgress.getConfidence();
@@ -249,7 +249,7 @@ public class CompetencyProgressService {
      * @param competencyProgress The user's progress
      * @return The mastery level in percent
      */
-    public static double getMasteryProgress(@NotNull CompetencyProgress competencyProgress) {
+    public static double getMasteryProgress(@Nonnull CompetencyProgress competencyProgress) {
         final double mastery = getMastery(competencyProgress);
         return mastery / competencyProgress.getCompetency().getMasteryThreshold();
     }
@@ -260,7 +260,7 @@ public class CompetencyProgressService {
      * @param competencyProgress The user's progress
      * @return True if the user mastered the competency, false otherwise
      */
-    public static boolean isMastered(@NotNull CompetencyProgress competencyProgress) {
+    public static boolean isMastered(@Nonnull CompetencyProgress competencyProgress) {
         final double mastery = getMastery(competencyProgress);
         return mastery >= competencyProgress.getCompetency().getMasteryThreshold();
     }
@@ -271,7 +271,7 @@ public class CompetencyProgressService {
      * @param competency the competency to check
      * @return true if the competency can be mastered without completing any exercises, false otherwise
      */
-    public static boolean canBeMasteredWithoutExercises(@NotNull Competency competency) {
+    public static boolean canBeMasteredWithoutExercises(@Nonnull Competency competency) {
         final var lectureUnits = competency.getLectureUnits().size();
         final var numberOfLearningObjects = lectureUnits + competency.getExercises().size();
         final var achievableMasteryScore = ((double) lectureUnits) / (3 * numberOfLearningObjects) * 100;
@@ -294,7 +294,7 @@ public class CompetencyProgressService {
      * @param course     The course for which to get the progress
      * @return The progress for the course
      */
-    public CourseCompetencyProgressDTO getCompetencyCourseProgress(@NotNull Competency competency, @NotNull Course course) {
+    public CourseCompetencyProgressDTO getCompetencyCourseProgress(@Nonnull Competency competency, @Nonnull Course course) {
         var numberOfStudents = competencyProgressRepository.countByCompetency(competency.getId());
         var numberOfMasteredStudents = competencyProgressRepository.countByCompetencyAndProgressAndConfidenceGreaterThanEqual(competency.getId(), 100.0,
                 (double) competency.getMasteryThreshold());

--- a/src/main/java/de/tum/in/www1/artemis/service/competency/CompetencyService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/competency/CompetencyService.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +76,7 @@ public class CompetencyService {
      * @param course The course for which the prerequisites should be retrieved.
      * @return A list of prerequisites.
      */
-    public Set<Competency> findAllPrerequisitesForCourse(@NotNull Course course) {
+    public Set<Competency> findAllPrerequisitesForCourse(@Nonnull Course course) {
         Set<Competency> prerequisites = competencyRepository.findPrerequisitesByCourseId(course.getId());
         // Remove all lecture units
         for (Competency prerequisite : prerequisites) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -32,9 +32,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
-import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.HiddenFileFilter;
@@ -649,7 +649,7 @@ public class GitService {
      * @param remoteRepositoryUri the remote repository uri for the git repository, will be added to the Repository object for later use, can be null
      * @return the git repository in the localPath or **null** if it does not exist on the server.
      */
-    public Repository getExistingCheckedOutRepositoryByLocalPath(@NotNull Path localPath, @Nullable VcsRepositoryUri remoteRepositoryUri) {
+    public Repository getExistingCheckedOutRepositoryByLocalPath(@Nonnull Path localPath, @Nullable VcsRepositoryUri remoteRepositoryUri) {
         return getExistingCheckedOutRepositoryByLocalPath(localPath, remoteRepositoryUri, defaultBranch);
     }
 
@@ -662,7 +662,7 @@ public class GitService {
      * @param defaultBranch       the name of the branch that should be used as default branch
      * @return the git repository in the localPath or **null** if it does not exist on the server.
      */
-    public Repository getExistingCheckedOutRepositoryByLocalPath(@NotNull Path localPath, @Nullable VcsRepositoryUri remoteRepositoryUri, String defaultBranch) {
+    public Repository getExistingCheckedOutRepositoryByLocalPath(@Nonnull Path localPath, @Nullable VcsRepositoryUri remoteRepositoryUri, String defaultBranch) {
         try {
             // Check if there is a folder with the provided path of the git repository.
             if (!Files.exists(localPath)) {
@@ -709,7 +709,7 @@ public class GitService {
      * @return The created Repository.
      * @throws IOException if the configuration file cannot be accessed.
      */
-    @NotNull
+    @Nonnull
     private static Repository createRepository(Path localPath, VcsRepositoryUri remoteRepositoryUri, String defaultBranch, FileRepositoryBuilder builder) throws IOException {
         // Create the JGit repository object
         Repository repository = new Repository(builder, localPath, remoteRepositoryUri);
@@ -1210,7 +1210,7 @@ public class GitService {
      * @param repo Local Repository Object.
      * @return Collection of File objects
      */
-    @NotNull
+    @Nonnull
     public Collection<File> listFiles(Repository repo) {
         // Check if list of files is already cached
         if (repo.getFiles() == null) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaConnector.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaConnector.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.service.connectors.athena;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +49,7 @@ class AthenaConnector<RequestType, ResponseType> {
      * @return response body from Athena
      * @throws NetworkingException exception in case of unsuccessful responses or responses without a body.
      */
-    private ResponseType invoke(@NotNull String url, @NotNull RequestType requestObject) throws NetworkingException {
+    private ResponseType invoke(@Nonnull String url, @Nonnull RequestType requestObject) throws NetworkingException {
         long start = System.nanoTime();
         log.debug("Calling Athena.");
 
@@ -90,7 +90,7 @@ class AthenaConnector<RequestType, ResponseType> {
      * @return response body from Athena
      * @throws NetworkingException exception in case of unsuccessful responses or responses without a body.
      */
-    ResponseType invokeWithRetry(@NotNull String url, @NotNull RequestType requestObject, int maxRetries) throws NetworkingException {
+    ResponseType invokeWithRetry(@Nonnull String url, @Nonnull RequestType requestObject, int maxRetries) throws NetworkingException {
         for (int retries = 0;; retries++) {
             try {
                 return invoke(url, requestObject);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/AbstractGitLabAuthorizationInterceptor.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/AbstractGitLabAuthorizationInterceptor.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.service.connectors.gitlab;
 
 import java.io.IOException;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpRequest;
@@ -17,9 +17,9 @@ public abstract class AbstractGitLabAuthorizationInterceptor implements ClientHt
     @Value("${artemis.version-control.token}")
     private String gitlabPrivateToken;
 
-    @NotNull
+    @Nonnull
     @Override
-    public ClientHttpResponse intercept(HttpRequest request, @NotNull byte[] body, @NotNull ClientHttpRequestExecution execution) throws IOException {
+    public ClientHttpResponse intercept(HttpRequest request, @Nonnull byte[] body, @Nonnull ClientHttpRequestExecution execution) throws IOException {
         request.getHeaders().add(GITLAB_AUTHORIZATION_HEADER_NAME, gitlabPrivateToken);
         return execution.execute(request, body);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsAuthorizationInterceptor.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsAuthorizationInterceptor.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.service.connectors.jenkins;
 import java.io.IOException;
 import java.net.URL;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,9 +43,9 @@ public class JenkinsAuthorizationInterceptor implements ClientHttpRequestInterce
         this.restTemplate = restTemplate;
     }
 
-    @NotNull
+    @Nonnull
     @Override
-    public ClientHttpResponse intercept(HttpRequest request, @NotNull byte[] body, @NotNull ClientHttpRequestExecution execution) throws IOException {
+    public ClientHttpResponse intercept(HttpRequest request, @Nonnull byte[] body, @Nonnull ClientHttpRequestExecution execution) throws IOException {
         request.getHeaders().setBasicAuth(username, password);
         if (useCrumb) {
             setCrumb(request.getHeaders());

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCFetchFilter.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCFetchFilter.java
@@ -2,11 +2,11 @@ package de.tum.in.www1.artemis.service.connectors.localvc;
 
 import java.io.IOException;
 
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +31,7 @@ public class LocalVCFetchFilter extends OncePerRequestFilter {
     }
 
     @Override
-    public void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse, @NotNull FilterChain filterChain) throws IOException, ServletException {
+    public void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse, @Nonnull FilterChain filterChain) throws IOException, ServletException {
 
         log.debug("Trying to fetch repository {}", servletRequest.getRequestURI());
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCPushFilter.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCPushFilter.java
@@ -2,11 +2,11 @@ package de.tum.in.www1.artemis.service.connectors.localvc;
 
 import java.io.IOException;
 
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +34,7 @@ public class LocalVCPushFilter extends OncePerRequestFilter {
      * Filters incoming push requests performing authentication and authorization.
      */
     @Override
-    public void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse, @NotNull FilterChain filterChain) throws IOException, ServletException {
+    public void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse, @Nonnull FilterChain filterChain) throws IOException, ServletException {
 
         log.debug("Trying to push to repository {}", servletRequest.getRequestURI());
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCService.java
@@ -10,8 +10,8 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
@@ -290,7 +290,7 @@ public class LocalVCService extends AbstractVersionControlService {
     }
 
     @Override
-    @NotNull
+    @Nonnull
     public Commit getLastCommitDetails(Object requestBody) {
         // The local VCS will create a Commit object straight away and hand that to the processNewProgrammingSubmission method in
         // ProgrammingSubmissionService.

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/lti/Lti13Service.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/lti/Lti13Service.java
@@ -7,8 +7,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
@@ -136,7 +136,7 @@ public class Lti13Service {
      * @param onlineCourseConfiguration the configuration for the online course
      * @return the username for the LTI user
      */
-    @NotNull
+    @Nonnull
     public String createUsernameFromLaunchRequest(OidcIdToken ltiIdToken, OnlineCourseConfiguration onlineCourseConfiguration) {
         String username;
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/lti/LtiService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/lti/LtiService.java
@@ -6,8 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,7 +113,7 @@ public class LtiService {
         throw new InternalAuthenticationServiceException("Could not find existing user or create new LTI user."); // If user couldn't be authenticated, throw an error
     }
 
-    @NotNull
+    @Nonnull
     protected Authentication createNewUserFromLaunchRequest(String email, String username, String firstName, String lastName) {
         final var user = userRepository.findOneByLogin(username).orElseGet(() -> {
             final User newUser;

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/GradingCriterionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/GradingCriterionDTO.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.service.dto;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -18,7 +18,7 @@ public record GradingCriterionDTO(long id, String title, Set<GradingInstructionD
      * @param gradingCriterion GradingCriterion to convert
      * @return GradingCriterionDTO
      */
-    public static GradingCriterionDTO of(@NotNull GradingCriterion gradingCriterion) {
+    public static GradingCriterionDTO of(@Nonnull GradingCriterion gradingCriterion) {
         return new GradingCriterionDTO(gradingCriterion.getId(), gradingCriterion.getTitle(),
                 gradingCriterion.getStructuredGradingInstructions().stream().map(GradingInstructionDTO::of).collect(Collectors.toSet()));
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/GradingInstructionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/GradingInstructionDTO.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.service.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.domain.GradingInstruction;
 
@@ -12,7 +12,7 @@ public record GradingInstructionDTO(long id, double credits, String gradingScale
      * @param gradingInstruction GradingInstruction to convert
      * @return GradingInstructionDTO
      */
-    public static GradingInstructionDTO of(@NotNull GradingInstruction gradingInstruction) {
+    public static GradingInstructionDTO of(@Nonnull GradingInstruction gradingInstruction) {
         return new GradingInstructionDTO(gradingInstruction.getId(), gradingInstruction.getCredits(), gradingInstruction.getGradingScale(),
                 gradingInstruction.getInstructionDescription(), gradingInstruction.getFeedback(), gradingInstruction.getUsageCount());
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingExerciseDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingExerciseDTO.java
@@ -4,7 +4,7 @@ import static de.tum.in.www1.artemis.config.Constants.ATHENA_PROGRAMMING_EXERCIS
 
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.service.dto.GradingCriterionDTO;
@@ -18,7 +18,7 @@ public record ProgrammingExerciseDTO(long id, String title, double maxPoints, do
     /**
      * Create a new TextExerciseDTO from a TextExercise
      */
-    public static ProgrammingExerciseDTO of(@NotNull ProgrammingExercise exercise, String artemisServerUrl) {
+    public static ProgrammingExerciseDTO of(@Nonnull ProgrammingExercise exercise, String artemisServerUrl) {
         return new ProgrammingExerciseDTO(exercise.getId(), exercise.getTitle(), exercise.getMaxPoints(), exercise.getBonusPoints(), exercise.getGradingInstructions(),
                 exercise.getGradingCriteria().stream().map(GradingCriterionDTO::of).toList(), exercise.getProblemStatement(), exercise.getProgrammingLanguage().name(),
                 artemisServerUrl + ATHENA_PROGRAMMING_EXERCISE_REPOSITORY_API_PATH + exercise.getId() + "/repository/solution",

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingFeedbackDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingFeedbackDTO.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.service.dto.athena;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.domain.Feedback;
 
@@ -18,7 +18,7 @@ public record ProgrammingFeedbackDTO(long id, long exerciseId, long submissionId
      * @param feedback     the feedback object
      * @return the TextFeedbackDTO
      */
-    public static ProgrammingFeedbackDTO of(long exerciseId, long submissionId, @NotNull Feedback feedback) {
+    public static ProgrammingFeedbackDTO of(long exerciseId, long submissionId, @Nonnull Feedback feedback) {
         // Referenced feedback has a reference looking like this: "file:src/main/java/SomeFile.java_line:42"
         String filePath = null;
         Integer lineStart = null;

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingSubmissionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingSubmissionDTO.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.service.dto.athena;
 
 import static de.tum.in.www1.artemis.config.Constants.ATHENA_PROGRAMMING_EXERCISE_REPOSITORY_API_PATH;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
 
@@ -18,7 +18,7 @@ public record ProgrammingSubmissionDTO(long id, long exerciseId, String reposito
      * @param submission The submission to create the DTO from
      * @return The created DTO
      */
-    public static ProgrammingSubmissionDTO of(long exerciseId, @NotNull ProgrammingSubmission submission, String artemisServerUrl) {
+    public static ProgrammingSubmissionDTO of(long exerciseId, @Nonnull ProgrammingSubmission submission, String artemisServerUrl) {
         return new ProgrammingSubmissionDTO(submission.getId(), exerciseId,
                 artemisServerUrl + ATHENA_PROGRAMMING_EXERCISE_REPOSITORY_API_PATH + exerciseId + "/submissions/" + submission.getId() + "/repository");
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextExerciseDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextExerciseDTO.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.service.dto.athena;
 
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.service.dto.GradingCriterionDTO;
@@ -16,7 +16,7 @@ public record TextExerciseDTO(long id, String title, double maxPoints, double bo
     /**
      * Create a new TextExerciseDTO from a TextExercise
      */
-    public static TextExerciseDTO of(@NotNull TextExercise exercise) {
+    public static TextExerciseDTO of(@Nonnull TextExercise exercise) {
         return new TextExerciseDTO(exercise.getId(), exercise.getTitle(), exercise.getMaxPoints(), exercise.getBonusPoints(), exercise.getGradingInstructions(),
                 exercise.getGradingCriteria().stream().map(GradingCriterionDTO::of).toList(), exercise.getProblemStatement(), exercise.getExampleSolution());
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextFeedbackDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextFeedbackDTO.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.service.dto.athena;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.domain.Feedback;
 import de.tum.in.www1.artemis.domain.TextBlock;
@@ -20,7 +20,7 @@ public record TextFeedbackDTO(long id, long exerciseId, long submissionId, Strin
      * @param feedbackBlock the TextBlock that the feedback is on (must be passed because this record cannot fetch it for itself)
      * @return the TextFeedbackDTO
      */
-    public static TextFeedbackDTO of(long exerciseId, long submissionId, @NotNull Feedback feedback, TextBlock feedbackBlock) {
+    public static TextFeedbackDTO of(long exerciseId, long submissionId, @Nonnull Feedback feedback, TextBlock feedbackBlock) {
         Integer startIndex = feedbackBlock == null ? null : feedbackBlock.getStartIndex();
         Integer endIndex = feedbackBlock == null ? null : feedbackBlock.getEndIndex();
         Long gradingInstructionId = null;

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextSubmissionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextSubmissionDTO.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.service.dto.athena;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.domain.TextSubmission;
 
@@ -16,7 +16,7 @@ public record TextSubmissionDTO(long id, long exerciseId, String text, String la
      * @param submission The submission to create the DTO from
      * @return The created DTO
      */
-    public static TextSubmissionDTO of(long exerciseId, @NotNull TextSubmission submission) {
+    public static TextSubmissionDTO of(long exerciseId, @Nonnull TextSubmission submission) {
         String language = null;
         if (submission.getLanguage() != null) {
             language = submission.getLanguage().toString();

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamDateService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamDateService.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -117,7 +117,7 @@ public class ExamDateService {
      * @return the latest end date or the exam end date if no student exams are found. May return <code>null</code>, if the exam has no start/end date.
      * @throws EntityNotFoundException if no exam with the given examId can be found
      */
-    @NotNull
+    @Nonnull
     public ZonedDateTime getLatestIndividualExamEndDate(Long examId) {
         final var exam = examRepository.findByIdElseThrow(examId);
         return getLatestIndividualExamEndDate(exam);
@@ -131,7 +131,7 @@ public class ExamDateService {
      * @param exam the exam
      * @return the latest end date or the exam end date if no student exams are found. May return <code>null</code>, if the exam has no start/end date.
      */
-    @NotNull
+    @Nonnull
     public ZonedDateTime getLatestIndividualExamEndDate(Exam exam) {
         var maxWorkingTime = studentExamRepository.findMaxWorkingTimeByExamId(exam.getId());
         return maxWorkingTime.map(timeInSeconds -> exam.getStartDate().plusSeconds(timeInSeconds)).orElse(exam.getEndDate());

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamDeletionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamDeletionService.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,7 +99,7 @@ public class ExamDeletionService {
      *
      * @param examId the ID of the exam to be deleted
      */
-    public void delete(@NotNull long examId) {
+    public void delete(@Nonnull long examId) {
         User user = userRepository.getUser();
         Exam exam = examRepository.findOneWithEagerExercisesGroupsAndStudentExams(examId);
         log.info("User {} has requested to delete the exam {}", user.getLogin(), exam.getTitle());
@@ -151,7 +151,7 @@ public class ExamDeletionService {
      *
      * @param examId the ID of the exam to be reset
      */
-    public void reset(@NotNull Long examId) {
+    public void reset(@Nonnull Long examId) {
         User user = userRepository.getUser();
         Exam exam = examRepository.findOneWithEagerExercisesGroupsAndStudentExams(examId);
         log.info("User {} has requested to reset the exam {}", user.getLogin(), exam.getTitle());
@@ -178,7 +178,7 @@ public class ExamDeletionService {
      *
      * @param examId the ID of the exam where the student exams and participations should be deleted
      */
-    public void deleteStudentExamsAndExistingParticipationsForExam(@NotNull Long examId) {
+    public void deleteStudentExamsAndExistingParticipationsForExam(@Nonnull Long examId) {
         User user = userRepository.getUser();
         Exam exam = examRepository.findOneWithEagerExercisesGroupsAndStudentExams(examId);
         log.info("User {} has requested to delete existing student exams and participations for exam {}", user.getLogin(), exam.getTitle());

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamQuizService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamQuizService.java
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +68,7 @@ public class ExamQuizService {
      *
      * @param quizExerciseId the id of the QuizExercise that should be evaluated
      */
-    public void evaluateQuizAndUpdateStatistics(@NotNull Long quizExerciseId) {
+    public void evaluateQuizAndUpdateStatistics(@Nonnull Long quizExerciseId) {
         long start = System.nanoTime();
         log.info("Starting quiz evaluation for quiz {}", quizExerciseId);
         // We have to load the questions and statistics so that we can evaluate and update and we also need the participations and submissions that exist for this exercise so that
@@ -161,7 +161,7 @@ public class ExamQuizService {
      * @param quizExercise the id of the QuizExercise that should be evaluated
      * @return the newly generated results
      */
-    private Set<Result> evaluateSubmissions(@NotNull QuizExercise quizExercise) {
+    private Set<Result> evaluateSubmissions(@Nonnull QuizExercise quizExercise) {
         Set<Result> createdResults = new HashSet<>();
         List<StudentParticipation> studentParticipations = studentParticipationRepository.findAllWithEagerLegalSubmissionsAndEagerResultsByExerciseId(quizExercise.getId());
         submittedAnswerRepository.loadQuizSubmissionsSubmittedAnswers(studentParticipations);

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -22,8 +22,8 @@ import java.util.OptionalDouble;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.slf4j.Logger;
@@ -240,7 +240,7 @@ public class ExamService {
      *                        and questions for the quiz should be loaded
      * @return the exam with exercise groups
      */
-    @NotNull
+    @Nonnull
     public Exam findByIdWithExerciseGroupsAndExercisesElseThrow(Long examId, boolean withDetails) {
         log.debug("Request to get exam {} with exercise groups (with details: {})", examId, withDetails);
         if (!withDetails) {
@@ -343,7 +343,7 @@ public class ExamService {
      * @param participationsOfStudent StudentParticipation list for the given studentExam
      * @return Student Exam results with exam grade calculated if applicable
      */
-    @NotNull
+    @Nonnull
     public StudentExamWithGradeDTO calculateStudentResultWithGradeAndPoints(StudentExam studentExam, List<StudentParticipation> participationsOfStudent) {
         // load again from the database because the exam object of the student exam might not have all the properties we need
         var exam = examRepository.findByIdElseThrow(studentExam.getExam().getId());

--- a/src/main/java/de/tum/in/www1/artemis/service/export/DataExportQuizExerciseCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/export/DataExportQuizExerciseCreationService.java
@@ -9,7 +9,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
 import org.springframework.context.annotation.Profile;
@@ -139,7 +139,7 @@ public class DataExportQuizExerciseCreationService {
      * @param exportErrors          a list of errors that occurred during the export
      * @param archivalReportEntries a list of report entries to report failed/successful exports
      */
-    public void exportStudentSubmissionsForArchival(QuizExercise quizExercise, Path exerciseDir, @NotNull List<String> exportErrors,
+    public void exportStudentSubmissionsForArchival(QuizExercise quizExercise, Path exerciseDir, @Nonnull List<String> exportErrors,
             List<ArchivalReportEntry> archivalReportEntries) {
         var participations = studentParticipationRepository.findByExerciseIdWithEagerSubmissions(quizExercise.getId());
         int participationsWithoutSubmission = 0;

--- a/src/main/java/de/tum/in/www1/artemis/service/export/DataExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/export/DataExportService.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,7 +140,7 @@ public class DataExportService {
      * @param dataExport the data export for which the next request date should be calculated
      * @return the next date when the user can request a data export
      */
-    @NotNull
+    @Nonnull
     private ZonedDateTime retrieveNextRequestDate(DataExport dataExport) {
         return dataExport.getCreatedDate().atZone(ZoneId.systemDefault()).plusDays(DAYS_BETWEEN_DATA_EXPORTS);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/export/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/export/ProgrammingExerciseExportService.java
@@ -20,8 +20,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
@@ -524,7 +524,7 @@ public class ProgrammingExerciseExportService extends ExerciseWithSubmissionsExp
      * @param repositoryExportOptions the options that should be used for the export
      * @return a zip file containing all requested participations
      */
-    public File exportStudentRepositoriesToZipFile(long programmingExerciseId, @NotNull List<ProgrammingExerciseStudentParticipation> participations,
+    public File exportStudentRepositoriesToZipFile(long programmingExerciseId, @Nonnull List<ProgrammingExerciseStudentParticipation> participations,
             RepositoryExportOptionsDTO repositoryExportOptions) {
         ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId)
                 .orElseThrow();
@@ -553,7 +553,7 @@ public class ProgrammingExerciseExportService extends ExerciseWithSubmissionsExp
      * @param exportErrors            A list of errors that occurred during export (populated by this function)
      * @return List of zip file paths
      */
-    public List<Path> exportStudentRepositories(ProgrammingExercise programmingExercise, @NotNull List<ProgrammingExerciseStudentParticipation> participations,
+    public List<Path> exportStudentRepositories(ProgrammingExercise programmingExercise, @Nonnull List<ProgrammingExerciseStudentParticipation> participations,
             RepositoryExportOptionsDTO repositoryExportOptions, Path workingDir, Path outputDir, List<String> exportErrors) {
         var programmingExerciseId = programmingExercise.getId();
         if (repositoryExportOptions.isExportAllParticipants()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -285,7 +285,7 @@ public class ProgrammingExerciseGitDiffReportService {
      * @throws IOException     If an error occurs while accessing the file system
      * @throws GitAPIException If an error occurs while accessing the git repository
      */
-    @NotNull
+    @Nonnull
     private ProgrammingExerciseGitDiffReport parseFilesAndCreateReport(Repository repo1, Repository repo2) throws IOException, GitAPIException {
         var oldTreeParser = new FileTreeIterator(repo1);
         var newTreeParser = new FileTreeIterator(repo2);
@@ -309,7 +309,7 @@ public class ProgrammingExerciseGitDiffReportService {
      * @throws IOException     If an error occurs while accessing the file system
      * @throws GitAPIException If an error occurs while accessing the git repository
      */
-    @NotNull
+    @Nonnull
     private ProgrammingExerciseGitDiffReport createReport(Repository repo1, FileTreeIterator oldTreeParser, FileTreeIterator newTreeParser) throws IOException, GitAPIException {
         try (ByteArrayOutputStream diffOutputStream = new ByteArrayOutputStream(); Git git = Git.wrap(repo1)) {
             git.diff().setOldTree(oldTreeParser).setNewTree(newTreeParser).setOutputStream(diffOutputStream).call();

--- a/src/main/java/de/tum/in/www1/artemis/service/ldap/LdapUserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ldap/LdapUserService.java
@@ -7,8 +7,8 @@ import static org.springframework.ldap.query.LdapQueryBuilder.query;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +57,7 @@ public class LdapUserService {
      * @return the found Ldap user details or null if the user cannot be found
      */
     @Nullable
-    public LdapUserDto loadUserDetailsFromLdap(@NotNull String login) {
+    public LdapUserDto loadUserDetailsFromLdap(@Nonnull String login) {
         try {
             Optional<LdapUserDto> ldapUserOptional = findByUsername(login);
             if (ldapUserOptional.isPresent()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathNgxService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathNgxService.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.jgrapht.alg.util.UnionFind;
 import org.springframework.context.annotation.Profile;
@@ -47,7 +47,7 @@ public class LearningPathNgxService {
      * @return Ngx graph representation of the learning path
      * @see NgxLearningPathDTO
      */
-    public NgxLearningPathDTO generateNgxGraphRepresentation(@NotNull LearningPath learningPath) {
+    public NgxLearningPathDTO generateNgxGraphRepresentation(@Nonnull LearningPath learningPath) {
         Set<NgxLearningPathDTO.Node> nodes = new HashSet<>();
         Set<NgxLearningPathDTO.Edge> edges = new HashSet<>();
         learningPath.getCompetencies().forEach(competency -> generateNgxGraphRepresentationForCompetency(learningPath, competency, nodes, edges));
@@ -212,7 +212,7 @@ public class LearningPathNgxService {
      * @return Ngx path representation of the learning path
      * @see NgxLearningPathDTO
      */
-    public NgxLearningPathDTO generateNgxPathRepresentation(@NotNull LearningPath learningPath) {
+    public NgxLearningPathDTO generateNgxPathRepresentation(@Nonnull LearningPath learningPath) {
         Set<NgxLearningPathDTO.Node> nodes = new HashSet<>();
         Set<NgxLearningPathDTO.Edge> edges = new HashSet<>();
 

--- a/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathService.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +97,7 @@ public class LearningPathService {
      *
      * @param course course the learning paths are created for
      */
-    public void enableLearningPathsForCourse(@NotNull Course course) {
+    public void enableLearningPathsForCourse(@Nonnull Course course) {
         course.setLearningPathsEnabled(true);
         generateLearningPaths(course);
         courseRepository.save(course);
@@ -109,7 +109,7 @@ public class LearningPathService {
      *
      * @param course course the learning paths are created for
      */
-    public void generateLearningPaths(@NotNull Course course) {
+    public void generateLearningPaths(@Nonnull Course course) {
         var students = userRepository.getStudents(course);
         students.forEach(student -> generateLearningPathForUser(course, student));
         log.debug("Successfully created learning paths for all {} students in course (id={})", students.size(), course.getId());
@@ -122,7 +122,7 @@ public class LearningPathService {
      * @param user   student for which the learning path is generated
      * @return the learning path of the user
      */
-    public LearningPath generateLearningPathForUser(@NotNull Course course, @NotNull User user) {
+    public LearningPath generateLearningPathForUser(@Nonnull Course course, @Nonnull User user) {
         var existingLearningPath = learningPathRepository.findByCourseIdAndUserId(course.getId(), user.getId());
         // the learning path has not to be generated if it already exits
         if (existingLearningPath.isPresent()) {
@@ -145,7 +145,7 @@ public class LearningPathService {
      * @param courseId the id of the course the learning paths are linked to
      * @return A wrapper object containing a list of all found learning paths and the total number of pages
      */
-    public SearchResultPageDTO<LearningPathInformationDTO> getAllOfCourseOnPageWithSize(@NotNull SearchTermPageableSearchDTO<String> search, long courseId) {
+    public SearchResultPageDTO<LearningPathInformationDTO> getAllOfCourseOnPageWithSize(@Nonnull SearchTermPageableSearchDTO<String> search, long courseId) {
         final var pageable = PageUtil.createDefaultPageRequest(search, PageUtil.ColumnMapping.LEARNING_PATH);
         final var searchTerm = search.getSearchTerm();
         final Page<LearningPath> learningPathPage = learningPathRepository.findByLoginOrNameInCourse(searchTerm, courseId, pageable);
@@ -159,7 +159,7 @@ public class LearningPathService {
      * @param competency Competency that should be added to each learning path
      * @param courseId   course id that the learning paths belong to
      */
-    public void linkCompetencyToLearningPathsOfCourse(@NotNull Competency competency, long courseId) {
+    public void linkCompetencyToLearningPathsOfCourse(@Nonnull Competency competency, long courseId) {
         var course = courseRepository.findWithEagerLearningPathsAndCompetenciesByIdElseThrow(courseId);
         var learningPaths = course.getLearningPaths();
         learningPaths.forEach(learningPath -> learningPath.addCompetency(competency));
@@ -173,7 +173,7 @@ public class LearningPathService {
      * @param competencies The list of competencies that should be added
      * @param courseId     course id that the learning paths belong to
      */
-    public void linkCompetenciesToLearningPathsOfCourse(@NotNull List<Competency> competencies, long courseId) {
+    public void linkCompetenciesToLearningPathsOfCourse(@Nonnull List<Competency> competencies, long courseId) {
         if (competencies.isEmpty()) {
             return;
         }
@@ -190,7 +190,7 @@ public class LearningPathService {
      * @param competency Competency that should be removed from each learning path
      * @param courseId   course id that the learning paths belong to
      */
-    public void removeLinkedCompetencyFromLearningPathsOfCourse(@NotNull Competency competency, long courseId) {
+    public void removeLinkedCompetencyFromLearningPathsOfCourse(@Nonnull Competency competency, long courseId) {
         var course = courseRepository.findWithEagerLearningPathsAndCompetenciesByIdElseThrow(courseId);
         var learningPaths = course.getLearningPaths();
         learningPaths.forEach(learningPath -> learningPath.removeCompetency(competency));
@@ -214,7 +214,7 @@ public class LearningPathService {
      *
      * @param learningPath learning path that is updated
      */
-    private void updateLearningPathProgress(@NotNull LearningPath learningPath) {
+    private void updateLearningPathProgress(@Nonnull LearningPath learningPath) {
         final var userId = learningPath.getUser().getId();
         final var competencyIds = learningPath.getCompetencies().stream().map(Competency::getId).collect(Collectors.toSet());
         final var competencyProgresses = competencyProgressRepository.findAllByCompetencyIdsAndUserId(competencyIds, userId);
@@ -237,7 +237,7 @@ public class LearningPathService {
      * @param course the course for which the health status should be generated
      * @return dto containing the health status and additional information (missing learning paths) if needed
      */
-    public LearningPathHealthDTO getHealthStatusForCourse(@NotNull Course course) {
+    public LearningPathHealthDTO getHealthStatusForCourse(@Nonnull Course course) {
         if (!course.getLearningPathsEnabled()) {
             return new LearningPathHealthDTO(Set.of(LearningPathHealthDTO.HealthStatus.DISABLED));
         }
@@ -255,7 +255,7 @@ public class LearningPathService {
         return new LearningPathHealthDTO(status, numberOfMissingLearningPaths);
     }
 
-    private Long checkMissingLearningPaths(@NotNull Course course, @NotNull Set<LearningPathHealthDTO.HealthStatus> status) {
+    private Long checkMissingLearningPaths(@Nonnull Course course, @Nonnull Set<LearningPathHealthDTO.HealthStatus> status) {
         long numberOfStudents = userRepository.countUserInGroup(course.getStudentGroupName());
         long numberOfLearningPaths = learningPathRepository.countLearningPathsOfEnrolledStudentsInCourse(course.getId());
         Long numberOfMissingLearningPaths = numberOfStudents - numberOfLearningPaths;
@@ -270,13 +270,13 @@ public class LearningPathService {
         return numberOfMissingLearningPaths;
     }
 
-    private void checkNoCompetencies(@NotNull Course course, @NotNull Set<LearningPathHealthDTO.HealthStatus> status) {
+    private void checkNoCompetencies(@Nonnull Course course, @Nonnull Set<LearningPathHealthDTO.HealthStatus> status) {
         if (competencyRepository.countByCourse(course) == 0) {
             status.add(LearningPathHealthDTO.HealthStatus.NO_COMPETENCIES);
         }
     }
 
-    private void checkNoRelations(@NotNull Course course, @NotNull Set<LearningPathHealthDTO.HealthStatus> status) {
+    private void checkNoRelations(@Nonnull Course course, @Nonnull Set<LearningPathHealthDTO.HealthStatus> status) {
         if (competencyRelationRepository.countByCourseId(course.getId()) == 0) {
             status.add(LearningPathHealthDTO.HealthStatus.NO_RELATIONS);
         }
@@ -289,7 +289,7 @@ public class LearningPathService {
      * @return Ngx graph representation of the learning path
      * @see NgxLearningPathDTO
      */
-    public NgxLearningPathDTO generateNgxGraphRepresentation(@NotNull LearningPath learningPath) {
+    public NgxLearningPathDTO generateNgxGraphRepresentation(@Nonnull LearningPath learningPath) {
         return this.learningPathNgxService.generateNgxGraphRepresentation(learningPath);
     }
 
@@ -300,7 +300,7 @@ public class LearningPathService {
      * @return Ngx path representation of the learning path
      * @see NgxLearningPathDTO
      */
-    public NgxLearningPathDTO generateNgxPathRepresentation(@NotNull LearningPath learningPath) {
+    public NgxLearningPathDTO generateNgxPathRepresentation(@Nonnull LearningPath learningPath) {
         return this.learningPathNgxService.generateNgxPathRepresentation(learningPath);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostingService.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.CourseInformationSharingConfiguration;
@@ -222,7 +222,7 @@ public abstract class PostingService {
      * @param postingContent content of the posting
      * @return set of mentioned users
      */
-    protected Set<User> parseUserMentions(@NotNull Course course, String postingContent) {
+    protected Set<User> parseUserMentions(@Nonnull Course course, String postingContent) {
         // Define a regular expression to match text enclosed in [user]...[/user] tags, along with login inside parentheses () within those tags.
         // It makes use of the possessive quantifier "*+" to avoid backtracking and increase performance.
         // Explanation:

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ChannelService.java
@@ -5,9 +5,9 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -357,7 +357,7 @@ public class ChannelService {
      * @param backupTitle         used as a basis for the resulting channel name if the provided channel name is empty
      * @return a default channel with the given name
      */
-    private static Channel createDefaultChannel(Optional<String> channelNameOptional, @NotNull String prefix, String backupTitle) {
+    private static Channel createDefaultChannel(Optional<String> channelNameOptional, @Nonnull String prefix, String backupTitle) {
         String channelName = channelNameOptional.filter(s -> !s.isEmpty()).orElse(generateChannelNameFromTitle(prefix, Optional.ofNullable(backupTitle)));
         Channel defaultChannel = new Channel();
         defaultChannel.setName(channelName);
@@ -387,7 +387,7 @@ public class ChannelService {
      * @param title  title of the lecture/exercise/exam to derive the channel name from
      * @return the generated channel name
      */
-    private static String generateChannelNameFromTitle(@NotNull String prefix, Optional<String> title) {
+    private static String generateChannelNameFromTitle(@Nonnull String prefix, Optional<String> title) {
         String channelName = prefix + title.orElse("");
         // [^a-z0-9]+ matches all occurrences of single or consecutive characters that are no digits and letters
         String specialCharacters = "[^a-z0-9]+";

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationDTOService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationDTOService.java
@@ -6,8 +6,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.Persistence;
-import jakarta.validation.constraints.NotNull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -116,7 +116,7 @@ public class ConversationDTOService {
      * @param channel        the channel to create the DTO from
      * @return the created ChannelDTO
      */
-    @NotNull
+    @Nonnull
     public ChannelDTO convertChannelToDTO(User requestingUser, Channel channel) {
         var channelDTO = new ChannelDTO(channel);
         channelDTO.setIsChannelModerator(channelAuthorizationService.isChannelModerator(channel.getId(), requestingUser.getId()));
@@ -143,7 +143,7 @@ public class ConversationDTOService {
      * @param channelSummary additional data about the channel
      * @return the created ChannelDTO
      */
-    @NotNull
+    @Nonnull
     private ChannelDTO convertChannelToDTO(User requestingUser, Channel channel, ConversationSummary channelSummary) {
         var channelDTO = new ChannelDTO(channel);
         this.fillGeneralConversationDtoFields(channelDTO, requestingUser, channelSummary);
@@ -171,7 +171,7 @@ public class ConversationDTOService {
      * @param oneToOneChat   the one to one chat to create the DTO from
      * @return the created OneToOneChatDTO
      */
-    @NotNull
+    @Nonnull
     public OneToOneChatDTO convertOneToOneChatToDto(User requestingUser, OneToOneChat oneToOneChat) {
         var course = oneToOneChat.getCourse();
         Set<ConversationParticipant> conversationParticipants = getConversationParticipants(oneToOneChat);
@@ -194,7 +194,7 @@ public class ConversationDTOService {
      * @param oneToOneChatSummary additional data about the oneToOneChat
      * @return the created OneToOneChatDTO
      */
-    @NotNull
+    @Nonnull
     private OneToOneChatDTO convertOneToOneChatToDto(User requestingUser, OneToOneChat oneToOneChat, ConversationSummary oneToOneChatSummary) {
         var oneToOneChatDTO = new OneToOneChatDTO(oneToOneChat);
         this.fillGeneralConversationDtoFields(oneToOneChatDTO, requestingUser, oneToOneChatSummary);
@@ -212,7 +212,7 @@ public class ConversationDTOService {
      * @param groupChat      the group chat to create the DTO from
      * @return the created GroupChatDTO
      */
-    @NotNull
+    @Nonnull
     public GroupChatDTO convertGroupChatToDto(User requestingUser, GroupChat groupChat) {
         var course = groupChat.getCourse();
         Set<ConversationParticipant> conversationParticipants = getConversationParticipants(groupChat);
@@ -235,7 +235,7 @@ public class ConversationDTOService {
      * @param groupChatSummary additional data about the groupChat
      * @return the created GroupChatDTO
      */
-    @NotNull
+    @Nonnull
     private GroupChatDTO convertGroupChatToDto(User requestingUser, GroupChat groupChat, ConversationSummary groupChatSummary) {
         var groupChatDTO = new GroupChatDTO(groupChat);
         this.fillGeneralConversationDtoFields(groupChatDTO, requestingUser, groupChatSummary);
@@ -246,7 +246,7 @@ public class ConversationDTOService {
         return groupChatDTO;
     }
 
-    @NotNull
+    @Nonnull
     private Set<ConversationParticipant> getConversationParticipants(Conversation conversation) {
         Set<ConversationParticipant> conversationParticipants;
         var participantsInitialized = Persistence.getPersistenceUtil().isLoaded(conversation, "conversationParticipants") && conversation.getConversationParticipants() != null
@@ -260,7 +260,7 @@ public class ConversationDTOService {
         return conversationParticipants;
     }
 
-    @NotNull
+    @Nonnull
     private Set<ConversationUserDTO> getChatParticipantDTOs(User requestingUser, Course course, Set<ConversationParticipant> conversationParticipants) {
         return conversationParticipants.stream().map(ConversationParticipant::getUser).map(user -> {
             var userDTO = new ConversationUserDTO(user);

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -8,7 +8,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
@@ -329,7 +329,7 @@ public class ConversationService {
         recipients.forEach(user -> sendToConversationMembershipChannel(metisCrudAction, conversation, user, conversationParticipantTopicName));
     }
 
-    @NotNull
+    @Nonnull
     public static String getConversationParticipantTopicName(Long courseId) {
         return METIS_WEBSOCKET_CHANNEL_PREFIX + "courses/" + courseId + "/conversations/user/";
     }
@@ -500,7 +500,7 @@ public class ConversationService {
      * @param channel the channel under consideration
      * @return true if the channel is visible to students
      */
-    public boolean isChannelVisibleToStudents(@NotNull Channel channel) {
+    public boolean isChannelVisibleToStudents(@Nonnull Channel channel) {
         if (channel.getLecture() != null) {
             return channel.getLecture().isVisibleToStudents();
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/auth/ChannelAuthorizationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/auth/ChannelAuthorizationService.java
@@ -7,8 +7,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -42,7 +42,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param course the course the channel should be created in
      * @param user   the user that wants to create the channel
      */
-    public void isAllowedToCreateChannel(@NotNull Course course, @NotNull User user) {
+    public void isAllowedToCreateChannel(@Nonnull Course course, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, userToCheck);
     }
@@ -53,7 +53,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param channel the channel the message should be created
      * @param user    the user that wants to create the message
      */
-    public void isAllowedToCreateNewAnswerPostInChannel(@NotNull Channel channel, @NotNull User user) {
+    public void isAllowedToCreateNewAnswerPostInChannel(@Nonnull Channel channel, @Nonnull User user) {
         var isArchivedChannel = channel.getIsArchived() != null && channel.getIsArchived();
         var userToCheck = getUserIfNecessary(user);
         if (isArchivedChannel) {
@@ -71,7 +71,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param channel the channel the answer message should be created
      * @param user    the user that wants to create answer the message
      */
-    public void isAllowedToCreateNewPostInChannel(@NotNull Channel channel, @NotNull User user) {
+    public void isAllowedToCreateNewPostInChannel(@Nonnull Channel channel, @Nonnull User user) {
         var isAnnouncementChannel = channel.getIsAnnouncementChannel() != null && channel.getIsAnnouncementChannel();
         var isArchivedChannel = channel.getIsArchived() != null && channel.getIsArchived();
         if (isArchivedChannel) {
@@ -91,7 +91,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param channel the channel that should be edited
      * @param user    the user that wants to edit the channel
      */
-    public void isAllowedToUpdateChannel(@NotNull Channel channel, @NotNull User user) {
+    public void isAllowedToUpdateChannel(@Nonnull Channel channel, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         if (!hasChannelModerationRights(channel.getId(), userToCheck)) {
             throw new AccessForbiddenException("You are not allowed to update this channel");
@@ -105,7 +105,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param user    the user that wants to edit or delete messages
      * @return true if the user is allowed to edit or delete messages in the channel, false otherwise
      */
-    public boolean isAllowedToEditOrDeleteMessagesOfOtherUsers(@NotNull Channel channel, @NotNull User user) {
+    public boolean isAllowedToEditOrDeleteMessagesOfOtherUsers(@Nonnull Channel channel, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         return hasChannelModerationRights(channel.getId(), userToCheck);
     }
@@ -116,7 +116,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param channel the channel that should be deleted
      * @param user    the user that wants to delete the channel
      */
-    public void isAllowedToDeleteChannel(@NotNull Channel channel, @NotNull User user) {
+    public void isAllowedToDeleteChannel(@Nonnull Channel channel, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         // either instructor or moderator who is also the creator
         var channelFromDb = channelRepository.findById(channel.getId()).orElseThrow();
@@ -178,7 +178,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param user      the user to check
      * @return true if the user has moderation rights, false otherwise
      */
-    public boolean hasChannelModerationRights(@NotNull Long channelId, @NotNull User user) {
+    public boolean hasChannelModerationRights(@Nonnull Long channelId, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         var channel = channelRepository.findById(channelId);
         return isChannelModerator(channelId, userToCheck.getId()) || authorizationCheckService.isAtLeastInstructorInCourse(channel.orElseThrow().getCourse(), userToCheck);
@@ -194,7 +194,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param participant optional participant for the user
      * @return true if the user has moderation rights, false otherwise
      */
-    public boolean hasChannelModerationRights(@NotNull Channel channel, @NotNull User user, Optional<ConversationParticipantSettingsView> participant) {
+    public boolean hasChannelModerationRights(@Nonnull Channel channel, @Nonnull User user, Optional<ConversationParticipantSettingsView> participant) {
         return participant.map(ConversationParticipantSettingsView::isModerator).orElse(false) || authorizationCheckService.isAtLeastInstructorInCourse(channel.getCourse(), user);
     }
 
@@ -205,7 +205,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param userLogins the logins of the users that should be registered
      * @param user       the user that wants to register the users
      */
-    public void isAllowedToRegisterUsersToChannel(@NotNull Channel channel, @Nullable List<String> userLogins, @NotNull User user) {
+    public void isAllowedToRegisterUsersToChannel(@Nonnull Channel channel, @Nullable List<String> userLogins, @Nonnull User user) {
         var userLoginsToCheck = Objects.requireNonNullElse(userLogins, new ArrayList<>());
         var userToCheck = getUserIfNecessary(user);
         var isJoinRequest = userLoginsToCheck.size() == 1 && userLoginsToCheck.get(0).equals(userToCheck.getLogin());
@@ -232,7 +232,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param channel the channel
      * @param user    the user that wants to grant the channel moderator role
      */
-    public void isAllowedToGrantChannelModeratorRole(@NotNull Channel channel, @NotNull User user) {
+    public void isAllowedToGrantChannelModeratorRole(@Nonnull Channel channel, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         if (!hasChannelModerationRights(channel.getId(), userToCheck)) {
             throw new AccessForbiddenException("You are not allowed to grant channel moderator role");
@@ -245,7 +245,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param channel the channel the rights should be revoked from
      * @param user    the user that wants to revoke the channel moderator role
      */
-    public void isAllowedToRevokeChannelModeratorRole(@NotNull Channel channel, @NotNull User user) {
+    public void isAllowedToRevokeChannelModeratorRole(@Nonnull Channel channel, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         if (!hasChannelModerationRights(channel.getId(), userToCheck)) {
             throw new AccessForbiddenException("You are not allowed to revoke the channel moderator role");
@@ -259,7 +259,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param userLogins the logins of the users that should be removed
      * @param user       the user that wants to remove the users
      */
-    public void isAllowedToDeregisterUsersFromChannel(@NotNull Channel channel, @Nullable List<String> userLogins, @NotNull User user) {
+    public void isAllowedToDeregisterUsersFromChannel(@Nonnull Channel channel, @Nullable List<String> userLogins, @Nonnull User user) {
         var userLoginsToCheck = Objects.requireNonNullElse(userLogins, new ArrayList<>());
         var userToCheck = getUserIfNecessary(user);
         if (hasChannelModerationRights(channel.getId(), userToCheck)) {
@@ -281,7 +281,7 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param channel the channel that should be archived
      * @param user    the user that wants to archive the channel
      */
-    public void isAllowedToArchiveChannel(@NotNull Channel channel, @NotNull User user) {
+    public void isAllowedToArchiveChannel(@Nonnull Channel channel, @Nonnull User user) {
         isAllowedToChangeArchivalStatus(channel, user);
     }
 
@@ -291,11 +291,11 @@ public class ChannelAuthorizationService extends ConversationAuthorizationServic
      * @param channel the channel that should be unarchived
      * @param user    the user that wants to unarchive the channel
      */
-    public void isAllowedToUnArchiveChannel(@NotNull Channel channel, @NotNull User user) {
+    public void isAllowedToUnArchiveChannel(@Nonnull Channel channel, @Nonnull User user) {
         isAllowedToChangeArchivalStatus(channel, user);
     }
 
-    private void isAllowedToChangeArchivalStatus(@NotNull Channel channel, @NotNull User user) {
+    private void isAllowedToChangeArchivalStatus(@Nonnull Channel channel, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         if (!hasChannelModerationRights(channel.getId(), userToCheck)) {
             throw new AccessForbiddenException("You are not allowed to archive/unarchive this channel");

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/auth/GroupChatAuthorizationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/auth/GroupChatAuthorizationService.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.service.metis.conversation.auth;
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import static de.tum.in.www1.artemis.domain.metis.conversation.ConversationSettings.MAX_GROUP_CHATS_PER_USER_PER_COURSE;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -47,7 +47,7 @@ public class GroupChatAuthorizationService extends ConversationAuthorizationServ
      * @param course the course the group chat should be created in
      * @param user   the user that wants to create the group chat
      */
-    public void isAllowedToCreateGroupChat(@NotNull Course course, @NotNull User user) {
+    public void isAllowedToCreateGroupChat(@Nonnull Course course, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         var createdGroupChats = groupChatRepository.countByCreatorIdAndCourseId(userToCheck.getId(), course.getId());
         if (createdGroupChats >= MAX_GROUP_CHATS_PER_USER_PER_COURSE) {
@@ -62,7 +62,7 @@ public class GroupChatAuthorizationService extends ConversationAuthorizationServ
      * @param groupChat the group chat the user should be added to
      * @param user      the user that wants to add the other user
      */
-    public void isAllowedToAddUsersToGroupChat(@NotNull GroupChat groupChat, @NotNull User user) {
+    public void isAllowedToAddUsersToGroupChat(@Nonnull GroupChat groupChat, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         if (!isMember(groupChat.getId(), userToCheck.getId())) {
             throw new AccessForbiddenException("You are not a member of this group chat");
@@ -75,7 +75,7 @@ public class GroupChatAuthorizationService extends ConversationAuthorizationServ
      * @param groupChat the group chat that should be edited
      * @param user      the user that wants to edit the group chatNotNull
      */
-    public void isAllowedToUpdateGroupChat(@NotNull GroupChat groupChat, @NotNull User user) {
+    public void isAllowedToUpdateGroupChat(@Nonnull GroupChat groupChat, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         if (!isMember(groupChat.getId(), userToCheck.getId())) {
             throw new AccessForbiddenException("You are not a member of this group chat");
@@ -88,7 +88,7 @@ public class GroupChatAuthorizationService extends ConversationAuthorizationServ
      * @param groupChat the group chat the user should be removed from
      * @param user      the user that wants to remove the other user
      */
-    public void isAllowedToRemoveUsersFromGroupChat(@NotNull GroupChat groupChat, @NotNull User user) {
+    public void isAllowedToRemoveUsersFromGroupChat(@Nonnull GroupChat groupChat, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         if (!isMember(groupChat.getId(), userToCheck.getId())) {
             throw new AccessForbiddenException("You are not a member of this group chat");

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/auth/OneToOneChatAuthorizationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/auth/OneToOneChatAuthorizationService.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.service.metis.conversation.auth;
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import static de.tum.in.www1.artemis.domain.metis.conversation.ConversationSettings.MAX_ONE_TO_ONE_CHATS_PER_USER_PER_COURSE;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -35,7 +35,7 @@ public class OneToOneChatAuthorizationService extends ConversationAuthorizationS
      * @param course the course the one to one chat should be created in
      * @param user   the user that wants to create the one to one chat
      */
-    public void isAllowedToCreateOneToOneChat(@NotNull Course course, @NotNull User user) {
+    public void isAllowedToCreateOneToOneChat(@Nonnull Course course, @Nonnull User user) {
         var userToCheck = getUserIfNecessary(user);
         var createdOneToOneChats = oneToOneChatRepository.countByCreatorIdAndCourseId(userToCheck.getId(), course.getId());
         if (createdOneToOneChats >= MAX_ONE_TO_ONE_CHATS_PER_USER_PER_COURSE) {

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/GeneralInstantNotificationService.java
@@ -6,7 +6,7 @@ import static de.tum.in.www1.artemis.service.notifications.NotificationSettingsC
 
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
@@ -111,7 +111,7 @@ public class GeneralInstantNotificationService implements InstantNotificationSer
      * @param channel      which channel to use (e.g. email or webapp or push)
      * @return filtered user list
      */
-    @NotNull
+    @Nonnull
     private Set<User> filterRecipients(Notification notification, Set<User> users, NotificationSettingsCommunicationChannel channel) {
         return notificationSettingsService.filterUsersByNotificationIsAllowedInCommunicationChannelBySettings(notification, users, channel);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/plagiarism/PlagiarismService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/plagiarism/PlagiarismService.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -184,7 +184,7 @@ public class PlagiarismService {
      * @param minimumScore the minimum score
      * @return a predicate that can be used in streams for filtering
      */
-    @NotNull
+    @Nonnull
     public static Predicate<ProgrammingExerciseParticipation> filterParticipationMinimumScore(int minimumScore) {
         return participation -> {
             Submission submission = participation.findLatestSubmission().orElse(null);
@@ -213,7 +213,7 @@ public class PlagiarismService {
      *
      * @return a predicate that can be used in streams for filtering
      */
-    @NotNull
+    @Nonnull
     public Predicate<StudentParticipation> filterForStudents() {
         return participation -> {
             // this filter excludes individual participations that are not from students

--- a/src/main/java/de/tum/in/www1/artemis/service/plagiarism/ProgrammingPlagiarismDetectionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/plagiarism/ProgrammingPlagiarismDetectionService.java
@@ -16,7 +16,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.slf4j.Logger;
@@ -181,7 +181,7 @@ public class ProgrammingPlagiarismDetectionService {
      * @param minimumScore        the minimum score
      * @return the JPlag result or null if there are not enough participations
      */
-    @NotNull
+    @Nonnull
     private JPlagResult computeJPlagResult(ProgrammingExercise programmingExercise, float similarityThreshold, int minimumScore, int minimumSize) {
         long programmingExerciseId = programmingExercise.getId();
         final var targetPath = fileService.getTemporaryUniqueSubfolderPath(repoDownloadClonePath, 60);

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/CommitHistoryService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/CommitHistoryService.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.DiffFormatter;
@@ -73,7 +73,7 @@ public class CommitHistoryService {
      * @return The report with the changes between the two commits
      * @throws IOException If an error occurs while accessing the file system
      */
-    @NotNull
+    @Nonnull
     private ProgrammingExerciseGitDiffReport createReport(Repository repository, RevCommit commitOld, RevCommit commitNew) throws IOException {
         StringBuilder diffs = new StringBuilder();
         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -17,8 +17,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.math3.util.Precision;
 import org.slf4j.Logger;
@@ -156,7 +156,7 @@ public class ProgrammingExerciseGradingService {
      * @return result after compilation (can only be null in case an error occurs)
      */
     @Nullable
-    public Result processNewProgrammingExerciseResult(@NotNull ProgrammingExerciseParticipation participation, @NotNull Object requestBody) {
+    public Result processNewProgrammingExerciseResult(@Nonnull ProgrammingExerciseParticipation participation, @Nonnull Object requestBody) {
         log.debug("Received new build result (NEW) for participation {}", participation.getId());
 
         try {
@@ -258,7 +258,7 @@ public class ProgrammingExerciseGradingService {
         }).max(Comparator.naturalOrder());
     }
 
-    @NotNull
+    @Nonnull
     protected ProgrammingSubmission createAndSaveFallbackSubmission(ProgrammingExerciseParticipation participation, AbstractBuildResultNotificationDTO buildResult) {
         final var commitHash = buildResult.getCommitHash(SubmissionType.MANUAL);
         if (ObjectUtils.isEmpty(commitHash)) {
@@ -626,7 +626,7 @@ public class ProgrammingExerciseGradingService {
      * @param applySubmissionPolicy true, if submission policies should be taken into account when updating the score.
      * @return The updated result
      */
-    private Result calculateScoreForResult(Set<ProgrammingExerciseTestCase> testCases, Set<ProgrammingExerciseTestCase> relevantTestCases, @NotNull Result result,
+    private Result calculateScoreForResult(Set<ProgrammingExerciseTestCase> testCases, Set<ProgrammingExerciseTestCase> relevantTestCases, @Nonnull Result result,
             ProgrammingExercise exercise, boolean applySubmissionPolicy) {
         List<Feedback> automaticFeedbacks = result.getFeedbacks().stream().filter(feedback -> FeedbackType.AUTOMATIC.equals(feedback.getType())).toList();
         List<Feedback> staticCodeAnalysisFeedback = new ArrayList<>();

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
@@ -8,7 +8,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -150,7 +150,7 @@ public class ProgrammingExerciseParticipationService {
      * @return the participation for the given exercise and user.
      * @throws EntityNotFoundException if there is no participation for the given exercise and user.
      */
-    @NotNull
+    @Nonnull
     public ProgrammingExerciseStudentParticipation findStudentParticipationByExerciseAndStudentLoginAndTestRunOrThrow(ProgrammingExercise exercise, String username,
             boolean isTestRun, boolean withSubmissions) {
 
@@ -178,7 +178,7 @@ public class ProgrammingExerciseParticipationService {
      * @return the participation for the given exercise and user.
      * @throws EntityNotFoundException if there is no participation for the given exercise and user.
      */
-    @NotNull
+    @Nonnull
     public ProgrammingExerciseStudentParticipation findStudentParticipationByExerciseAndStudentId(Exercise exercise, String username) throws EntityNotFoundException {
         Optional<ProgrammingExerciseStudentParticipation> participation;
         if (exercise.isTeamMode()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AthenaScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AthenaScheduleService.java
@@ -4,8 +4,8 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.ScheduledFuture;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.PostConstruct;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,7 +88,7 @@ public class AthenaScheduleService {
         log.debug("Scheduled Athena for Exercise '{}' (#{}) for {}.", exercise.getTitle(), exercise.getId(), exercise.getDueDate());
     }
 
-    @NotNull
+    @Nonnull
     private Runnable athenaRunnableForExercise(Exercise exercise) {
         return () -> {
             SecurityUtils.setAuthorizationObject();

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ModelingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ModelingExerciseScheduleService.java
@@ -6,8 +6,8 @@ import static java.time.Instant.now;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.PostConstruct;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,7 +168,7 @@ public class ModelingExerciseScheduleService implements IExerciseScheduleService
      * @param exercise The exercise for which the clusters will be created
      * @return a Runnable that will build clusters once it is executed
      */
-    @NotNull
+    @Nonnull
     private Runnable buildModelingClusters(ModelingExercise exercise) {
         Long modelingExerciseId = exercise.getId();
         return () -> {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ParticipantScoreScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ParticipantScoreScheduleService.java
@@ -8,9 +8,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.Hibernate;
 import org.slf4j.Logger;
@@ -189,7 +189,7 @@ public class ParticipantScoreScheduleService {
      * @param participantId       the id of the participant (user or team, determined by the exercise)
      * @param resultIdToBeDeleted the id of the result that is about to be deleted (or null, if result is created/updated)
      */
-    public void scheduleTask(@NotNull Long exerciseId, @NotNull Long participantId, Long resultIdToBeDeleted) {
+    public void scheduleTask(@Nonnull Long exerciseId, @Nonnull Long participantId, Long resultIdToBeDeleted) {
         if (!isRunning.get()) {
             log.debug("Cannot schedule task, because the service is not running");
             return;

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -17,8 +17,8 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.PostConstruct;
-import jakarta.validation.constraints.NotNull;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.slf4j.Logger;
@@ -430,7 +430,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
         log.debug("Scheduled Exam Programming Exercise '{}' (#{}).", exercise.getTitle(), exercise.getId());
     }
 
-    @NotNull
+    @Nonnull
     private Runnable combineTemplateCommitsForExercise(ProgrammingExercise exercise) {
         return () -> {
             SecurityUtils.setAuthorizationObject();
@@ -446,7 +446,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
         };
     }
 
-    @NotNull
+    @Nonnull
     private Runnable buildAndTestRunnableForExercise(ProgrammingExercise exercise) {
         return () -> {
             SecurityUtils.setAuthorizationObject();
@@ -470,7 +470,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise for which the repositories should be locked.
      * @return a Runnable that will lock the repositories once it is executed.
      */
-    @NotNull
+    @Nonnull
     public Runnable lockAllStudentRepositoriesAndParticipations(ProgrammingExercise exercise) {
         return lockStudentRepositoriesAndParticipations(exercise, participation -> true);
     }
@@ -486,7 +486,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise for which the repositories should be locked.
      * @return a Runnable that will lock the repositories once it is executed.
      */
-    @NotNull
+    @Nonnull
     public Runnable lockAllStudentRepositories(ProgrammingExercise exercise) {
         return lockStudentRepositories(exercise, participation -> true);
     }
@@ -500,7 +500,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise for which the repositories should be locked.
      * @return a Runnable that will lock the repositories and participations once it is executed.
      */
-    @NotNull
+    @Nonnull
     public Runnable lockAllStudentRepositoriesAndParticipationsWithEarlierDueDate(ProgrammingExercise exercise) {
         return lockStudentRepositoriesAndParticipations(exercise, exerciseDateService::isAfterDueDate);
     }
@@ -515,7 +515,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise for which the repositories should be locked.
      * @return a Runnable that will lock the participations once it is executed.
      */
-    @NotNull
+    @Nonnull
     public Runnable lockAllStudentParticipationsWithEarlierDueDate(ProgrammingExercise exercise) {
         return lockStudentParticipations(exercise, exerciseDateService::isAfterDueDate);
     }
@@ -530,7 +530,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise for which the repositories should be locked.
      * @return a Runnable that will lock the repositories once it is executed.
      */
-    @NotNull
+    @Nonnull
     public Runnable lockStudentRepositoriesAndParticipationsRegularDueDate(ProgrammingExercise exercise) {
         return lockStudentRepositoriesAndParticipations(exercise, participation -> participation.getIndividualDueDate() == null);
     }
@@ -551,7 +551,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise for which the results should be updated.
      * @return a Runnable that will update all results for the given exercise.
      */
-    @NotNull
+    @Nonnull
     public Runnable updateStudentScoresRegularDueDate(final ProgrammingExercise exercise) {
         return () -> {
             SecurityUtils.setAuthorizationObject();
@@ -569,7 +569,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param condition a condition that determines whether the operation will be executed for a specific participation
      * @return a Runnable that will lock the repositories once it is executed
      */
-    @NotNull
+    @Nonnull
     public Runnable lockStudentRepositoriesAndParticipations(ProgrammingExercise exercise, Predicate<ProgrammingExerciseStudentParticipation> condition) {
         Long programmingExerciseId = exercise.getId();
         return () -> {
@@ -593,7 +593,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param condition a condition that determines whether the operation will be executed for a specific participation
      * @return a Runnable that will lock the repositories once it is executed
      */
-    @NotNull
+    @Nonnull
     public Runnable lockStudentRepositories(ProgrammingExercise exercise, Predicate<ProgrammingExerciseStudentParticipation> condition) {
         Long programmingExerciseId = exercise.getId();
         return () -> {
@@ -617,7 +617,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param condition a condition that determines whether the operation will be executed for a specific participation
      * @return a Runnable that will lock the participations once it is executed
      */
-    @NotNull
+    @Nonnull
     public Runnable lockStudentParticipations(ProgrammingExercise exercise, Predicate<ProgrammingExerciseStudentParticipation> condition) {
         Long programmingExerciseId = exercise.getId();
         return () -> {
@@ -676,7 +676,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param participation of which the Git repository will be locked.
      * @return a runnable that will lock the Git repository of the participation when run.
      */
-    @NotNull
+    @Nonnull
     private Runnable lockStudentRepositoryAndParticipation(ProgrammingExerciseStudentParticipation participation) {
         return () -> {
             SecurityUtils.setAuthorizationObject();
@@ -699,7 +699,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param condition       a condition that determines whether the operation will be executed for a specific participation
      * @return a Runnable that will unlock the repositories once it is executed
      */
-    @NotNull
+    @Nonnull
     public Runnable runUnlockOperation(ProgrammingExercise exercise, Consumer<ProgrammingExerciseStudentParticipation> unlockOperation,
             Predicate<ProgrammingExerciseStudentParticipation> condition) {
         Long programmingExerciseId = exercise.getId();
@@ -753,7 +753,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise The exercise for which the repositories and participations should be unlocked
      * @return a Runnable that will unlock the repositories once it is executed
      */
-    @NotNull
+    @Nonnull
     public Runnable unlockAllStudentRepositoriesAndParticipations(ProgrammingExercise exercise) {
         return runUnlockOperation(exercise, programmingExerciseParticipationService::unlockStudentRepositoryAndParticipation, participation -> true);
     }
@@ -766,7 +766,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise The exercise for which the repositories should be unlocked
      * @return a Runnable that will unlock the repositories once it is executed
      */
-    @NotNull
+    @Nonnull
     public Runnable unlockAllStudentRepositories(ProgrammingExercise exercise) {
         return runUnlockOperation(exercise, programmingExerciseParticipationService::unlockStudentRepository, participation -> true);
     }
@@ -780,7 +780,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise The exercise for which the repositories should be unlocked
      * @return a Runnable that will unlock the repositories once it is executed
      */
-    @NotNull
+    @Nonnull
     public Runnable unlockAllStudentRepositoriesAndParticipationsWithEarlierStartDateAndLaterDueDate(ProgrammingExercise exercise) {
         return runUnlockOperation(exercise, programmingExerciseParticipationService::unlockStudentRepositoryAndParticipation,
                 participation -> participation.getProgrammingExercise().isReleased() && exerciseDateService.isBeforeDueDate(participation));
@@ -794,7 +794,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise The exercise for which the repositories should be unlocked
      * @return a Runnable that will unlock the repositories once it is executed
      */
-    @NotNull
+    @Nonnull
     public Runnable unlockAllStudentRepositoriesWithEarlierStartDateAndLaterDueDate(ProgrammingExercise exercise) {
         return runUnlockOperation(exercise, programmingExerciseParticipationService::unlockStudentRepository,
                 participation -> participation.getProgrammingExercise().isReleased() && exerciseDateService.isBeforeDueDate(participation));
@@ -808,7 +808,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @param exercise The exercise for which the participations should be unlocked
      * @return a Runnable that will unlock the participations once it is executed
      */
-    @NotNull
+    @Nonnull
     public Runnable unlockAllStudentParticipationsWithEarlierStartDateAndLaterDueDate(ProgrammingExercise exercise) {
         return runUnlockOperation(exercise, programmingExerciseParticipationService::unlockStudentParticipation,
                 participation -> participation.getProgrammingExercise().isReleased() && exerciseDateService.isBeforeDueDate(participation));

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/quiz/QuizScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/quiz/QuizScheduleService.java
@@ -10,9 +10,9 @@ import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
-import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.Hibernate;
 import org.hibernate.exception.ConstraintViolationException;
@@ -227,7 +227,7 @@ public class QuizScheduleService {
      *
      * @param quizExercise should include questions and statistics without Hibernate proxies!
      */
-    public void updateQuizExercise(@NotNull QuizExercise quizExercise) {
+    public void updateQuizExercise(@Nonnull QuizExercise quizExercise) {
         log.info("updateQuizExercise invoked for {}", quizExercise.getId());
         quizCache.updateQuizExercise(quizExercise);
     }
@@ -611,7 +611,7 @@ public class QuizScheduleService {
      * @param batchCache        a Map of all the batches for the given quizExercise
      * @return                  the number of processed submissions (submit or timeout)
      */
-    private int saveQuizSubmissionWithParticipationAndResultToDatabase(@NotNull QuizExercise quizExercise, Map<String, QuizSubmission> userSubmissionMap, Map<String, Long> userBatchMap, Map<Long, QuizBatch> batchCache) {
+    private int saveQuizSubmissionWithParticipationAndResultToDatabase(@Nonnull QuizExercise quizExercise, Map<String, QuizSubmission> userSubmissionMap, Map<String, Long> userBatchMap, Map<Long, QuizBatch> batchCache) {
 
         int count = 0;
 

--- a/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupScheduleService.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -76,7 +76,7 @@ public class TutorialGroupScheduleService {
         tutorialGroupSessionRepository.saveAll(individualSessions);
     }
 
-    @NotNull
+    @Nonnull
     private Set<TutorialGroupSession> findOverlappingExistingSessions(TutorialGroup tutorialGroup, List<TutorialGroupSession> individualSessions) {
         var overlappingIndividualSessions = new HashSet<TutorialGroupSession>();
         for (var individualSession : individualSessions) {
@@ -128,7 +128,7 @@ public class TutorialGroupScheduleService {
         return sessions;
     }
 
-    @NotNull
+    @Nonnull
     private TutorialGroupSession generateScheduledSession(Course course, TutorialGroupSchedule tutorialGroupSchedule, ZonedDateTime sessionStart, ZonedDateTime sessionEnd) {
         TutorialGroupSession session = new TutorialGroupSession();
         session.setStart(sessionStart);

--- a/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupService.java
@@ -9,8 +9,8 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -502,7 +502,7 @@ public class TutorialGroupService {
      * @param user   The user for whom to set the transient properties of the tutorial groups.
      * @return A list of tutorial groups for the given course with the transient properties set for the given user.
      */
-    public Set<TutorialGroup> findAllForCourse(@NotNull Course course, @NotNull User user) {
+    public Set<TutorialGroup> findAllForCourse(@Nonnull Course course, @Nonnull User user) {
         // do not load all sessions here as they are not needed for the overview page and would slow down the request
         Set<TutorialGroup> tutorialGroups = tutorialGroupRepository.findAllByCourseIdWithTeachingAssistantRegistrationsAndSchedule(course.getId());
         // TODO: this is some overkill, we calculate way too many information with way too many database calls, we must reduce this
@@ -524,7 +524,7 @@ public class TutorialGroupService {
      * @param course          The course for which the tutorial group should be retrieved.
      * @return The tutorial group of the course with the transient properties set for the given user.
      */
-    public TutorialGroup getOneOfCourse(@NotNull Course course, @NotNull User user, @NotNull Long tutorialGroupId) {
+    public TutorialGroup getOneOfCourse(@Nonnull Course course, @Nonnull User user, @Nonnull Long tutorialGroupId) {
         TutorialGroup tutorialGroup = tutorialGroupRepository.findByIdWithTeachingAssistantAndRegistrationsAndSessionsElseThrow(tutorialGroupId);
         if (!course.equals(tutorialGroup.getCourse())) {
             throw new BadRequestAlertException("The courseId in the path does not match the courseId in the tutorial group", "tutorialGroup", "courseIdMismatch");
@@ -543,7 +543,7 @@ public class TutorialGroupService {
      * @param user          the user for which to check permission
      * @return true if the user is allowed, false otherwise
      */
-    public boolean isAllowedToSeePrivateTutorialGroupInformation(@NotNull TutorialGroup tutorialGroup, @Nullable User user) {
+    public boolean isAllowedToSeePrivateTutorialGroupInformation(@Nonnull TutorialGroup tutorialGroup, @Nullable User user) {
         var userToCheck = user;
         var persistenceUtil = getPersistenceUtil();
         if (userToCheck == null || !persistenceUtil.isLoaded(userToCheck, "authorities") || !persistenceUtil.isLoaded(userToCheck, "groups") || userToCheck.getGroups() == null
@@ -576,7 +576,7 @@ public class TutorialGroupService {
      * @param tutorialGroup the tutorial group for which to check permission
      * @param user          the user for which to check permission
      */
-    public void isAllowedToChangeRegistrationsOfTutorialGroup(@NotNull TutorialGroup tutorialGroup, @Nullable User user) {
+    public void isAllowedToChangeRegistrationsOfTutorialGroup(@Nonnull TutorialGroup tutorialGroup, @Nullable User user) {
         // ToDo: Clarify if this is the correct permission check
         if (!this.isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
             throw new AccessForbiddenException("The user is not allowed to change the registrations of tutorial group: " + tutorialGroup.getId());
@@ -589,7 +589,7 @@ public class TutorialGroupService {
      * @param tutorialGroup the tutorial group for which to check permission
      * @param user          the user for which to check permission
      */
-    public void isAllowedToModifySessionsOfTutorialGroup(@NotNull TutorialGroup tutorialGroup, @Nullable User user) {
+    public void isAllowedToModifySessionsOfTutorialGroup(@Nonnull TutorialGroup tutorialGroup, @Nullable User user) {
         // ToDo: Clarify if this is the correct permission check
         if (!this.isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
             throw new AccessForbiddenException("The user is not allowed to modify the sessions of tutorial group: " + tutorialGroup.getId());

--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -247,8 +247,8 @@ public class UserCreationService {
      * @param updatedUserDTO The DTO containing the to be updated values
      * @return updated user
      */
-    @NotNull
-    public User updateUser(@NotNull User user, ManagedUserVM updatedUserDTO) {
+    @Nonnull
+    public User updateUser(@Nonnull User user, ManagedUserVM updatedUserDTO) {
         user.setLogin(updatedUserDTO.getLogin().toLowerCase());
         user.setFirstName(updatedUserDTO.getFirstName());
         user.setLastName(updatedUserDTO.getLastName());

--- a/src/main/java/de/tum/in/www1/artemis/service/util/CommonsMultipartFile.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/util/CommonsMultipartFile.java
@@ -7,7 +7,7 @@ import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
@@ -40,7 +40,7 @@ public class CommonsMultipartFile implements MultipartFile, Serializable {
     }
 
     @Override
-    public @NotNull String getName() {
+    public @Nonnull String getName() {
         return this.fileItem.getFieldName();
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/util/HttpRequestUtils.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/util/HttpRequestUtils.java
@@ -2,8 +2,8 @@ package de.tum.in.www1.artemis.service.util;
 
 import java.util.Optional;
 
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.constraints.NotNull;
 
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
@@ -19,7 +19,7 @@ public class HttpRequestUtils {
      * @param request Http Request
      * @return String representation of IP Address
      */
-    private static String getIpStringFromRequest(@NotNull HttpServletRequest request) {
+    private static String getIpStringFromRequest(@Nonnull HttpServletRequest request) {
         for (String header : IP_HEADER_CANDIDATES) {
             String ipList = request.getHeader(header);
             if (ipList != null && !ipList.isEmpty() && !"unknown".equalsIgnoreCase(ipList)) {
@@ -36,7 +36,7 @@ public class HttpRequestUtils {
      * @param request Http Request
      * @return IPAddress Object
      */
-    public static Optional<IPAddress> getIpAddressFromRequest(@NotNull HttpServletRequest request) {
+    public static Optional<IPAddress> getIpAddressFromRequest(@Nonnull HttpServletRequest request) {
         final String ipString = getIpStringFromRequest(request);
         final IPAddress ipAddress = new IPAddressString(ipString).getAddress();
         return Optional.ofNullable(ipAddress);

--- a/src/main/java/de/tum/in/www1/artemis/service/util/XmlFileUtils.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/util/XmlFileUtils.java
@@ -6,8 +6,8 @@ import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.util.Map;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -79,7 +79,7 @@ public class XmlFileUtils {
      * @return a document builder factor with secure settings for parsing xml files
      * @throws ParserConfigurationException config exception
      */
-    @NotNull
+    @Nonnull
     public static DocumentBuilderFactory getDocumentBuilderFactory() throws ParserConfigurationException {
         final var domFactory = DocumentBuilderFactory.newInstance();
         domFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CompetencyResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CompetencyResource.java
@@ -7,7 +7,7 @@ import java.net.URISyntaxException;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import jakarta.ws.rs.BadRequestException;
 
 import org.slf4j.Logger;
@@ -589,7 +589,7 @@ public class CompetencyResource {
      * @param course     The course for which to check the authorization role for
      * @param competency The competency to be accessed by the user
      */
-    private void checkAuthorizationForCompetency(Role role, @NotNull Course course, @NotNull Competency competency) {
+    private void checkAuthorizationForCompetency(Role role, @Nonnull Course course, @Nonnull Competency competency) {
         if (competency.getCourse() == null) {
             throw new BadRequestAlertException("A competency must belong to a course", ENTITY_NAME, "competencyNoCourse");
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1209,7 +1209,7 @@ public class CourseResource {
      * @param role              the role which should be added
      * @return empty ResponseEntity with status 200 (OK) or with status 404 (Not Found) or with status 403 (Forbidden)
      */
-    @NotNull
+    @Nonnull
     public ResponseEntity<Void> addUserToCourseGroup(String userLogin, User instructorOrAdmin, Course course, String group, Role role) {
         if (authCheckService.isAtLeastInstructorInCourse(course, instructorOrAdmin)) {
             Optional<User> userToAddToGroup = userRepository.findOneWithGroupsAndAuthoritiesByLogin(userLogin);
@@ -1298,7 +1298,7 @@ public class CourseResource {
      * @param group             the group from which the userLogin should be removed
      * @return empty ResponseEntity with status 200 (OK) or with status 404 (Not Found) or with status 403 (Forbidden)
      */
-    @NotNull
+    @Nonnull
     public ResponseEntity<Void> removeUserFromCourseGroup(String userLogin, User instructorOrAdmin, Course course, String group) {
         if (!authCheckService.isAtLeastInstructorInCourse(course, instructorOrAdmin)) {
             throw new AccessForbiddenException();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/DataExportResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/DataExportResource.java
@@ -8,7 +8,7 @@ import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -126,7 +126,7 @@ public class DataExportResource {
      * @param dataExport the data export that needs to be checked
      * @throws AccessForbiddenException if logged-in user isn't the owner of the data export
      */
-    private void currentlyLoggedInUserIsOwnerOfDataExportElseThrow(@NotNull DataExport dataExport) {
+    private void currentlyLoggedInUserIsOwnerOfDataExportElseThrow(@Nonnull DataExport dataExport) {
         if (!currentlyLoggedInUserIsOwnerOfDataExport(dataExport)) {
             throw new AccessForbiddenException("data export", dataExport.getId());
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import jakarta.ws.rs.BadRequestException;
 
 import org.slf4j.Logger;
@@ -891,7 +891,7 @@ public class ExamResource {
         return ResponseEntity.ok().body(studentExams);
     }
 
-    @NotNull
+    @Nonnull
     private Exam checkAccessForStudentExamGenerationAndLogAuditEvent(Long courseId, Long examId, String auditEventAction) {
         final Exam exam = examRepository.findByIdWithExamUsersExerciseGroupsAndExercisesElseThrow(examId);
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExampleSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExampleSubmissionResource.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,7 +137,7 @@ public class ExampleSubmissionResource {
         return ResponseEntity.ok(null);
     }
 
-    @NotNull
+    @Nonnull
     private ResponseEntity<ExampleSubmission> handleExampleSubmission(Long exerciseId, ExampleSubmission exampleSubmission) {
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, exampleSubmission.getExercise(), null);
         if (!exampleSubmission.getExercise().getId().equals(exerciseId)) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
@@ -10,7 +10,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import javax.activation.MimetypesFileTypeMap;
 
@@ -488,7 +488,7 @@ public class FileResource {
         }
     }
 
-    private Path getActualPathFromPublicPathString(@NotNull String publicPath) {
+    private Path getActualPathFromPublicPathString(@Nonnull String publicPath) {
         if (publicPath == null) {
             throw new EntityNotFoundException("No file linked");
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 import java.io.IOException;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,7 +92,7 @@ public class FileUploadSubmissionResource extends AbstractSubmissionResource {
         return handleFileUploadSubmission(exerciseId, fileUploadSubmission, file);
     }
 
-    @NotNull
+    @Nonnull
     private ResponseEntity<FileUploadSubmission> handleFileUploadSubmission(long exerciseId, FileUploadSubmission fileUploadSubmission, MultipartFile file) {
         long start = System.currentTimeMillis();
         checkFileLength(file);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -4,8 +4,8 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.util.*;
 
+import jakarta.annotation.Nonnull;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,7 +115,7 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
         return handleModelingSubmission(exerciseId, modelingSubmission);
     }
 
-    @NotNull
+    @Nonnull
     private ResponseEntity<ModelingSubmission> handleModelingSubmission(Long exerciseId, ModelingSubmission modelingSubmission) {
         long start = System.currentTimeMillis();
         final var user = userRepository.getUserWithGroupsAndAuthorities();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/NotificationSettingsResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/NotificationSettingsResource.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +83,7 @@ public class NotificationSettingsResource {
      */
     @PutMapping("notification-settings")
     @EnforceAtLeastStudent
-    public ResponseEntity<NotificationSetting[]> saveNotificationSettingsForCurrentUser(@NotNull @RequestBody NotificationSetting[] notificationSettings) {
+    public ResponseEntity<NotificationSetting[]> saveNotificationSettingsForCurrentUser(@Nonnull @RequestBody NotificationSetting[] notificationSettings) {
         if (notificationSettings.length == 0) {
             throw new BadRequestAlertException("Cannot save non-existing Notification Settings", "NotificationSettings", "notificationSettingsEmpty");
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -10,8 +10,8 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -851,7 +851,7 @@ public class ParticipationResource {
      * @param user             the currently logged-in user who initiated the delete operation
      * @return the response to the client
      */
-    @NotNull
+    @Nonnull
     private ResponseEntity<Void> deleteParticipation(StudentParticipation participation, boolean deleteBuildPlan, boolean deleteRepository, User user) {
         String name = participation.getParticipantName();
         var logMessage = "Delete Participation " + participation.getId() + " of exercise " + participation.getExercise().getTitle() + " for " + name + ", deleteBuildPlan: "

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -12,8 +12,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BadRequestException;
 
 import org.slf4j.Logger;
@@ -443,7 +443,7 @@ public class StudentExamResource {
         return ResponseEntity.ok(testRun);
     }
 
-    @NotNull
+    @Nonnull
     private StudentExam findStudentExamWithExercisesElseThrow(User user, Long examId, Long courseId, boolean isTestRun) {
         StudentExam studentExam = studentExamRepository.findWithExercisesByUserIdAndExamId(user.getId(), examId, isTestRun)
                 .orElseThrow(() -> new EntityNotFoundException("No student exam found for examId " + examId + " and userId " + user.getId()));

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -6,8 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,7 +117,7 @@ public class TextSubmissionResource extends AbstractSubmissionResource {
         return handleTextSubmission(exerciseId, textSubmission);
     }
 
-    @NotNull
+    @Nonnull
     private ResponseEntity<TextSubmission> handleTextSubmission(long exerciseId, TextSubmission textSubmission) {
         long start = System.currentTimeMillis();
         final var user = userRepository.getUserWithGroupsAndAuthorities();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/TutorialGroupFreePeriodDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/TutorialGroupFreePeriodDTO.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.web.rest.dto;
 
 import java.time.LocalDateTime;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -14,5 +14,5 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * @param reason
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record TutorialGroupFreePeriodDTO(@NotNull LocalDateTime startDate, @NotNull LocalDateTime endDate, String reason) {
+public record TutorialGroupFreePeriodDTO(@Nonnull LocalDateTime startDate, @Nonnull LocalDateTime endDate, String reason) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/lectureunit/LectureUnitForLearningPathNodeDetailsDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/lectureunit/LectureUnitForLearningPathNodeDetailsDTO.java
@@ -1,12 +1,12 @@
 package de.tum.in.www1.artemis.web.rest.dto.lectureunit;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 
-public record LectureUnitForLearningPathNodeDetailsDTO(long id, @NotNull String name, @NotNull String type) {
+public record LectureUnitForLearningPathNodeDetailsDTO(long id, @Nonnull String name, @Nonnull String type) {
 
-    public static LectureUnitForLearningPathNodeDetailsDTO of(@NotNull LectureUnit lectureUnit) {
+    public static LectureUnitForLearningPathNodeDetailsDTO of(@Nonnull LectureUnit lectureUnit) {
         return new LectureUnitForLearningPathNodeDetailsDTO(lectureUnit.getId(), lectureUnit.getName(), lectureUnit.getType());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/plagiarism/PlagiarismVerdictDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/plagiarism/PlagiarismVerdictDTO.java
@@ -1,11 +1,11 @@
 package de.tum.in.www1.artemis.web.rest.dto.plagiarism;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismVerdict;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismVerdictDTO(@NotNull PlagiarismVerdict verdict, String verdictMessage, int verdictPointDeduction) {
+public record PlagiarismVerdictDTO(@Nonnull PlagiarismVerdict verdict, String verdictMessage, int verdictPointDeduction) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/errors/ExceptionTranslator.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/errors/ExceptionTranslator.java
@@ -3,9 +3,9 @@ package de.tum.in.www1.artemis.web.rest.errors;
 import java.io.IOException;
 import java.util.List;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BadRequestException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -57,7 +57,7 @@ public class ExceptionTranslator implements ProblemHandling, SecurityAdviceTrait
      * Post-process the Problem payload to add the message key for the front-end if needed.
      */
     @Override
-    public ResponseEntity<Problem> process(@Nullable ResponseEntity<Problem> entity, @NotNull NativeWebRequest request) {
+    public ResponseEntity<Problem> process(@Nullable ResponseEntity<Problem> entity, @Nonnull NativeWebRequest request) {
         if (entity == null) {
             return null;
         }
@@ -82,7 +82,7 @@ public class ExceptionTranslator implements ProblemHandling, SecurityAdviceTrait
     }
 
     @Override
-    public ResponseEntity<Problem> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, @NotNull NativeWebRequest request) {
+    public ResponseEntity<Problem> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, @Nonnull NativeWebRequest request) {
         BindingResult result = ex.getBindingResult();
         List<FieldErrorVM> fieldErrors = result.getFieldErrors().stream().map(f -> new FieldErrorVM(f.getObjectName().replaceFirst("DTO$", ""), f.getField(), f.getCode()))
                 .toList();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/ChannelResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/ChannelResource.java
@@ -9,7 +9,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -464,7 +464,7 @@ public class ChannelResource extends ConversationManagementResource {
         return channelDTOs.filter(channelDTO -> channelDTO.getIsPublic() || channelDTO.getIsMember());
     }
 
-    private void checkChannelMembership(Channel channel, @NotNull User user) {
+    private void checkChannelMembership(Channel channel, @Nonnull User user) {
         if (channel == null || channel.getIsCourseWide() || conversationService.isMember(channel.getId(), user.getId())) {
             return;
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/programming/ProgrammingExerciseExportImportResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/programming/ProgrammingExerciseExportImportResource.java
@@ -12,7 +12,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.slf4j.Logger;
@@ -447,7 +447,7 @@ public class ProgrammingExerciseExportImportResource {
         return provideZipForParticipations(exportedStudentParticipations, programmingExercise, repositoryExportOptions);
     }
 
-    private ResponseEntity<Resource> provideZipForParticipations(@NotNull List<ProgrammingExerciseStudentParticipation> exportedStudentParticipations,
+    private ResponseEntity<Resource> provideZipForParticipations(@Nonnull List<ProgrammingExerciseStudentParticipation> exportedStudentParticipations,
             ProgrammingExercise programmingExercise, RepositoryExportOptionsDTO repositoryExportOptions) throws IOException {
         long start = System.nanoTime();
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/science/ScienceSettingsResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/science/ScienceSettingsResource.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +74,7 @@ public class ScienceSettingsResource {
      */
     @PutMapping("science-settings")
     @EnforceAtLeastStudent
-    public ResponseEntity<ScienceSetting[]> saveScienceSettingsForCurrentUser(@NotNull @RequestBody ScienceSetting[] scienceSettings) {
+    public ResponseEntity<ScienceSetting[]> saveScienceSettingsForCurrentUser(@Nonnull @RequestBody ScienceSetting[] scienceSettings) {
         if (scienceSettings.length == 0) {
             throw new BadRequestAlertException("Cannot save non-existing Science Settings", "ScienceSettings", "scienceSettingsEmpty");
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupResource.java
@@ -8,9 +8,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import jakarta.ws.rs.BadRequestException;
 
@@ -282,7 +282,7 @@ public class TutorialGroupResource {
      * @param notificationText               the optional notification text
      * @param updateTutorialGroupChannelName whether the tutorial group channel name should be updated with the new tutorial group title or not
      */
-    public record TutorialGroupUpdateDTO(@Valid @NotNull TutorialGroup tutorialGroup, @Size(min = 1, max = 1000) @Nullable String notificationText,
+    public record TutorialGroupUpdateDTO(@Valid @Nonnull TutorialGroup tutorialGroup, @Size(min = 1, max = 1000) @Nullable String notificationText,
             @Nullable Boolean updateTutorialGroupChannelName) {
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupSessionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupSessionResource.java
@@ -12,10 +12,10 @@ import java.time.ZoneId;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nonnull;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import jakarta.ws.rs.BadRequestException;
 
@@ -336,7 +336,7 @@ public class TutorialGroupSessionResource {
     /**
      * DTO used because we want to interpret the dates in the time zone of the tutorial groups configuration
      */
-    public record TutorialGroupSessionDTO(@NotNull LocalDate date, @NotNull LocalTime startTime, @NotNull LocalTime endTime, @Size(min = 1, max = 2000) String location) {
+    public record TutorialGroupSessionDTO(@Nonnull LocalDate date, @Nonnull LocalTime startTime, @Nonnull LocalTime endTime, @Size(min = 1, max = 2000) String location) {
 
         public void validityCheck() {
             if (startTime.isAfter(endTime)) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/util/PageUtil.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/util/PageUtil.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.web.rest.util;
 
 import java.util.Map;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -82,7 +82,7 @@ public class PageUtil {
         }
     }
 
-    @NotNull
+    @Nonnull
     public static PageRequest createDefaultPageRequest(PageableSearchDTO<String> search, ColumnMapping columnMapping) {
         var sortOptions = Sort.by(columnMapping.getMappedColumnName(search.getSortedColumn()));
         sortOptions = search.getSortingOrder() == SortingOrder.ASCENDING ? sortOptions.ascending() : sortOptions.descending();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/vm/LoginVM.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/vm/LoginVM.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.web.rest.vm;
 
 import static de.tum.in.www1.artemis.config.Constants.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import jakarta.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -13,11 +13,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class LoginVM {
 
-    @NotNull
+    @Nonnull
     @Size(min = USERNAME_MIN_LENGTH, max = USERNAME_MAX_LENGTH)
     private String username;
 
-    @NotNull
+    @Nonnull
     @Size(min = PASSWORD_MIN_LENGTH, max = PASSWORD_MAX_LENGTH)
     private String password;
 

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/dto/TeamAssignmentPayload.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/dto/TeamAssignmentPayload.java
@@ -2,8 +2,8 @@ package de.tum.in.www1.artemis.web.websocket.dto;
 
 import java.util.List;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -12,7 +12,7 @@ import de.tum.in.www1.artemis.domain.Team;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record TeamAssignmentPayload(@NotNull Exercise exercise, @Nullable Team team, @NotNull List<StudentParticipation> studentParticipations) {
+public record TeamAssignmentPayload(@Nonnull Exercise exercise, @Nullable Team team, @Nonnull List<StudentParticipation> studentParticipations) {
 
     public long getExerciseId() {
         return exercise.getId();

--- a/src/test/java/de/tum/in/www1/artemis/architecture/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/architecture/ArchitectureTest.java
@@ -124,17 +124,17 @@ class ArchitectureTest extends AbstractArchitectureTest {
     }
 
     @Test
-    void testNullnessAnnotations() {
-        var notNullPredicate = and(not(resideInPackageAnnotation("jakarta.validation.constraints")), simpleNameAnnotation("NotNull"));
+    void testNullabilityAnnotations() {
+        var notNullPredicate = simpleNameAnnotation("NotNull");
         var nonNullPredicate = simpleNameAnnotation("NonNull");
-        var nonnullPredicate = simpleNameAnnotation("Nonnull");
+        var nonnullPredicate = and(not(resideInPackageAnnotation("jakarta.annotation")), simpleNameAnnotation("Nonnull"));
         var nullablePredicate = and(not(resideInPackageAnnotation("jakarta.annotation")), simpleNameAnnotation("Nullable"));
 
         Set<DescribedPredicate<? super JavaAnnotation<?>>> allPredicates = Set.of(notNullPredicate, nonNullPredicate, nonnullPredicate, nullablePredicate);
 
         for (var predicate : allPredicates) {
-            ArchRule units = noCodeUnits().should().beAnnotatedWith(predicate);
-            ArchRule parameters = methods().should(notHaveAnyParameterAnnotatedWith(predicate));
+            ArchRule units = noCodeUnits().should().beAnnotatedWith(predicate).because("you should use `jakarta.annotation` annotations instead.");
+            ArchRule parameters = methods().should(notHaveAnyParameterAnnotatedWith(predicate)).because("you should use `jakarta.annotation` annotations instead.");
 
             units.check(allClasses);
             parameters.check(allClasses);

--- a/src/test/java/de/tum/in/www1/artemis/assessment/GradingScaleUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/GradingScaleUtilService.java
@@ -6,7 +6,7 @@ import java.io.FileReader;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -34,7 +34,7 @@ public class GradingScaleUtilService {
      * @param valid        whether the second grade step is valid (i.e. the upper bound of the second grade step is equal to the lower bound of the third grade step)
      * @return a set of grade steps
      */
-    @NotNull
+    @Nonnull
     public Set<GradeStep> generateGradeStepSet(GradingScale gradingScale, boolean valid) {
         GradeStep gradeStep1 = new GradeStep();
         GradeStep gradeStep2 = new GradeStep();

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -193,7 +193,7 @@ class TutorParticipationIntegrationTest extends AbstractSpringIntegrationIndepen
         request.postWithResponseBody(path, exampleSubmission, TutorParticipation.class, HttpStatus.BAD_REQUEST);
     }
 
-    @NotNull
+    @Nonnull
     private ExampleSubmission prepareTextExampleSubmission(boolean usedForTutorial) throws Exception {
         var exampleSubmissionText = "This is first sentence:This is second sentence.";
         ExampleSubmission exampleSubmission = participationUtilService.generateExampleSubmission(exampleSubmissionText, textExercise, false, usedForTutorial);
@@ -232,7 +232,7 @@ class TutorParticipationIntegrationTest extends AbstractSpringIntegrationIndepen
         return exampleSubmission;
     }
 
-    @NotNull
+    @Nonnull
     private ExampleSubmission prepareModelingExampleSubmission(boolean usedForTutorial) throws Exception {
         String validModel = TestResourceUtils.loadFileFromResources("test-data/model-submission/model.54727.json");
         ExampleSubmission exampleSubmission = participationUtilService.generateExampleSubmission(validModel, modelingExercise, false, usedForTutorial);

--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -151,7 +151,7 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
         assertThat(updatedGroups).as("User is registered for course").contains(course1.getStudentGroupName());
     }
 
-    @NotNull
+    @Nonnull
     private User createUserWithRestApi(Set<Authority> authorities) throws Exception {
         userRepository.findOneByLogin("user1").ifPresent(userRepository::delete);
         gitlabRequestMockProvider.enableMockingOfRequests();

--- a/src/test/java/de/tum/in/www1/artemis/bonus/BonusIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/bonus/BonusIntegrationTest.java
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -261,7 +261,7 @@ class BonusIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     }
 
-    @NotNull
+    @Nonnull
     private GradingScale createBonusToGradingScale(Exam bonusToExam) {
         GradingScale bonusToGradingScale = gradingScaleUtilService.generateGradingScaleWithStickyStep(new double[] { 40, 20, 15, 15, 10, 100 },
                 Optional.of(new String[] { "5.0", "4.0", "3.0", "2.0", "1.0", "1.0" }), true, 1);
@@ -271,7 +271,7 @@ class BonusIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         return bonusToGradingScale;
     }
 
-    @NotNull
+    @Nonnull
     private GradingScale createSourceGradingScaleWithGradeStepsForGradesBonusStrategy(Course sourceCourse) {
         GradingScale sourceGradingScale = gradingScaleUtilService.generateGradingScaleWithStickyStep(new double[] { 30, 40, 70 }, Optional.of(new String[] { "0", "0.1", "0.2" }),
                 true, 1);
@@ -397,7 +397,7 @@ class BonusIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     }
 
-    @NotNull
+    @Nonnull
     private BonusExampleDTO calculateFinalGradeAtServer(BonusStrategy bonusStrategy, double weight, double bonusToPoints, double sourcePoints, String expectedExamGrade,
             double expectedBonusGrade, Double expectedFinalPoints, String expectedFinalGrade, boolean expectedExceedsMax, long sourceGradingScaleId) throws Exception {
         BonusExampleDTO bonusExample = request.get("/api/courses/" + courseId + "/exams/" + examId + "/bonus/calculate-raw?bonusStrategy=" + bonusStrategy + "&calculationSign="
@@ -411,7 +411,7 @@ class BonusIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         return bonusExample;
     }
 
-    @NotNull
+    @Nonnull
     private GradingScale createSourceGradingScaleWithGradeStepsForPointsBonusStrategy(Course sourceCourse) {
         GradingScale sourceGradingScale = gradingScaleUtilService.generateGradingScaleWithStickyStep(new double[] { 30, 40, 70 }, Optional.of(new String[] { "0", "10", "20" }),
                 true, 1);

--- a/src/test/java/de/tum/in/www1/artemis/competency/CompetencyUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/CompetencyUtilService.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.competency;
 
 import java.time.ZonedDateTime;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -164,7 +164,7 @@ public class CompetencyUtilService {
      * @param masteryThreshold The new mastery threshold
      * @return The updated Competency
      */
-    public Competency updateMasteryThreshold(@NotNull Competency competency, int masteryThreshold) {
+    public Competency updateMasteryThreshold(@Nonnull Competency competency, int masteryThreshold) {
         competency.setMasteryThreshold(masteryThreshold);
         return competencyRepo.save(competency);
     }

--- a/src/test/java/de/tum/in/www1/artemis/course/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/course/CourseTestService.java
@@ -36,7 +36,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import javax.imageio.ImageIO;
 
@@ -3264,11 +3264,11 @@ public class CourseTestService {
         assertThat(dto.registrationId()).isEqualTo(clientId);
     }
 
-    public MockHttpServletRequestBuilder buildCreateCourse(@NotNull Course course) throws JsonProcessingException {
+    public MockHttpServletRequestBuilder buildCreateCourse(@Nonnull Course course) throws JsonProcessingException {
         return buildCreateCourse(course, null);
     }
 
-    public MockHttpServletRequestBuilder buildCreateCourse(@NotNull Course course, String fileContent) throws JsonProcessingException {
+    public MockHttpServletRequestBuilder buildCreateCourse(@Nonnull Course course, String fileContent) throws JsonProcessingException {
         var coursePart = new MockMultipartFile("course", "", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsString(course).getBytes());
         var builder = MockMvcRequestBuilders.multipart(HttpMethod.POST, "/api/admin/courses").file(coursePart);
         if (fileContent != null) {
@@ -3278,11 +3278,11 @@ public class CourseTestService {
         return builder.contentType(MediaType.MULTIPART_FORM_DATA_VALUE);
     }
 
-    public MockHttpServletRequestBuilder buildUpdateCourse(long id, @NotNull Course course) throws JsonProcessingException {
+    public MockHttpServletRequestBuilder buildUpdateCourse(long id, @Nonnull Course course) throws JsonProcessingException {
         return buildUpdateCourse(id, course, null);
     }
 
-    public MockHttpServletRequestBuilder buildUpdateCourse(long id, @NotNull Course course, String fileContent) throws JsonProcessingException {
+    public MockHttpServletRequestBuilder buildUpdateCourse(long id, @Nonnull Course course, String fileContent) throws JsonProcessingException {
         var coursePart = new MockMultipartFile("course", "", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsString(course).getBytes());
         var builder = MockMvcRequestBuilders.multipart(HttpMethod.PUT, "/api/courses/" + id).file(coursePart);
         if (fileContent != null) {

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
@@ -12,7 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -301,7 +301,7 @@ class ExamUserIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest
         }
     }
 
-    private MockHttpServletRequestBuilder buildUpdateExamUser(@NotNull ExamUserDTO examUserDTO, boolean hasSigned, long courseId, long examId) throws Exception {
+    private MockHttpServletRequestBuilder buildUpdateExamUser(@Nonnull ExamUserDTO examUserDTO, boolean hasSigned, long courseId, long examId) throws Exception {
         var examUserPart = new MockMultipartFile("examUserDTO", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(examUserDTO).getBytes());
         if (hasSigned) {
             var signingImage = loadFile("classpath:test-data/exam-users", "examUserSigningImage.png");

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.eclipse.jgit.lib.ObjectId;
 import org.gitlab4j.api.GitLabApiException;
@@ -1867,7 +1867,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabT
         deleteExamWithInstructor(exam1);
     }
 
-    @NotNull
+    @Nonnull
     private StudentExam createStudentExamWithResultsAndAssessments(boolean setFields, int numberOfStudents) throws Exception {
         StudentExam studentExam = prepareStudentExamsForConduction(false, setFields, numberOfStudents).get(0);
         var exam = examRepository.findById(studentExam.getExam().getId()).orElseThrow();
@@ -2192,7 +2192,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabT
         assertThat(studentExamGradeInfoFromServer.studentResult().gradeWithBonus().mostSeverePlagiarismVerdict()).isNull();
     }
 
-    @NotNull
+    @Nonnull
     private Exam configureFinalExamWithBonusExam(StudentExam finalStudentExam, StudentExam bonusStudentExam, BonusStrategy bonusStrategy) {
         var finalExam = examRepository.findById(finalStudentExam.getExam().getId()).orElseThrow();
         var bonusExam = examRepository.findById(bonusStudentExam.getExam().getId()).orElseThrow();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseUtilService.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.ZonedDateTime;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -335,7 +335,7 @@ public class ExerciseUtilService {
      * @param title     The title of the exercise to look for.
      * @return The found file upload exercise.
      */
-    @NotNull
+    @Nonnull
     public FileUploadExercise findFileUploadExerciseWithTitle(Collection<Exercise> exercises, String title) {
         Optional<Exercise> exercise = exercises.stream().filter(e -> e.getTitle().equals(title)).findFirst();
         if (exercise.isEmpty()) {
@@ -358,7 +358,7 @@ public class ExerciseUtilService {
      * @param title     The title of the exercise to look for.
      * @return The found modeling exercise.
      */
-    @NotNull
+    @Nonnull
     public ModelingExercise findModelingExerciseWithTitle(Collection<Exercise> exercises, String title) {
         Optional<Exercise> exercise = exercises.stream().filter(e -> e.getTitle().equals(title)).findFirst();
         if (exercise.isEmpty()) {
@@ -381,7 +381,7 @@ public class ExerciseUtilService {
      * @param title     The title of the exercise to look for.
      * @return The found text exercise.
      */
-    @NotNull
+    @Nonnull
     public TextExercise findTextExerciseWithTitle(Collection<Exercise> exercises, String title) {
         Optional<Exercise> exercise = exercises.stream().filter(e -> e.getTitle().equals(title)).findFirst();
         if (exercise.isEmpty()) {
@@ -404,7 +404,7 @@ public class ExerciseUtilService {
      * @param title     The title of the exercise to look for.
      * @return The found programming exercise.
      */
-    @NotNull
+    @Nonnull
     public ProgrammingExercise findProgrammingExerciseWithTitle(Collection<Exercise> exercises, String title) {
         Optional<Exercise> exercise = exercises.stream().filter(e -> e.getTitle().equals(title)).findFirst();
         if (exercise.isEmpty()) {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/GitServiceTest.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
@@ -164,7 +164,7 @@ class GitServiceTest extends AbstractSpringIntegrationIndependentTest {
         }
     }
 
-    @NotNull
+    @Nonnull
     private String getCommitHash(String msg) {
         AtomicReference<String> commitHash = new AtomicReference<>();
         gitUtilService.getLog(GitUtilService.REPOS.LOCAL).forEach(revCommit -> {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -57,7 +57,7 @@ import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 import java.util.zip.ZipFile;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.data.Offset;
@@ -1505,7 +1505,7 @@ class ProgrammingExerciseIntegrationTestService {
         request.post(getDefaultAPIEndpointForExportRepos(), getOptions(), HttpStatus.FORBIDDEN);
     }
 
-    @NotNull
+    @Nonnull
     private String getDefaultAPIEndpointForExportRepos() {
         return ROOT + EXPORT_SUBMISSIONS_BY_PARTICIPANTS.replace("{exerciseId}", String.valueOf(programmingExercise.getId())).replace("{participantIdentifiers}", "1,2,3");
     }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/ProgrammingExerciseTestService.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
@@ -2030,7 +2030,7 @@ public class ProgrammingExerciseTestService {
         return participation;
     }
 
-    @NotNull
+    @Nonnull
     private Team setupTeam(User user) {
         // create a team for the user (necessary condition before starting an exercise)
         Set<User> students = Set.of(user);
@@ -2163,7 +2163,7 @@ public class ProgrammingExerciseTestService {
         assertThat(teamLocalPath).doesNotExist();
     }
 
-    @NotNull
+    @Nonnull
     private Team setupTeamForBadRequestForStartExercise() throws Exception {
         setupTeamExercise();
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/RepositoryIntegrationTest.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
@@ -393,7 +393,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTe
         GitService.commit(studentRepository.localGit).setMessage("my commit 2").call();
     }
 
-    @NotNull
+    @Nonnull
     private String getCommitHash(Git repo) throws GitAPIException {
         AtomicReference<String> commitHash = new AtomicReference<>();
         repo.log().call().forEach(revCommit -> {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quizexercise/QuizExerciseFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quizexercise/QuizExerciseFactory.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
 import org.springframework.util.ResourceUtils;
@@ -38,7 +38,7 @@ public class QuizExerciseFactory {
      * @param quizMode    The quiz mode used. SYNCHRONIZED, BATCHED, or INDIVIDUAL.
      * @return The created quiz.
      */
-    @NotNull
+    @Nonnull
     public static QuizExercise createQuiz(Course course, ZonedDateTime releaseDate, ZonedDateTime dueDate, QuizMode quizMode) {
         QuizExercise quizExercise = generateQuizExercise(releaseDate, dueDate, quizMode, course);
         addQuestionsToQuizExercise(quizExercise);
@@ -53,7 +53,7 @@ public class QuizExerciseFactory {
      * @param exerciseGroup Exercise group of an exam to which the quiz should be added.
      * @return The created quiz.
      */
-    @NotNull
+    @Nonnull
     public static QuizExercise createQuizForExam(ExerciseGroup exerciseGroup) {
         QuizExercise quizExercise = generateQuizExerciseForExam(exerciseGroup);
         addQuestionsToQuizExercise(quizExercise);
@@ -82,7 +82,7 @@ public class QuizExerciseFactory {
      *
      * @return The created short answer question.
      */
-    @NotNull
+    @Nonnull
     public static ShortAnswerQuestion createShortAnswerQuestion() {
         ShortAnswerQuestion sa = (ShortAnswerQuestion) new ShortAnswerQuestion().title("SA").score(2).text("This is a long answer text");
         sa.setScoringType(ScoringType.PROPORTIONAL_WITHOUT_PENALTY);
@@ -128,7 +128,7 @@ public class QuizExerciseFactory {
      *
      * @return The created drag and drop question.
      */
-    @NotNull
+    @Nonnull
     public static DragAndDropQuestion createDragAndDropQuestion() {
         DragAndDropQuestion dnd = (DragAndDropQuestion) new DragAndDropQuestion().title("DnD").score(3).text("Q2");
         dnd.setScoringType(ScoringType.PROPORTIONAL_WITH_PENALTY);
@@ -200,7 +200,7 @@ public class QuizExerciseFactory {
      *
      * @return The created multiple choice question.
      */
-    @NotNull
+    @Nonnull
     public static MultipleChoiceQuestion createMultipleChoiceQuestion() {
         MultipleChoiceQuestion mc = (MultipleChoiceQuestion) new MultipleChoiceQuestion().title("MC").score(4).text("Q1");
         mc.setScoringType(ScoringType.ALL_OR_NOTHING);
@@ -495,7 +495,7 @@ public class QuizExerciseFactory {
      *
      * @return The created multiple choice question.
      */
-    @NotNull
+    @Nonnull
     public static MultipleChoiceQuestion createMultipleChoiceQuestionWithAllTypesOfAnswerOptions() {
         MultipleChoiceQuestion mc = (MultipleChoiceQuestion) new MultipleChoiceQuestion().title("MC").score(4).text("Q1");
         mc.setScoringType(ScoringType.ALL_OR_NOTHING);
@@ -513,7 +513,7 @@ public class QuizExerciseFactory {
      *
      * @return The created single choice question.
      */
-    @NotNull
+    @Nonnull
     public static MultipleChoiceQuestion createSingleChoiceQuestion() {
         var singleChoiceQuestion = createMultipleChoiceQuestion();
         singleChoiceQuestion.setSingleChoice(true);
@@ -656,7 +656,7 @@ public class QuizExerciseFactory {
      * @param title         The title which is used to set the quiz title together with a 3 character random UUID suffix.
      * @return The created exam quiz exercise.
      */
-    @NotNull
+    @Nonnull
     public static QuizExercise createQuizWithAllQuestionTypesForExam(ExerciseGroup exerciseGroup, String title) {
         QuizExercise quizExercise = QuizExerciseFactory.generateQuizExerciseForExam(exerciseGroup, title);
         addAllQuestionTypesToQuizExercise(quizExercise);
@@ -701,7 +701,7 @@ public class QuizExerciseFactory {
      * @param name The name of the quiz group.
      * @return The created quiz group.
      */
-    @NotNull
+    @Nonnull
     public static QuizGroup createQuizGroup(String name) {
         QuizGroup quizGroup = new QuizGroup();
         quizGroup.setName(name);
@@ -715,7 +715,7 @@ public class QuizExerciseFactory {
      * @param quizGroup The group of the quiz question.
      * @return The created multiple choice question.
      */
-    @NotNull
+    @Nonnull
     public static MultipleChoiceQuestion createMultipleChoiceQuestionWithTitleAndGroup(String title, QuizGroup quizGroup) {
         MultipleChoiceQuestion quizQuestion = QuizExerciseFactory.createMultipleChoiceQuestion();
         setQuizQuestionsTitleAndGroup(quizQuestion, title, quizGroup);
@@ -729,7 +729,7 @@ public class QuizExerciseFactory {
      * @param quizGroup The group of the quiz question.
      * @return The created drag and drop question.
      */
-    @NotNull
+    @Nonnull
     public static DragAndDropQuestion createDragAndDropQuestionWithTitleAndGroup(String title, QuizGroup quizGroup) {
         DragAndDropQuestion quizQuestion = QuizExerciseFactory.createDragAndDropQuestion();
         setQuizQuestionsTitleAndGroup(quizQuestion, title, quizGroup);
@@ -743,7 +743,7 @@ public class QuizExerciseFactory {
      * @param quizGroup The group of the quiz question.
      * @return The created short answer question.
      */
-    @NotNull
+    @Nonnull
     public static ShortAnswerQuestion createShortAnswerQuestionWithTitleAndGroup(String title, QuizGroup quizGroup) {
         ShortAnswerQuestion quizQuestion = QuizExerciseFactory.createShortAnswerQuestion();
         setQuizQuestionsTitleAndGroup(quizQuestion, title, quizGroup);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quizexercise/QuizExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quizexercise/QuizExerciseUtilService.java
@@ -8,7 +8,7 @@ import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -225,7 +225,7 @@ public class QuizExerciseUtilService {
      * @param endDate   The end date of the exam, also used to set the end date of the course the exam is in.
      * @return The created exam quiz exercise.
      */
-    @NotNull
+    @Nonnull
     public QuizExercise createAndSaveExamQuiz(ZonedDateTime startDate, ZonedDateTime endDate) {
         Course course = courseUtilService.createAndSaveCourse(null, startDate.minusDays(1), endDate.plusDays(1), new HashSet<>());
 

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitIntegrationTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -95,11 +95,11 @@ class AttachmentUnitIntegrationTest extends AbstractSpringIntegrationIndependent
         request.get("/api/lectures/" + lecture1.getId() + "/attachment-units/42", HttpStatus.FORBIDDEN, AttachmentUnit.class);
     }
 
-    private MockHttpServletRequestBuilder buildUpdateAttachmentUnit(@NotNull AttachmentUnit attachmentUnit, @NotNull Attachment attachment) throws Exception {
+    private MockHttpServletRequestBuilder buildUpdateAttachmentUnit(@Nonnull AttachmentUnit attachmentUnit, @Nonnull Attachment attachment) throws Exception {
         return buildUpdateAttachmentUnit(attachmentUnit, attachment, null, true);
     }
 
-    private MockHttpServletRequestBuilder buildUpdateAttachmentUnit(@NotNull AttachmentUnit attachmentUnit, @NotNull Attachment attachment, String fileContent, boolean contentType)
+    private MockHttpServletRequestBuilder buildUpdateAttachmentUnit(@Nonnull AttachmentUnit attachmentUnit, @Nonnull Attachment attachment, String fileContent, boolean contentType)
             throws Exception {
         MockMultipartHttpServletRequestBuilder builder = buildUpdateAttachmentUnit(attachmentUnit, attachment, fileContent);
         if (contentType) {
@@ -108,7 +108,7 @@ class AttachmentUnitIntegrationTest extends AbstractSpringIntegrationIndependent
         return builder;
     }
 
-    private MockMultipartHttpServletRequestBuilder buildUpdateAttachmentUnit(@NotNull AttachmentUnit attachmentUnit, @NotNull Attachment attachment, String fileContent)
+    private MockMultipartHttpServletRequestBuilder buildUpdateAttachmentUnit(@Nonnull AttachmentUnit attachmentUnit, @Nonnull Attachment attachment, String fileContent)
             throws Exception {
         var attachmentUnitPart = new MockMultipartFile("attachmentUnit", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachmentUnit).getBytes());
         var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachment).getBytes());
@@ -122,7 +122,7 @@ class AttachmentUnitIntegrationTest extends AbstractSpringIntegrationIndependent
         return builder.file(attachmentUnitPart).file(attachmentPart);
     }
 
-    private MockHttpServletRequestBuilder buildCreateAttachmentUnit(@NotNull AttachmentUnit attachmentUnit, @NotNull Attachment attachment) throws Exception {
+    private MockHttpServletRequestBuilder buildCreateAttachmentUnit(@Nonnull AttachmentUnit attachmentUnit, @Nonnull Attachment attachment) throws Exception {
         var attachmentUnitPart = new MockMultipartFile("attachmentUnit", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachmentUnit).getBytes());
         var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachment).getBytes());
         var filePart = createAttachmentUnitPdf();

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationFactory.java
@@ -7,7 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.*;
@@ -244,7 +244,7 @@ public class ParticipationFactory {
      * @param type The FeedbackType of the Feedback
      * @return The generated Feedback
      */
-    @NotNull
+    @Nonnull
     public static Feedback createPositiveFeedback(FeedbackType type) {
         Feedback positiveFeedback = new Feedback();
         positiveFeedback.setCredits(2D);
@@ -259,7 +259,7 @@ public class ParticipationFactory {
      * @param type The FeedbackType of the Feedback
      * @return The generated Feedback
      */
-    @NotNull
+    @Nonnull
     public static Feedback createNegativeFeedback(FeedbackType type) {
         Feedback negativeFeedback = new Feedback();
         negativeFeedback.setCredits(-1D);
@@ -275,7 +275,7 @@ public class ParticipationFactory {
      * @param textBlockReference The textBlockReference of the Feedback
      * @return The generated Feedback
      */
-    @NotNull
+    @Nonnull
     public static Feedback createManualTextFeedback(Double credits, String textBlockReference) {
         Feedback feedback = new Feedback();
         feedback.setCredits(credits);

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismPostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismPostIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -372,7 +372,7 @@ class PlagiarismPostIntegrationTest extends AbstractSpringIntegrationLocalCILoca
         assertThat(createdPost.getPlagiarismCase()).isEqualTo(expectedPost.getPlagiarismCase());
     }
 
-    @NotNull
+    @Nonnull
     private List<Post> getPosts(LinkedMultiValueMap<String, String> params) throws Exception {
         List<Post> returnedPosts = request.getList("/api/courses/" + courseId + "/posts", HttpStatus.OK, Post.class, params);
         conversationUtilService.assertSensitiveInformationHidden(returnedPosts);

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismUtilService.java
@@ -4,7 +4,7 @@ import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -186,7 +186,7 @@ public class PlagiarismUtilService {
      *
      * @return The generated LinkedMultiValueMap
      */
-    @NotNull
+    @Nonnull
     public LinkedMultiValueMap<String, String> getDefaultPlagiarismOptions() {
         return getPlagiarismOptions(50, 0, 0);
     }
@@ -200,7 +200,7 @@ public class PlagiarismUtilService {
      * @param minimumSize         The minimum size
      * @return The generated LinkedMultiValueMap
      */
-    @NotNull
+    @Nonnull
     public LinkedMultiValueMap<String, String> getPlagiarismOptions(int similarityThreshold, int minimumScore, int minimumSize) {
         var params = new LinkedMultiValueMap<String, String>();
         params.add("similarityThreshold", String.valueOf(similarityThreshold));

--- a/src/test/java/de/tum/in/www1/artemis/post/ConversationUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/post/ConversationUtilService.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.ZonedDateTime;
 import java.util.*;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -353,7 +353,7 @@ public class ConversationUtilService {
      *
      * @param postings The list of Postings to check
      */
-    public <T extends Posting> void assertSensitiveInformationHidden(@NotNull Collection<T> postings) {
+    public <T extends Posting> void assertSensitiveInformationHidden(@Nonnull Collection<T> postings) {
         for (Posting posting : postings) {
             assertSensitiveInformationHidden(posting);
         }
@@ -364,7 +364,7 @@ public class ConversationUtilService {
      *
      * @param posting The Posting to check
      */
-    public void assertSensitiveInformationHidden(@NotNull Posting posting) {
+    public void assertSensitiveInformationHidden(@Nonnull Posting posting) {
         if (posting.getAuthor() != null) {
             assertThat(posting.getAuthor().getEmail()).isNull();
             assertThat(posting.getAuthor().getLogin()).isNull();
@@ -377,7 +377,7 @@ public class ConversationUtilService {
      *
      * @param reaction The Reaction to check
      */
-    public void assertSensitiveInformationHidden(@NotNull Reaction reaction) {
+    public void assertSensitiveInformationHidden(@Nonnull Reaction reaction) {
         if (reaction.getUser() != null) {
             assertThat(reaction.getUser().getEmail()).isNull();
             assertThat(reaction.getUser().getLogin()).isNull();

--- a/src/test/java/de/tum/in/www1/artemis/repository/ProgrammingSubmissionTestRepository.java
+++ b/src/test/java/de/tum/in/www1/artemis/repository/ProgrammingSubmissionTestRepository.java
@@ -5,7 +5,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -61,7 +61,7 @@ public interface ProgrammingSubmissionTestRepository extends JpaRepository<Progr
      * @param submissionId the id of the submission that should be loaded from the database
      * @return the programming submission with the given id
      */
-    @NotNull
+    @Nonnull
     default ProgrammingSubmission findByIdWithResultsFeedbacksAssessorTestCases(long submissionId) {
         return findWithEagerResultsFeedbacksTestCasesAssessorById(submissionId).orElseThrow(() -> new EntityNotFoundException("Programming Submission", submissionId));
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseFeedbackCreationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseFeedbackCreationServiceTest.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -339,7 +339,7 @@ class ProgrammingExerciseFeedbackCreationServiceTest extends AbstractSpringInteg
                 .hasSizeLessThanOrEqualTo(Constants.FEEDBACK_DETAIL_TEXT_DATABASE_MAX_LENGTH);
     }
 
-    @NotNull
+    @Nonnull
     private static StaticCodeAnalysisReportDTO createStaticCodeAnalysisReportDTO() {
         final String longText = "0".repeat(Constants.FEEDBACK_DETAIL_TEXT_SOFT_MAX_LENGTH * 2);
 

--- a/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.AfterEach;
@@ -1013,7 +1013,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         assertThat(blocksFrom2ndRequest.toArray()).containsExactlyInAnyOrder(blocks.toArray());
     }
 
-    @NotNull
+    @Nonnull
     private List<TextSubmission> prepareTextSubmissionsWithFeedbackForAutomaticFeedback() {
         TextSubmission textSubmission1 = ParticipationFactory.generateTextSubmission("This is Part 1, and this is Part 2. There is also Part 3.", Language.ENGLISH, true);
         TextSubmission textSubmission2 = ParticipationFactory.generateTextSubmission("This is another Submission.", Language.ENGLISH, true);

--- a/src/test/java/de/tum/in/www1/artemis/user/AccountResourceWithGitLabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/user/AccountResourceWithGitLabIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.gitlab4j.api.UserApi;
 import org.junit.jupiter.api.AfterEach;
@@ -283,7 +283,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         request.postWithoutLocation("/api/public/register", userVM, HttpStatus.BAD_REQUEST, null);
     }
 
-    @NotNull
+    @Nonnull
     private static User createUser(String newLogin, String email) {
         User newUser = UserFactory.generateActivatedUser(newLogin);
         newUser.setActivated(false);

--- a/src/test/java/de/tum/in/www1/artemis/util/FixMissingServletPathProcessor.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/FixMissingServletPathProcessor.java
@@ -1,8 +1,8 @@
 package de.tum.in.www1.artemis.util;
 
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.http.HttpServletMapping;
 import jakarta.servlet.http.MappingMatch;
-import jakarta.validation.constraints.NotNull;
 
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -18,7 +18,7 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationLocalCILocalVCTest;
  */
 public class FixMissingServletPathProcessor implements RequestPostProcessor {
 
-    @NotNull
+    @Nonnull
     @Override
     public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
         request.setHttpServletMapping(new HttpServletMapping() {

--- a/src/test/java/de/tum/in/www1/artemis/util/classpath/ClassPathNode.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/classpath/ClassPathNode.java
@@ -6,7 +6,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import org.assertj.core.util.TriFunction;
 
@@ -99,7 +99,7 @@ public abstract class ClassPathNode implements Comparable<ClassPathNode>, Iterab
      */
     public abstract Stream<ClassNode> allClassNodes();
 
-    @NotNull
+    @Nonnull
     @Override
     public Iterator<ClassNode> iterator() {
         return allClassNodes().iterator();


### PR DESCRIPTION
### Development Hint

If IntelliJ complaints about the fact that your signatures don't provide nullability annotations despite them being there, you have to fix your settings:
- Settings > Editor > Inspections
- Search for `Nullability and data flow problems` and click on it
- Scroll down on the right to `Configure Annotations...` and click it.
- Make sure you select `jakarta.annotation.Nullable` for `Nullable` and `jakarta.annotation.Nonnull` for `NotNull`. You might have to add them if they are not on the list
- Confirm

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [X] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I considered it always odd that we use nullability annotations from several packages. There were times we had even more usages; then we chose one for each, positive and negative. They were replaced when Java moved from javax to jakarta, but the internal packages stayed the same.

### Description
<!-- Describe your changes in detail -->
I decided to go for the shorter package name `jakarta.annotation` using `Nullable` and `Nonnull`. Thus, I had to replace `jakarta.validation.constraints.NotNull` with `jakarta.annotation.Nonnull`. We already use `jakarta.annotation.Nullable` throughout the system.

I did a simple search-and-replace for all imports and another for all annotations, so these are automated changes. I then fixed the corresponding architecture test and renamed it. `Nullability` is the term used by IntelliJ for these sort of annotations.

**The only manual changes are in the architecture test.**

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
