### PR TITLE
`Development`: Add arch rule to verify that DTOs with nullable fields use JSON annotation

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/apollon/dto/ApollonModelDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/apollon/dto/ApollonModelDTO.java
@@ -2,6 +2,9 @@ package de.tum.in.www1.artemis.service.connectors.apollon.dto;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ApollonModelDTO implements Serializable {
 
     private String model;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaFeedbackSendingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaFeedbackSendingService.java
@@ -10,6 +10,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Feedback;
 import de.tum.in.www1.artemis.domain.Submission;
@@ -44,6 +46,7 @@ public class AthenaFeedbackSendingService {
         this.athenaDTOConverterService = athenaDTOConverterService;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record RequestDTO(ExerciseDTO exercise, SubmissionDTO submission, List<FeedbackDTO> feedbacks) {
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaFeedbackSendingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaFeedbackSendingService.java
@@ -50,6 +50,7 @@ public class AthenaFeedbackSendingService {
     private record RequestDTO(ExerciseDTO exercise, SubmissionDTO submission, List<FeedbackDTO> feedbacks) {
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record ResponseDTO(String data) {
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaFeedbackSuggestionsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaFeedbackSuggestionsService.java
@@ -10,6 +10,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
 import de.tum.in.www1.artemis.domain.TextExercise;
@@ -63,12 +65,15 @@ public class AthenaFeedbackSuggestionsService {
     private record RequestDTO(ExerciseDTO exercise, SubmissionDTO submission, boolean isGraded) {
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record ResponseDTOText(List<TextFeedbackDTO> data) {
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record ResponseDTOProgramming(List<ProgrammingFeedbackDTO> data) {
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record ResponseDTOModeling(List<ModelingFeedbackDTO> data) {
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaFeedbackSuggestionsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaFeedbackSuggestionsService.java
@@ -62,6 +62,7 @@ public class AthenaFeedbackSuggestionsService {
         this.athenaModuleService = athenaModuleService;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record RequestDTO(ExerciseDTO exercise, SubmissionDTO submission, boolean isGraded) {
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaModuleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaModuleService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,6 +56,7 @@ public class AthenaModuleService {
         this.exerciseRepository = exerciseRepository;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record AthenaModuleDTO(String name, String type) {
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaSubmissionSelectionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaSubmissionSelectionService.java
@@ -12,6 +12,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -35,6 +36,7 @@ public class AthenaSubmissionSelectionService {
 
     private final AthenaDTOConverterService athenaDTOConverterService;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record RequestDTO(ExerciseDTO exercise, List<Long> submissionIds// Athena just needs submission IDs => quicker request, because less data is sent
     ) {
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaSubmissionSendingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaSubmissionSendingService.java
@@ -15,6 +15,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Submission;
 import de.tum.in.www1.artemis.exception.NetworkingException;
@@ -53,6 +55,7 @@ public class AthenaSubmissionSendingService {
         this.athenaDTOConverterService = athenaDTOConverterService;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record RequestDTO(ExerciseDTO exercise, List<SubmissionDTO> submissions) {
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaSubmissionSendingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaSubmissionSendingService.java
@@ -59,6 +59,7 @@ public class AthenaSubmissionSendingService {
     private record RequestDTO(ExerciseDTO exercise, List<SubmissionDTO> submissions) {
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record ResponseDTO(String data) {
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/BuildResult.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/dto/BuildResult.java
@@ -156,6 +156,7 @@ public class BuildResult extends AbstractBuildResultNotificationDTO implements S
      * @param failedTests     list of failed tests.
      * @param successfulTests list of successful tests.
      */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record LocalCIJobDTO(List<LocalCITestJobDTO> failedTests, List<LocalCITestJobDTO> successfulTests) implements BuildJobDTOInterface, Serializable {
 
         @Override
@@ -175,6 +176,7 @@ public class BuildResult extends AbstractBuildResultNotificationDTO implements S
      * @param name   name of the test case.
      * @param errors list of error messages.
      */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record LocalCITestJobDTO(String name, List<String> errors) implements TestCaseDTOInterface, Serializable {
 
         @Override

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/PyrisErrorResponseDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/PyrisErrorResponseDTO.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.service.connectors.pyris.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * A DTO representing an error response from Pyris.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisErrorResponseDTO(String errorMessage) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/PyrisHealthStatusDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/PyrisHealthStatusDTO.java
@@ -1,5 +1,8 @@
 package de.tum.in.www1.artemis.service.connectors.pyris.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisHealthStatusDTO(String model, ModelStatus status) {
 
     public enum ModelStatus {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/PyrisModelDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/PyrisModelDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.service.connectors.pyris.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisModelDTO(String id, String name, String description) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/PyrisPipelineExecutionSettingsDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/PyrisPipelineExecutionSettingsDTO.java
@@ -2,6 +2,8 @@ package de.tum.in.www1.artemis.service.connectors.pyris.dto;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * DTO representing the settings required to execute a Pyris pipeline.
  *
@@ -9,5 +11,6 @@ import java.util.List;
  * @param allowedModelIdentifiers the allowed model identifiers
  * @param artemisBaseUrl          the base URL of the Artemis instance
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisPipelineExecutionSettingsDTO(String authenticationToken, List<String> allowedModelIdentifiers, String artemisBaseUrl) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisBuildLogEntryDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisBuildLogEntryDTO.java
@@ -2,5 +2,8 @@ package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisBuildLogEntryDTO(Instant timestamp, String message) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisCourseDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisCourseDTO.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.Course;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisCourseDTO(long id, String name, String description) {
 
     public PyrisCourseDTO(Course course) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisFeedbackDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisFeedbackDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisFeedbackDTO(String text, String testCaseName, double credits) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisImageMessageContentDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisImageMessageContentDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisImageMessageContentDTO(String imageData) implements PyrisMessageContentDTO {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisJsonMessageContentDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisJsonMessageContentDTO.java
@@ -1,6 +1,8 @@
 package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisJsonMessageContentDTO(@JsonRawValue String jsonContent) implements PyrisMessageContentDTO {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisLectureUnitDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisLectureUnitDTO.java
@@ -2,5 +2,8 @@ package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisLectureUnitDTO(long id, long lectureId, Instant releaseDate, String name, int attachmentVersion) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisMessageDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisMessageDTO.java
@@ -3,7 +3,10 @@ package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 import java.time.Instant;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.iris.message.IrisMessageSender;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisMessageDTO(Instant sentAt, IrisMessageSender sender, List<PyrisMessageContentDTO> contents) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisProgrammingExerciseDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisProgrammingExerciseDTO.java
@@ -3,8 +3,11 @@ package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 import java.time.Instant;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisProgrammingExerciseDTO(long id, String name, ProgrammingLanguage programmingLanguage, Map<String, String> templateRepository,
         Map<String, String> solutionRepository, Map<String, String> testRepository, String problemStatement, Instant startDate, Instant endDate) {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisResultDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisResultDTO.java
@@ -3,5 +3,8 @@ package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 import java.time.Instant;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisResultDTO(Instant completionDate, boolean successful, List<PyrisFeedbackDTO> feedbacks) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisSubmissionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisSubmissionDTO.java
@@ -4,6 +4,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisSubmissionDTO(long id, Instant date, Map<String, String> repository, boolean isPractice, boolean buildFailed, List<PyrisBuildLogEntryDTO> buildLogEntries,
         PyrisResultDTO latestResult) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisTextMessageContentDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisTextMessageContentDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisTextMessageContentDTO(String textContent) implements PyrisMessageContentDTO {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisUserDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/data/PyrisUserDTO.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.service.connectors.pyris.dto.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.User;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisUserDTO(long id, String firstName, String lastName) {
 
     public PyrisUserDTO(User user) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/status/PyrisStageDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/status/PyrisStageDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.service.connectors.pyris.dto.status;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisStageDTO(String name, int weight, PyrisStageStateDTO state, String message) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/tutorChat/PyrisTutorChatPipelineExecutionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/tutorChat/PyrisTutorChatPipelineExecutionDTO.java
@@ -2,6 +2,8 @@ package de.tum.in.www1.artemis.service.connectors.pyris.dto.tutorChat;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.service.connectors.pyris.dto.PyrisPipelineExecutionSettingsDTO;
 import de.tum.in.www1.artemis.service.connectors.pyris.dto.data.PyrisCourseDTO;
 import de.tum.in.www1.artemis.service.connectors.pyris.dto.data.PyrisMessageDTO;
@@ -10,6 +12,7 @@ import de.tum.in.www1.artemis.service.connectors.pyris.dto.data.PyrisSubmissionD
 import de.tum.in.www1.artemis.service.connectors.pyris.dto.data.PyrisUserDTO;
 import de.tum.in.www1.artemis.service.connectors.pyris.dto.status.PyrisStageDTO;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisTutorChatPipelineExecutionDTO(PyrisSubmissionDTO submission, PyrisProgrammingExerciseDTO exercise, PyrisCourseDTO course, List<PyrisMessageDTO> chatHistory,
         PyrisUserDTO user, PyrisPipelineExecutionSettingsDTO settings, List<PyrisStageDTO> initialStages) {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/tutorChat/PyrisTutorChatStatusUpdateDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/tutorChat/PyrisTutorChatStatusUpdateDTO.java
@@ -2,7 +2,10 @@ package de.tum.in.www1.artemis.service.connectors.pyris.dto.tutorChat;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.service.connectors.pyris.dto.status.PyrisStageDTO;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisTutorChatStatusUpdateDTO(String result, List<PyrisStageDTO> stages) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/ComplaintRequestDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/ComplaintRequestDTO.java
@@ -2,7 +2,10 @@ package de.tum.in.www1.artemis.service.dto;
 
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.enumeration.ComplaintType;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ComplaintRequestDTO(long resultId, String complaintText, ComplaintType complaintType, Optional<Long> examId) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/ComplaintResponseUpdateDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/ComplaintResponseUpdateDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.service.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ComplaintResponseUpdateDTO(String responseText, Boolean complaintIsAccepted, ComplaintAction action) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/ConsistencyErrorDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/ConsistencyErrorDTO.java
@@ -2,11 +2,14 @@ package de.tum.in.www1.artemis.service.dto;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 
 /**
  * A DTO representing a consistency error
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ConsistencyErrorDTO {
 
     private ProgrammingExercise programmingExercise;

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/GradingInstructionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/GradingInstructionDTO.java
@@ -2,8 +2,11 @@ package de.tum.in.www1.artemis.service.dto;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.GradingInstruction;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record GradingInstructionDTO(long id, double credits, String gradingScale, String instructionDescription, String feedback, int usageCount) {
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/ResponsibleUserDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/ResponsibleUserDTO.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.service.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * A DTO representing a course's responsible user, i.e., a person to report misconduct to.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ResponsibleUserDTO(String name, String email) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ModelingExerciseDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ModelingExerciseDTO.java
@@ -4,12 +4,15 @@ import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.service.dto.GradingCriterionDTO;
 
 /**
  * A DTO representing a ModelingExercise, for transferring data to Athena
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ModelingExerciseDTO(long id, String title, double maxPoints, double bonusPoints, String gradingInstructions, List<GradingCriterionDTO> gradingCriteria,
         String problemStatement, String exampleSolution) implements ExerciseDTO {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ModelingFeedbackDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ModelingFeedbackDTO.java
@@ -4,11 +4,14 @@ import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.Feedback;
 
 /**
  * A DTO representing a Feedback on a ModelingExercise, for transferring data to Athena and receiving suggestions from Athena
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ModelingFeedbackDTO(long id, long exerciseId, long submissionId, String title, String description, double credits, Long structuredGradingInstructionId,
         List<String> elementIds) implements FeedbackDTO {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ModelingSubmissionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ModelingSubmissionDTO.java
@@ -2,11 +2,14 @@ package de.tum.in.www1.artemis.service.dto.athena;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 
 /**
  * A DTO representing a ModelingSubmission, for transferring data to Athena
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ModelingSubmissionDTO(long id, long exerciseId, String model) implements SubmissionDTO {
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingExerciseDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingExerciseDTO.java
@@ -6,12 +6,15 @@ import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.service.dto.GradingCriterionDTO;
 
 /**
  * A DTO representing a ProgrammingExercise, for transferring data to Athena
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ProgrammingExerciseDTO(long id, String title, double maxPoints, double bonusPoints, String gradingInstructions, List<GradingCriterionDTO> gradingCriteria,
         String problemStatement, String programmingLanguage, String solutionRepositoryUri, String templateRepositoryUri, String testsRepositoryUri) implements ExerciseDTO {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingFeedbackDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingFeedbackDTO.java
@@ -2,11 +2,14 @@ package de.tum.in.www1.artemis.service.dto.athena;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.Feedback;
 
 /**
  * A DTO representing a Feedback on a ProgrammingExercise, for transferring data to Athena and receiving suggestions from Athena
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ProgrammingFeedbackDTO(long id, long exerciseId, long submissionId, String title, String description, double credits, Long structuredGradingInstructionId,
         String filePath, Integer lineStart, Integer lineEnd) implements FeedbackDTO {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingSubmissionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/ProgrammingSubmissionDTO.java
@@ -4,11 +4,14 @@ import static de.tum.in.www1.artemis.config.Constants.ATHENA_PROGRAMMING_EXERCIS
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
 
 /**
  * A DTO representing a ProgrammingSubmission, for transferring data to Athena
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ProgrammingSubmissionDTO(long id, long exerciseId, String repositoryUri) implements SubmissionDTO {
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextExerciseDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextExerciseDTO.java
@@ -4,12 +4,15 @@ import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.service.dto.GradingCriterionDTO;
 
 /**
  * A DTO representing a TextExercise, for transferring data to Athena
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record TextExerciseDTO(long id, String title, double maxPoints, double bonusPoints, String gradingInstructions, List<GradingCriterionDTO> gradingCriteria,
         String problemStatement, String exampleSolution) implements ExerciseDTO {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextFeedbackDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextFeedbackDTO.java
@@ -2,12 +2,15 @@ package de.tum.in.www1.artemis.service.dto.athena;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.Feedback;
 import de.tum.in.www1.artemis.domain.TextBlock;
 
 /**
  * A DTO representing a Feedback on a TextExercise, for transferring data to Athena and receiving suggestions from Athena
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record TextFeedbackDTO(long id, long exerciseId, long submissionId, String title, String description, double credits, Long structuredGradingInstructionId,
         Integer indexStart, Integer indexEnd) implements FeedbackDTO {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextSubmissionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/athena/TextSubmissionDTO.java
@@ -2,11 +2,14 @@ package de.tum.in.www1.artemis.service.dto.athena;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.TextSubmission;
 
 /**
  * A DTO representing a TextSubmission, for transferring data to Athena
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record TextSubmissionDTO(long id, long exerciseId, String text, String language) implements SubmissionDTO {
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamUserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamUserService.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.ExamUser;
 import de.tum.in.www1.artemis.repository.ExamUserRepository;
@@ -154,6 +156,7 @@ public class ExamUserService {
     /**
      * Contains the information about an exam user with image
      */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record ExamUserWithImageDTO(String studentRegistrationNumber, ImageDTO image) {
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/iris/session/IrisCompetencyGenerationSessionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/iris/session/IrisCompetencyGenerationSessionService.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import de.tum.in.www1.artemis.domain.Course;
@@ -102,12 +103,9 @@ public class IrisCompetencyGenerationSessionService implements IrisButtonBasedFe
         irisMessageService.saveMessage(userMessage, session, IrisMessageSender.USER);
     }
 
-    // @formatter:off
-    record CompetencyGenerationDTO(
-            String courseDescription,
-            CompetencyTaxonomy[] taxonomyOptions
-    ) {}
-    // @formatter:on
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    record CompetencyGenerationDTO(String courseDescription, CompetencyTaxonomy[] taxonomyOptions) {
+    }
 
     @Override
     public List<Competency> executeRequest(IrisCompetencyGenerationSession session) {

--- a/src/main/java/de/tum/in/www1/artemis/service/iris/session/IrisHestiaSessionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/iris/session/IrisHestiaSessionService.java
@@ -7,6 +7,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.hestia.CodeHint;
@@ -70,13 +72,9 @@ public class IrisHestiaSessionService implements IrisButtonBasedFeatureInterface
         return irisSession;
     }
 
-    // @formatter:off
-    record HestiaDTO(
-            CodeHint codeHint,
-            IrisHestiaSession session,
-            ProgrammingExercise exercise
-    ) {}
-    // @formatter:on
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    record HestiaDTO(CodeHint codeHint, IrisHestiaSession session, ProgrammingExercise exercise) {
+    }
 
     /**
      * Generates the description and content for a code hint.

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/BuildLogStatisticsDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/BuildLogStatisticsDTO.java
@@ -1,5 +1,8 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record BuildLogStatisticsDTO(Long buildCount, Double agentSetupDuration, Double testDuration, Double scaDuration, Double totalJobDuration,
         Double dependenciesDownloadedCount) {
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/DataExportDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/DataExportDTO.java
@@ -2,7 +2,10 @@ package de.tum.in.www1.artemis.web.rest.dto;
 
 import java.time.ZonedDateTime;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.enumeration.DataExportState;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record DataExportDTO(Long id, DataExportState dataExportState, ZonedDateTime createdDate, ZonedDateTime nextRequestDate) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamSessionDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamSessionDTO.java
@@ -3,8 +3,11 @@ package de.tum.in.www1.artemis.web.rest.dto;
 import java.time.Instant;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.exam.SuspiciousSessionReason;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ExamSessionDTO(long id, String browserFingerprintHash, String ipAddress, Set<SuspiciousSessionReason> suspiciousReasons, Instant createdDate,
         StudentExamWithIdAndExamAndUserDTO studentExam) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamUserAttendanceCheckDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamUserAttendanceCheckDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ExamUserAttendanceCheckDTO(Long id, String studentImagePath, String login, String registrationNumber, String signingImagePath, Boolean started, Boolean submitted) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamUserDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamUserDTO.java
@@ -3,9 +3,12 @@ package de.tum.in.www1.artemis.web.rest.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Contains the information about an exam user
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ExamUserDTO(@Size(max = 50) String login, @Size(max = 50) String firstName, @Size(max = 50) String lastName, @Size(max = 10) String registrationNumber,
         @Email @Size(max = 100) String email, String studentIdentifier, String room, String seat, boolean didCheckImage, boolean didCheckName, boolean didCheckRegistrationNumber,
         boolean didCheckLogin, @Size(max = 100) String signingImagePath) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamUsersNotFoundDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamUsersNotFoundDTO.java
@@ -2,8 +2,11 @@ package de.tum.in.www1.artemis.web.rest.dto;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * A DTO representing information about exam users that were not found and number of saved images.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ExamUsersNotFoundDTO(int numberOfUsersNotFound, int numberOfImagesSaved, List<String> listOfExamUserRegistrationNumbers) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamWithIdAndCourseDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamWithIdAndCourseDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ExamWithIdAndCourseDTO(long id, CourseWithIdDTO course) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExerciseForPlagiarismCasesOverviewDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExerciseForPlagiarismCasesOverviewDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ExerciseForPlagiarismCasesOverviewDTO(long id, String title, String type, ExerciseGroupWithIdAndExamDTO exerciseGroup) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExerciseGroupWithIdAndExamDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExerciseGroupWithIdAndExamDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ExerciseGroupWithIdAndExamDTO(long id, ExamWithIdAndCourseDTO exam) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/FileUploadAssessmentDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/FileUploadAssessmentDTO.java
@@ -2,7 +2,10 @@ package de.tum.in.www1.artemis.web.rest.dto;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.Feedback;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record FileUploadAssessmentDTO(List<Feedback> feedbacks, String assessmentNote) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ImageDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ImageDTO.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Contains the information about image
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ImageDTO(int page, float xPosition, float yPosition, int originalWidth, int originalHeight, int renderedWidth, int renderedHeight, byte[] imageInBytes) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/LectureUnitSplitDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/LectureUnitSplitDTO.java
@@ -2,8 +2,11 @@ package de.tum.in.www1.artemis.web.rest.dto;
 
 import java.time.ZonedDateTime;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Information of a lecture unit to be splitted
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record LectureUnitSplitDTO(String unitName, ZonedDateTime releaseDate, int startPage, int endPage) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/LinkPreviewDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/LinkPreviewDTO.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Information of a link
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record LinkPreviewDTO(String title, String description, String image, String url) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/RequestDataExportDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/RequestDataExportDTO.java
@@ -2,7 +2,10 @@ package de.tum.in.www1.artemis.web.rest.dto;
 
 import java.time.ZonedDateTime;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.enumeration.DataExportState;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record RequestDataExportDTO(long id, DataExportState dataExportState, ZonedDateTime createdDate) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/StudentExamWithIdAndExamAndUserDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/StudentExamWithIdAndExamAndUserDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record StudentExamWithIdAndExamAndUserDTO(long id, ExamWithIdAndCourseDTO exam, UserWithIdAndLoginDTO user) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/UserWithIdAndLoginDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/UserWithIdAndLoginDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record UserWithIdAndLoginDTO(long id, String login) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/competency/CompetencyImportResponseDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/competency/CompetencyImportResponseDTO.java
@@ -2,9 +2,12 @@ package de.tum.in.www1.artemis.web.rest.dto.competency;
 
 import java.time.ZonedDateTime;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.competency.Competency;
 import de.tum.in.www1.artemis.domain.competency.CompetencyTaxonomy;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record CompetencyImportResponseDTO(long id, String title, String description, CompetencyTaxonomy taxonomy, ZonedDateTime softDueDate, Integer masteryThreshold,
         boolean optional, Long courseId, Long linkedStandardizedCompetencyId) {
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/examevent/ExamAttendanceCheckEventDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/examevent/ExamAttendanceCheckEventDTO.java
@@ -2,9 +2,12 @@ package de.tum.in.www1.artemis.web.rest.dto.examevent;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * A DTO for the {@link de.tum.in.www1.artemis.domain.exam.event.ExamAttendanceCheckEvent} entity.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ExamAttendanceCheckEventDTO extends ExamLiveEventDTO {
 
     private String text;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/examevent/ExamWideAnnouncementEventDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/examevent/ExamWideAnnouncementEventDTO.java
@@ -2,9 +2,12 @@ package de.tum.in.www1.artemis.web.rest.dto.examevent;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * A DTO for the {@link de.tum.in.www1.artemis.domain.exam.event.ExamWideAnnouncementEvent} entity.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ExamWideAnnouncementEventDTO extends ExamLiveEventDTO {
 
     private String text;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/examevent/ProblemStatementUpdateEventDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/examevent/ProblemStatementUpdateEventDTO.java
@@ -2,9 +2,12 @@ package de.tum.in.www1.artemis.web.rest.dto.examevent;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * A DTO for the {@link de.tum.in.www1.artemis.domain.exam.event.ProblemStatementUpdateEvent} entity.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ProblemStatementUpdateEventDTO extends ExamLiveEventDTO {
 
     private String text;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/examevent/WorkingTimeUpdateEventDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/examevent/WorkingTimeUpdateEventDTO.java
@@ -2,9 +2,12 @@ package de.tum.in.www1.artemis.web.rest.dto.examevent;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * A DTO for the {@link de.tum.in.www1.artemis.domain.exam.event.WorkingTimeUpdateEvent} entity.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class WorkingTimeUpdateEventDTO extends ExamLiveEventDTO {
 
     private int newWorkingTime;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/lectureunit/LectureUnitForLearningPathNodeDetailsDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/lectureunit/LectureUnitForLearningPathNodeDetailsDTO.java
@@ -2,8 +2,11 @@ package de.tum.in.www1.artemis.web.rest.dto.lectureunit;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record LectureUnitForLearningPathNodeDetailsDTO(long id, @NotNull String name, @NotNull String type) {
 
     public static LectureUnitForLearningPathNodeDetailsDTO of(@NotNull LectureUnit lectureUnit) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/plagiarism/PlagiarismResultDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/plagiarism/PlagiarismResultDTO.java
@@ -1,5 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.dto.plagiarism;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismResult;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismSubmissionElement;
 import de.tum.in.www1.artemis.web.rest.plagiarism.PlagiarismResultStats;
@@ -11,5 +13,6 @@ import de.tum.in.www1.artemis.web.rest.plagiarism.PlagiarismResultStats;
  * @param plagiarismResultStats the statistics regarding the plagiarism result
  * @param <T>                   the type of plagiarism result
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PlagiarismResultDTO<T extends PlagiarismResult<? extends PlagiarismSubmissionElement>>(T plagiarismResult, PlagiarismResultStats plagiarismResultStats) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/standardizedCompetency/SourceDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/standardizedCompetency/SourceDTO.java
@@ -1,10 +1,13 @@
 package de.tum.in.www1.artemis.web.rest.dto.standardizedCompetency;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.competency.Source;
 
 /**
  * DTO containing source information
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record SourceDTO(long id, String title, String author, String uri) {
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/iris/IrisExerciseChatBasedSessionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/iris/IrisExerciseChatBasedSessionResource.java
@@ -10,6 +10,8 @@ import java.util.function.Function;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.http.ResponseEntity;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.iris.session.IrisChatSession;
@@ -120,6 +122,7 @@ public abstract class IrisExerciseChatBasedSessionResource<E extends Exercise, S
         return new IrisHealthDTO(health.getStatus() == Status.UP, rateLimitInfo);
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record IrisHealthDTO(boolean active, IrisRateLimitService.IrisRateLimitInformation rateLimitInfo) {
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/iris/dto/IrisTutorChatStatusUpdateDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/iris/dto/IrisTutorChatStatusUpdateDTO.java
@@ -2,9 +2,12 @@ package de.tum.in.www1.artemis.web.rest.iris.dto;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.iris.message.IrisMessage;
 import de.tum.in.www1.artemis.service.connectors.pyris.dto.status.PyrisStageDTO;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record IrisTutorChatStatusUpdateDTO(IrisMessage result, List<PyrisStageDTO> stages) {
 
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ChannelIdAndNameDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ChannelIdAndNameDTO.java
@@ -1,10 +1,13 @@
 package de.tum.in.www1.artemis.web.rest.metis.conversation.dtos;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * A DTO representing a channel which contains only the id and name
  *
  * @param id   id of the channel
  * @param name name of the channel
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ChannelIdAndNameDTO(Long id, String name) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ConversationUserDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/metis/conversation/dtos/ConversationUserDTO.java
@@ -1,11 +1,14 @@
 package de.tum.in.www1.artemis.web.rest.metis.conversation.dtos;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.service.dto.UserPublicInfoDTO;
 
 /**
  * Extension of the UserPublicInfoDTO with special flags for the conversation context
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ConversationUserDTO extends UserPublicInfoDTO {
 
     private Boolean isChannelModerator;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/push_notification/PushNotificationRegisterDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/push_notification/PushNotificationRegisterDTO.java
@@ -1,4 +1,7 @@
 package de.tum.in.www1.artemis.web.rest.push_notification;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PushNotificationRegisterDTO(String secretKey, String algorithm) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupResource.java
@@ -294,6 +294,7 @@ public class TutorialGroupResource {
      * @param notificationText               the optional notification text
      * @param updateTutorialGroupChannelName whether the tutorial group channel name should be updated with the new tutorial group title or not
      */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record TutorialGroupUpdateDTO(@Valid @NotNull TutorialGroup tutorialGroup, @Size(min = 1, max = 1000) @Nullable String notificationText,
             @Nullable Boolean updateTutorialGroupChannelName) {
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupSessionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupSessionResource.java
@@ -34,6 +34,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.enumeration.TutorialGroupSessionStatus;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupFreePeriod;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupSession;
@@ -330,12 +332,14 @@ public class TutorialGroupSessionResource {
     /**
      * DTO used to send the status explanation when i.g. cancelling a tutorial group session
      */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record TutorialGroupStatusDTO(String status_explanation) {
     }
 
     /**
      * DTO used because we want to interpret the dates in the time zone of the tutorial groups configuration
      */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record TutorialGroupSessionDTO(@NotNull LocalDate date, @NotNull LocalTime startTime, @NotNull LocalTime endTime, @Size(min = 1, max = 2000) String location) {
 
         public void validityCheck() {

--- a/src/test/java/de/tum/in/www1/artemis/architecture/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/architecture/ArchitectureTest.java
@@ -32,7 +32,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -264,8 +263,7 @@ class ArchitectureTest extends AbstractArchitectureTest {
 
             @Override
             public boolean test(JavaClass javaClass) {
-                return javaClass.getAllFields().stream().map(field -> field.getRawType().reflect())
-                        .anyMatch(field -> field.equals(List.class) || field.equals(Set.class) || field.equals(Map.class) || field.equals(Collection.class));
+                return javaClass.getAllFields().stream().map(field -> field.getRawType().reflect()).anyMatch(Collection.class::isAssignableFrom);
             }
         };
     }

--- a/src/test/java/de/tum/in/www1/artemis/architecture/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/architecture/ArchitectureTest.java
@@ -263,7 +263,8 @@ class ArchitectureTest extends AbstractArchitectureTest {
 
             @Override
             public boolean test(JavaClass javaClass) {
-                return javaClass.getAllFields().stream().map(field -> field.getRawType().reflect()).anyMatch(Collection.class::isAssignableFrom);
+                return javaClass.getAllFields().stream().map(field -> field.getRawType().reflect())
+                        .anyMatch(type -> Collection.class.isAssignableFrom(type) || Map.class.isAssignableFrom(type));
             }
         };
     }

--- a/src/test/java/de/tum/in/www1/artemis/architecture/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/architecture/ArchitectureTest.java
@@ -12,6 +12,7 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameContaining;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.core.domain.JavaCodeUnit.Predicates.constructor;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameContaining;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With.owner;
 import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
@@ -30,6 +31,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 import java.nio.file.Files;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -244,6 +247,27 @@ class ArchitectureTest extends AbstractArchitectureTest {
                 .because("we want to be able to exclude these classes from application startup by specifying profiles");
 
         rule.check(productionClasses);
+    }
+
+    @Test
+    void dtosWithCollectionsHaveJsonAnnotation() {
+        var DTOs = allClasses.that(nameContaining("DTO"));
+        var DTOsWithCollections = DTOs.that(haveACollectionField());
+
+        ArchRule rule = classes().should().beAnnotatedWith(JsonInclude.class).because("empty collections should not be part of the json");
+
+        rule.check(DTOsWithCollections);
+    }
+
+    private DescribedPredicate<JavaClass> haveACollectionField() {
+        return new DescribedPredicate<>("have a field that is a collection") {
+
+            @Override
+            public boolean test(JavaClass javaClass) {
+                return javaClass.getAllFields().stream().map(field -> field.getRawType().reflect())
+                        .anyMatch(field -> field.equals(List.class) || field.equals(Set.class) || field.equals(Map.class) || field.equals(Collection.class));
+            }
+        };
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
@@ -249,12 +249,16 @@ class FileUploadAssessmentIntegrationTest extends AbstractSpringIntegrationIndep
         FileUploadSubmission fileUploadSubmission = ParticipationFactory.generateFileUploadSubmission(true);
         fileUploadSubmission = fileUploadExerciseUtilService.addFileUploadSubmission(afterReleaseFileUploadExercise, fileUploadSubmission, TEST_PREFIX + "student1");
 
-        FileUploadAssessmentDTO body = new FileUploadAssessmentDTO(new ArrayList<>(), "text");
+        List<Feedback> feedbacks = ParticipationFactory.generateFeedback();
+        FileUploadAssessmentDTO body = new FileUploadAssessmentDTO(feedbacks, "text");
         Result result = request.putWithResponseBody(API_FILE_UPLOAD_SUBMISSIONS + fileUploadSubmission.getId() + "/feedback", body, Result.class, HttpStatus.OK);
 
         assertThat(result).as("saved result found").isNotNull();
         assertThat(result.isRated()).isNull();
         assertThat(((StudentParticipation) result.getParticipation()).getStudent()).as("student of participation is hidden").isEmpty();
+        assertThat(result.getFeedbacks()).hasSize(3);
+        assertThat(result.getFeedbacks().get(0).getCredits()).isEqualTo(feedbacks.get(0).getCredits());
+        assertThat(result.getFeedbacks().get(1).getCredits()).isEqualTo(feedbacks.get(1).getCredits());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaFeedbackSendingServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaFeedbackSendingServiceTest.java
@@ -123,7 +123,6 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
         athenaRequestMockProvider.mockSendFeedbackAndExpect("text", jsonPath("$.exercise.id").value(textExercise.getId()),
                 jsonPath("$.submission.id").value(textSubmission.getId()), jsonPath("$.submission.exerciseId").value(textExercise.getId()),
                 jsonPath("$.feedbacks[0].id").value(textFeedback.getId()), jsonPath("$.feedbacks[0].exerciseId").value(textExercise.getId()),
-                jsonPath("$.feedbacks[0].title").value(textFeedback.getText()), jsonPath("$.feedbacks[0].description").value(textFeedback.getDetailText()),
                 jsonPath("$.feedbacks[0].credits").value(textFeedback.getCredits()), jsonPath("$.feedbacks[0].credits").value(textFeedback.getCredits()),
                 jsonPath("$.feedbacks[0].indexStart").value(textBlock.getStartIndex()), jsonPath("$.feedbacks[0].indexEnd").value(textBlock.getEndIndex()));
 
@@ -164,8 +163,7 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
                 jsonPath("$.exercise.gradingCriteria[0].structuredGradingInstructions[0].feedback").value("Well done!"),
                 jsonPath("$.exercise.gradingCriteria[0].structuredGradingInstructions[0].usageCount").value(1), jsonPath("$.submission.id").value(textSubmission.getId()),
                 jsonPath("$.submission.exerciseId").value(textExercise.getId()), jsonPath("$.feedbacks[0].id").value(textFeedback.getId()),
-                jsonPath("$.feedbacks[0].exerciseId").value(textExercise.getId()), jsonPath("$.feedbacks[0].title").value(textFeedback.getText()),
-                jsonPath("$.feedbacks[0].description").value(textFeedback.getDetailText()), jsonPath("$.feedbacks[0].credits").value(textFeedback.getCredits()),
+                jsonPath("$.feedbacks[0].exerciseId").value(textExercise.getId()), jsonPath("$.feedbacks[0].credits").value(textFeedback.getCredits()),
                 jsonPath("$.feedbacks[0].credits").value(textFeedback.getCredits()), jsonPath("$.feedbacks[0].indexStart").value(textBlock.getStartIndex()),
                 jsonPath("$.feedbacks[0].indexEnd").value(textBlock.getEndIndex()), jsonPath("$.feedbacks[0].structuredGradingInstructionId").value(101));
 
@@ -178,7 +176,6 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
         athenaRequestMockProvider.mockSendFeedbackAndExpect("programming", jsonPath("$.exercise.id").value(programmingExercise.getId()),
                 jsonPath("$.submission.id").value(programmingSubmission.getId()), jsonPath("$.submission.exerciseId").value(programmingExercise.getId()),
                 jsonPath("$.feedbacks[0].id").value(programmingFeedback.getId()), jsonPath("$.feedbacks[0].exerciseId").value(programmingExercise.getId()),
-                jsonPath("$.feedbacks[0].title").value(programmingFeedback.getText()), jsonPath("$.feedbacks[0].description").value(programmingFeedback.getDetailText()),
                 jsonPath("$.feedbacks[0].credits").value(programmingFeedback.getCredits()), jsonPath("$.feedbacks[0].credits").value(programmingFeedback.getCredits()),
                 jsonPath("$.feedbacks[0].lineStart").value(12), jsonPath("$.feedbacks[0].lineEnd").value(12));
 

--- a/src/test/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaSubmissionSendingServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/connectors/athena/AthenaSubmissionSendingServiceTest.java
@@ -108,8 +108,7 @@ class AthenaSubmissionSendingServiceTest extends AbstractAthenaTest {
         createTextSubmissionsForSubmissionSending(1);
         athenaRequestMockProvider.mockSendSubmissionsAndExpect("text", jsonPath("$.exercise.id").value(textExercise.getId()),
                 jsonPath("$.exercise.title").value(textExercise.getTitle()), jsonPath("$.exercise.maxPoints").value(textExercise.getMaxPoints()),
-                jsonPath("$.exercise.bonusPoints").value(textExercise.getBonusPoints()), jsonPath("$.exercise.gradingInstructions").value(textExercise.getGradingInstructions()),
-                jsonPath("$.exercise.problemStatement").value(textExercise.getProblemStatement()), jsonPath("$.submissions[0].exerciseId").value(textExercise.getId()),
+                jsonPath("$.exercise.bonusPoints").value(textExercise.getBonusPoints()), jsonPath("$.submissions[0].exerciseId").value(textExercise.getId()),
                 jsonPath("$.submissions[0].text").value(DEFAULT_SUBMISSION_TEXT), jsonPath("$.submissions[0].language").value(DEFAULT_SUBMISSION_LANGUAGE.toString()));
 
         athenaSubmissionSendingService.sendSubmissions(textExercise);
@@ -133,10 +132,8 @@ class AthenaSubmissionSendingServiceTest extends AbstractAthenaTest {
         createProgrammingSubmissionForSubmissionSending();
         athenaRequestMockProvider.mockSendSubmissionsAndExpect("programming", jsonPath("$.exercise.id").value(programmingExercise.getId()),
                 jsonPath("$.exercise.title").value(programmingExercise.getTitle()), jsonPath("$.exercise.maxPoints").value(programmingExercise.getMaxPoints()),
-                jsonPath("$.exercise.bonusPoints").value(programmingExercise.getBonusPoints()),
-                jsonPath("$.exercise.gradingInstructions").value(programmingExercise.getGradingInstructions()),
-                jsonPath("$.exercise.problemStatement").value(programmingExercise.getProblemStatement()),
-                jsonPath("$.submissions[0].exerciseId").value(programmingExercise.getId()), jsonPath("$.submissions[0].repositoryUri").isString());
+                jsonPath("$.exercise.bonusPoints").value(programmingExercise.getBonusPoints()), jsonPath("$.submissions[0].exerciseId").value(programmingExercise.getId()),
+                jsonPath("$.submissions[0].repositoryUri").isString());
 
         athenaSubmissionSendingService.sendSubmissions(programmingExercise);
         athenaRequestMockProvider.verify();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I missed the annotations in #8649 for the DTOs, which was found in the review [here](https://github.com/ls1intum/Artemis/pull/8649/files/44e03db35d0ace9150cc6049a8100194549202c4#diff-0bd6adf757a2dde42b7a3d30eac3cd58a62f359ffc0fd62c1b89c77c652afed8). This can easily be checked automatically, so we should do that.

### Description
<!-- Describe your changes in detail -->
Added arch test that all DTOs with nullable attribute (i.e. everything that is not a base type) should have the annotation `@JsonInclude(JsonInclude.Include.NON_EMPTY)` and fixed all violations.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
No manual testing

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
#### Code Review
- [x] Code Review 1
- [x] Code Review 2