### PR TITLE
`Programming exercises`: Remove pull progress build logs

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/BuildLogEntryService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/BuildLogEntryService.java
@@ -166,7 +166,7 @@ public class BuildLogEntryService {
                 // Each of the following is prefixed by a 12 character hash, so the length is the length of the suffix + 12
                 || (log.endsWith(": Pulling fs layer") && log.length() == 30) || (log.endsWith(": Waiting") && log.length() == 21)
                 || (log.endsWith(": Verifying Checksum") && log.length() == 32) || (log.endsWith(": Download complete") && log.length() == 31)
-                || (log.endsWith(": Pull complete") && log.length() == 27);
+                || (log.endsWith(": Pull complete") && log.length() == 27) || log.startsWith("~~~~~~~~~~~~~~~~~~~~ Pull image progress:");
     }
 
     private static final Set<String> GIT_LOGS = Set.of("Checking out", "Switched to branch", ".git", "Fetching 'refs/heads", "Updating source code to revision",

--- a/src/test/java/de/tum/in/www1/artemis/service/BuildLogEntryServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/BuildLogEntryServiceTest.java
@@ -21,6 +21,22 @@ import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 class BuildLogEntryServiceTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String GRADLE_SCENARIO = """
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Downloading ~~~~~~~~~~~~~~~~~~~~
+            ~~~~~~~~~~~~~~~~~~~~ Pull image progress: Download complete ~~~~~~~~~~~~~~~~~~~~
             Build ABC23H01E01 - AB12345 - Default Job #5 (MY-JOB) started building on agent ls1Agent-test.artemistest.in.tum.de, jenkins version: 8.2.5
             Remote agent on host ls1Agent-test.artemistest.in.tum.de
             Build working directory is /opt/jenkinsagent/jenkins-agent-home/xml-data/build-dir/ABC23H01E01


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
When a buid job requires a docker image that is not present on the build agent, the build agent needs to pull the image first. This generates many logs, making a potential build failure hard to see.


### Description
The saved build log (that is later shown to students) no longer contains the pulling-image lines. They are still present in the server logs.


### Steps for Testing
code review should be enough. You can test this by changing the docker image of an exercise and then triggering a build that leads to an error (e.g. by having a compilation error). Check that the build log does not contain these many many pulling-logs.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2