### PR TITLE
`Development`: Bump hibernate version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,7 @@ npm_version=10.2.3
 jhipster_dependencies_version=8.4.0
 spring_boot_version=3.2.5
 spring_security_version=6.2.4
-# TODO: Update to 6.5.0.Final not possible, would lead to errors
-hibernate_version=6.4.4.Final
+hibernate_version=6.5.1.Final
 # TODO: can we update to 5.x?
 opensaml_version=4.3.2
 jwt_version=0.12.5

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
@@ -1147,7 +1147,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
             WHERE p.exercise.course.id = :courseId
                 AND p.presentationScore IS NOT NULL
                 AND (p.student.id IN :studentIds OR ts.id IN :studentIds)
-            GROUP BY COALESCE(p.student.id, ts.id)
+            GROUP BY id
             """)
     Set<IdToPresentationScoreSum> sumPresentationScoreByStudentIdsAndCourseId(@Param("courseId") long courseId, @Param("studentIds") Set<Long> studentIds);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/OneToOneChatRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/OneToOneChatRepository.java
@@ -60,12 +60,7 @@ public interface OneToOneChatRepository extends JpaRepository<OneToOneChat, Long
                 LEFT JOIN FETCH p.user u
                 LEFT JOIN FETCH u.groups
             WHERE o.course.id = :courseId
-                AND EXISTS (
-                    SELECT 1
-                    FROM ConversationParticipant cp
-                    WHERE cp.conversation = o
-                        AND cp.user.id = :userIdA
-                )
+                AND u.id = :userIdA
                 AND EXISTS (
                     SELECT 1
                     FROM ConversationParticipant cp
@@ -73,7 +68,9 @@ public interface OneToOneChatRepository extends JpaRepository<OneToOneChat, Long
                         AND cp.user.id = :userIdB
                 )
             """)
-    // Exist checks required because we have a many-to-many relationship and hibernate doesn't allow multiple joins on the same table anymore
+    // Exist checks required because we have a many-to-many relationship and hibernate doesn't allow multiple joins on the same table anymore.
+    // We only execute the exists check for the second user, because we can filter the chats by the first user. This reduces the amounts of existence checks to the number of
+    // one-to-one chats userA has in that specific course.
     Optional<OneToOneChat> findWithParticipantsAndUserGroupsInCourseBetweenUsers(@Param("courseId") Long courseId, @Param("userIdA") Long userIdA, @Param("userIdB") Long userIdB);
 
     @Query("""

--- a/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/OneToOneChatRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metis/conversation/OneToOneChatRepository.java
@@ -56,16 +56,24 @@ public interface OneToOneChatRepository extends JpaRepository<OneToOneChat, Long
     @Query("""
             SELECT DISTINCT o
             FROM OneToOneChat o
-                LEFT JOIN FETCH o.conversationParticipants p1
-                LEFT JOIN FETCH o.conversationParticipants p2
-                LEFT JOIN FETCH p1.user u1
-                LEFT JOIN FETCH p2.user u2
-                LEFT JOIN FETCH u1.groups
-                LEFT JOIN FETCH u2.groups
+                LEFT JOIN FETCH o.conversationParticipants p
+                LEFT JOIN FETCH p.user u
+                LEFT JOIN FETCH u.groups
             WHERE o.course.id = :courseId
-                AND u1.id = :userIdA
-                AND u2.id = :userIdB
+                AND EXISTS (
+                    SELECT 1
+                    FROM ConversationParticipant cp
+                    WHERE cp.conversation = o
+                        AND cp.user.id = :userIdA
+                )
+                AND EXISTS (
+                    SELECT 1
+                    FROM ConversationParticipant cp
+                    WHERE cp.conversation = o
+                        AND cp.user.id = :userIdB
+                )
             """)
+    // Exist checks required because we have a many-to-many relationship and hibernate doesn't allow multiple joins on the same table anymore
     Optional<OneToOneChat> findWithParticipantsAndUserGroupsInCourseBetweenUsers(@Param("courseId") Long courseId, @Param("userIdA") Long userIdA, @Param("userIdB") Long userIdB);
 
     @Query("""

--- a/src/test/java/de/tum/in/www1/artemis/metis/OneToOneChatIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/OneToOneChatIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -34,6 +35,12 @@ class OneToOneChatIntegrationTest extends AbstractConversationTest {
         }
     }
 
+    @AfterEach
+    void tearDown() {
+        conversationMessageRepository.deleteAll();
+        conversationRepository.deleteAll();
+    }
+
     @Override
     String getTestPrefix() {
         return TEST_PREFIX;
@@ -55,9 +62,6 @@ class OneToOneChatIntegrationTest extends AbstractConversationTest {
         assertParticipants(chat2.getId(), 2, "student1", "student3");
         // members of the created one to one chat are only notified in case the first message within the conversation is created
         verifyNoParticipantTopicWebsocketSent();
-
-        // cleanup
-        conversationRepository.deleteAllById(List.of(chat1.getId(), chat2.getId()));
     }
 
     @Test
@@ -79,10 +83,6 @@ class OneToOneChatIntegrationTest extends AbstractConversationTest {
 
         // members of the created one to one chat are only notified in case the first message within the conversation is created
         verifyNoParticipantTopicWebsocketSent();
-
-        // cleanup
-        var conversation = oneToOneChatRepository.findByIdWithConversationParticipantsAndUserGroups(chat.getId()).orElseThrow();
-        conversationRepository.delete(conversation);
     }
 
     @Test
@@ -140,9 +140,6 @@ class OneToOneChatIntegrationTest extends AbstractConversationTest {
         // members of the created one to one chat are only notified in case the first message within the conversation is created
         verifyNoParticipantTopicWebsocketSent();
 
-        // cleanup
-        var conversation = oneToOneChatRepository.findByIdWithConversationParticipantsAndUserGroups(chat.getId()).orElseThrow();
-        conversationRepository.delete(conversation);
     }
 
     @Test
@@ -158,9 +155,5 @@ class OneToOneChatIntegrationTest extends AbstractConversationTest {
                 (Object) argThat(argument -> argument instanceof PostDTO postDTO && postDTO.post().equals(post)));
         verifyNoParticipantTopicWebsocketSentExceptAction(MetisCrudAction.CREATE, MetisCrudAction.NEW_MESSAGE);
 
-        // cleanup
-        var conversation = oneToOneChatRepository.findByIdWithConversationParticipantsAndUserGroups(chat.getId()).orElseThrow();
-        conversationMessageRepository.deleteById(post.getId());
-        conversationRepository.delete(conversation);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/metis/OneToOneChatIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/OneToOneChatIntegrationTest.java
@@ -41,19 +41,23 @@ class OneToOneChatIntegrationTest extends AbstractConversationTest {
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void startOneToOneChat_asStudent1WithStudent2_shouldCreateOneToOneChat() throws Exception {
+    void startOneToOneChat_asStudent1_shouldCreateMultipleOneToOneChats() throws Exception {
         // when
-        var chat = request.postWithResponseBody("/api/courses/" + exampleCourseId + "/one-to-one-chats", List.of(testPrefix + "student2"), OneToOneChatDTO.class,
+        var chat1 = request.postWithResponseBody("/api/courses/" + exampleCourseId + "/one-to-one-chats", List.of(testPrefix + "student2"), OneToOneChatDTO.class,
+                HttpStatus.CREATED);
+
+        var chat2 = request.postWithResponseBody("/api/courses/" + exampleCourseId + "/one-to-one-chats", List.of(testPrefix + "student3"), OneToOneChatDTO.class,
                 HttpStatus.CREATED);
         // then
-        assertThat(chat).isNotNull();
-        assertParticipants(chat.getId(), 2, "student1", "student2");
+        assertThat(chat1).isNotNull();
+        assertParticipants(chat1.getId(), 2, "student1", "student2");
+        assertThat(chat2).isNotNull();
+        assertParticipants(chat2.getId(), 2, "student1", "student3");
         // members of the created one to one chat are only notified in case the first message within the conversation is created
         verifyNoParticipantTopicWebsocketSent();
 
         // cleanup
-        var conversation = oneToOneChatRepository.findByIdWithConversationParticipantsAndUserGroups(chat.getId()).orElseThrow();
-        conversationRepository.delete(conversation);
+        conversationRepository.deleteAllById(List.of(chat1.getId(), chat2.getId()));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).


#### Server
- [X] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [X] I ~added multiple~ _modified one_ integration test~s~ (Spring) related to the features (with a high test coverage).
- [X] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We want to keep our dependencies updated and the newest version caused an error as Hibernate doesn't allow joining the same table multiple times anymore.

Additionally, one test failed, indicating an issue with a JPQL query and its GROUP BY clause in the StudentParticipationRepository.

### Description
<!-- Describe your changes in detail -->
I have to rely on existence checks now, which probably is slightly less efficient Because the one-to-one chats don't have specific join fields (like userA_id, userB_id) but rely on the participant's relation instead. We had no other choice so far if we wanted to do it in one query. Now, we have to do an existence check. We could avoid this by refactoring the participants' structure; however, considering that we already filter it by course and the first user, it won't be too expensive)

I used the alias to reference what to group by instead of the term to avoid issues with Hibernate.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Course with Messaging enabled

Messages:
1. Log in to Artemis with both users (different browsers or incognito mode)
2. Navigate to messages on both
3. Start a new conversation between those two students.
4. Engage in the conversation
5. Make sure as the instructor that there are no leaks (i.e. you don't have access to the DM)

Scores:
1. Create any exercise and participate in it (you can also reuse existing participations in your course)
2. Set a Grading scale for the course (e.g. via the Scores page, top right or Assessment page)
3. Open the Scores page, and you should get no error.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
No changes in testing coverage
