### PR TITLE
`Development`: Update setup documentation to JDK 21

### DIFF
--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -26,7 +26,7 @@ following dependencies/tools on your machine:
 
 1. `Java
    JDK <https://www.oracle.com/java/technologies/javase-downloads.html>`__:
-   We use Java (JDK 17) to develop and run the Artemis application
+   We use Java (JDK 21) to develop and run the Artemis application
    server, which is based on `Spring
    Boot <http://projects.spring.io/spring-boot>`__.
 2. `MySQL Database Server 8 <https://dev.mysql.com/downloads/mysql>`__, or `PostgreSQL <https://www.postgresql.org/>`_:


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
When setting up my local Artemis instance I noticed that there is a mismatch between the currently [stated java version JDK17 in the documentation](https://artemis-platform.readthedocs.io/en/7.0.1/dev/setup.html) and the actually used version JDK21, as defined in [build.gradle](https://github.com/ls1intum/Artemis/blob/develop/build.gradle).


### Description
Adjusted the documentation to display the currently used JDK version.


### Steps for Testing
1. Open the documentation at `Contributor Guide` > `Setup Guide` and see that JDK 21 is displayed instead of JDK 17

You can find the build documentation in the GitHub Actions: https://artemis-platform--8450.org.readthedocs.build/en/8450/dev/setup.html
### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
