### PR TITLE
`Programming exercises`: Remove Java 16 specific Spotbugs Rule 

### DIFF
--- a/src/main/resources/templates/java/test/staticCodeAnalysisConfig/spotbugs-exclusions.xml
+++ b/src/main/resources/templates/java/test/staticCodeAnalysisConfig/spotbugs-exclusions.xml
@@ -8,12 +8,6 @@
     The examples below show some filter options.
     -->
 
-    <!-- In case of using Records from Java 16, the equals check should get disabled for that record
-    <Match>
-        <Class name="Package.NameOfRecord" />
-        <Bug code="EQ_UNUSUAL" />
-    </Match> -->
-
     <!-- Matches a whole class
     <Match>
         <Class name="com.foobar.ClassNotToBeAnalyzed" />


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#3092 updated programming exercises to Java 16, which introduced records. Spotbugs did not fully support them at the start, which had to be excluded by a specific rule. This was offered as a comment for instructors to include it as they needed if for potentially added records.
Since we now use Java 17 and Spotbugs was also updated long ago to support Records, this specific rule will no longer be used for records in our programming exercises.

### Description
<!-- Describe your changes in detail -->
Remove unused comment for filter option for potential records in the students code.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
No testing needed, since only a comment is affected.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed outdated code analysis exclusion rules to enhance the accuracy of static code analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->