### PR TITLE
`Development`: Remove disabled test

### DIFF
--- a/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
@@ -500,31 +500,6 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
         }),
     );
 
-    // until a policy is set
-    it.skip('assureConditionsSatisfied should alert and return false if not all hidden tests have passed', () => {
-        jest.spyOn(window, 'alert').mockImplementation(() => {});
-        comp.exercise = {
-            type: ExerciseType.PROGRAMMING,
-            dueDate: dayjs().subtract(5, 'minutes'),
-            studentParticipations: [
-                {
-                    id: 2,
-                    results: [
-                        {
-                            assessmentType: AssessmentType.AUTOMATIC,
-                            score: 80,
-                        },
-                    ],
-                },
-            ] as StudentParticipation[],
-        } as ProgrammingExercise;
-
-        const result = comp.assureConditionsSatisfied();
-
-        expect(window.alert).toHaveBeenCalledWith('artemisApp.exercise.notEnoughPoints');
-        expect(result).toBeFalse();
-    });
-
     it('assureConditionsSatisfied should alert and return false if the feedback request has already been sent', () => {
         jest.spyOn(window, 'alert').mockImplementation(() => {});
         comp.exercise = {


### PR DESCRIPTION
### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
Remove a disabled test as it isn't relevant anymore. The scenario it tests is outdated.



### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
