### PR TITLE
`Lectures`: Group lectures in sidebar by start and end date

### DIFF
--- a/src/main/webapp/app/overview/course-overview.service.ts
+++ b/src/main/webapp/app/overview/course-overview.service.ts
@@ -41,7 +41,7 @@ export class CourseOverviewService {
         }
     }
 
-    getCorrespondingGroupByDate(date: dayjs.Dayjs | undefined): TimeGroupCategory {
+    getCorrespondingExerciseGroupByDate(date: dayjs.Dayjs | undefined): TimeGroupCategory {
         if (!date) {
             return 'noDate';
         }
@@ -62,11 +62,31 @@ export class CourseOverviewService {
         return 'future';
     }
 
+    getCorrespondingLectureGroupByDate(startDate: dayjs.Dayjs | undefined, endDate?: dayjs.Dayjs | undefined): TimeGroupCategory {
+        if (!startDate) {
+            return 'noDate';
+        }
+
+        const now = dayjs();
+        const isStartDateWithinLastWeek = startDate.isAfter(now.subtract(1, 'week'));
+        const isDateInThePast = endDate ? endDate.isBefore(now) : startDate.isBefore(now) && !isStartDateWithinLastWeek;
+
+        if (isDateInThePast) {
+            return 'past';
+        }
+
+        const isDateCurrent = endDate ? startDate.isBefore(now) && endDate.isAfter(now) : isStartDateWithinLastWeek;
+        if (isDateCurrent) {
+            return 'current';
+        }
+        return 'future';
+    }
+
     groupExercisesByDueDate(sortedExercises: Exercise[]): AccordionGroups {
         const groupedExerciseGroups = cloneDeep(DEFAULT_UNIT_GROUPS) as AccordionGroups;
 
         for (const exercise of sortedExercises) {
-            const exerciseGroup = this.getCorrespondingGroupByDate(exercise.dueDate);
+            const exerciseGroup = this.getCorrespondingExerciseGroupByDate(exercise.dueDate);
             const exerciseCardItem = this.mapExerciseToSidebarCardElement(exercise);
             groupedExerciseGroups[exerciseGroup].entityData.push(exerciseCardItem);
         }
@@ -78,7 +98,7 @@ export class CourseOverviewService {
         const groupedLectureGroups = cloneDeep(DEFAULT_UNIT_GROUPS) as AccordionGroups;
 
         for (const lecture of sortedLectures) {
-            const lectureGroup = this.getCorrespondingGroupByDate(lecture.startDate);
+            const lectureGroup = this.getCorrespondingLectureGroupByDate(lecture.startDate, lecture?.endDate);
             const lectureCardItem = this.mapLectureToSidebarCardElement(lecture);
             groupedLectureGroups[lectureGroup].entityData.push(lectureCardItem);
         }

--- a/src/main/webapp/app/overview/course-overview.service.ts
+++ b/src/main/webapp/app/overview/course-overview.service.ts
@@ -68,8 +68,8 @@ export class CourseOverviewService {
         }
 
         const now = dayjs();
-        const isStartDateWithinLastWeek = startDate.isAfter(now.subtract(1, 'week'));
-        const isDateInThePast = endDate ? endDate.isBefore(now) : startDate.isBefore(now) && !isStartDateWithinLastWeek;
+        const isStartDateWithinLastWeek = startDate.isBetween(now.subtract(1, 'week'), now);
+        const isDateInThePast = endDate ? endDate.isBefore(now) : startDate.isBefore(now.subtract(1, 'week'));
 
         if (isDateInThePast) {
             return 'past';

--- a/src/test/javascript/spec/component/course/course-overview.service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.service.spec.ts
@@ -111,17 +111,18 @@ describe('CourseOverviewService', () => {
     it('should group lectures by start date and map to sidebar card elements', () => {
         const sortedLectures = [futureLecture, pastLecture, currentLecture];
 
-        jest.spyOn(service, 'getCorrespondingGroupByDate');
+        jest.spyOn(service, 'getCorrespondingLectureGroupByDate');
 
         jest.spyOn(service, 'mapLectureToSidebarCardElement');
         const groupedLectures = service.groupLecturesByStartDate(sortedLectures);
 
         expect(groupedLectures['current'].entityData).toHaveLength(1);
-        expect(groupedLectures['past'].entityData).toHaveLength(2);
+        expect(groupedLectures['past'].entityData).toHaveLength(1);
+        expect(groupedLectures['future'].entityData).toHaveLength(1);
         expect(service.mapLectureToSidebarCardElement).toHaveBeenCalledTimes(3);
-        expect(groupedLectures['current'].entityData[0].title).toBe('Advanced Topics in Computer Science');
+        expect(groupedLectures['future'].entityData[0].title).toBe('Advanced Topics in Computer Science');
         expect(groupedLectures['past'].entityData[0].title).toBe('Introduction to Computer Science');
-        expect(groupedLectures['past'].entityData[1].title).toBe('Algorithms');
+        expect(groupedLectures['current'].entityData[0].title).toBe('Algorithms');
     });
 
     it('should return undefined if lectures array is undefined', () => {
@@ -156,7 +157,7 @@ describe('CourseOverviewService', () => {
     it('should group exercises by start date and map to sidebar card elements', () => {
         const sortedExercises = [futureExercise, pastExercise, currentExercise];
 
-        jest.spyOn(service, 'getCorrespondingGroupByDate');
+        jest.spyOn(service, 'getCorrespondingExerciseGroupByDate');
 
         jest.spyOn(service, 'mapExerciseToSidebarCardElement');
         const groupedExercises = service.groupExercisesByDueDate(sortedExercises);
@@ -178,7 +179,7 @@ describe('CourseOverviewService', () => {
         ];
         const sortedExercises = service.sortExercises(pastExercises);
 
-        jest.spyOn(service, 'getCorrespondingGroupByDate');
+        jest.spyOn(service, 'getCorrespondingExerciseGroupByDate');
 
         jest.spyOn(service, 'mapExerciseToSidebarCardElement');
         const groupedExercises = service.groupExercisesByDueDate(sortedExercises);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
New grouping is easier to understand

### Description
<!-- Describe your changes in detail -->
Lectures are now grouped by their start and end date. 

**Past:** 
- Without end date: The start date of a Lecture is older than 1 week 
- With end date: the end date is in the past

**Current:** 
- Without end date: The start state is within the last week
- With end date: the start state is in the past and the end date is in the future

**Future:** Everything else (except no date)

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student
- Some Lectures with different start and end dates 

1. Log in to Artemis
2. Navigate to lectures 
3. check that the lectures are grouped correctly  



### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

