### PR TITLE
`Programming exercises`: Fix an issue when re-evaluating results

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Feedback.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Feedback.java
@@ -23,6 +23,7 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
@@ -135,7 +136,9 @@ public class Feedback extends DomainObject {
      */
     public void setDetailTextTruncated(@Nullable final String detailText) {
         this.detailText = StringUtils.truncate(detailText, FEEDBACK_DETAIL_TEXT_DATABASE_MAX_LENGTH);
-        this.longFeedbackText.clear();
+        if (Hibernate.isInitialized(longFeedbackText)) {
+            longFeedbackText.clear();
+        }
         this.hasLongFeedbackText = false;
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseUtilService.java
@@ -690,8 +690,9 @@ public class ProgrammingExerciseUtilService {
      * @param exercise   The exercise for which to create the submission/participation/result combination.
      * @param submission The submission to use for adding to the exercise/participation/result.
      * @param login      The login of the user used to access or create an exercise participation.
+     * @return the newly created result
      */
-    public void addProgrammingSubmissionWithResult(ProgrammingExercise exercise, ProgrammingSubmission submission, String login) {
+    public Result addProgrammingSubmissionWithResult(ProgrammingExercise exercise, ProgrammingSubmission submission, String login) {
         StudentParticipation participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, login);
         submission = programmingSubmissionRepo.save(submission);
         Result result = resultRepo.save(new Result().participation(participation));
@@ -703,6 +704,30 @@ public class ProgrammingExerciseUtilService {
         result = resultRepo.save(result);
         participation.addResult(result);
         studentParticipationRepo.save(participation);
+        return result;
+    }
+
+    /**
+     * Adds a template submission with a result to the given programming exercise.
+     * The method will make sure that all necessary entities are connected.
+     *
+     * @param exerciseId The id of the programming exercise to which the submission should be added.
+     * @return the newly created result
+     */
+    public Result addTemplateSubmissionWithResult(long exerciseId) {
+        var templateParticipation = templateProgrammingExerciseParticipationRepo.findWithEagerResultsAndSubmissionsByProgrammingExerciseIdElseThrow(exerciseId);
+        ProgrammingSubmission submission = new ProgrammingSubmission();
+        submission = submissionRepository.save(submission);
+        Result result = resultRepo.save(new Result().participation(templateParticipation));
+        templateParticipation.addSubmission(submission);
+        submission.setParticipation(templateParticipation);
+        submission.addResult(result);
+        submission = submissionRepository.save(submission);
+        result.setSubmission(submission);
+        result = resultRepo.save(result);
+        templateParticipation.addResult(result);
+        templateProgrammingExerciseParticipationRepo.save(templateParticipation);
+        return result;
     }
 
     /**


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
In https://github.com/ls1intum/Artemis/pull/8462#pullrequestreview-2064779614 @Jan-Thurner found a bug where re-evaluating a programming exercise is not possible when the sca visibility gets changed.


### Description
The server tried to call `longFeedbackText.clear()` which led to an error since the longFeedbackText did not get loaded from the database. However, in the case of SCA issues there is never a long feedback text present and this call is unnecessary.


### Steps for Testing
- 1 Instructor
- 1 Programming Exericse with SCA enabled
- 1 Submission with SCA issues in the latest result

1. Navigate to the exercise -> grading -> code analysis
2. Change the visibilty of  a category from active to inactive
3. Save and press "re-evaluate"
4. Verify that the feedback of the changed category is no longer visible.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress

#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
test added, line-coverage unchanged.

### Screenshots
![grafik](https://github.com/ls1intum/Artemis/assets/26540346/9bb74c47-7553-45a1-861f-564dbac86288)
