### PR TITLE
`Development`: Remove java assert statements

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/apollon/ApollonConversionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/apollon/ApollonConversionService.java
@@ -47,14 +47,15 @@ public class ApollonConversionService {
             request.setModel(model);
 
             var response = restTemplate.postForEntity(apollonConversionUrl + "/pdf", request, Resource.class);
-            assert response.getBody() != null;
-            return response.getBody().getInputStream();
+            if (response.getBody() != null) {
+                return response.getBody().getInputStream();
+            }
         }
         catch (HttpClientErrorException ex) {
             log.error("Error while calling Remote Service: {}", ex.getMessage());
         }
         catch (IOException ex) {
-            log.error(ex.getMessage());
+            log.error(ex.getMessage(), ex);
         }
         return null;
 

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/conversation/ConversationService.java
@@ -373,7 +373,7 @@ public class ConversationService {
     public Page<User> searchMembersOfConversation(Course course, Conversation conversation, Pageable pageable, String searchTerm,
             Optional<ConversationMemberSearchFilters> filter) {
         if (filter.isEmpty()) {
-            if (conversation instanceof Channel && ((Channel) conversation).getIsCourseWide()) {
+            if (conversation instanceof Channel channel && channel.getIsCourseWide()) {
                 return userRepository.searchAllByLoginOrNameInCourse(pageable, searchTerm, course.getId());
             }
             return userRepository.searchAllByLoginOrNameInConversation(pageable, searchTerm, conversation.getId());
@@ -389,13 +389,15 @@ public class ConversationService {
                 }
                 case STUDENT -> groups.add(course.getStudentGroupName());
                 case CHANNEL_MODERATOR -> {
-                    assert conversation instanceof Channel : "The filter CHANNEL_MODERATOR is only allowed for channels!";
+                    if (!(conversation instanceof Channel)) {
+                        throw new IllegalArgumentException("The filter CHANNEL_MODERATOR is only allowed for channels!");
+                    }
                     return userRepository.searchChannelModeratorsByLoginOrNameInConversation(pageable, searchTerm, conversation.getId());
                 }
                 default -> throw new IllegalArgumentException("The filter is not supported.");
             }
 
-            if (conversation instanceof Channel && ((Channel) conversation).getIsCourseWide()) {
+            if (conversation instanceof Channel channel && channel.getIsCourseWide()) {
                 return userRepository.searchAllByLoginOrNameInGroups(pageable, searchTerm, groups);
             }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupService.java
@@ -457,7 +457,7 @@ public class TutorialGroupService {
     private static Optional<User> getMatchingUser(Set<User> users, TutorialGroupRegistrationImportDTO registration) {
         return users.stream().filter(user -> {
             if (registration.student() == null) {
-                throw new IllegalStateException(); // should be the case as we filtered out all registrations without a student
+                return false;
             }
             boolean hasRegistrationNumber = StringUtils.hasText(registration.student().registrationNumber());
             boolean hasLogin = StringUtils.hasText(registration.student().login());
@@ -478,7 +478,7 @@ public class TutorialGroupService {
 
         for (var registration : registrations) {
             if (registration.student() == null) {
-                throw new IllegalStateException(); // should be the case as we filtered out all registrations without a student in the calling method
+                continue; // should not be the case as we filtered out all registrations without a student in the calling method
             }
             boolean hasRegistrationNumber = StringUtils.hasText(registration.student().registrationNumber());
             boolean hasLogin = StringUtils.hasText(registration.student().login());

--- a/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/tutorialgroups/TutorialGroupService.java
@@ -337,8 +337,8 @@ public class TutorialGroupService {
         // === Step 3: Register all found users to their respective tutorial groups ===
         Map<TutorialGroup, Set<User>> tutorialGroupToRegisteredUsers = new HashMap<>();
         for (var registrationUserPair : uniqueRegistrationsWithMatchingUsers.entrySet()) {
-            assert registrationUserPair.getKey().title() != null;
-            var tutorialGroup = tutorialGroupTitleToTutorialGroup.get(registrationUserPair.getKey().title().trim());
+            String title = Objects.requireNonNull(registrationUserPair.getKey().title());
+            var tutorialGroup = tutorialGroupTitleToTutorialGroup.get(title.trim());
             var user = registrationUserPair.getValue();
             tutorialGroupToRegisteredUsers.computeIfAbsent(tutorialGroup, key -> new HashSet<>()).add(user);
         }
@@ -456,7 +456,9 @@ public class TutorialGroupService {
 
     private static Optional<User> getMatchingUser(Set<User> users, TutorialGroupRegistrationImportDTO registration) {
         return users.stream().filter(user -> {
-            assert registration.student() != null; // should be the case as we filtered out all registrations without a student
+            if (registration.student() == null) {
+                throw new IllegalStateException(); // should be the case as we filtered out all registrations without a student
+            }
             boolean hasRegistrationNumber = StringUtils.hasText(registration.student().registrationNumber());
             boolean hasLogin = StringUtils.hasText(registration.student().login());
 
@@ -475,7 +477,9 @@ public class TutorialGroupService {
         var loginsToSearchFor = new HashSet<String>();
 
         for (var registration : registrations) {
-            assert registration.student() != null; // should be the case as we filtered out all registrations without a student in the calling method
+            if (registration.student() == null) {
+                throw new IllegalStateException(); // should be the case as we filtered out all registrations without a student in the calling method
+            }
             boolean hasRegistrationNumber = StringUtils.hasText(registration.student().registrationNumber());
             boolean hasLogin = StringUtils.hasText(registration.student().login());
 

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupFreePeriodIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupFreePeriodIntegrationTest.java
@@ -270,7 +270,7 @@ class TutorialGroupFreePeriodIntegrationTest extends AbstractTutorialGroupIntegr
         List<TutorialGroupSession> sessions = this.getTutorialGroupSessionsAscending(exampleTutorialGroupId);
         TutorialGroupSession firstMondayOfAugustSession = sessions.get(0);
         assertIndividualSessionIsCancelledOnDate(firstMondayOfAugustSession, FIRST_AUGUST_MONDAY_00_00, exampleTutorialGroupId, null);
-        assert (firstMondayOfAugustSession.getTutorialGroupFreePeriod().getId()).equals(createdPeriod.getId());
+        assertThat(firstMondayOfAugustSession.getTutorialGroupFreePeriod().getId()).isEqualTo(createdPeriod.getId());
         assertTutorialGroupFreePeriodCreatedCorrectlyFromDTO(firstMondayOfAugustSession.getTutorialGroupFreePeriod(), dto);
 
         // cleanup
@@ -301,7 +301,7 @@ class TutorialGroupFreePeriodIntegrationTest extends AbstractTutorialGroupIntegr
         // then
         firstMondayOfAugustSession = tutorialGroupSessionRepository.findByIdElseThrow(firstMondayOfAugustSession.getId());
         assertIndividualSessionIsCancelledOnDate(firstMondayOfAugustSession, FIRST_AUGUST_MONDAY_00_00, exampleTutorialGroupId, null);
-        assert (firstMondayOfAugustSession.getTutorialGroupFreePeriod().getId()).equals(createdPeriod2.getId());
+        assertThat(firstMondayOfAugustSession.getTutorialGroupFreePeriod().getId()).isEqualTo(createdPeriod2.getId());
 
         // cleanup
         tutorialGroupSessionRepository.deleteById(firstMondayOfAugustSession.getId());


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
The integrated java assert statement should not be used. It is only active when the `-ea` option is present, which is typically not the case for a production environment. Therefore, this statement alters the code flow between a test and productions setup.


### Description
I replaced all assert statements by if checks (production) or assertThat calls (tests)


### Steps for Testing
code review

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2