### PR TITLE
`Development`: Regenerate Aeolus LocalCI build scripts

### DIFF
--- a/src/main/resources/templates/aeolus/assembler/default.sh
+++ b/src/main/resources/templates/aeolus/assembler/default.sh
@@ -20,7 +20,6 @@ provide_environment_information () {
   else
       echo "$REQ_FILE does not exist"
   fi
-
 }
 
 prepare_makefile () {
@@ -30,7 +29,6 @@ prepare_makefile () {
   rm -f assignment/io.inc
   cp -f tests/Makefile assignment/Makefile || exit 2
   cp -f tests/io.inc assignment/io.inc || exit 2
-
 }
 
 run_and_compile () {
@@ -39,13 +37,11 @@ run_and_compile () {
   python3 compileTest.py ../assignment/
   rm compileTest.py
   cp result.xml ../assignment/result.xml
-
 }
 
 junit () {
   echo '⚙️ executing junit'
   chmod -R 777 .
-
 }
 
 final_aeolus_post_action () {

--- a/src/main/resources/templates/aeolus/assembler/default.yaml
+++ b/src/main/resources/templates/aeolus/assembler/default.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: provide_environment_information
-    script: |
+    script: |-
       #!/bin/bash
       echo "--------------------Python versions--------------------"
       python3 --version
@@ -21,7 +21,7 @@ actions:
       fi
     runAlways: false
   - name: prepare_makefile
-    script: |
+    script: |-
       #!/usr/bin/env bash
       rm -f assignment/{GNUmakefile, Makefile, makefile}
       rm -f assignment/io.inc
@@ -29,14 +29,14 @@ actions:
       cp -f tests/io.inc assignment/io.inc || exit 2
     runAlways: false
   - name: run_and_compile
-    script: |
+    script: |-
       cd tests
       python3 compileTest.py ../assignment/
       rm compileTest.py
       cp result.xml ../assignment/result.xml
     runAlways: false
   - name: junit
-    script: |
+    script: |-
       chmod -R 777 .
     runAlways: true
     results:

--- a/src/main/resources/templates/aeolus/c/fact.sh
+++ b/src/main/resources/templates/aeolus/c/fact.sh
@@ -12,7 +12,6 @@ setup_the_build_environment () {
   sudo chown artemis_user:artemis_user assignment/ -R || true
   sudo mkdir test-reports
   sudo chown artemis_user:artemis_user test-reports/ -R || true
-
 }
 
 build_and_run_all_tests () {
@@ -30,7 +29,6 @@ build_and_run_all_tests () {
   python3 Tests.py
   rm Tests.py
   rm -rf ./tests || true
-
 }
 
 main () {

--- a/src/main/resources/templates/aeolus/c/fact.yaml
+++ b/src/main/resources/templates/aeolus/c/fact.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: setup_the_build_environment
-    script: |
+    script: |-
       #!/usr/bin/env bash
       # ------------------------------
       # Task Description:
@@ -13,7 +13,7 @@ actions:
       sudo chown artemis_user:artemis_user test-reports/ -R || true
     runAlways: false
   - name: build_and_run_all_tests
-    script: |
+    script: |-
       #!/usr/bin/env bash
       # ------------------------------
       # Task Description:

--- a/src/main/resources/templates/aeolus/c/gcc.sh
+++ b/src/main/resources/templates/aeolus/c/gcc.sh
@@ -24,7 +24,6 @@ setup_the_build_environment () {
       echo "$REQ_FILE does not exist"
   fi
   cd ..
-
 }
 
 setup_makefile () {
@@ -65,7 +64,6 @@ build_and_run_all_tests () {
       cd tests || exit 0
       python3 Tests.py || true
   fi
-
 }
 
 main () {

--- a/src/main/resources/templates/aeolus/c/gcc.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: setup_the_build_environment
-    script: |
+    script: |-
       #!/usr/bin/env bash
 
       # ------------------------------
@@ -47,7 +47,7 @@ actions:
       sed -i "s~\bINCLUDEDIRS\s*=.*~${foundIncludeDirs}~; s~\bSOURCE\s*=.*~${foundSource}~" assignment/Makefile
     runAlways: false
   - name: build_and_run_all_tests
-    script: |
+    script: |-
       #!/usr/bin/env bash
 
       # ------------------------------

--- a/src/main/resources/templates/aeolus/c/gcc_static.sh
+++ b/src/main/resources/templates/aeolus/c/gcc_static.sh
@@ -24,7 +24,6 @@ setup_the_build_environment () {
       echo "$REQ_FILE does not exist"
   fi
   cd ..
-
 }
 
 setup_makefile () {
@@ -67,7 +66,6 @@ build_and_run_all_tests () {
   else
       exit 1
   fi
-
 }
 
 main () {

--- a/src/main/resources/templates/aeolus/c/gcc_static.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc_static.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: setup_the_build_environment
-    script: |
+    script: |-
       #!/usr/bin/env bash
 
       # ------------------------------
@@ -47,7 +47,7 @@ actions:
       sed -i "s~\bINCLUDEDIRS\s*=.*~${foundIncludeDirs}~; s~\bSOURCE\s*=.*~${foundSource}~" assignment/Makefile
     runAlways: false
   - name: build_and_run_all_tests
-    script: |
+    script: |-
       #!/usr/bin/env bash
 
       # ------------------------------

--- a/src/main/resources/templates/aeolus/haskell/default.sh
+++ b/src/main/resources/templates/aeolus/haskell/default.sh
@@ -7,7 +7,6 @@ build_and_test_the_code () {
   # -s enables the safe testing mode
   chmod +x run.sh
   ./run.sh -s
-
 }
 
 main () {

--- a/src/main/resources/templates/aeolus/haskell/default.yaml
+++ b/src/main/resources/templates/aeolus/haskell/default.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: build_and_test_the_code
-    script: |
+    script: |-
       # the build process is specified in `run.sh` in the test repository
       # -s enables the safe testing mode
       chmod +x run.sh

--- a/src/main/resources/templates/aeolus/haskell/default_sequential.sh
+++ b/src/main/resources/templates/aeolus/haskell/default_sequential.sh
@@ -7,7 +7,6 @@ run_structural_tests () {
   # -s enables the safe testing mode
   chmod +x run.sh
   ./run.sh -s
-
 }
 
 run_behavior_tests () {
@@ -16,7 +15,6 @@ run_behavior_tests () {
   # -s enables the safe testing mode
   chmod +x run.sh
   ./run.sh -s
-
 }
 
 main () {

--- a/src/main/resources/templates/aeolus/haskell/default_sequential.yaml
+++ b/src/main/resources/templates/aeolus/haskell/default_sequential.yaml
@@ -1,14 +1,14 @@
 api: v0.0.1
 actions:
   - name: run_structural_tests
-    script: |
+    script: |-
       # the build process is specified in `run.sh` in the test repository
       # -s enables the safe testing mode
       chmod +x run.sh
       ./run.sh -s
     runAlways: false
   - name: run_behavior_tests
-    script: |
+    script: |-
       # the build process is specified in `run.sh` in the test repository
       # -s enables the safe testing mode
       chmod +x run.sh

--- a/src/main/resources/templates/aeolus/java/plain_gradle.yaml
+++ b/src/main/resources/templates/aeolus/java/plain_gradle.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: gradle
-    script: |
+    script: |-
       chmod +x ./gradlew
       ./gradlew clean test
     runAlways: false

--- a/src/main/resources/templates/aeolus/java/plain_gradle_sequential.yaml
+++ b/src/main/resources/templates/aeolus/java/plain_gradle_sequential.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: structural_tests
-    script: |
+    script: |-
       chmod +x ./gradlew
       ./gradlew clean structuralTests
     runAlways: false

--- a/src/main/resources/templates/aeolus/java/plain_gradle_static.yaml
+++ b/src/main/resources/templates/aeolus/java/plain_gradle_static.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: gradle
-    script: |
+    script: |-
       chmod +x ./gradlew
       ./gradlew clean test
     runAlways: false

--- a/src/main/resources/templates/aeolus/java/plain_gradle_static_coverage.yaml
+++ b/src/main/resources/templates/aeolus/java/plain_gradle_static_coverage.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: tests
-    script: |
+    script: |-
       chmod +x ./gradlew
       ./gradlew clean test tiaTests --run-all-tests
     runAlways: false

--- a/src/main/resources/templates/aeolus/java/plain_maven_blackbox.yaml
+++ b/src/main/resources/templates/aeolus/java/plain_maven_blackbox.yaml
@@ -3,7 +3,7 @@ actions:
   - name: build
     script: mvn -B clean compile
   - name: checkers
-    script: |
+    script: |-
       # all java files in the assignment folder should have maximal line length 80
       pipeline-helper line-length -l 80 -s assignment/ -e java
       # checks that the file exists and is not empty for non gui programs
@@ -24,7 +24,7 @@ actions:
       export tool=$(find testsuite -name "*.tests" -type d -printf "%f" | sed 's#.tests$##')
       sed -i "s#TESTFILES_DIRECTORY#../${testfiles_base_path}#" testsuite/${tool}.tests/*.exp
   - name: secret-tests
-    script: |
+    script: |-
       export tool=$(find testsuite -name "*.tests" -type d -printf "%f" | sed 's#.tests$##')
       export step="secret"
       cd testsuite || exit
@@ -43,7 +43,7 @@ actions:
         rm "${testfiles_base_path}/secret"
       fi
   - name: public-tests
-    script: |
+    script: |-
       export tool=$(find testsuite -name "*.tests" -type d -printf "%f" | sed 's#.tests$##')
       sed -i "s#TESTFILES_DIRECTORY#../${testfiles_base_path}#" testsuite/${tool}.tests/*.exp
 
@@ -55,7 +55,7 @@ actions:
       cd ..
       pipeline-helper -o customFeedbacks dejagnu -n "dejagnu[${step}]" -l testsuite/${tool}.log
   - name: advanced-tests
-    script: |
+    script: |-
       export testfiles_base_path="./testsuite/testfiles"
       export tool=$(find testsuite -name "*.tests" -type d -printf "%f" | sed 's#.tests$##')
       sed -i "s#TESTFILES_DIRECTORY#../${testfiles_base_path}#" testsuite/${tool}.tests/*.exp

--- a/src/main/resources/templates/aeolus/java/plain_maven_blackbox_static.yaml
+++ b/src/main/resources/templates/aeolus/java/plain_maven_blackbox_static.yaml
@@ -3,7 +3,7 @@ actions:
   - name: build
     script: mvn -B clean compile
   - name: checkers
-    script: |
+    script: |-
       # all java files in the assignment folder should have maximal line length 80
       pipeline-helper line-length -l 80 -s assignment/ -e java
       # checks that the file exists and is not empty for non gui programs
@@ -24,7 +24,7 @@ actions:
       export tool=$(find testsuite -name "*.tests" -type d -printf "%f" | sed 's#.tests$##')
       sed -i "s#TESTFILES_DIRECTORY#../${testfiles_base_path}#" testsuite/${tool}.tests/*.exp
   - name: secret-tests
-    script: |
+    script: |-
       export tool=$(find testsuite -name "*.tests" -type d -printf "%f" | sed 's#.tests$##')
       export step="secret"
       cd testsuite || exit
@@ -43,7 +43,7 @@ actions:
         rm "${testfiles_base_path}/secret"
       fi
   - name: public-tests
-    script: |
+    script: |-
       export tool=$(find testsuite -name "*.tests" -type d -printf "%f" | sed 's#.tests$##')
       sed -i "s#TESTFILES_DIRECTORY#../${testfiles_base_path}#" testsuite/${tool}.tests/*.exp
 
@@ -55,7 +55,7 @@ actions:
       cd ..
       pipeline-helper -o customFeedbacks dejagnu -n "dejagnu[${step}]" -l testsuite/${tool}.log
   - name: advanced-tests
-    script: |
+    script: |-
       export testfiles_base_path="./testsuite/testfiles"
       export tool=$(find testsuite -name "*.tests" -type d -printf "%f" | sed 's#.tests$##')
       sed -i "s#TESTFILES_DIRECTORY#../${testfiles_base_path}#" testsuite/${tool}.tests/*.exp
@@ -70,7 +70,7 @@ actions:
       - name: only-for-sending-back
         path: "does-not-exist.json"
   - name: static-code-analysis
-    script: |
+    script: |-
       mvn -B checkstyle:checkstyle
       mkdir -p staticCodeAnalysisReports
       cp target/checkstyle-result.xml staticCodeAnalysisReports

--- a/src/main/resources/templates/aeolus/ocaml/default.sh
+++ b/src/main/resources/templates/aeolus/ocaml/default.sh
@@ -7,7 +7,6 @@ build_and_test_the_code () {
   # the build process is specified in `run.sh` in the test repository
   chmod +x run.sh
   ./run.sh -s
-
 }
 
 junit () {

--- a/src/main/resources/templates/aeolus/ocaml/default.yaml
+++ b/src/main/resources/templates/aeolus/ocaml/default.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: build_and_test_the_code
-    script: |
+    script: |-
       # the build process is specified in `run.sh` in the test repository
       chmod +x run.sh
       ./run.sh -s

--- a/src/main/resources/templates/aeolus/python/default_sequential.sh
+++ b/src/main/resources/templates/aeolus/python/default_sequential.sh
@@ -4,7 +4,6 @@ export AEOLUS_INITIAL_DIRECTORY=${PWD}
 compile_the_code () {
   echo '⚙️ executing compile_the_code'
   python3 -m compileall . -q
-
 }
 
 run_structural_tests () {

--- a/src/main/resources/templates/aeolus/python/default_sequential.yaml
+++ b/src/main/resources/templates/aeolus/python/default_sequential.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: compile_the_code
-    script: |
+    script: |-
       python3 -m compileall . -q
     runAlways: false
   - name: run_structural_tests

--- a/src/main/resources/templates/aeolus/swift/plain.sh
+++ b/src/main/resources/templates/aeolus/swift/plain.sh
@@ -22,7 +22,6 @@ build_and_test_the_code () {
   # so we need to allow everyone to access these files
   cd ..
   chmod -R 777 .
-
 }
 
 main () {

--- a/src/main/resources/templates/aeolus/swift/plain.yaml
+++ b/src/main/resources/templates/aeolus/swift/plain.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: build_and_test_the_code
-    script: |
+    script: |-
       # copy test files
       cp -R Tests assignment
       cp Package.swift assignment

--- a/src/main/resources/templates/aeolus/swift/plain_static.sh
+++ b/src/main/resources/templates/aeolus/swift/plain_static.sh
@@ -23,7 +23,6 @@ build_and_test_the_code () {
   # so we need to allow everyone to access these files
   cd ..
   chmod -R 777 .
-
 }
 
 run_static_code_analysis () {
@@ -35,7 +34,6 @@ run_static_code_analysis () {
   cd assignment
   # Execute static code analysis
   swiftlint > ../target/swiftlint-result.xml
-
 }
 
 final_aeolus_post_action () {

--- a/src/main/resources/templates/aeolus/swift/plain_static.yaml
+++ b/src/main/resources/templates/aeolus/swift/plain_static.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: build_and_test_the_code
-    script: |
+    script: |-
       cp -R Sources assignment
       # copy test files
       cp -R Tests assignment
@@ -24,7 +24,7 @@ actions:
       chmod -R 777 .
     runAlways: false
   - name: run_static_code_analysis
-    script: |
+    script: |-
       # Copy SwiftLint rules
       cp .swiftlint.yml assignment || true
       # create target directory for SCA Parser

--- a/src/main/resources/templates/aeolus/vhdl/default.sh
+++ b/src/main/resources/templates/aeolus/vhdl/default.sh
@@ -22,14 +22,12 @@ provide_environment_information () {
   else
       echo "$REQ_FILE does not exist"
   fi
-
 }
 
 prepare_makefile () {
   echo '⚙️ executing prepare_makefile'
   rm -f assignment/{GNUmakefile, Makefile, makefile}
   cp -f tests/Makefile assignment/Makefile || exit 2
-
 }
 
 run_and_compile () {
@@ -38,7 +36,6 @@ run_and_compile () {
   python3 compileTest.py ../assignment/
   rm compileTest.py
   cp result.xml ../assignment/result.xml
-
 }
 
 junit () {

--- a/src/main/resources/templates/aeolus/vhdl/default.yaml
+++ b/src/main/resources/templates/aeolus/vhdl/default.yaml
@@ -1,7 +1,7 @@
 api: v0.0.1
 actions:
   - name: provide_environment_information
-    script: |
+    script: |-
       #!/bin/bash
       echo "--------------------Python versions--------------------"
       python3 --version
@@ -23,12 +23,12 @@ actions:
       fi
     runAlways: false
   - name: prepare_makefile
-    script: |
+    script: |-
       rm -f assignment/{GNUmakefile, Makefile, makefile}
       cp -f tests/Makefile assignment/Makefile || exit 2
     runAlways: false
   - name: run_and_compile
-    script: |
+    script: |-
       python3 compileTest.py ../assignment/
       rm compileTest.py
       cp result.xml ../assignment/result.xml


### PR DESCRIPTION
@coderabbitai ignore

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Windfiles CI check kept failing in other unrelated PRs due to changes in the scripts, e.g. #8388, #8323:
```
7a8
> 
File ./src/main/resources/templates/aeolus/java/plain_gradle.yaml has changed
```

### Description
<!-- Describe your changes in detail -->
Fixes the ‘Check if windfiles and scripts match’ CI step.

This PR ensures the additional final newlines in multiline strings are always removed.
I’m not sure why it started failing for only this case, as far as I can tell the multiline string block for `plain_gradle.yaml` looks the same as in the other build scripts.

Some of the build scripts already made use of the final newline removal (`c/gcc.yaml` on `develop` right now): https://github.com/ls1intum/Artemis/blob/2ce2dd7540959a50e70e5cd8c2b817c95edd594c/src/main/resources/templates/aeolus/c/gcc.yaml#L28
Therefore, this is supported by Aeolus. This PR unifies the behaviour across all build scripts.


### Steps for Testing
Code review is enough. As you can see there, only empty lines are removed in the generated shell scripts.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2