### PR TITLE
`Programming exercises`: Display error message for title and shortname conflicts on localVCS

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/errors/HttpStatusException.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/errors/HttpStatusException.java
@@ -21,8 +21,8 @@ public abstract class HttpStatusException extends AbstractThrowableProblem {
      * @param type
      * @param defaultMessage that will be displayed if the translation is not found in the client side i18n error.json files
      * @param status         of the http response (e.g. 400 BAD REQUEST)
-     * @param entityName     where the error occurred
-     * @param errorKey       which is the translation key in the client side i18n error.json files
+     * @param entityName     of the component where the error occurred
+     * @param errorKey       that matches a translation key in the client side i18n error.json files
      * @param parameters     contains additional information (e.g. the field 'skipAlert' to tell the client side alert service
      *                           interceptor that the error should not be handled by the interceptor - this is useful when the
      *                           component where the error occurred has information to display a more concrete error message)

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/errors/HttpStatusException.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/errors/HttpStatusException.java
@@ -31,6 +31,13 @@ public abstract class HttpStatusException extends AbstractThrowableProblem {
         return errorKey;
     }
 
+    /**
+     * @param entityName of the component where the error occurred
+     * @param errorKey   that matches a translation key in the client side i18n files
+     * @param skipAlert  if the error should not be handled by the client side alert service
+     *                       (e.g. when a component has more information to display a more concrete error message and
+     *                       handles the error instead of the interceptor)
+     */
     protected static Map<String, Object> getAlertParameters(String entityName, String errorKey, boolean skipAlert) {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("message", "error." + errorKey);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/errors/HttpStatusException.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/errors/HttpStatusException.java
@@ -17,6 +17,16 @@ public abstract class HttpStatusException extends AbstractThrowableProblem {
 
     private final String errorKey;
 
+    /**
+     * @param type
+     * @param defaultMessage that will be displayed if the translation is not found in the client side i18n error.json files
+     * @param status         of the http response (e.g. 400 BAD REQUEST)
+     * @param entityName     where the error occurred
+     * @param errorKey       which is the translation key in the client side i18n error.json files
+     * @param parameters     contains additional information (e.g. the field 'skipAlert' to tell the client side alert service
+     *                           interceptor that the error should not be handled by the interceptor - this is useful when the
+     *                           component where the error occurred has information to display a more concrete error message)
+     */
     public HttpStatusException(URI type, String defaultMessage, Status status, String entityName, String errorKey, Map<String, Object> parameters) {
         super(type, defaultMessage, status, null, null, null, parameters);
         this.entityName = entityName;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/errors/HttpStatusException.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/errors/HttpStatusException.java
@@ -33,7 +33,7 @@ public abstract class HttpStatusException extends AbstractThrowableProblem {
 
     /**
      * @param entityName of the component where the error occurred
-     * @param errorKey   that matches a translation key in the client side i18n files
+     * @param errorKey   that matches a translation key in the client side i18n error.json files
      * @param skipAlert  if the error should not be handled by the client side intercepting alert service
      *                       (e.g. when a client side component has more information to display a more concrete error
      *                       message and handles the error instead of the interceptor)

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/errors/HttpStatusException.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/errors/HttpStatusException.java
@@ -34,9 +34,9 @@ public abstract class HttpStatusException extends AbstractThrowableProblem {
     /**
      * @param entityName of the component where the error occurred
      * @param errorKey   that matches a translation key in the client side i18n files
-     * @param skipAlert  if the error should not be handled by the client side alert service
-     *                       (e.g. when a component has more information to display a more concrete error message and
-     *                       handles the error instead of the interceptor)
+     * @param skipAlert  if the error should not be handled by the client side intercepting alert service
+     *                       (e.g. when a client side component has more information to display a more concrete error
+     *                       message and handles the error instead of the interceptor)
      */
     protected static Map<String, Object> getAlertParameters(String entityName, String errorKey, boolean skipAlert) {
         Map<String, Object> parameters = new HashMap<>();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/errors/InternalServerErrorAlertException.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/errors/InternalServerErrorAlertException.java
@@ -1,0 +1,30 @@
+package de.tum.in.www1.artemis.web.rest.errors;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.zalando.problem.Status;
+
+public class InternalServerErrorAlertException extends HttpStatusException {
+
+    public InternalServerErrorAlertException(String defaultMessage, String entityName, String errorKey, boolean skipAlert) {
+        this(ErrorConstants.DEFAULT_TYPE, defaultMessage, entityName, errorKey, skipAlert);
+    }
+
+    public InternalServerErrorAlertException(String defaultMessage, String entityName, String errorKey) {
+        this(ErrorConstants.DEFAULT_TYPE, defaultMessage, entityName, errorKey, false);
+    }
+
+    public InternalServerErrorAlertException(String defaultMessage, String entityName, String errorKey, Map<String, Object> translationParameters) {
+        // translation params are expected to be a child of the "params" object
+        this(ErrorConstants.PARAMETERIZED_TYPE, defaultMessage, entityName, errorKey, Map.of("params", translationParameters));
+    }
+
+    public InternalServerErrorAlertException(URI type, String defaultMessage, String entityName, String errorKey, boolean skipAlert) {
+        super(type, defaultMessage, Status.INTERNAL_SERVER_ERROR, entityName, errorKey, getAlertParameters(entityName, errorKey, skipAlert));
+    }
+
+    public InternalServerErrorAlertException(URI type, String defaultMessage, String entityName, String errorKey, Map<String, Object> parameters) {
+        super(type, defaultMessage, Status.INTERNAL_SERVER_ERROR, entityName, errorKey, parameters);
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/errors/InternalServerErrorAlertException.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/errors/InternalServerErrorAlertException.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.web.rest.errors;
 
 import java.net.URI;
-import java.util.Map;
 
 import org.zalando.problem.Status;
 
@@ -13,9 +12,5 @@ public class InternalServerErrorAlertException extends HttpStatusException {
 
     public InternalServerErrorAlertException(URI type, String defaultMessage, String entityName, String errorKey, boolean skipAlert) {
         super(type, defaultMessage, Status.INTERNAL_SERVER_ERROR, entityName, errorKey, getAlertParameters(entityName, errorKey, skipAlert));
-    }
-
-    public InternalServerErrorAlertException(URI type, String defaultMessage, String entityName, String errorKey, Map<String, Object> parameters) {
-        super(type, defaultMessage, Status.INTERNAL_SERVER_ERROR, entityName, errorKey, parameters);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/errors/InternalServerErrorAlertException.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/errors/InternalServerErrorAlertException.java
@@ -7,17 +7,8 @@ import org.zalando.problem.Status;
 
 public class InternalServerErrorAlertException extends HttpStatusException {
 
-    public InternalServerErrorAlertException(String defaultMessage, String entityName, String errorKey, boolean skipAlert) {
-        this(ErrorConstants.DEFAULT_TYPE, defaultMessage, entityName, errorKey, skipAlert);
-    }
-
     public InternalServerErrorAlertException(String defaultMessage, String entityName, String errorKey) {
         this(ErrorConstants.DEFAULT_TYPE, defaultMessage, entityName, errorKey, false);
-    }
-
-    public InternalServerErrorAlertException(String defaultMessage, String entityName, String errorKey, Map<String, Object> translationParameters) {
-        // translation params are expected to be a child of the "params" object
-        this(ErrorConstants.PARAMETERIZED_TYPE, defaultMessage, entityName, errorKey, Map.of("params", translationParameters));
     }
 
     public InternalServerErrorAlertException(URI type, String defaultMessage, String entityName, String errorKey, boolean skipAlert) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/programming/ProgrammingExerciseExportImportResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/programming/ProgrammingExerciseExportImportResource.java
@@ -73,6 +73,7 @@ import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.ConflictException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
+import de.tum.in.www1.artemis.web.rest.errors.HttpStatusException;
 import de.tum.in.www1.artemis.web.rest.errors.InternalServerErrorAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.InternalServerErrorException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
@@ -255,8 +256,8 @@ public class ProgrammingExerciseExportImportResource {
         catch (Exception exception) {
             log.error(exception.getMessage(), exception);
 
-            // TODO maybe throw all HttpsError Exceptions? (= AlertException)
-            if (exception instanceof BadRequestAlertException) {
+            boolean isExceptionWithTranslationKeys = exception instanceof HttpStatusException;
+            if (isExceptionWithTranslationKeys) {
                 throw exception;
             }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/programming/ProgrammingExerciseExportImportResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/programming/ProgrammingExerciseExportImportResource.java
@@ -261,7 +261,7 @@ public class ProgrammingExerciseExportImportResource {
                 throw exception;
             }
 
-            throw new InternalServerErrorAlertException("Unable to import programming exercise: " + exception.getMessage(), ENTITY_NAME, "importExerciseTriggerPlanFail");
+            throw new InternalServerErrorAlertException("Unable to import programming exercise: " + exception.getMessage(), ENTITY_NAME, "unableToImportProgrammingExercise");
         }
     }
 

--- a/src/main/webapp/app/course/manage/course-update.component.ts
+++ b/src/main/webapp/app/course/manage/course-update.component.ts
@@ -30,6 +30,7 @@ import { FileService } from 'app/shared/http/file.service';
 import { onError } from 'app/shared/util/global.utils';
 import { getSemesters } from 'app/utils/semester-utils';
 import { ImageCropperModalComponent } from 'app/course/manage/image-cropper-modal.component';
+import { scrollToTopOfPage } from 'app/shared/util/utils';
 
 const DEFAULT_CUSTOM_GROUP_NAME = 'artemis-dev';
 
@@ -340,6 +341,7 @@ export class CourseUpdateComponent implements OnInit {
         }
 
         this.router.navigate(['course-management', updatedCourse?.id?.toString()]);
+        scrollToTopOfPage();
     }
 
     /**

--- a/src/main/webapp/i18n/de/error.json
+++ b/src/main/webapp/i18n/de/error.json
@@ -92,6 +92,7 @@
         "ltiNotSupported": "LTI wird auf dieser Artemis-Instanz nicht unterstützt",
         "exportFailed": "Aufgabenexport fehlgeschlagen",
         "unableToImportProgrammingExercise": "Fehler beim Importieren der Programmieraufgabe.",
-        "shortnameAlreadyExists": "Es existiert bereits eine Programmieraufgabe mit dem gewählten Kurznamen, bitte nutze einen anderen Kurznamen."
+        "titleAlreadyExists": "Es existiert bereits eine Programmieraufgabe mit demselben Title, bitte nutze einen anderen Titel.",
+        "shortnameAlreadyExists": "Es existiert bereits eine Programmieraufgabe mit demselben Kurznamen, bitte nutze einen anderen Kurznamen."
     }
 }

--- a/src/main/webapp/i18n/de/error.json
+++ b/src/main/webapp/i18n/de/error.json
@@ -92,7 +92,7 @@
         "ltiNotSupported": "LTI wird auf dieser Artemis-Instanz nicht unterstützt",
         "exportFailed": "Aufgabenexport fehlgeschlagen",
         "unableToImportProgrammingExercise": "Fehler beim Importieren der Programmieraufgabe.",
-        "titleAlreadyExists": "Es existiert bereits eine Programmieraufgabe mit demselben Title, bitte nutze einen anderen Titel.",
+        "titleAlreadyExists": "Es existiert bereits eine Programmieraufgabe mit demselben Titel, bitte nutze einen anderen Titel.",
         "shortnameAlreadyExists": "Es existiert bereits eine Programmieraufgabe mit demselben Kurznamen, bitte nutze einen anderen Kurznamen."
     }
 }

--- a/src/main/webapp/i18n/de/error.json
+++ b/src/main/webapp/i18n/de/error.json
@@ -91,6 +91,7 @@
         "systemNotificationNeedsNotificationBeforeExpiration": "Das Ablaufdatum muss nach dem Mitteilungsdatum liegen.",
         "ltiNotSupported": "LTI wird auf dieser Artemis-Instanz nicht unterstützt",
         "exportFailed": "Aufgabenexport fehlgeschlagen",
-        "unableToImportProgrammingExercise": "Fehler beim Importieren der Programmieraufgabe."
+        "unableToImportProgrammingExercise": "Fehler beim Importieren der Programmieraufgabe.",
+        "shortnameAlreadyExists": "Es existiert bereits eine Programmieraufgabe mit dem gewählten Kurznamen, bitte nutze einen anderen Kurznamen."
     }
 }

--- a/src/main/webapp/i18n/de/error.json
+++ b/src/main/webapp/i18n/de/error.json
@@ -90,6 +90,7 @@
         "systemNotificationNeedsBothDates": "Sowohl das Mitteilungsdatum als auch das Ablaufdatum müssen gesetzt sein.",
         "systemNotificationNeedsNotificationBeforeExpiration": "Das Ablaufdatum muss nach dem Mitteilungsdatum liegen.",
         "ltiNotSupported": "LTI wird auf dieser Artemis-Instanz nicht unterstützt",
-        "exportFailed": "Aufgabenexport fehlgeschlagen"
+        "exportFailed": "Aufgabenexport fehlgeschlagen",
+        "unableToImportProgrammingExercise": "Fehler beim Importieren der Programmieraufgabe."
     }
 }

--- a/src/main/webapp/i18n/en/error.json
+++ b/src/main/webapp/i18n/en/error.json
@@ -90,6 +90,7 @@
         "systemNotificationNeedsBothDates": "Both notification date and expiration date must be set.",
         "systemNotificationNeedsNotificationBeforeExpiration": "The expiration date must be after the notification date.",
         "ltiNotSupported": "LTI is not supported on this Artemis instance",
-        "exportFailed": "Exercise export failed"
+        "exportFailed": "Exercise export failed",
+        "unableToImportProgrammingExercise": "Unable to import programming exercise."
     }
 }

--- a/src/main/webapp/i18n/en/error.json
+++ b/src/main/webapp/i18n/en/error.json
@@ -91,6 +91,7 @@
         "systemNotificationNeedsNotificationBeforeExpiration": "The expiration date must be after the notification date.",
         "ltiNotSupported": "LTI is not supported on this Artemis instance",
         "exportFailed": "Exercise export failed",
-        "unableToImportProgrammingExercise": "Unable to import programming exercise."
+        "unableToImportProgrammingExercise": "Unable to import programming exercise.",
+        "shortnameAlreadyExists": "A programming exercise with the same short name already exists. Please choose a different short name."
     }
 }

--- a/src/main/webapp/i18n/en/error.json
+++ b/src/main/webapp/i18n/en/error.json
@@ -92,6 +92,7 @@
         "ltiNotSupported": "LTI is not supported on this Artemis instance",
         "exportFailed": "Exercise export failed",
         "unableToImportProgrammingExercise": "Unable to import programming exercise.",
+        "titleAlreadyExists": "A programming exercise with the same title already exists. Please choose a different title.",
         "shortnameAlreadyExists": "A programming exercise with the same short name already exists. Please choose a different short name."
     }
 }


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested ~on a test server~ locally.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
In a previous Artemis version (7.0.3 right now), it was possible that when an error occurred during creating/importing/deleting a programming exercise the respective folders for that programming exercise were not cleaned up.
This means that the short names that are related to the folder names stay blocked, however, there was no error message shown in this case, for the blocked short names.

### Description
- This PR adds adjusts the error message thrown from the server, so that the client displays an alert.
- adds translations for error message on validation of programming exercise `title` and `short title`
- adds a scroll to top when saving course details

### Steps for Testing **Locally**
Prerequisites:
- 1 Instructor

1. Create a programming exercise with title and short name "blockedShortName"
2. See that in `local-vcs-repos` and `repos` a folder `coursePrefix` + `BLOCKEDSHORTNAME` will be created
3. Duplicate the folder from step 2 in `local-vcs-repos` and rename it to `coursePrefix` + `BLOCKEDSHORTNAME1`
4. Try to import a programming exercise with the shortname `coursePrefix` + `BLOCKEDSHORTNAME1` and see that an error message is displayed that explains that the shortname is already taken

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
Now using actual translations instead of hardcoded english messages
![image](https://github.com/ls1intum/Artemis/assets/63976129/2d88e9d6-8f48-4af3-be74-10add99a3681)


