### PR TITLE
`Programming exercises`: Fix setting language without project type

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-creation-config.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-creation-config.ts
@@ -23,7 +23,7 @@ export type ProgrammingExerciseCreationConfig = {
     isImportFromExistingExercise: boolean;
     isImportFromFile: boolean;
     appNamePatternForSwift: string;
-    modePickerOptions: ModePickerOption<ProjectType>[];
+    modePickerOptions?: ModePickerOption<ProjectType>[];
     withDependencies: boolean;
     onWithDependenciesChanged: (withDependencies: boolean) => boolean;
     packageNameRequired: boolean;
@@ -31,9 +31,9 @@ export type ProgrammingExerciseCreationConfig = {
     supportedLanguages: string[];
     selectedProgrammingLanguage: ProgrammingLanguage;
     onProgrammingLanguageChange: (language: ProgrammingLanguage) => ProgrammingLanguage;
-    projectTypes: ProjectType[];
-    selectedProjectType: ProjectType;
-    onProjectTypeChange: (projectType: ProjectType) => ProjectType;
+    projectTypes?: ProjectType[];
+    selectedProjectType?: ProjectType;
+    onProjectTypeChange: (projectType: ProjectType) => ProjectType | undefined;
     staticCodeAnalysisAllowed: boolean;
     onStaticCodeAnalysisChanged: () => void;
     maxPenaltyPattern: string;

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -95,7 +95,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
     // This is used to revert the select if the user cancels to override the new selected programming language.
     private selectedProgrammingLanguageValue: ProgrammingLanguage;
     // This is used to revert the select if the user cancels to override the new selected project type.
-    private selectedProjectTypeValue: ProjectType;
+    private selectedProjectTypeValue?: ProjectType;
     maxPenaltyPattern = '^([0-9]|([1-9][0-9])|100)$';
     // Java package name Regex according to Java 14 JLS (https://docs.oracle.com/javase/specs/jls/se14/html/jls-7.html#jls-7.4.1),
     // with the restriction to a-z,A-Z,_ as "Java letter" and 0-9 as digits due to JavaScript/Browser Unicode character class limitations
@@ -150,11 +150,11 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
     };
     public originalStaticCodeAnalysisEnabled: boolean | undefined;
 
-    public projectTypes: ProjectType[] = [];
+    public projectTypes?: ProjectType[] = [];
     // flag describing if the template and solution projects should include a dependency
     public withDependenciesValue = false;
 
-    public modePickerOptions: ModePickerOption<ProjectType>[] = [];
+    public modePickerOptions?: ModePickerOption<ProjectType>[] = [];
 
     // Icons
     faQuestionCircle = faQuestionCircle;
@@ -251,8 +251,8 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
         this.testwiseCoverageAnalysisSupported = programmingLanguageFeature.testwiseCoverageAnalysisSupported;
         this.auxiliaryRepositoriesSupported = programmingLanguageFeature.auxiliaryRepositoriesSupported;
         // filter out MAVEN_MAVEN and GRADLE_GRADLE because they are not directly selectable but only via a checkbox
-        this.projectTypes = programmingLanguageFeature.projectTypes.filter((projectType) => projectType !== ProjectType.MAVEN_MAVEN && projectType !== ProjectType.GRADLE_GRADLE);
-        this.modePickerOptions = this.projectTypes.map((projectType) => ({
+        this.projectTypes = programmingLanguageFeature.projectTypes?.filter((projectType) => projectType !== ProjectType.MAVEN_MAVEN && projectType !== ProjectType.GRADLE_GRADLE);
+        this.modePickerOptions = this.projectTypes?.map((projectType) => ({
             value: projectType,
             labelKey: 'artemisApp.programmingExercise.projectTypes.' + projectType.toString(),
             btnClass: 'btn-secondary',
@@ -260,8 +260,8 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
 
         if (languageChanged) {
             // Reset project type when changing programming language as not all programming languages support (the same) project types
-            this.programmingExercise.projectType = this.projectTypes[0];
-            this.selectedProjectTypeValue = this.projectTypes[0]!;
+            this.programmingExercise.projectType = this.projectTypes?.[0];
+            this.selectedProjectTypeValue = this.projectTypes?.[0];
             this.withDependenciesValue = false;
             this.buildPlanLoaded = false;
             this.programmingExercise.windFile = undefined;
@@ -312,7 +312,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
         }
     }
 
-    get selectedProjectType() {
+    get selectedProjectType(): ProjectType | undefined {
         return this.selectedProjectTypeValue;
     }
 

--- a/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-language.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/update-components/programming-exercise-language.component.html
@@ -23,7 +23,7 @@
             }
         </select>
     </div>
-    @if (programmingExercise.programmingLanguage && programmingExerciseCreationConfig.projectTypes && programmingExerciseCreationConfig.projectTypes.length > 0) {
+    @if (programmingExercise.programmingLanguage && programmingExerciseCreationConfig.projectTypes?.length && programmingExerciseCreationConfig.modePickerOptions) {
         <div class="form-group mt-2">
             <label class="label-narrow" jhiTranslate="artemisApp.programmingExercise.projectType" for="field_projectType"></label>
             <jhi-mode-picker

--- a/src/main/webapp/app/exercises/programming/shared/service/programming-language-feature/programming-language-feature.service.ts
+++ b/src/main/webapp/app/exercises/programming/shared/service/programming-language-feature/programming-language-feature.service.ts
@@ -13,7 +13,7 @@ export type ProgrammingLanguageFeature = {
     plagiarismCheckSupported: boolean;
     packageNameRequired: boolean;
     checkoutSolutionRepositoryAllowed: boolean;
-    projectTypes: ProjectType[];
+    projectTypes?: ProjectType[];
     testwiseCoverageAnalysisSupported: boolean;
     auxiliaryRepositoriesSupported: boolean;
 };

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -1107,7 +1107,6 @@ const getProgrammingLanguageFeature = (programmingLanguage: ProgrammingLanguage)
                 plagiarismCheckSupported: false,
                 packageNameRequired: false,
                 checkoutSolutionRepositoryAllowed: true,
-                projectTypes: [],
                 testwiseCoverageAnalysisSupported: false,
                 auxiliaryRepositoriesSupported: true,
             } as ProgrammingLanguageFeature;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.


### Motivation and Context
Resolves #8394


### Description
The server was adapted to not send an empty array but undefined for non existing project types for programming languages (#8360 ) -> this resulted in a type error in the typescript code.
![image](https://github.com/ls1intum/Artemis/assets/78978542/90c2df7f-b98d-4c5a-84cc-1a456df2a8c0)

This PR makes projectType typing in ts optional to match server implementation.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Create a Python exercise (or some other where no project type can be set)
3. Verify that it is possible and created correctly (language PYTHON is visible on the detail page)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration flexibility in programming exercises by making project types and mode options optional.

- **Bug Fixes**
	- Updated UI components to handle optional project types and mode options, preventing potential errors.

- **Refactor**
	- Improved code robustness by introducing optional chaining in programming exercise management components.

- **Tests**
	- Adjusted tests to align with the new optional fields in programming exercise configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->