### PR TITLE
`Development`: Add IntelliJ run configuration for Jenkins+LocalVC

### DIFF
--- a/.idea/runConfigurations/Artemis__Server__Jenkins___LocalVC_.xml
+++ b/.idea/runConfigurations/Artemis__Server__Jenkins___LocalVC_.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Artemis (Server, Jenkins &amp; LocalVC)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ACTIVE_PROFILES" value="dev,jenkins,localvc,artemis,scheduling,core,local" />
+    <module name="Artemis.main" />
+    <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.tum.in.www1.artemis.ArtemisApp" />
+    <option name="VM_PARAMETERS" value="-XX:+ShowCodeDetailsInExceptionMessages -Duser.country=US -Duser.language=en" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <method v="2">
+      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessCheck -x checkstyleMain -x checkstyleTest" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In the future, we want to make it possible to use LocalVC together with the external CI Jenkins. To make it easier to test this configuration during development a corresponding IDE run configuration should be present.


### Description
<!-- Describe your changes in detail -->
Added the run configuration. It is basically a copy of the localvc+localci config with the `localci` profile replaced by `jenkins`.

In initial testing, the basic functionality of creating an exercise, building it in Jenkins, and getting back the results worked for both solution/template and students.

Future work:
- Use some token instead of an admin password (alternatively, one could create a specific admin account in Artemis only for Jenkins access)
- Ensure exercise clean-up works correctly. → #8543
- Ensure descriptions and links to the external Jenkins service are shown in the Artemis UI even though LocalVC is used. (some places might assume at the moment that LocalVC is only used together with LocalCI) → #8543


### Steps for Testing
If you have not used a local Jenkins setup before, you can follow the [setup instructions](https://docs.artemis.cit.tum.de/dev/setup/jenkins-gitlab.html#automated-jenkins-server-setup) first. Skip the first step that creates the API token in GitLab.

If you want to try it out and used GitLab+Jenkins before, you have to make the following changes to your `application-local.yml`:
```yaml
artemis:
  continuous-integration:
    vcs-credentials: artemis-vc-credentials  # global credentials in Jenkins with Artemis Admin username + password
  version-control:
    url: <like server.url>
```
The `vcs-credentials` have to be created in Jenkins at `${JENKINS_URL}/manage/credentials/store/system/domain/_/` (Dashboard > Manage Jenkins > Credentials > System > Global credentials (unrestricted)) as Username+Password of an Artemis admin user. The ID of the credential should be `artemis-vc-credentials`.


### Review Progress

#### Manual Test
- [x] Review 1
- [x] Review 2

@coderabbitai ignore