### PR TITLE
`Development`: Delete process polyfill and adjust paste-related e2e tests

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -38,7 +38,6 @@
               "mobile-drag-drop",
               "papaparse",
               "pepjs",
-              "process",
               "prop-types",
               "react",
               "react-dom",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
                 "ngx-webstorage": "13.0.1",
                 "papaparse": "5.4.1",
                 "posthog-js": "1.120.3",
-                "process": "0.11.10",
                 "rxjs": "7.8.1",
                 "showdown": "2.1.0",
                 "showdown-highlight": "3.1.0",
@@ -17532,14 +17531,6 @@
             "dev": true,
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/process": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-            "engines": {
-                "node": ">= 0.6.0"
             }
         },
         "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
         "ngx-webstorage": "13.0.1",
         "papaparse": "5.4.1",
         "posthog-js": "1.120.3",
-        "process": "0.11.10",
         "rxjs": "7.8.1",
         "showdown": "2.1.0",
         "showdown-highlight": "3.1.0",

--- a/src/main/webapp/app/polyfills.ts
+++ b/src/main/webapp/app/polyfills.ts
@@ -1,8 +1,5 @@
 import 'zone.js';
 import '@angular/localize/init';
-import * as process from 'process';
 
 // Fix needed for SockJS, see https://github.com/sockjs/sockjs-client/issues/439
 (window as any).global = window;
-
-window['process'] = process;

--- a/src/test/cypress/support/pageobjects/exercises/programming/OnlineEditorPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/programming/OnlineEditorPage.ts
@@ -31,15 +31,17 @@ export class OnlineEditorPage {
             }
             cy.fixture(newFile.path)
                 .then(($fileContent) => {
-                    cy.window().then((win) => {
-                        win.navigator.clipboard.writeText($fileContent).then(() => {
-                            // Some files have 200+ lines; typing would be too slow. Instead, paste the file content.
-                            // On MacOS (darwin), the keyboard shortcut is CMD (meta) + V instead of CTRL + V.
-                            const keyModifier = Cypress.platform === 'darwin' ? 'meta' : 'ctrl';
-                            // view-lines is the class of the text area in monaco.
-                            getExercise(exerciseID).find('.view-lines').click().type(`{${keyModifier}}v`).wait(200);
-                        });
-                    });
+                    const clipboardData = new DataTransfer();
+                    const format = 'text/plain';
+                    clipboardData.setData(format, $fileContent);
+                    const pasteEvent = new ClipboardEvent('paste', { clipboardData });
+                    const editorElement = getExercise(exerciseID).find('.view-lines').first();
+                    editorElement
+                        .click()
+                        .then((element) => {
+                            element[0].dispatchEvent(pasteEvent);
+                        })
+                        .wait(500);
                 })
                 .wait(500);
         }

--- a/src/test/playwright/playwright.config.ts
+++ b/src/test/playwright/playwright.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
 import dotenv from 'dotenv';
-import * as process from 'process';
 import { parseNumber } from './support/utils';
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context

- In the Webpack 5 upgrade (#3470), support for the automatic polyfill of the process variable was [discontinued](https://webpack.js.org/migrate/5/#run-a-single-build-and-follow-advice) as it should be avoided in web environments. Nevertheless, we use the process dependency and manually polyfill this into the web environment. Note that we no longer use Webpack
- The Monaco editor uses `typeof process !== undefined` when checking if it is running in a native (rather than a web) environment. This broke pasting into the editor with CTRL+V on multiple browsers (Firefox was unaffected).
 
### Description
<!-- Describe your changes in detail -->
- Removes the `process` polyfill and its dependency. 
- Removes an import of 'process' from playwright
- Makes the paste mechanism used in Cypress more consistent (& platform-independent) with the playwright E2E tests.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Google Chrome or Microsoft Edge
- 1 Student
- 1 Programming exercise with the online code editor enabled

1. Log in to Artemis
2. Navigate to the programming exercise and open it in the online code editor
3. Open a file and ensure you can cut, copy, and paste using the keyboard shortcuts (usually Ctrl+X,Ctrl+C, and Ctrl+V).

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress

#### Code Review
- [ ] Code Review 1
#### Manual Tests
- [ ] Test 1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the paste functionality in the Online Editor by changing the method used to insert text.
- **Chores**
	- Removed the `process` dependency across various configuration and script files, streamlining the project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->