### PR TITLE
`Programming exercises`: Display hidden files when editing as instructor and viewing the repository

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -37,7 +37,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.HiddenFileFilter;
+import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.CommitCommand;
@@ -1161,6 +1161,21 @@ public class GitService {
         }
     }
 
+    private static class FileAndDirectoryFilter implements IOFileFilter {
+
+        private static final String GIT_DIRECTORY_NAME = ".git";
+
+        @Override
+        public boolean accept(java.io.File file) {
+            return !GIT_DIRECTORY_NAME.equals(file.getName());
+        }
+
+        @Override
+        public boolean accept(java.io.File directory, String fileName) {
+            return !GIT_DIRECTORY_NAME.equals(directory.getName());
+        }
+    }
+
     /**
      * List all files and folders in the repository
      *
@@ -1170,7 +1185,9 @@ public class GitService {
     public Map<File, FileType> listFilesAndFolders(Repository repo) {
         // Check if list of files is already cached
         if (repo.getContent() == null) {
-            Iterator<java.io.File> itr = FileUtils.iterateFilesAndDirs(repo.getLocalPath().toFile(), HiddenFileFilter.VISIBLE, HiddenFileFilter.VISIBLE);
+            FileAndDirectoryFilter filter = new FileAndDirectoryFilter();
+
+            Iterator<java.io.File> itr = FileUtils.iterateFilesAndDirs(repo.getLocalPath().toFile(), filter, filter);
             Map<File, FileType> files = new HashMap<>();
 
             while (itr.hasNext()) {
@@ -1183,10 +1200,8 @@ public class GitService {
                     continue;
                 }
 
-                // Files starting with a '.' are not marked as hidden in Windows. WE must exclude these
-                if (nextFile.getName().charAt(0) != '.') {
-                    files.put(nextFile, nextFile.isFile() ? FileType.FILE : FileType.FOLDER);
-                }
+                files.put(nextFile, nextFile.isFile() ? FileType.FILE : FileType.FOLDER);
+
             }
 
             // TODO: rene: idea: ask in setup to include hidden files? only allow for tutors and instructors?
@@ -1214,7 +1229,8 @@ public class GitService {
     public Collection<File> listFiles(Repository repo) {
         // Check if list of files is already cached
         if (repo.getFiles() == null) {
-            Iterator<java.io.File> itr = FileUtils.iterateFiles(repo.getLocalPath().toFile(), HiddenFileFilter.VISIBLE, HiddenFileFilter.VISIBLE);
+            FileAndDirectoryFilter filter = new FileAndDirectoryFilter();
+            Iterator<java.io.File> itr = FileUtils.iterateFiles(repo.getLocalPath().toFile(), filter, filter);
             Collection<File> files = new ArrayList<>();
 
             while (itr.hasNext()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -1201,16 +1201,7 @@ public class GitService {
                 }
 
                 files.put(nextFile, nextFile.isFile() ? FileType.FILE : FileType.FOLDER);
-
             }
-
-            // TODO: rene: idea: ask in setup to include hidden files? only allow for tutors and instructors?
-            // Current problem: .swiftlint.yml gets filtered out
-            /*
-             * Uncomment to show hidden files // Filter for hidden config files, e.g. '.swiftlint.yml' Iterator<java.io.File> hiddenFiles =
-             * FileUtils.iterateFilesAndDirs(repo.getLocalPath().toFile(), HiddenFileFilter.HIDDEN, HiddenFileFilter.HIDDEN); while (hiddenFiles.hasNext()) { File nextFile = new
-             * File(hiddenFiles.next(), repo); if (nextFile.isFile() && nextFile.getName().contains(".swiftlint")) { files.put(nextFile, FileType.FILE); } }
-             */
 
             // Cache the list of files
             // Avoid expensive rescanning

--- a/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-and-editor-container.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-and-editor-container.component.html
@@ -21,6 +21,7 @@
         [participation]="selectedParticipation!"
         [buildable]="selectedRepository !== REPOSITORY.TEST"
         [course]="course"
+        [allowHiddenFiles]="true"
         [useMonacoEditor]="true"
         (onResizeEditorInstructions)="onResizeEditorInstructions()"
     >

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.html
@@ -33,6 +33,7 @@
         [isTutorAssessment]="isTutorAssessment"
         [highlightFileChanges]="highlightFileChanges"
         [fileBadges]="fileBadges"
+        [allowHiddenFiles]="allowHiddenFiles"
         [(selectedFile)]="selectedFile"
         [(commitState)]="commitState"
         (onFileChange)="onFileChange($event)"

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
@@ -63,6 +63,8 @@ export class CodeEditorContainerComponent implements OnChanges, ComponentCanDeac
     @Input()
     highlightFileChanges = false;
     @Input()
+    allowHiddenFiles = false;
+    @Input()
     feedbackSuggestions: Feedback[] = [];
     @Input()
     readOnlyManualFeedback = false;

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
@@ -76,6 +76,8 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
     highlightFileChanges = false;
     @Input()
     fileBadges: { [path: string]: FileBadge[] } = {};
+    @Input()
+    allowHiddenFiles = false;
 
     @Output()
     onToggleCollapse = new EventEmitter<InteractableEvent>();
@@ -416,7 +418,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
         if (Object.keys(this.repositoryFiles).includes(newFilePath)) {
             this.onError.emit('fileExists');
             return;
-        } else if (!CodeEditorFileBrowserComponent.shouldDisplayFile(newFileName, fileType)) {
+        } else if (!this.allowHiddenFiles && !CodeEditorFileBrowserComponent.shouldDisplayFile(newFileName, fileType)) {
             this.onError.emit('unsupportedFile');
             return;
         }
@@ -454,7 +456,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
         }
         const [folderPath, fileType] = this.creatingFile;
 
-        if (!CodeEditorFileBrowserComponent.shouldDisplayFile(fileName, fileType)) {
+        if (!this.allowHiddenFiles && !CodeEditorFileBrowserComponent.shouldDisplayFile(fileName, fileType)) {
             this.onError.emit('unsupportedFile');
             return;
         } else if (Object.keys(this.repositoryFiles).includes(folderPath ? [folderPath, fileName].join('/') : fileName)) {
@@ -509,7 +511,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
             rxMap((files) =>
                 fromPairs(
                     toPairs(files)
-                        .filter(([fileName, fileType]) => CodeEditorFileBrowserComponent.shouldDisplayFile(fileName, fileType))
+                        .filter(([fileName, fileType]) => this.allowHiddenFiles || CodeEditorFileBrowserComponent.shouldDisplayFile(fileName, fileType))
                         // Filter Readme file that was historically in the student's assignment repo
                         .filter(([value]) => !value.includes('README.md'))
                         // Filter root folder
@@ -525,7 +527,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
             rxMap((files) =>
                 fromPairs(
                     toPairs(files)
-                        .filter(([filename]) => CodeEditorFileBrowserComponent.shouldDisplayFile(filename, FileType.FILE))
+                        .filter(([filename]) => this.allowHiddenFiles || CodeEditorFileBrowserComponent.shouldDisplayFile(filename, FileType.FILE))
                         // Filter Readme file that was historically in the student's assignment repo
                         .filter(([value]) => !value.includes('README.md')),
                 ),

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/monaco/code-editor-monaco.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/monaco/code-editor-monaco.component.html
@@ -52,7 +52,7 @@
         }
         <jhi-monaco-editor
             (textChanged)="onFileTextChanged($event)"
-            [hidden]="!selectedFile || isLoading"
+            [hidden]="!selectedFile || isLoading || binaryFileSelected"
             [readOnly]="editorLocked"
             [textChangedEmitDelay]="200"
             #editor
@@ -64,6 +64,8 @@
             <p id="no-file-selected" class="code-editor-ace__content__no-selected text-center lead text-body-secondary pt-5" jhiTranslate="artemisApp.editor.selectFile">
                 Select a file to get started!.
             </p>
+        } @else if (binaryFileSelected) {
+            <p id="binary-file-selected" class="code-editor-ace__content__no-selected text-center lead pt-5" jhiTranslate="artemisApp.editor.binaryFileSelected"></p>
         }
     </div>
 </div>

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/monaco/code-editor-monaco.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/monaco/code-editor-monaco.component.html
@@ -61,11 +61,9 @@
         />
 
         @if (!selectedFile && !isLoading) {
-            <p id="no-file-selected" class="code-editor-ace__content__no-selected text-center lead text-body-secondary pt-5" jhiTranslate="artemisApp.editor.selectFile">
-                Select a file to get started!.
-            </p>
+            <p id="no-file-selected" class="text-center lead text-body-secondary pt-5" jhiTranslate="artemisApp.editor.selectFile"></p>
         } @else if (binaryFileSelected) {
-            <p id="binary-file-selected" class="code-editor-ace__content__no-selected text-center lead pt-5" jhiTranslate="artemisApp.editor.binaryFileSelected"></p>
+            <p id="binary-file-selected" class="text-center lead pt-5" jhiTranslate="artemisApp.editor.binaryFileSelected"></p>
         }
     </div>
 </div>

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/monaco/code-editor-monaco.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/monaco/code-editor-monaco.component.ts
@@ -35,6 +35,8 @@ import { fromPairs, pickBy } from 'lodash-es';
 import { faPlusSquare } from '@fortawesome/free-solid-svg-icons';
 import { CodeEditorTutorAssessmentInlineFeedbackSuggestionComponent } from 'app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback-suggestion.component';
 import { MonacoEditorLineHighlight } from 'app/shared/monaco-editor/model/monaco-editor-line-highlight.model';
+import { FileTypeService } from 'app/exercises/programming/shared/service/file-type.service';
+
 @Component({
     selector: 'jhi-code-editor-monaco',
     templateUrl: './code-editor-monaco.component.html',
@@ -98,6 +100,7 @@ export class CodeEditorMonacoComponent implements OnChanges {
 
     fileSession: FileSession = {};
     newFeedbackLines: number[] = [];
+    binaryFileSelected = false;
 
     faPlusSquare = faPlusSquare;
 
@@ -113,6 +116,7 @@ export class CodeEditorMonacoComponent implements OnChanges {
         private fileService: CodeEditorFileService,
         protected localStorageService: LocalStorageService,
         private changeDetectorRef: ChangeDetectorRef,
+        private fileTypeService: FileTypeService,
     ) {}
 
     async ngOnChanges(changes: SimpleChanges): Promise<void> {
@@ -168,8 +172,13 @@ export class CodeEditorMonacoComponent implements OnChanges {
             this.isLoading = false;
         }
 
-        this.editor.changeModel(fileName, this.fileSession[fileName].code);
-        this.editor.setPosition(this.fileSession[fileName].cursor);
+        const code = this.fileSession[fileName].code;
+        this.binaryFileSelected = this.fileTypeService.isBinaryContent(code);
+
+        if (!this.binaryFileSelected) {
+            this.editor.changeModel(fileName, code);
+            this.editor.setPosition(this.fileSession[fileName].cursor);
+        }
     }
 
     onFileTextChanged(text: string): void {

--- a/src/main/webapp/app/exercises/programming/shared/service/file-type.service.ts
+++ b/src/main/webapp/app/exercises/programming/shared/service/file-type.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+
+const CHAR_CODE_TAB = 9;
+const CHAR_CODE_LINE_FEED = 10;
+const CHAR_CODE_CARRIAGE_RETURN = 13;
+const CHAR_CODE_SPACE = 32;
+const IGNORED_CHAR_CODES = [CHAR_CODE_TAB, CHAR_CODE_LINE_FEED, CHAR_CODE_CARRIAGE_RETURN];
+@Injectable({
+    providedIn: 'root',
+})
+export class FileTypeService {
+    constructor() {}
+
+    /**
+     * Determines for a string whether it represents the content of a binary file.
+     * This is done by checking for characters that would not typically be found in plain text files, e.g. the 0-byte.
+     * @param content The content to check.
+     */
+    isBinaryContent(content: string): boolean {
+        for (let i = 0; i < content.length; i++) {
+            const charCode = content.charCodeAt(i);
+            // Check for control characters which are typically not found in text files.
+            if (charCode < CHAR_CODE_SPACE && !IGNORED_CHAR_CODES.includes(charCode)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/webapp/app/localvc/repository-view/repository-view.component.html
+++ b/src/main/webapp/app/localvc/repository-view/repository-view.component.html
@@ -23,6 +23,7 @@
             [buildable]="false"
             [participation]="participation"
             [showEditorInstructions]="showEditorInstructions"
+            [allowHiddenFiles]="true"
             [isTutorAssessment]="true"
             [readOnlyManualFeedback]="true"
             [course]="getCourseFromExercise(exercise)"

--- a/src/main/webapp/i18n/de/editor.json
+++ b/src/main/webapp/i18n/de/editor.json
@@ -34,6 +34,7 @@
             "buildFailed": "Build gescheitert",
             "noBuildOutput": "Keine Build-Ergebnisse verfügbar.",
             "selectFile": "Wähle eine Datei aus, um zu beginnen!",
+            "binaryFileSelected": "Diese Datei ist eine Binärdatei, die nicht angezeigt werden kann.",
             "downloadBuildResult": "Build-Ergebnis herunterladen",
             "saving": "Speichert",
             "saveFiles": "Speichern",

--- a/src/main/webapp/i18n/en/editor.json
+++ b/src/main/webapp/i18n/en/editor.json
@@ -34,6 +34,7 @@
             "buildFailed": "Build failed",
             "noBuildOutput": "No build results available",
             "selectFile": "Select a file to get started!",
+            "binaryFileSelected": "This is a binary file that cannot be displayed.",
             "downloadBuildResult": "Download Build Result",
             "saving": "Saving",
             "saveFiles": "Save",

--- a/src/test/javascript/spec/component/code-editor/code-editor-monaco.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-monaco.component.spec.ts
@@ -191,6 +191,19 @@ describe('CodeEditorMonacoComponent', () => {
         expect(comp.fileSession).toEqual({ [fileToLoad.fileName]: { code: fileToLoad.fileContent, loadingError: false, cursor: { row: 0, column: 0 } } });
     });
 
+    it('should not load binaries into the editor', async () => {
+        const changeModelSpy = jest.spyOn(comp.editor, 'changeModel');
+        const fileName = 'file-to-load';
+        comp.fileSession = {
+            [fileName]: { code: '\0\0\0\0 (binary content)', loadingError: false, cursor: { row: 0, column: 0 } },
+        };
+        fixture.detectChanges();
+        comp.selectedFile = fileName;
+        await comp.selectFileInEditor(fileName);
+        expect(changeModelSpy).not.toHaveBeenCalled();
+        expect(comp.binaryFileSelected).toBeTrue();
+    });
+
     it.each([
         [new ConnectionError(), 'loadingFailedInternetDisconnected'],
         [new Error(), 'loadingFailed'],

--- a/src/test/javascript/spec/service/file-type.service.spec.ts
+++ b/src/test/javascript/spec/service/file-type.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FileTypeService } from 'app/exercises/programming/shared/service/file-type.service';
+
+describe('FileTypeService', () => {
+    let service: FileTypeService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+        });
+
+        service = TestBed.inject(FileTypeService);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it.each([
+        { content: '', isBinary: false },
+        { content: 'this is ordinary text', isBinary: false },
+        { content: 'this contains\0 a 0-byte', isBinary: true },
+        { content: 'more\x01\x02\x03 binary content', isBinary: true },
+        { content: 'newlines\n, tabs \t, and carriage returns\r do not indicate binaries', isBinary: false },
+    ])('should correctly identify binary file content', ({ content, isBinary }) => {
+        const result = service.isBinaryContent(content);
+        expect(result).toBe(isBinary);
+    });
+});


### PR DESCRIPTION
### Checklist
#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context

The code editor currently filters out files based on their name, e.g. files that start with `.` or files that have unsupported extensions. This is inconvenient when editing the exercise in the online code editor and viewing the repository, as parts of the repository may be hidden by these rules.

Furthermore, hidden files do not appear when viewing the commit history in the repository view.

### Description
<!-- Describe your changes in detail -->
This PR adds some new functionality to display these files:

- Server:
  - New filter for retrieving files and directories
  - When retrieving the repository, all files are now retrieved - except for the .git directory.
- Client:
  - New service that checks whether a file's contents are likely binary
  - Binary files are not loaded into the code editor
  - The code editor now displays hidden files
    - when an instructor edits the exercise (Edit in Editor)
    - when a user views the repository (Open Repository)
  - Hidden files are also visible when a user checks the commit history and selects a commit, except for binaries.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Test Server with LocalCI
- 1 Instructor
- 1 Student
- 1 Programming Exercise with the Online Code Editor enabled. Use the default Java template

**Edit in editor**

1. Log in to Artemis as the instructor
2. Navigate to Course Management > Your course > Your programming exercise > Edit in Editor.
3. Edit the template repository: verify that files such as .gitignore, .gitattributes are visible and that you can make changes.
4. Verify that you cannot load the gradle-wrapper.jar into the editor (but that it is visible in the file browser) and that an appropriate placeholder is displayed if you try.

**Participating**

5. Log in as the student
6. Navigate to your course > Your programming exercise > Open code editor
7. Verify that the files .gitignore, .gitattributes, and the gradle-wrapper.jar are not visible.

**Repository view**

8. Go back to the programming exercise.
9. Click "Open Repository". In the file browser, the hidden files should be visible.
10. Click "Open Commit History" and pick the initial commit
11. Verify that .gitattributes and .gitignore are visible and that the gradle-wrapper.jar is not listed.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [code-editor-monaco.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6493/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/programming/shared/code-editor/monaco/code-editor-monaco.component.ts.html) | 91.46% | ✅ |
| [file-type.service.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6493/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/programming/shared/service/file-type.service.ts.html) | 100% | ✅ |


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://github.com/ls1intum/Artemis/assets/38403547/28aef412-baf6-4be5-8e01-e73d98978e89)

![image](https://github.com/ls1intum/Artemis/assets/38403547/17d188b1-fc47-48e7-828e-7f6740cb0858)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced file and directory filtering in the Git service.
  - Enabled support for hidden files in various code editor components across the platform.
  - Introduced conditional rendering for file selection messages in Monaco editor component.
  - Added functionality to identify binary file content.

- **Bug Fixes**
  - Adjusted file visibility settings to allow hidden files in the repository view and code editor components.

- **Tests**
  - Added tests to ensure binary files are not loaded into the Monaco editor.
  - Implemented a test suite for verifying binary file content identification.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->