### PR TITLE
`Programming exercises`: Fix diff view for renamed files

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/GitDiffReportParserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/GitDiffReportParserService.java
@@ -3,9 +3,7 @@ package de.tum.in.www1.artemis.web.rest;
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -21,10 +19,6 @@ public class GitDiffReportParserService {
 
     private final Pattern gitDiffLinePattern = Pattern.compile("@@ -(?<previousLine>\\d+)(,(?<previousLineCount>\\d+))? \\+(?<newLine>\\d+)(,(?<newLineCount>\\d+))? @@");
 
-    private final Pattern gitRenameFromPattern = Pattern.compile("rename from (?<previousFileName>.*)");
-
-    private final Pattern gitRenameToPattern = Pattern.compile("rename to (?<newFileName>.*)");
-
     /**
      * Extracts the ProgrammingExerciseGitDiffEntry from the raw git-diff output
      *
@@ -35,7 +29,7 @@ public class GitDiffReportParserService {
     public List<ProgrammingExerciseGitDiffEntry> extractDiffEntries(String diff, boolean useAbsoluteLineCount) {
         var lines = diff.split("\n");
         var parserState = new ParserState();
-        Map<String, String> renamedFilePaths = new HashMap<>();
+
         for (int i = 0; i < lines.length; i++) {
             var line = lines[i];
             // Filter out no new line message
@@ -45,16 +39,6 @@ public class GitDiffReportParserService {
             var lineMatcher = gitDiffLinePattern.matcher(line);
             if (lineMatcher.matches()) {
                 handleNewDiffBlock(lines, i, parserState, lineMatcher);
-            }
-            // Under certain circumstances, Git can track renamed files. These may not always contain diff entries,
-            // so keep track of renamed files manually.
-            var renameFromMatcher = gitRenameFromPattern.matcher(line);
-            if (renameFromMatcher.matches() && i + 1 < lines.length) {
-                var nextLine = lines[i + 1];
-                var renameToMatcher = gitRenameToPattern.matcher(nextLine);
-                if (renameToMatcher.matches()) {
-                    renamedFilePaths.put(renameFromMatcher.group("previousFileName"), renameToMatcher.group("newFileName"));
-                }
             }
             else if (!parserState.deactivateCodeReading) {
                 switch (line.charAt(0)) {
@@ -67,16 +51,6 @@ public class GitDiffReportParserService {
         }
         if (!parserState.currentEntry.isEmpty()) {
             parserState.entries.add(parserState.currentEntry);
-        }
-        // Add empty diff entries for each renamed file if not already present
-        for (String previousPath : renamedFilePaths.keySet()) {
-            String newPath = renamedFilePaths.get(previousPath);
-            if (parserState.entries.stream().noneMatch(entry -> entry.getPreviousFilePath().equals(previousPath))) {
-                var entry = new ProgrammingExerciseGitDiffEntry();
-                entry.setPreviousFilePath(previousPath);
-                entry.setFilePath(newPath);
-                parserState.entries.add(entry);
-            }
         }
         return parserState.entries;
     }

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-file.component.html
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-file.component.html
@@ -1,3 +1,9 @@
-<div class="git-diff-file ph-1">
-    <jhi-monaco-diff-editor [allowSplitView]="allowSplitView" (onReadyForDisplayChange)="onDiffReady.emit($event)" />
+<div class="ph-1">
+    @if (fileUnchanged) {
+        <div class="w-100 d-flex justify-content-center">
+            <span class="p-2" jhiTranslate="artemisApp.repository.commitHistory.commitDetails.fileUnchanged"></span>
+        </div>
+    }
+    <!-- The editor is only hidden, not removed, as we still want it to report its readiness. -->
+    <jhi-monaco-diff-editor [hidden]="fileUnchanged" [allowSplitView]="allowSplitView" (onReadyForDisplayChange)="onDiffReady.emit($event)" />
 </div>

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-file.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-file.component.ts
@@ -31,10 +31,12 @@ export class GitDiffFileComponent implements OnInit {
 
     originalFilePath?: string;
     modifiedFilePath?: string;
+    fileUnchanged = false;
 
     ngOnInit(): void {
         this.determineFilePaths();
         this.monacoDiffEditor.setFileContents(this.originalFileContent, this.originalFilePath, this.modifiedFileContent, this.modifiedFilePath);
+        this.fileUnchanged = this.originalFileContent === this.modifiedFileContent;
     }
 
     /**

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.html
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.html
@@ -71,7 +71,7 @@
                     [allowSplitView]="allowSplitView"
                     [diffForTemplateAndSolution]="diffForTemplateAndSolution"
                     [diffEntries]="entriesByPath.get(filePath) ?? []"
-                    [templateFileContent]="templateFileContentByPath.get(filePath)"
+                    [templateFileContent]="templateFileContentByPath.get(renamedFilePaths[filePath] ?? filePath)"
                     [solutionFileContent]="solutionFileContentByPath.get(filePath)"
                     (onDiffReady)="onDiffReady(filePath, $event)"
                 />

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.html
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.html
@@ -71,7 +71,7 @@
                     [allowSplitView]="allowSplitView"
                     [diffForTemplateAndSolution]="diffForTemplateAndSolution"
                     [diffEntries]="entriesByPath.get(filePath) ?? []"
-                    [templateFileContent]="templateFileContentByPath.get(renamedFilePaths[filePath] ?? filePath)"
+                    [templateFileContent]="templateFileContentByPath.get(renamedFilePaths[filePath] || filePath)"
                     [solutionFileContent]="solutionFileContentByPath.get(filePath)"
                     (onDiffReady)="onDiffReady(filePath, $event)"
                 />

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.ts
@@ -114,7 +114,6 @@ export class GitDiffReportComponent implements OnInit {
             }
         });
         this.nothingToDisplay = Object.keys(this.diffsReadyByPath).length === 0;
-        console.warn('Renamed: ' + JSON.stringify(this.renamedFilePaths));
     }
 
     /**

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.ts
@@ -87,7 +87,7 @@ export class GitDiffReportComponent implements OnInit {
         this.filePaths = [...new Set([...this.templateFileContentByPath.keys(), ...this.solutionFileContentByPath.keys()])].sort();
         // Track renamed files
         this.entries.forEach((entry) => {
-            // Accounts only for files that have existed in the original and the modified version
+            // Accounts only for files that have existed in the original and the modified version, but under different names
             if (entry.filePath && entry.previousFilePath && entry.filePath !== entry.previousFilePath) {
                 this.renamedFilePaths[entry.filePath] = entry.previousFilePath;
             }

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.ts
@@ -35,6 +35,7 @@ export class GitDiffReportComponent implements OnInit {
     allDiffsReady = false;
     nothingToDisplay = false;
     allowSplitView = true;
+    renamedFilePaths: { [before: string]: string } = {};
 
     faSpinner = faSpinner;
     faTableColumns = faTableColumns;
@@ -84,6 +85,13 @@ export class GitDiffReportComponent implements OnInit {
 
         // Create a set of all file paths
         this.filePaths = [...new Set([...this.templateFileContentByPath.keys(), ...this.solutionFileContentByPath.keys()])].sort();
+        // Track renamed files
+        this.entries.forEach((entry) => {
+            // Accounts only for files that have existed in the original and the modified version
+            if (entry.filePath && entry.previousFilePath && entry.filePath !== entry.previousFilePath) {
+                this.renamedFilePaths[entry.filePath] = entry.previousFilePath;
+            }
+        });
         // Group the diff entries by file path
         this.entriesByPath = new Map<string, ProgrammingExerciseGitDiffEntry[]>();
         [...this.templateFileContentByPath.keys()].forEach((filePath) => {
@@ -106,6 +114,7 @@ export class GitDiffReportComponent implements OnInit {
             }
         });
         this.nothingToDisplay = Object.keys(this.diffsReadyByPath).length === 0;
+        console.warn('Renamed: ' + JSON.stringify(this.renamedFilePaths));
     }
 
     /**

--- a/src/main/webapp/i18n/de/repository.json
+++ b/src/main/webapp/i18n/de/repository.json
@@ -12,7 +12,8 @@
                     "author": "Autor",
                     "date": "Datum",
                     "commit": "Commit",
-                    "empty": "Keine Änderungen"
+                    "empty": "Keine Änderungen",
+                    "fileUnchanged": "Keine Änderungen am Dateiinhalt"
                 }
             }
         }

--- a/src/main/webapp/i18n/en/repository.json
+++ b/src/main/webapp/i18n/en/repository.json
@@ -12,7 +12,8 @@
                     "author": "Author",
                     "date": "Date",
                     "commit": "Commit",
-                    "empty": "No changes"
+                    "empty": "No changes",
+                    "fileUnchanged": "No changes in the file content"
                 }
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
@@ -136,6 +136,20 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractLocalCILoc
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void getGitDiffReportForCommitsWithRenamedFile() throws Exception {
+        String fileContent = "content\ncontent\ncontent\ncontent";
+        exercise = hestiaUtilTestService.setupTemplate(FILE_NAME, fileContent, exercise, templateRepo);
+        participationRepo.configureRepos("participationLocalRepo", "participationOriginRepo");
+        var studentLogin = TEST_PREFIX + "student1";
+        var submission = hestiaUtilTestService.setupSubmission(FILE_NAME, fileContent, exercise, participationRepo, studentLogin);
+        // Simulate a renaming by deleting the file and creating a new one with the same content. Git will track this as long as the content is similar enough.
+        var submission2 = hestiaUtilTestService.deleteFileAndSetupSubmission(FILE_NAME, FILE_NAME + "-renamed", fileContent, exercise, participationRepo, studentLogin);
+        request.get("/api/programming-exercises/" + exercise.getId() + "/commits/" + submission.getCommitHash() + "/diff-report/" + submission2.getCommitHash()
+                + "?participationId=" + submission.getParticipation().getId(), HttpStatus.OK, ProgrammingExerciseGitDiffReport.class);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void getGitDiffReportForCommitsThrowsConflictException() throws Exception {
         exercise = hestiaUtilTestService.setupTemplate(FILE_NAME, "ABC", exercise, templateRepo);
         var wrongExerciseId = exercise.getId() + 1;

--- a/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
@@ -192,6 +192,8 @@ public class HestiaUtilTestService {
             LocalRepository participationRepo, String login) throws Exception {
         Path oldFilePath = Path.of(participationRepo.localRepoFile + "/" + oldFileName);
         Files.delete(oldFilePath);
+        // Ensure JGit realizes the file has been removed
+        participationRepo.localGit.rm().addFilepattern(oldFileName).call();
         return setupSubmission(newFileName, content, exercise, participationRepo, login);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
@@ -188,6 +188,13 @@ public class HestiaUtilTestService {
         return setupSubmission(Collections.singletonMap(fileName, content), exercise, participationRepo, login);
     }
 
+    public ProgrammingSubmission deleteFileAndSetupSubmission(String oldFileName, String newFileName, String content, ProgrammingExercise exercise,
+            LocalRepository participationRepo, String login) throws Exception {
+        Path oldFilePath = Path.of(participationRepo.localRepoFile + "/" + oldFileName);
+        Files.delete(oldFilePath);
+        return setupSubmission(newFileName, content, exercise, participationRepo, login);
+    }
+
     public ProgrammingSubmission setupSubmission(Map<String, String> files, ProgrammingExercise exercise, LocalRepository participationRepo, String login) throws Exception {
         for (Map.Entry<String, String> entry : files.entrySet()) {
             String fileName = entry.getKey();

--- a/src/test/javascript/spec/component/hestia/git-diff-report/git-diff-report.component.spec.ts
+++ b/src/test/javascript/spec/component/hestia/git-diff-report/git-diff-report.component.spec.ts
@@ -182,4 +182,32 @@ describe('ProgrammingExerciseGitDiffReport Component', () => {
         expect(comp.diffsReadyByPath[filePath1]).toBeTrue();
         expect(comp.diffsReadyByPath[filePath2]).toBeTrue();
     });
+
+    it('should correctly identify renamed files', () => {
+        const originalFilePath1 = 'src/original-a.java';
+        const originalFilePath2 = 'src/original-b.java';
+        const renamedFilePath1 = 'src/renamed-without-changes.java';
+        const renamedFilePath2 = 'src/renamed-with-changes.java';
+        const notRenamedFilePath = 'src/not-renamed.java';
+        const entries: ProgrammingExerciseGitDiffEntry[] = [
+            { filePath: renamedFilePath1, previousFilePath: originalFilePath1 },
+            { filePath: renamedFilePath2, previousFilePath: originalFilePath2, startLine: 1 },
+            { filePath: notRenamedFilePath, previousFilePath: notRenamedFilePath, startLine: 1 },
+        ];
+        const defaultContent = 'some content that might change';
+        const modifiedContent = 'some content that has changed';
+        comp.report = { entries } as ProgrammingExerciseGitDiffReport;
+        const originalFileContents = new Map<string, string>();
+        const modifiedFileContents = new Map<string, string>();
+        [originalFilePath1, originalFilePath2, notRenamedFilePath].forEach((path) => {
+            originalFileContents.set(path, defaultContent);
+            modifiedFileContents.set(path, path === originalFilePath1 ? defaultContent : modifiedContent);
+        });
+        comp.templateFileContentByPath = originalFileContents;
+        comp.solutionFileContentByPath = modifiedFileContents;
+
+        fixture.detectChanges();
+
+        expect(comp.renamedFilePaths).toEqual({ [renamedFilePath1]: originalFilePath1, [renamedFilePath2]: originalFilePath2 });
+    });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
During the review of #8540, I noticed that renaming files wasn't working as expected when viewing commit details. This had two causes:

- Renamed files that had no diff blocks were not mentioned in the generated diff report.
- For renamed and modified files, the wrong "before" content was shown (we used the updated file path)

### Description
<!-- Describe your changes in detail -->
- We now explicitly track the renamed files in the server and add corresponding diff entries if needed
- We now use the correct file content when displaying renamed & modified files.
- For renamed and otherwise unchanged files, we now display a placeholder

When processing the diff, we now keep track of entries like this:
```
diff --git a/src/de/tum/cit/ase/Client2.java b/src/de/tum/cit/ase/Client23.java
similarity index 98%
rename from src/de/tum/cit/ase/Client2.java
rename to src/de/tum/cit/ase/Client23.java
```

### Steps for Testing

Prerequisites:
- Test Server with LocalVC enabled
- 1 Student
- 1 Programming exercise (clone the repository; it'll be easier to verify that this feature works correctly)

1. Log in and navigate to the programming exercise
2. Clone the repository
3. Take a file and change 1-2 lines, then rename the file. (**Note**: it's important that you do not change too many lines; otherwise, git will not be able to track the rename. If you're unsure: you should get something like `rename src/de/tum/cit/ase/{WillRename.java => HaveRenamed.java} (82%)` when committing using the command line)
4. Commit your changes.
5. Rename the file again, this time without changing its content.
6. Commit your changes.
7. Make some other changes, e.g. delete / create / modify some files.
8. Commit your changes.
9. Push your changes.
10. On Artemis, click "Open repository," then open the commit history.
11. Verify for each commit that your changes were tracked and are displayed correctly.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage

#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [git-diff-file.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6613/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/programming/hestia/git-diff-report/git-diff-file.component.ts.html) | 100% | ✅ |
| [git-diff-report.component.ts](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6613/latest/artifact/shared/Coverage-Report-Client-Tests/app/exercises/programming/hestia/git-diff-report/git-diff-report.component.ts.html) | 100% | ✅ |

#### Server

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| [GitDiffReportParserService.java](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS6613/latest/artifact/shared/Coverage-Report-Server-Tests/de.tum.in.www1.artemis.web.rest/GitDiffReportParserService.html) | 86% | ✅ |



### Screenshots

![image](https://github.com/ls1intum/Artemis/assets/38403547/85b3fba3-b59b-43c2-b9f5-36bc6c590471)
![image](https://github.com/ls1intum/Artemis/assets/38403547/bb55fffa-4fcd-41c4-8975-8cef3e75f665)
