### PR TITLE
`Development`: Speedup loading of exercises in course management

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/FeedbackRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/FeedbackRepository.java
@@ -36,6 +36,13 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
             """)
     List<Feedback> findFeedbackByGradingInstructionIds(@Param("gradingInstructionsIds") List<Long> gradingInstructionsIds);
 
+    @Query("""
+                SELECT COUNT(*) > 0
+                FROM Feedback feedback
+                WHERE feedback.gradingInstruction.id IN :gradingInstructionsIds
+            """)
+    boolean hasFeedbackFromGradingInstructionIds(@Param("gradingInstructionsIds") List<Long> gradingInstructionsIds);
+
     /**
      * Save the given feedback elements to the database in case they are not yet connected to a result
      *
@@ -67,5 +74,18 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
         List<Long> gradingInstructionsIds = gradingCriteria.stream().flatMap(gradingCriterion -> gradingCriterion.getStructuredGradingInstructions().stream())
                 .map(GradingInstruction::getId).toList();
         return findFeedbackByGradingInstructionIds(gradingInstructionsIds);
+    }
+
+    /**
+     * Given the grading criteria, this method checks if any criteria
+     * is used in some feedback.
+     *
+     * @param gradingCriteria The grading criteria belongs to exercise in a specific course
+     * @return true if any grading criteria gets used in any feedback
+     */
+    default boolean hasFeedbackByExerciseGradingCriteria(Set<GradingCriterion> gradingCriteria) {
+        List<Long> gradingInstructionsIds = gradingCriteria.stream().flatMap(gradingCriterion -> gradingCriterion.getStructuredGradingInstructions().stream())
+                .map(GradingInstruction::getId).toList();
+        return hasFeedbackFromGradingInstructionIds(gradingInstructionsIds);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/FeedbackRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/FeedbackRepository.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.artemis.repository;
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -71,6 +72,9 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
      * @return list including feedback entries which are associated with the grading instructions
      */
     default List<Feedback> findFeedbackByExerciseGradingCriteria(Set<GradingCriterion> gradingCriteria) {
+        if (gradingCriteria.isEmpty()) {
+            return Collections.emptyList();
+        }
         List<Long> gradingInstructionsIds = gradingCriteria.stream().flatMap(gradingCriterion -> gradingCriterion.getStructuredGradingInstructions().stream())
                 .map(GradingInstruction::getId).toList();
         return findFeedbackByGradingInstructionIds(gradingInstructionsIds);
@@ -84,6 +88,9 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
      * @return true if any grading criteria gets used in any feedback
      */
     default boolean hasFeedbackByExerciseGradingCriteria(Set<GradingCriterion> gradingCriteria) {
+        if (gradingCriteria.isEmpty()) {
+            return false;
+        }
         List<Long> gradingInstructionsIds = gradingCriteria.stream().flatMap(gradingCriterion -> gradingCriterion.getStructuredGradingInstructions().stream())
                 .map(GradingInstruction::getId).toList();
         return hasFeedbackFromGradingInstructionIds(gradingInstructionsIds);

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -678,7 +678,7 @@ public class ExerciseService {
     public void checkExerciseIfStructuredGradingInstructionFeedbackUsed(Set<GradingCriterion> gradingCriteria, Exercise exercise) {
         boolean hasFeedbackFromStructuredGradingInstructionUsed = feedbackRepository.hasFeedbackByExerciseGradingCriteria(gradingCriteria);
 
-        if (!hasFeedbackFromStructuredGradingInstructionUsed) {
+        if (hasFeedbackFromStructuredGradingInstructionUsed) {
             exercise.setGradingInstructionFeedbackUsed(true);
         }
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -676,9 +676,9 @@ public class ExerciseService {
      * @param exercise        exercise to update *
      */
     public void checkExerciseIfStructuredGradingInstructionFeedbackUsed(Set<GradingCriterion> gradingCriteria, Exercise exercise) {
-        List<Feedback> feedback = feedbackRepository.findFeedbackByExerciseGradingCriteria(gradingCriteria);
+        boolean hasFeedbackFromStructuredGradingInstructionUsed = feedbackRepository.hasFeedbackByExerciseGradingCriteria(gradingCriteria);
 
-        if (!feedback.isEmpty()) {
+        if (!hasFeedbackFromStructuredGradingInstructionUsed) {
             exercise.setGradingInstructionFeedbackUsed(true);
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
After upgrading Hibernate, we experienced long loading times when opening the programming exercise details. This was caused by a query loading a lot of feedbacks, which in turn only got used for a `isEmpty()` check on the list.

### Description
I replaced the query with a boolean exists check.


### Steps for Testing
code review

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2