### PR TITLE
`Lectures`: Fix display of end date in header

### DIFF
--- a/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.html
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.html
@@ -19,7 +19,7 @@
                             @if (lecture?.startDate && lecture?.endDate) {
                                 <span class="me-2">
                                     {{ 'artemisApp.courseOverview.lectureDetails.date' | artemisTranslate }} {{ lecture!.startDate | artemisDate }} -
-                                    {{ lecture!.endDate | artemisDate }}
+                                    {{ lecture!.endDate | artemisDate: (endsSameDay ? 'time' : 'long') }}
                                 </span>
                             }
                         </h4>

--- a/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.html
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.html
@@ -19,7 +19,7 @@
                             @if (lecture?.startDate && lecture?.endDate) {
                                 <span class="me-2">
                                     {{ 'artemisApp.courseOverview.lectureDetails.date' | artemisTranslate }} {{ lecture!.startDate | artemisDate }} -
-                                    {{ lecture!.endDate | artemisDate: 'time' }}
+                                    {{ lecture!.endDate | artemisDate }}
                                 </span>
                             }
                         </h4>

--- a/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.ts
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.ts
@@ -111,7 +111,7 @@ export class CourseLectureDetailsComponent extends AbstractScienceComponent impl
                             // We need to manually update the lecture property of the student questions component
                             this.discussionComponent.lecture = this.lecture;
                         }
-                        this.endsSameDay = !!this.lecture?.startDate && !!this.lecture.endDate && this.lecture.startDate.diff(this.lecture.endDate, 'days') === 0;
+                        this.endsSameDay = !!this.lecture?.startDate && !!this.lecture.endDate && dayjs(this.lecture.startDate).isSame(this.lecture.endDate, 'day');
                     },
                     error: (errorResponse: HttpErrorResponse) => onError(this.alertService, errorResponse),
                 });

--- a/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.ts
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.ts
@@ -46,6 +46,7 @@ export class CourseLectureDetailsComponent extends AbstractScienceComponent impl
     profileSubscription?: Subscription;
     isProduction = true;
     isTestServer = false;
+    endsSameDay = false;
 
     readonly LectureUnitType = LectureUnitType;
     readonly isCommunicationEnabled = isCommunicationEnabled;
@@ -110,6 +111,7 @@ export class CourseLectureDetailsComponent extends AbstractScienceComponent impl
                             // We need to manually update the lecture property of the student questions component
                             this.discussionComponent.lecture = this.lecture;
                         }
+                        this.endsSameDay = !!this.lecture?.startDate && !!this.lecture.endDate && this.lecture.startDate.diff(this.lecture.endDate, 'days') === 0;
                     },
                     error: (errorResponse: HttpErrorResponse) => onError(this.alertService, errorResponse),
                 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix the wrong display of end date in lecture header for students.

### Description
<!-- Describe your changes in detail -->
The header only displayed the time for the end date of the lecture. But some lectures can span a week since they are used for tutorials that are spread across the week.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a lecture with a start and end date on different days
4. Look at the student perspective and check that the time frame is correctly displayed in the header
5. Change the end date to be on the same day as the start date
6. Check that the header now only displays the time for the end

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
![Bildschirmfoto 2024-04-13 um 13 55 43](https://github.com/ls1intum/Artemis/assets/38322605/8bfc0af5-daf3-4e45-b7f5-6ba6be8d46d3)
After:
![Bildschirmfoto 2024-04-13 um 13 55 36](https://github.com/ls1intum/Artemis/assets/38322605/f3876e37-808a-4bd4-9cf7-a6c6d439dcf2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the lecture details display to show end dates only when they differ from the start date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->