### PR TITLE
`Tutorial groups`: Improve tutor usability

### DIFF
--- a/src/main/webapp/app/course/tutorial-groups/services/tutorial-group-session.service.ts
+++ b/src/main/webapp/app/course/tutorial-groups/services/tutorial-group-session.service.ts
@@ -23,6 +23,7 @@ export class TutorialGroupSessionService {
         private httpClient: HttpClient,
         private tutorialGroupFreePeriodService: TutorialGroupFreePeriodService,
     ) {}
+
     getOneOfTutorialGroup(courseId: number, tutorialGroupId: number, sessionId: number) {
         return this.httpClient
             .get<TutorialGroupSession>(`${this.resourceURL}/courses/${courseId}/tutorial-groups/${tutorialGroupId}/sessions/${sessionId}`, { observe: 'response' })

--- a/src/main/webapp/app/course/tutorial-groups/shared/tutorial-group-detail/tutorial-group-detail.component.html
+++ b/src/main/webapp/app/course/tutorial-groups/shared/tutorial-group-detail/tutorial-group-detail.component.html
@@ -19,6 +19,7 @@
                 [tutorialGroup]="tutorialGroup"
                 [showIdColumn]="false"
                 [isReadOnly]="!course.isAtLeastTutor"
+                (attendanceUpdated)="recalculateAttendanceDetails()"
             />
         </div>
     } @else {

--- a/src/main/webapp/app/course/tutorial-groups/shared/tutorial-group-detail/tutorial-group-detail.component.html
+++ b/src/main/webapp/app/course/tutorial-groups/shared/tutorial-group-detail/tutorial-group-detail.component.html
@@ -13,7 +13,13 @@
     </div>
     @if (sessions && sessions.length) {
         <div class="scrollbar table-wrapper-scroll-y border border-lightgrey p-3">
-            <jhi-tutorial-group-sessions-table [timeZone]="timeZone" [sessions]="sessions" [tutorialGroup]="tutorialGroup" [showIdColumn]="false" [isReadOnly]="true" />
+            <jhi-tutorial-group-sessions-table
+                [timeZone]="timeZone"
+                [sessions]="sessions"
+                [tutorialGroup]="tutorialGroup"
+                [showIdColumn]="false"
+                [isReadOnly]="!course.isAtLeastTutor"
+            />
         </div>
     } @else {
         <span>{{ '-' }}</span>

--- a/src/main/webapp/app/course/tutorial-groups/shared/tutorial-groups-table/tutorial-group-row/tutorial-group-row.component.html
+++ b/src/main/webapp/app/course/tutorial-groups/shared/tutorial-groups-table/tutorial-group-row/tutorial-group-row.component.html
@@ -12,7 +12,7 @@
     <td>
         <jhi-tutorial-group-utilization-indicator [tutorialGroup]="tutorialGroup" />
     </td>
-    <td>{{ (tutorialGroup.capacity ?? '') + ' / ' + (tutorialGroup.numberOfRegisteredUsers ?? '') }}</td>
+    <td>{{ (tutorialGroup.numberOfRegisteredUsers ?? '') + ' / ' + (tutorialGroup.capacity ?? '') }}</td>
     <td>{{ tutorialGroup.isUserTutor ? ('global.generic.you' | artemisTranslate) : tutorialGroup.teachingAssistantName }}</td>
     <td>
         @if (tutorialGroup.tutorialGroupSchedule) {

--- a/src/main/webapp/app/course/tutorial-groups/shared/tutorial-groups-table/tutorial-groups-table.component.html
+++ b/src/main/webapp/app/course/tutorial-groups/shared/tutorial-groups-table/tutorial-groups-table.component.html
@@ -22,7 +22,7 @@
                     <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.entities.tutorialGroup.utilizationHelp' | artemisTranslate }}" />
                 </th>
                 <th jhiSortBy="capacityAndRegistrations">
-                    <a class="th-link">{{ 'artemisApp.entities.tutorialGroup.capacityWithRegistrations' | artemisTranslate }}</a>
+                    <a class="th-link">{{ 'artemisApp.entities.tutorialGroup.registrationsWithCapacity' | artemisTranslate }}</a>
                     <fa-icon [icon]="faSort" />
                 </th>
                 <th jhiSortBy="teachingAssistantName">

--- a/src/main/webapp/app/overview/course-tutorial-groups/course-tutorial-groups.component.ts
+++ b/src/main/webapp/app/overview/course-tutorial-groups/course-tutorial-groups.component.ts
@@ -53,7 +53,11 @@ export class CourseTutorialGroupsComponent implements AfterViewInit, OnInit, OnD
     }
 
     get registeredTutorialGroups() {
-        return this.tutorialGroups.filter((tutorialGroup) => tutorialGroup.isUserRegistered);
+        if (this.course?.isAtLeastTutor) {
+            return this.tutorialGroups.filter((tutorialGroup) => tutorialGroup.isUserTutor);
+        } else {
+            return this.tutorialGroups.filter((tutorialGroup) => tutorialGroup.isUserRegistered);
+        }
     }
 
     ngOnInit(): void {

--- a/src/main/webapp/i18n/de/tutorialGroups.json
+++ b/src/main/webapp/i18n/de/tutorialGroups.json
@@ -40,7 +40,7 @@
                 "language": "Sprache",
                 "teachingAssistant": "Tutor:in",
                 "registrations": "Registrierungen",
-                "capacityWithRegistrations": "Kapazität / Registrierungen",
+                "registrationsWithCapacity": "Registrierungen / Kapazität",
                 "schedule": "Sitzungsplan",
                 "sessions": "Sitzungen",
                 "nextSession": "Nächste Sitzung",

--- a/src/main/webapp/i18n/en/tutorialGroups.json
+++ b/src/main/webapp/i18n/en/tutorialGroups.json
@@ -40,7 +40,7 @@
                 "language": "Language",
                 "teachingAssistant": "Tutor",
                 "registrations": "Registrations",
-                "capacityWithRegistrations": "Capacity / Registrations",
+                "registrationsWithCapacity": "Registrations / Capacity",
                 "schedule": "Schedule",
                 "sessions": "Sessions",
                 "nextSession": "Next Session",

--- a/src/test/javascript/spec/component/tutorial-groups/course-tutorial-groups/course-tutorial-groups.component.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/course-tutorial-groups/course-tutorial-groups.component.spec.ts
@@ -48,8 +48,9 @@ describe('CourseTutorialGroupsComponent', () => {
     let fixture: ComponentFixture<CourseTutorialGroupsComponent>;
     let component: CourseTutorialGroupsComponent;
 
-    let tutorialGroupTwo: TutorialGroup;
     let tutorialGroupOne: TutorialGroup;
+    let tutorialGroupTwo: TutorialGroup;
+    let tutorialGroupThree: TutorialGroup;
 
     const router = new MockRouter();
 
@@ -88,8 +89,9 @@ describe('CourseTutorialGroupsComponent', () => {
             .then(() => {
                 fixture = TestBed.createComponent(CourseTutorialGroupsComponent);
                 component = fixture.componentInstance;
-                tutorialGroupOne = generateExampleTutorialGroup({ id: 1 });
-                tutorialGroupTwo = generateExampleTutorialGroup({ id: 2 });
+                tutorialGroupOne = generateExampleTutorialGroup({ id: 1, isUserTutor: true });
+                tutorialGroupTwo = generateExampleTutorialGroup({ id: 2, isUserRegistered: true });
+                tutorialGroupThree = generateExampleTutorialGroup({ id: 3 });
             });
     });
 
@@ -163,5 +165,17 @@ describe('CourseTutorialGroupsComponent', () => {
             queryParamsHandling: 'merge',
             replaceUrl: true,
         });
+    });
+
+    it('should filter registered tutorial groups for student', () => {
+        component.tutorialGroups = [tutorialGroupOne, tutorialGroupTwo, tutorialGroupThree];
+        component.course = { id: 1, title: 'Test Course' } as Course;
+        expect(component.registeredTutorialGroups).toEqual([tutorialGroupTwo]);
+    });
+
+    it('should filter registered tutorial groups for tutor', () => {
+        component.tutorialGroups = [tutorialGroupOne, tutorialGroupTwo, tutorialGroupThree];
+        component.course = { id: 1, title: 'Test Course', isAtLeastTutor: true } as Course;
+        expect(component.registeredTutorialGroups).toEqual([tutorialGroupOne]);
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Tutors also have to navigate to their tutorials to either verify or look up information there or to insert the number of attendees for the latest session. This should be made as easy as possible.
Additionally fixes #8428

### Description
<!-- Describe your changes in detail -->
- Now shows the tutorial group of the tutor in the course view instead of `You are not registered to any tutorial group in this course.`
- When navigating to the details view of the tutorial group, the tutor can now enter the attending students in the sessions table. This also updates the average attendees and utilization if that is necessary (one of the latest three sessions that are already past were edited)
- The update is not done when the tutor enters the information via the session detail view, since this was not implemented previously as well
- The attendance is now displayed before the capacity, see: #8428

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a tutorial group and assign yourself as tutor and create a few sessions in the future and past
4. Head to the course view and check out the tutorial group view there. Make sure that you see your assigned tutorial group
5. Click on that tutorial group and input different attendee numbers for different sessions. The average attendees should update when editing any of the latest three past sessions

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [tutorial-group-session.service.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6440/latest/artifact/shared/Coverage-Report-Client-Tests/app/course/tutorial-groups/services/tutorial-group-session.service.ts.html) | 94.87% | ✅ |
| [tutorial-group-detail.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6440/latest/artifact/shared/Coverage-Report-Client-Tests/app/course/tutorial-groups/shared/tutorial-group-detail/tutorial-group-detail.component.ts.html) | 90.24% | ✅ |
| [course-tutorial-groups.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6440/latest/artifact/shared/Coverage-Report-Client-Tests/app/overview/course-tutorial-groups/course-tutorial-groups.component.ts.html) | 85.41% | ✅ |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="498" alt="Bildschirmfoto 2024-04-17 um 23 02 47" src="https://github.com/ls1intum/Artemis/assets/38322605/e851f159-c535-437c-b683-db4043ced83d">
<img width="1728" alt="Bildschirmfoto 2024-04-17 um 23 03 09" src="https://github.com/ls1intum/Artemis/assets/38322605/ef679866-4633-43ff-a5b0-0f3dfd11a3ba">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a read-only attribute to the tutorial group sessions table based on user role.
	- Introduced an event to recalculate attendance details upon updates.
	- Enhanced filtering of tutorial groups for users based on their roles.

- **Bug Fixes**
	- Adjusted attendance calculation method in `TutorialGroupDetailComponent`.

- **Tests**
	- Updated and added new test cases to reflect changes in user role filtering and attendance calculations in tutorial groups components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->