### PR TITLE
`Integrated code lifecycle`: Fix test results path for C exercises

### DIFF
--- a/src/main/resources/templates/aeolus/c/gcc.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc.yaml
@@ -64,5 +64,5 @@ actions:
     runAlways: false
     results:
       - name: junit_test-reports/tests-results.xml
-        path: test-reports/tests-results.xml
+        path: 'test-reports/*.xml'
         type: junit

--- a/src/main/resources/templates/aeolus/c/gcc_static.yaml
+++ b/src/main/resources/templates/aeolus/c/gcc_static.yaml
@@ -69,6 +69,6 @@ actions:
         path: target/gcc.xml
         type: static-code-analysis
       - name: junit_test-reports/tests-results.xml
-        path: test-reports/tests-results.xml
+        path: 'test-reports/*.xml'
         type: junit
         before: true


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

### Motivation and Context
We encountered an issue where for C exercises no test resulst were visible.

### Description
Similar to #8497 I updated the windfile to accept all xml result files.


### Steps for Testing


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2