### PR TITLE
`Development`: Improve the server tests for AuxiliaryRepositoryService

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/programming/AuxiliaryRepositoryService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/AuxiliaryRepositoryService.java
@@ -64,7 +64,7 @@ public class AuxiliaryRepositoryService {
                 return true;
             }
             AuxiliaryRepository auxiliaryRepositoryBeforeUpdate = auxiliaryRepositoryRepository.findById(repo.getId())
-                    .orElseThrow(() -> new IllegalStateException("Edited an existing repository that is not in the data base!"));
+                    .orElseThrow(() -> new IllegalStateException("Edited an existing repository that is not in the database!"));
             return !repo.containsEqualStringValues(auxiliaryRepositoryBeforeUpdate);
         }).toList());
         validateAndUpdateExistingAuxiliaryRepositoriesOfProgrammingExercise(programmingExercise, newOrEditedAuxiliaryRepositories, updatedExercise);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/AuxiliaryRepositoryServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/AuxiliaryRepositoryServiceTest.java
@@ -58,7 +58,7 @@ class AuxiliaryRepositoryServiceTest extends AbstractSpringIntegrationIndependen
     }
 
     @Test
-    void shouldReturnTureIfAuxiliaryRepositoryOfExercise() {
+    void shouldReturnTrueIfAuxiliaryRepositoryOfExercise() {
         auxiliaryRepositoryRepository.save(createAuxiliaryRepository("test", "test", "test", programmingExerciseBeforeUpdate, null));
 
         assertThat(auxiliaryRepositoryService.isAuxiliaryRepositoryOfExercise("test", programmingExerciseBeforeUpdate)).isTrue();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/AuxiliaryRepositoryServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programmingexercise/AuxiliaryRepositoryServiceTest.java
@@ -1,0 +1,223 @@
+package de.tum.in.www1.artemis.exercise.programmingexercise;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
+import de.tum.in.www1.artemis.domain.AuxiliaryRepository;
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
+import de.tum.in.www1.artemis.repository.AuxiliaryRepositoryRepository;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+import de.tum.in.www1.artemis.service.programming.AuxiliaryRepositoryService;
+import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
+
+class AuxiliaryRepositoryServiceTest extends AbstractSpringIntegrationIndependentTest {
+
+    private static final String TEST_INVALID_LENGTH_STRING = "a".repeat(AuxiliaryRepository.MAX_NAME_LENGTH + 1);
+
+    private static final String TEST_INVALID_DESCRIPTION_LENGTH_STRING = "a".repeat(AuxiliaryRepository.MAX_DESCRIPTION_LENGTH + 1);
+
+    @Autowired
+    private AuxiliaryRepositoryRepository auxiliaryRepositoryRepository;
+
+    @Autowired
+    private AuxiliaryRepositoryService auxiliaryRepositoryService;
+
+    @Autowired
+    private ExerciseUtilService exerciseUtilService;
+
+    @Autowired
+    private ProgrammingExerciseUtilService programmingExerciseUtilService;
+
+    @Autowired
+    private ProgrammingExerciseRepository programmingExerciseRepository;
+
+    private static ProgrammingExercise programmingExerciseBeforeUpdate;
+
+    private static ProgrammingExercise updatedProgrammingExercise;
+
+    @BeforeEach
+    void setUp() {
+        var course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
+        programmingExerciseBeforeUpdate = exerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
+        programmingExerciseBeforeUpdate.setReleaseDate(null);
+        programmingExerciseBeforeUpdate.setAuxiliaryRepositories(new ArrayList<>());
+        programmingExerciseRepository.save(programmingExerciseBeforeUpdate);
+
+        updatedProgrammingExercise = programmingExerciseRepository.findById(programmingExerciseBeforeUpdate.getId()).orElseThrow();
+        updatedProgrammingExercise.setAuxiliaryRepositories(new ArrayList<>());
+        auxiliaryRepositoryRepository.deleteAll();
+    }
+
+    @Test
+    void shouldReturnTureIfAuxiliaryRepositoryOfExercise() {
+        auxiliaryRepositoryRepository.save(createAuxiliaryRepository("test", "test", "test", programmingExerciseBeforeUpdate, null));
+
+        assertThat(auxiliaryRepositoryService.isAuxiliaryRepositoryOfExercise("test", programmingExerciseBeforeUpdate)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseIfNotAuxiliaryRepositoryOfExercise() {
+        auxiliaryRepositoryRepository.save(createAuxiliaryRepository("test", "test", "test", programmingExerciseBeforeUpdate, null));
+
+        assertThat(auxiliaryRepositoryService.isAuxiliaryRepositoryOfExercise("asd", programmingExerciseBeforeUpdate)).isFalse();
+    }
+
+    @Test
+    void shouldAddAuxiliaryRepositoriesSuccessfully() {
+        AuxiliaryRepository auxiliaryRepository = createAuxiliaryRepository("test", "test", "test", programmingExerciseBeforeUpdate, null);
+        AuxiliaryRepository auxiliaryRepository2 = createAuxiliaryRepository("test2", "test2", "test2", programmingExerciseBeforeUpdate, null);
+        auxiliaryRepositoryRepository.save(auxiliaryRepository);
+        programmingExerciseBeforeUpdate.setAuxiliaryRepositories(List.of(auxiliaryRepository));
+
+        auxiliaryRepositoryService.validateAndAddAuxiliaryRepositoriesOfProgrammingExercise(programmingExerciseBeforeUpdate, List.of(auxiliaryRepository2));
+
+        assertThat(programmingExerciseBeforeUpdate.getAuxiliaryRepositories()).containsExactly(auxiliaryRepository, auxiliaryRepository2);
+    }
+
+    @Test
+    void shouldThrowErrorWhenNotNullId() {
+        List<AuxiliaryRepository> newAuxiliaryRepos = List.of(createAuxiliaryRepository("test", "test", "test", programmingExerciseBeforeUpdate, 1L));
+
+        assertThatThrownBy(() -> auxiliaryRepositoryService.validateAndAddAuxiliaryRepositoriesOfProgrammingExercise(programmingExerciseBeforeUpdate, newAuxiliaryRepos))
+                .isInstanceOf(BadRequestAlertException.class).hasMessage("Auxiliary repositories must not have an id.");
+    }
+
+    @Test
+    void shouldThrowErrorWhenEmptyName() {
+        List<AuxiliaryRepository> newAuxiliaryRepos = List.of(createAuxiliaryRepository("", "test", "test", programmingExerciseBeforeUpdate, null));
+
+        assertThatThrownBy(() -> auxiliaryRepositoryService.validateAndAddAuxiliaryRepositoriesOfProgrammingExercise(programmingExerciseBeforeUpdate, newAuxiliaryRepos))
+                .isInstanceOf(BadRequestAlertException.class).hasMessage("Cannot set empty name for auxiliary repositories!");
+
+    }
+
+    @Test
+    void shouldThrowErrorWhenNameLongerThan100Characters() {
+        List<AuxiliaryRepository> newAuxiliaryRepos = List.of(createAuxiliaryRepository(TEST_INVALID_LENGTH_STRING, "test", "test", programmingExerciseBeforeUpdate, null));
+
+        assertThatThrownBy(() -> auxiliaryRepositoryService.validateAndAddAuxiliaryRepositoriesOfProgrammingExercise(programmingExerciseBeforeUpdate, newAuxiliaryRepos))
+                .isInstanceOf(BadRequestAlertException.class).hasMessage("The name of an auxiliary repository must not be longer than 100 characters!");
+    }
+
+    @Test
+    void shouldThrowErrorWhenDuplicateName() {
+        AuxiliaryRepository auxiliaryRepository = createAuxiliaryRepository("test", "test", "test", programmingExerciseBeforeUpdate, null);
+        List<AuxiliaryRepository> newAuxiliaryRepos = List.of(createAuxiliaryRepository("test", "test2", "test2", programmingExerciseBeforeUpdate, null));
+        auxiliaryRepositoryRepository.save(auxiliaryRepository);
+        programmingExerciseBeforeUpdate.setAuxiliaryRepositories(List.of(auxiliaryRepository));
+
+        assertThatThrownBy(() -> auxiliaryRepositoryService.validateAndAddAuxiliaryRepositoriesOfProgrammingExercise(programmingExerciseBeforeUpdate, newAuxiliaryRepos))
+                .isInstanceOf(BadRequestAlertException.class).hasMessage("The name 'test' is not allowed for auxiliary repositories!");
+    }
+
+    @Test
+    void shouldThrowErrorWhenRestrictedName() {
+        List<AuxiliaryRepository> newAuxiliaryRepos = List.of(createAuxiliaryRepository("tests", "test", "test", programmingExerciseBeforeUpdate, null));
+
+        assertThatThrownBy(() -> auxiliaryRepositoryService.validateAndAddAuxiliaryRepositoriesOfProgrammingExercise(programmingExerciseBeforeUpdate, newAuxiliaryRepos))
+                .isInstanceOf(BadRequestAlertException.class).hasMessage("The name 'tests' is not allowed for auxiliary repositories!");
+    }
+
+    @Test
+    void shouldThrowErrorWhenInvalidDirectory() {
+        List<AuxiliaryRepository> newAuxiliaryRepos = List.of(createAuxiliaryRepository("test", "123vg-q@", "test", "test", programmingExerciseBeforeUpdate, null));
+
+        assertThatThrownBy(() -> auxiliaryRepositoryService.validateAndAddAuxiliaryRepositoriesOfProgrammingExercise(programmingExerciseBeforeUpdate, newAuxiliaryRepos))
+                .isInstanceOf(BadRequestAlertException.class).hasMessage("The checkout directory '123vg-q@' is invalid!");
+    }
+
+    @Test
+    void shouldSetDirectoryToNullWhenEmptyDirectory() {
+        AuxiliaryRepository repo = createAuxiliaryRepository("test", "", "test", "test", programmingExerciseBeforeUpdate, null);
+
+        auxiliaryRepositoryService.validateAndAddAuxiliaryRepositoriesOfProgrammingExercise(programmingExerciseBeforeUpdate, List.of(repo));
+        assertThat(repo.getCheckoutDirectory()).isNull();
+    }
+
+    @Test
+    void shouldThrowErrorWhenInvalidDirectoryLength() {
+        List<AuxiliaryRepository> newAuxiliaryRepos = List.of(createAuxiliaryRepository("test", TEST_INVALID_LENGTH_STRING, "test", programmingExerciseBeforeUpdate, null));
+
+        assertThatThrownBy(() -> auxiliaryRepositoryService.validateAndAddAuxiliaryRepositoriesOfProgrammingExercise(programmingExerciseBeforeUpdate, newAuxiliaryRepos))
+                .isInstanceOf(BadRequestAlertException.class).hasMessage("The checkout directory path '" + TEST_INVALID_LENGTH_STRING + "' is too long!");
+    }
+
+    @Test
+    void shouldThrowErrorWhenInvalidDescriptionLength() {
+        List<AuxiliaryRepository> newAuxiliaryRepos = List
+                .of(createAuxiliaryRepository("test", "test", TEST_INVALID_DESCRIPTION_LENGTH_STRING, "test", programmingExerciseBeforeUpdate, null));
+
+        assertThatThrownBy(() -> auxiliaryRepositoryService.validateAndAddAuxiliaryRepositoriesOfProgrammingExercise(programmingExerciseBeforeUpdate, newAuxiliaryRepos))
+                .isInstanceOf(BadRequestAlertException.class).hasMessage("The provided description is too long!");
+    }
+
+    @Test
+    void shouldChangeRepositorySuccessfully() {
+        AuxiliaryRepository auxiliaryRepository = createAuxiliaryRepository("test", "test", "test", programmingExerciseBeforeUpdate, null);
+        AuxiliaryRepository auxiliaryRepository2 = createAuxiliaryRepository("test2", "test2", "test2", updatedProgrammingExercise, null);
+        auxiliaryRepositoryRepository.save(auxiliaryRepository);
+        programmingExerciseBeforeUpdate.setAuxiliaryRepositories(List.of(auxiliaryRepository));
+        updatedProgrammingExercise.setAuxiliaryRepositories(List.of(auxiliaryRepository2));
+
+        // Check if the repository was created
+        assertThat(auxiliaryRepositoryRepository.findAll()).containsExactly(auxiliaryRepository);
+
+        auxiliaryRepositoryService.handleAuxiliaryRepositoriesWhenUpdatingExercises(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
+
+        // Check if the repository was updated, deletes the old repository
+        assertThat(auxiliaryRepositoryRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void shouldThrowErrorWhenEditingExistingRepositoryNotInDatabase() {
+        AuxiliaryRepository auxiliaryRepository = createAuxiliaryRepository("test", "test", "test", programmingExerciseBeforeUpdate, null);
+        AuxiliaryRepository auxiliaryRepository2 = createAuxiliaryRepository("test2", "test2", "test2", updatedProgrammingExercise, 2L);
+        auxiliaryRepositoryRepository.save(auxiliaryRepository);
+        programmingExerciseBeforeUpdate.setAuxiliaryRepositories(List.of(auxiliaryRepository));
+        updatedProgrammingExercise.setAuxiliaryRepositories(List.of(auxiliaryRepository2));
+
+        assertThatThrownBy(() -> auxiliaryRepositoryService.handleAuxiliaryRepositoriesWhenUpdatingExercises(programmingExerciseBeforeUpdate, updatedProgrammingExercise))
+                .isInstanceOf(IllegalStateException.class).hasMessage("Edited an existing repository that is not in the database!");
+    }
+
+    @Test
+    void shouldThrowErrorWhenInvalidRepository() {
+        AuxiliaryRepository auxiliaryRepository = createAuxiliaryRepository("test", "test", "test", programmingExerciseBeforeUpdate, null);
+        AuxiliaryRepository auxiliaryRepository2 = createAuxiliaryRepository("", "test", "test", updatedProgrammingExercise, null);
+        auxiliaryRepositoryRepository.save(auxiliaryRepository);
+        auxiliaryRepository2.setId(auxiliaryRepository.getId());
+        programmingExerciseBeforeUpdate.setAuxiliaryRepositories(List.of(auxiliaryRepository));
+        updatedProgrammingExercise.setAuxiliaryRepositories(List.of(auxiliaryRepository2));
+
+        assertThatThrownBy(() -> auxiliaryRepositoryService.handleAuxiliaryRepositoriesWhenUpdatingExercises(programmingExerciseBeforeUpdate, updatedProgrammingExercise))
+                .isInstanceOf(BadRequestAlertException.class).hasMessage("Cannot set empty name for auxiliary repositories!");
+    }
+
+    private AuxiliaryRepository createAuxiliaryRepository(String name, String checkoutDirectory, String repositoryUri, ProgrammingExercise exercise, Long id) {
+        return createAuxiliaryRepository(name, checkoutDirectory, "test", repositoryUri, exercise, id);
+    }
+
+    private static AuxiliaryRepository createAuxiliaryRepository(String name, String checkoutDirectory, String description, String repositoryUri, ProgrammingExercise exercise,
+            Long id) {
+        AuxiliaryRepository auxiliaryRepository = new AuxiliaryRepository();
+        auxiliaryRepository.setName(name);
+        auxiliaryRepository.setDescription(description);
+        auxiliaryRepository.setCheckoutDirectory(checkoutDirectory);
+        auxiliaryRepository.setRepositoryUri(repositoryUri);
+        auxiliaryRepository.setExercise(exercise);
+        if (id != null) {
+            auxiliaryRepository.setId(id);
+        }
+        return auxiliaryRepository;
+    }
+
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The test coverage should be higher than 90% in the AuxiliaryRepositoryService, but it was around 27%.



### Description
<!-- Describe your changes in detail -->
Added AuxiliaryRepositoryServiceTest to cover all lines of code in the AuxiliaryRepositoryService. Also changed an grammatical mistake in an error message.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Local Artemis

1. Run the AuxiliaryRepositoryServiceTest with coverage, check if line coverage is higher than 90%

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| AuxiliaryRepositoryService.java | 97% | ✅                           |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
![image](https://github.com/ls1intum/Artemis/assets/92453703/bf9da1a0-b48c-4b82-a28c-be1b86dc04c2)

After:
![image](https://github.com/ls1intum/Artemis/assets/92453703/049c69f5-b221-43e6-aa57-08c7ae0d0e73)

