### PR TITLE
`Programming exercises`: Display automatic assessment history correctly

### DIFF
--- a/src/main/webapp/app/shared/sidebar/sidebar-card/sidebar-card.component.html
+++ b/src/main/webapp/app/shared/sidebar/sidebar-card/sidebar-card.component.html
@@ -7,8 +7,8 @@
         'border-danger': sidebarItem?.difficulty === DifficultyLevel.HARD,
         'border-module': !sidebarItem?.difficulty
     }"
-    [routerLink]="itemSelected ? '../' + sidebarItem?.id : './' + sidebarItem?.id"
-    (click)="emitStoreLastSelectedItem(sidebarItem.id)"
+    [routerLink]="itemSelected ? ['../' + sidebarItem?.id] : ['./' + sidebarItem?.id]"
+    (click)="emitStoreLastSelectedItem(sidebarItem.id); forceReload()"
     [routerLinkActive]="'bg-selected border-selected'"
 >
     <jhi-sidebar-card-item [sidebarType]="sidebarType" [sidebarItem]="sidebarItem" />

--- a/src/main/webapp/app/shared/sidebar/sidebar-card/sidebar-card.component.html
+++ b/src/main/webapp/app/shared/sidebar/sidebar-card/sidebar-card.component.html
@@ -7,7 +7,7 @@
         'border-danger': sidebarItem?.difficulty === DifficultyLevel.HARD,
         'border-module': !sidebarItem?.difficulty
     }"
-    [routerLink]="itemSelected ? ['../' + sidebarItem?.id] : ['./' + sidebarItem?.id]"
+    [routerLink]="itemSelected ? '../' + sidebarItem?.id : './' + sidebarItem?.id"
     (click)="emitStoreLastSelectedItem(sidebarItem.id); forceReload()"
     [routerLinkActive]="'bg-selected border-selected'"
 >

--- a/src/main/webapp/app/shared/sidebar/sidebar-card/sidebar-card.component.ts
+++ b/src/main/webapp/app/shared/sidebar/sidebar-card/sidebar-card.component.ts
@@ -3,6 +3,7 @@ import { DifficultyLevel } from 'app/entities/exercise.model';
 import { SidebarCardElement, SidebarTypes } from 'app/types/sidebar';
 import { Subscription } from 'rxjs';
 import { SidebarEventService } from '../sidebar-event.service';
+import { ActivatedRoute, Router } from '@angular/router';
 @Component({
     selector: 'jhi-sidebar-card',
     templateUrl: './sidebar-card.component.html',
@@ -19,9 +20,21 @@ export class SidebarCardComponent {
     paramSubscription?: Subscription;
     noItemSelected: boolean = false;
 
-    constructor(private sidebarEventService: SidebarEventService) {}
+    constructor(
+        private sidebarEventService: SidebarEventService,
+        private router: Router,
+        private route: ActivatedRoute,
+    ) {}
 
     emitStoreLastSelectedItem(itemId: number | string) {
         this.sidebarEventService.emitSidebarCardEvent(itemId);
+    }
+
+    forceReload(): void {
+        this.router.navigate(['../'], { skipLocationChange: true, relativeTo: this.route }).then(() => {
+            this.itemSelected
+                ? this.router.navigate(['../' + this.sidebarItem?.id], { relativeTo: this.route })
+                : this.router.navigate(['./' + this.sidebarItem?.id], { relativeTo: this.route });
+        });
     }
 }

--- a/src/test/javascript/spec/component/shared/sidebar/sidebar-card.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/sidebar/sidebar-card.component.spec.ts
@@ -61,10 +61,12 @@ describe('SidebarCardComponent', () => {
 
     it('should store route on click', () => {
         jest.spyOn(component, 'emitStoreLastSelectedItem');
+        jest.spyOn(component, 'forceReload');
         const element: HTMLElement = fixture.nativeElement.querySelector('#test-sidebar-card');
         element.click();
         fixture.detectChanges();
         expect(component.emitStoreLastSelectedItem).toHaveBeenCalledWith(component.sidebarItem.id);
+        expect(component.forceReload).toHaveBeenCalled();
     });
 
     it('should navigate to the item URL on click', async () => {

--- a/src/test/javascript/spec/helpers/mocks/mock-router.ts
+++ b/src/test/javascript/spec/helpers/mocks/mock-router.ts
@@ -5,7 +5,7 @@ import { NavigationEnd, RouterEvent, RouterState, UrlTree } from '@angular/route
 export class MockRouter {
     url = '/';
     navigateByUrl = jest.fn().mockReturnValue(true);
-    navigate = jest.fn().mockReturnValue(true);
+    navigate = jest.fn().mockReturnValue(Promise.resolve(true));
     routerState: RouterState;
     createUrlTree = jest.fn().mockReturnValue({ path: 'testValue' } as unknown as UrlTree);
     serializeUrl = jest.fn().mockReturnValue('testValue');


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes this issue:  https://github.com/ls1intum/Artemis/issues/8529


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student

1. Log in to Artemis
2. Navigate to a Course
3. Go to an exercise with automated assessment history
4. Click on another exercise which must be unstarted
5. See that the assessment history of the first exercise is no longer incorrectly displayed on the page for the second exercise


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [x] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Exercise with History
![image](https://github.com/ls1intum/Artemis/assets/75392103/c280ab1d-9fed-4d6f-ba57-16f77cc9c792)
History is no longer displayed when switching to another exercises 
![image](https://github.com/ls1intum/Artemis/assets/75392103/7c2246b8-30c0-4141-bf0e-cc1a8e445177)


