### PR TITLE
`Development`: Fix version table check for MySQL

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/migration/DatabaseMigration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/DatabaseMigration.java
@@ -179,7 +179,7 @@ public class DatabaseMigration {
             if (e.getMessage().contains("databasechangelog") && (e.getMessage().contains("does not exist") || (e.getMessage().contains("doesn't exist")))) {
                 return null;
             }
-            log.error(error);
+            log.error(error, e);
             System.exit(13);
         }
         // this path cannot happen

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/DatabaseMigration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/DatabaseMigration.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/DatabaseMigration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/DatabaseMigration.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -176,7 +177,7 @@ public class DatabaseMigration {
             System.exit(12);
         }
         catch (SQLException e) {
-            if (e.getMessage().contains("databasechangelog") && (e.getMessage().contains("does not exist") || (e.getMessage().contains("doesn't exist")))) {
+            if (StringUtils.containsIgnoreCase(e.getMessage(), "databasechangelog") && (e.getMessage().contains("does not exist") || (e.getMessage().contains("doesn't exist")))) {
                 return null;
             }
             log.error(error, e);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
During the setup of the Artemis instance at the TU Dortmund, we encountered an issue where the MySQL database could not be setup. There was not exception of any kind it just failed to start with the message that the version table does not exist.


### Description
<!-- Describe your changes in detail -->
I firstly added the exception that happened to the log output.
Secondly the issue was that we execute `statement.executeQuery("SELECT * FROM DATABASECHANGELOG;");`, which on some MySQL setups leads to a message `table databasechangelog doesn't exist`, but on other MySQL setups leads to  `table DATABASECHANGELOG doesn't exist`. To support both I replaced `contains` with `StringUtils:: containsIgnoreCase`. 

This was already tested and works for the TU Dortmund.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Only locally possible
- A completely fresh (bare-metal) MySQL database
- Start Artemis for this DB

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2