### PR TITLE
`Development`: Fix server starts check script

### DIFF
--- a/supporting_scripts/extract_number_of_server_starts.sh
+++ b/supporting_scripts/extract_number_of_server_starts.sh
@@ -9,8 +9,8 @@ then
   exit 1
 fi
 
-if [[ $numberOfStarts -gt 4 ]]
+if [[ $numberOfStarts -ne 4 ]]
 then
-  echo "The number of Server Starts should not be greater than 4!"
+  echo "The number of Server Starts should be equal to 4! Please adapt this check if the change is intended or try to fix the underlying issue causing a different number of server starts!"
   exit 1
 fi

--- a/supporting_scripts/extract_number_of_server_starts.sh
+++ b/supporting_scripts/extract_number_of_server_starts.sh
@@ -9,8 +9,8 @@ then
   exit 1
 fi
 
-if [[ $numberOfStarts -gt 5 ]]
+if [[ $numberOfStarts -gt 4 ]]
 then
-  echo "The number of Server Starts should not be greater than 5!"
+  echo "The number of Server Starts should not be greater than 4!"
   exit 1
 fi


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
After the removal of the Atlassian stack in #8201 , the number of server starts in our integration test suite decreased by 1 but the script to check the number of server starts wasn't adapted accordingly. This allowed the introduction of an additional server start as in #8449 without causing a failure of the server-tests job.

### Description
<!-- Describe your changes in detail -->
Adapted the script to only allow 4 server starts now.

### Steps for Testing
Make sure the server-tests job still passes.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the server start threshold from 5 to 4 for triggering error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->