### PR TITLE
`Development`: Add eureka configuration to documentation for localCI setup

### DIFF
--- a/docs/dev/setup/integrated-code-lifecycle.rst
+++ b/docs/dev/setup/integrated-code-lifecycle.rst
@@ -49,6 +49,10 @@ Create a file ``src/main/resources/config/application-local.yml`` with the follo
                image-architecture: arm64
                # Only necessary on Windows:
                docker-connection-uri: tcp://localhost:2375
+       eureka:
+           client:
+               register-with-eureka: false
+               fetch-registry: false
 
 The values configured here are sufficient for a basic Artemis setup that allows for running programming exercises with Integrated Code Lifecycle.
 


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
With the ssh clone introduction https://github.com/ls1intum/Artemis/pull/8110 the server tries to establish a connection to eureka, which will fail on usual localCI setups, leading to the logs being full of error messages. 

### Description
Added config values to the documentation so devs can look up how to configure their local setup and new devs will have a proper configuration right away.


### Steps for Testing
1. Copy the config from https://artemis-platform--8693.org.readthedocs.build/en/8693/dev/setup/integrated-code-lifecycle.html to you `application-local.yml`
2. Start the server with the localCI config and see that no eureka related errors are thrown


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Screenshots
#### Before Fix
![eurekaIssue](https://github.com/ls1intum/Artemis/assets/63976129/f32ceda5-f447-4a11-ad73-d4c0cdaef12a)


Error messages making the server logs hard to read 
```
2024-05-29T14:09:27.975+02:00  WARN 4119 --- [Artemis] [tbeatExecutor-0] c.n.d.s.t.d.RetryableEurekaHttpClient    : Request execution failed with message: I/O error on PUT request for "http://localhost:8761/eureka/apps/ARTEMIS/Artemis:1": Connect to http://localhost:8761 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused
2024-05-29T14:09:27.975+02:00 ERROR 4119 --- [Artemis] [tbeatExecutor-0] com.netflix.discovery.DiscoveryClient    : DiscoveryClient_ARTEMIS/Artemis:1 - was unable to send heartbeat!

com.netflix.discovery.shared.transport.TransportException: Cannot execute request on any known server
	at com.netflix.discovery.shared.transport.decorator.RetryableEurekaHttpClient.execute(RetryableEurekaHttpClient.java:112)
	at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator.sendHeartBeat(EurekaHttpClientDecorator.java:89)
	at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator$3.execute(EurekaHttpClientDecorator.java:92)
	at com.netflix.discovery.shared.transport.decorator.SessionedEurekaHttpClient.execute(SessionedEurekaHttpClient.java:77)
	at com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator.sendHeartBeat(EurekaHttpClientDecorator.java:89)
	at com.netflix.discovery.DiscoveryClient.renew(DiscoveryClient.java:837)
	at com.netflix.discovery.DiscoveryClient$HeartbeatThread.run(DiscoveryClient.java:1401)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```
#### With Fix
![eurekaIssueFixed](https://github.com/ls1intum/Artemis/assets/63976129/dcabd706-6046-40f1-8a57-bd9799d0b211)

