### PR TITLE
`Development`: Remove multiple occurrences of deprecated code

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCRepositoryUri.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localvc/LocalVCRepositoryUri.java
@@ -148,12 +148,12 @@ public class LocalVCRepositoryUri extends VcsRepositoryUri {
      * <ul>
      * <li>
      * Input: Local repository path - {@code Paths.get("/local/path/projectX/my-repo/.git")}
-     * and Local VC server URL - {@code new URL("https://artemis.cit.tum.de")}
+     * and Local VC server URL - {@code new URI("https://artemis.cit.tum.de").getURL()}
      * Output: {@code https://artemis.cit.tum.de/git/projectX/my-repo.git}
      * </li>
      * <li>
      * Input: Remote repository path - {@code Paths.get("/remote/path/projectY/my-repo")}
-     * and Local VC server URL - {@code new URL("https://artemis.cit.tum.de")}
+     * and Local VC server URL - {@code new URI("https://artemis.cit.tum.de").getURL()}
      * Output: {@code https://artemis.cit.tum.de/git/projectY/my-repo.git}
      * </li>
      * </ul>

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -277,7 +277,8 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         Result storedResult = resultRepo.findWithBidirectionalSubmissionAndFeedbackAndAssessorAndAssessmentNoteAndTeamStudentsByIdElseThrow(modelingAssessment.getId());
         Result updatedResult = storedResult.getSubmission().getLatestResult();
         participationUtilService.checkFeedbackCorrectlyStored(modelingAssessment.getFeedbacks(), updatedResult.getFeedbacks(), FeedbackType.MANUAL);
-        assertThat(storedResult).as("only feedbacks are changed in the result").usingRecursiveComparison().ignoringFields("feedbacks").isEqualTo(modelingAssessment);
+        final String[] ignoringFields = { "feedbacks", "submission", "participation", "assessor" };
+        assertThat(storedResult).as("only feedbacks are changed in the result").usingRecursiveComparison().ignoringFields(ignoringFields).isEqualTo(modelingAssessment);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -277,7 +277,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         Result storedResult = resultRepo.findWithBidirectionalSubmissionAndFeedbackAndAssessorAndAssessmentNoteAndTeamStudentsByIdElseThrow(modelingAssessment.getId());
         Result updatedResult = storedResult.getSubmission().getLatestResult();
         participationUtilService.checkFeedbackCorrectlyStored(modelingAssessment.getFeedbacks(), updatedResult.getFeedbacks(), FeedbackType.MANUAL);
-        assertThat(storedResult).as("only feedbacks are changed in the result").isEqualToIgnoringGivenFields(modelingAssessment, "feedbacks");
+        assertThat(storedResult).as("only feedbacks are changed in the result").usingRecursiveComparison().ignoringFields("feedbacks").isEqualTo(modelingAssessment);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
@@ -320,8 +320,8 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
         FileUploadSubmission storedSubmission = request.get("/api/exercises/" + releasedFileUploadExercise.getId() + "/file-upload-submission-without-assessment", HttpStatus.OK,
                 FileUploadSubmission.class);
 
-        assertThat(storedSubmission).as("in-time submission was found").usingRecursiveComparison()
-                .ignoringFields("results", "submissionDate", "fileService", "filePathService", "entityFileService").isEqualTo(submission);
+        final String[] ignoringFields = { "results", "submissionDate", "fileService", "filePathService", "entityFileService", "participation" };
+        assertThat(storedSubmission).as("in-time submission was found").usingRecursiveComparison().ignoringFields(ignoringFields).isEqualTo(submission);
         assertThat(storedSubmission.getSubmissionDate()).as("submission date is correct").isCloseTo(submission.getSubmissionDate(), HalfSecond());
         assertThat(storedSubmission.getLatestResult()).as("result is not set").isNull();
         checkDetailsHidden(storedSubmission, false);
@@ -342,8 +342,8 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
         FileUploadSubmission storedSubmission = request.get("/api/exercises/" + releasedFileUploadExercise.getId() + "/file-upload-submission-without-assessment", HttpStatus.OK,
                 FileUploadSubmission.class);
 
-        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison()
-                .ignoringFields("results", "submissionDate", "fileService", "filePathService", "entityFileService").isEqualTo(lateSubmission);
+        final String[] ignoringFields = { "results", "submissionDate", "fileService", "filePathService", "entityFileService", "participation" };
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields(ignoringFields).isEqualTo(lateSubmission);
         assertThat(storedSubmission.getLatestResult()).as("result is not set").isNull();
         checkDetailsHidden(storedSubmission, false);
     }
@@ -364,8 +364,8 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
         FileUploadSubmission storedSubmission = request.get("/api/exercises/" + releasedFileUploadExercise.getId() + "/file-upload-submission-without-assessment?lock=true",
                 HttpStatus.OK, FileUploadSubmission.class);
 
-        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison()
-                .ignoringFields("results", "submissionDate", "fileService", "filePathService", "entityFileService").isEqualTo(lateSubmission);
+        final String[] ignoringFields = { "results", "submissionDate", "fileService", "filePathService", "entityFileService", "participation" };
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields(ignoringFields).isEqualTo(lateSubmission);
         assertThat(storedSubmission.getLatestResult()).as("result is set").isNotNull();
         checkDetailsHidden(storedSubmission, false);
     }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
@@ -320,8 +320,8 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
         FileUploadSubmission storedSubmission = request.get("/api/exercises/" + releasedFileUploadExercise.getId() + "/file-upload-submission-without-assessment", HttpStatus.OK,
                 FileUploadSubmission.class);
 
-        assertThat(storedSubmission).as("in-time submission was found").isEqualToIgnoringGivenFields(submission, "results", "submissionDate", "fileService", "filePathService",
-                "entityFileService");
+        assertThat(storedSubmission).as("in-time submission was found").usingRecursiveComparison()
+                .ignoringFields("results", "submissionDate", "fileService", "filePathService", "entityFileService").isEqualTo(submission);
         assertThat(storedSubmission.getSubmissionDate()).as("submission date is correct").isCloseTo(submission.getSubmissionDate(), HalfSecond());
         assertThat(storedSubmission.getLatestResult()).as("result is not set").isNull();
         checkDetailsHidden(storedSubmission, false);
@@ -342,8 +342,8 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
         FileUploadSubmission storedSubmission = request.get("/api/exercises/" + releasedFileUploadExercise.getId() + "/file-upload-submission-without-assessment", HttpStatus.OK,
                 FileUploadSubmission.class);
 
-        assertThat(storedSubmission).as("submission was found").isEqualToIgnoringGivenFields(lateSubmission, "result", "submissionDate", "fileService", "filePathService",
-                "entityFileService");
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison()
+                .ignoringFields("results", "submissionDate", "fileService", "filePathService", "entityFileService").isEqualTo(lateSubmission);
         assertThat(storedSubmission.getLatestResult()).as("result is not set").isNull();
         checkDetailsHidden(storedSubmission, false);
     }
@@ -364,8 +364,8 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
         FileUploadSubmission storedSubmission = request.get("/api/exercises/" + releasedFileUploadExercise.getId() + "/file-upload-submission-without-assessment?lock=true",
                 HttpStatus.OK, FileUploadSubmission.class);
 
-        assertThat(storedSubmission).as("submission was found").isEqualToIgnoringGivenFields(lateSubmission, "results", "submissionDate", "fileService", "filePathService",
-                "entityFileService");
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison()
+                .ignoringFields("results", "submissionDate", "fileService", "filePathService", "entityFileService").isEqualTo(lateSubmission);
         assertThat(storedSubmission.getLatestResult()).as("result is set").isNotNull();
         checkDetailsHidden(storedSubmission, false);
     }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
@@ -1054,10 +1054,12 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
 
         modelingAssessment = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission2.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("assessment is correctly stored").hasSize(1);
-        assertThat(modelingAssessment.getFeedbacks().get(0)).as("feedback credits and text are correct").isEqualToComparingOnlyGivenFields(changedFeedback, "credits", "text");
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("feedback credits are correct").isEqualTo(changedFeedback.getCredits());
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("feedback text are correct").isEqualTo(changedFeedback.getText());
         modelingAssessment = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("existing manual assessment has correct amount of feedback").hasSize(1);
-        assertThat(modelingAssessment.getFeedbacks().get(0)).as("existing manual assessment did not change").isEqualToComparingOnlyGivenFields(originalFeedback, "credits", "text");
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("existing manual assessment did not change credits").isEqualTo(originalFeedback.getCredits());
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("existing manual assessment did not change text").isEqualTo(originalFeedback.getText());
     }
 
     @Test
@@ -1080,11 +1082,12 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
 
         modelingAssessment = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("overridden assessment has correct amount of feedback").hasSize(1);
-        assertThat(modelingAssessment.getFeedbacks().get(0)).as("feedback is properly overridden").isEqualToComparingOnlyGivenFields(changedFeedback, "credits", "text");
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("feedback credits are properly overridden").isEqualTo(changedFeedback.getCredits());
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("feedback text is properly overridden").isEqualTo(changedFeedback.getText());
         modelingAssessment = compassService.getSuggestionResult(modelingSubmission2, classExercise);
         assertThat(modelingAssessment.getFeedbacks()).as("automatic assessment still exists").hasSize(1);
-        assertThat(modelingAssessment.getFeedbacks().get(0)).as("automatic assessment is overridden properly").isEqualToComparingOnlyGivenFields(changedFeedback, "credits",
-                "text");
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("automatic assessment credits are overridden properly").isEqualTo(changedFeedback.getCredits());
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("automatic assessment text is overridden properly").isEqualTo(changedFeedback.getText());
     }
 
     @Test
@@ -1112,10 +1115,12 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
 
         modelingAssessment = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("overridden assessment has correct amount of feedback").hasSize(2);
-        assertThat(modelingAssessment.getFeedbacks().get(0)).as("feedback is properly overridden").isEqualToComparingOnlyGivenFields(changedFeedback, "credits", "text");
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("feedback credits are properly overridden").isEqualTo(changedFeedback.getCredits());
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("feedback text is properly overridden").isEqualTo(changedFeedback.getText());
         modelingAssessment = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission2.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("existing submitted assessment still exists").hasSize(2);
-        assertThat(modelingAssessment.getFeedbacks().get(0)).as("existing feedback is still the same").isEqualToComparingOnlyGivenFields(originalFeedback, "credits", "text");
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("existing feedback credits are still the same").isEqualTo(originalFeedback.getCredits());
+        assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("existing feedback text is still the same").isEqualTo(originalFeedback.getText());
         modelingAssessment = compassService.getSuggestionResult(modelingSubmission3, classExercise);
         assertThat(modelingAssessment).as("automatic assessment is not possible").isNull();
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
@@ -584,7 +584,7 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         ModelingSubmission storedSubmission = request.get("/api/exercises/" + classExercise.getId() + "/modeling-submission-without-assessment", HttpStatus.OK,
                 ModelingSubmission.class);
 
-        assertThat(storedSubmission).as("submission was found").isEqualToIgnoringGivenFields(submission, "results", "submissionDate");
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields("results", "submissionDate").isEqualTo(submission);
         assertThat(storedSubmission.getSubmissionDate()).as("submission date is correct").isCloseTo(submission.getSubmissionDate(), HalfSecond());
         assertThat(storedSubmission.getLatestResult()).as("result is not set").isNull();
         checkDetailsHidden(storedSubmission, false);
@@ -630,7 +630,7 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         // set dates to UTC and round to milliseconds for comparison
         submission.setSubmissionDate(ZonedDateTime.ofInstant(submission.getSubmissionDate().truncatedTo(ChronoUnit.SECONDS).toInstant(), ZoneId.of("UTC")));
         storedSubmission.setSubmissionDate(ZonedDateTime.ofInstant(storedSubmission.getSubmissionDate().truncatedTo(ChronoUnit.SECONDS).toInstant(), ZoneId.of("UTC")));
-        assertThat(storedSubmission).as("submission was found").isEqualToIgnoringGivenFields(submission, "results", "similarElementCounts");
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields("results", "submissionDate").isEqualTo(submission);
         assertThat(storedSubmission.getLatestResult()).as("result is set").isNotNull();
         assertThat(storedSubmission.getLatestResult().getAssessor()).as("assessor is tutor1").isEqualTo(user);
         checkDetailsHidden(storedSubmission, false);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
@@ -584,7 +584,7 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         ModelingSubmission storedSubmission = request.get("/api/exercises/" + classExercise.getId() + "/modeling-submission-without-assessment", HttpStatus.OK,
                 ModelingSubmission.class);
 
-        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields("results", "submissionDate").isEqualTo(submission);
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields("results", "submissionDate", "participation").isEqualTo(submission);
         assertThat(storedSubmission.getSubmissionDate()).as("submission date is correct").isCloseTo(submission.getSubmissionDate(), HalfSecond());
         assertThat(storedSubmission.getLatestResult()).as("result is not set").isNull();
         checkDetailsHidden(storedSubmission, false);
@@ -630,7 +630,8 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         // set dates to UTC and round to milliseconds for comparison
         submission.setSubmissionDate(ZonedDateTime.ofInstant(submission.getSubmissionDate().truncatedTo(ChronoUnit.SECONDS).toInstant(), ZoneId.of("UTC")));
         storedSubmission.setSubmissionDate(ZonedDateTime.ofInstant(storedSubmission.getSubmissionDate().truncatedTo(ChronoUnit.SECONDS).toInstant(), ZoneId.of("UTC")));
-        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields("results", "submissionDate").isEqualTo(submission);
+        final String[] ignoringFields = { "results", "submissionDate", "participation", "similarElementCounts" };
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields(ignoringFields).isEqualTo(submission);
         assertThat(storedSubmission.getLatestResult()).as("result is set").isNotNull();
         assertThat(storedSubmission.getLatestResult().getAssessor()).as("assessor is tutor1").isEqualTo(user);
         checkDetailsHidden(storedSubmission, false);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseTemplateIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseTemplateIntegrationTest.java
@@ -306,7 +306,7 @@ class ProgrammingExerciseTemplateIntegrationTest extends AbstractSpringIntegrati
         InvocationRequest mvnRequest = new DefaultInvocationRequest();
         mvnRequest.setJavaHome(java17Home);
         mvnRequest.setPomFile(testRepo.localRepoFile);
-        mvnRequest.setGoals(List.of("clean", "test"));
+        mvnRequest.addArgs(List.of("clean", "test"));
         if (testwiseCoverageAnalysis) {
             mvnRequest.addArg("-Pcoverage");
         }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionIntegrationTest.java
@@ -765,7 +765,8 @@ class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrationJenk
         String url = "/api/exercises/" + exercise.getId() + "/programming-submission-without-assessment";
         ProgrammingSubmission storedSubmission = request.get(url, HttpStatus.OK, ProgrammingSubmission.class);
 
-        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields("results", "submissionDate").isEqualTo(submission);
+        final String[] ignoringFields = { "results", "submissionDate", "participation" };
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields(ignoringFields).isEqualTo(submission);
         assertThat(storedSubmission.getSubmissionDate()).as("submission date is correct").isCloseTo(submission.getSubmissionDate(), HalfSecond());
         assertThat(storedSubmission.getLatestResult()).as("result is not set").isNull();
     }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionIntegrationTest.java
@@ -765,7 +765,7 @@ class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrationJenk
         String url = "/api/exercises/" + exercise.getId() + "/programming-submission-without-assessment";
         ProgrammingSubmission storedSubmission = request.get(url, HttpStatus.OK, ProgrammingSubmission.class);
 
-        assertThat(storedSubmission).as("submission was found").isEqualToIgnoringGivenFields(submission, "results", "submissionDate");
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields("results", "submissionDate").isEqualTo(submission);
         assertThat(storedSubmission.getSubmissionDate()).as("submission date is correct").isCloseTo(submission.getSubmissionDate(), HalfSecond());
         assertThat(storedSubmission.getLatestResult()).as("result is not set").isNull();
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/JenkinsInternalUriServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/JenkinsInternalUriServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Optional;
@@ -37,8 +38,8 @@ class JenkinsInternalUriServiceTest extends AbstractSpringIntegrationJenkinsGitl
     void initTestCase() throws Exception {
         vcsRepositoryUri = new VcsRepositoryUri("http://localhost:80/some-repo.git");
         ciUrl = "http://localhost:8080/some-ci-path";
-        internalVcsUrl = new URL("http://1.2.3.4:123");
-        internalCiUrl = new URL("http://5.6.7.8:123");
+        internalVcsUrl = new URI("http://1.2.3.4:123").toURL();
+        internalCiUrl = new URI("http://5.6.7.8:123").toURL();
         ReflectionTestUtils.setField(jenkinsInternalUrlService, "internalVcsUrl", Optional.empty());
         ReflectionTestUtils.setField(jenkinsInternalUrlService, "internalCiUrl", Optional.empty());
     }
@@ -93,8 +94,8 @@ class JenkinsInternalUriServiceTest extends AbstractSpringIntegrationJenkinsGitl
 
     @Test
     void testGetUrlOnInternalUrlWithoutPort() throws Exception {
-        ReflectionTestUtils.setField(jenkinsInternalUrlService, "internalCiUrl", Optional.of(new URL("http://www.host.name.com/")));
-        ReflectionTestUtils.setField(jenkinsInternalUrlService, "internalVcsUrl", Optional.of(new URL("http://www.hostname.com/")));
+        ReflectionTestUtils.setField(jenkinsInternalUrlService, "internalCiUrl", Optional.of(new URI("http://www.host.name.com/").toURL()));
+        ReflectionTestUtils.setField(jenkinsInternalUrlService, "internalVcsUrl", Optional.of(new URI("http://www.hostname.com/").toURL()));
 
         var newVcsUrl = jenkinsInternalUrlService.toInternalVcsUrl(vcsRepositoryUri);
         assertThat(newVcsUrl).hasToString("http://www.hostname.com/some-repo.git");

--- a/src/test/java/de/tum/in/www1/artemis/service/ResourceLoaderServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ResourceLoaderServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -131,7 +132,7 @@ class ResourceLoaderServiceTest extends AbstractSpringIntegrationIndependentTest
     void testGetResourceFilePathFromJar() throws IOException, URISyntaxException {
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         Resource resource = mock(Resource.class);
-        URL resourceUrl = new URL("jar:file:/example.jar!/path/to/resource.txt");
+        URL resourceUrl = new URI("jar:file:/example.jar!/path/to/resource.txt").toURL();
 
         // Mock the getResource() method.
         doReturn(true).when(resource).exists();

--- a/src/test/java/de/tum/in/www1/artemis/service/connectors/lti/LtiDeepLinkingServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/connectors/lti/LtiDeepLinkingServiceTest.java
@@ -8,7 +8,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -71,7 +72,7 @@ class LtiDeepLinkingServiceTest {
     }
 
     @Test
-    void testPerformDeepLinking() throws MalformedURLException {
+    void testPerformDeepLinking() throws MalformedURLException, URISyntaxException {
         createMockOidcIdToken();
         when(tokenRetriever.createDeepLinkingJWT(anyString(), anyMap())).thenReturn("test_jwt");
 
@@ -83,7 +84,7 @@ class LtiDeepLinkingServiceTest {
     }
 
     @Test
-    void testEmptyJwtBuildLtiDeepLinkResponse() throws MalformedURLException {
+    void testEmptyJwtBuildLtiDeepLinkResponse() throws MalformedURLException, URISyntaxException {
         createMockOidcIdToken();
         when(tokenRetriever.createDeepLinkingJWT(anyString(), anyMap())).thenReturn(null);
 
@@ -95,7 +96,7 @@ class LtiDeepLinkingServiceTest {
     }
 
     @Test
-    void testEmptyReturnUrlBuildLtiDeepLinkResponse() throws JsonProcessingException, MalformedURLException {
+    void testEmptyReturnUrlBuildLtiDeepLinkResponse() throws JsonProcessingException, MalformedURLException, URISyntaxException {
         createMockOidcIdToken();
         when(tokenRetriever.createDeepLinkingJWT(anyString(), anyMap())).thenReturn("test_jwt");
         ObjectMapper mapper = new ObjectMapper();
@@ -134,7 +135,7 @@ class LtiDeepLinkingServiceTest {
     }
 
     @Test
-    void testEmptyDeploymentIdBuildLtiDeepLinkResponse() throws MalformedURLException {
+    void testEmptyDeploymentIdBuildLtiDeepLinkResponse() throws MalformedURLException, URISyntaxException {
         createMockOidcIdToken();
         when(tokenRetriever.createDeepLinkingJWT(anyString(), anyMap())).thenReturn("test_jwt");
         when(oidcIdToken.getClaim(de.tum.in.www1.artemis.domain.lti.Claims.LTI_DEPLOYMENT_ID)).thenReturn(null);
@@ -145,7 +146,7 @@ class LtiDeepLinkingServiceTest {
                 .withMessage("Missing claim: " + Claims.LTI_DEPLOYMENT_ID);
     }
 
-    private void createMockOidcIdToken() throws MalformedURLException {
+    private void createMockOidcIdToken() throws MalformedURLException, URISyntaxException {
         Map<String, Object> mockSettings = new TreeMap<>();
         mockSettings.put("deep_link_return_url", "test_return_url");
         when(oidcIdToken.getClaim(Claims.DEEP_LINKING_SETTINGS)).thenReturn(mockSettings);
@@ -154,7 +155,7 @@ class LtiDeepLinkingServiceTest {
         when(oidcIdToken.getClaim("exp")).thenReturn("12345");
         when(oidcIdToken.getClaim("iat")).thenReturn("test");
         when(oidcIdToken.getClaim("nonce")).thenReturn("1234-34535-abcbcbd");
-        when(oidcIdToken.getIssuer()).thenReturn(new URL("http://artemis.com"));
+        when(oidcIdToken.getIssuer()).thenReturn(new URI("http://artemis.com").toURL());
         when(oidcIdToken.getAudience()).thenReturn(Arrays.asList("http://moodle.com"));
         when(oidcIdToken.getExpiresAt()).thenReturn(Instant.now().plus(2, ChronoUnit.HOURS));
         when(oidcIdToken.getIssuedAt()).thenReturn(Instant.now());

--- a/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
@@ -1337,7 +1337,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         verify(textBlockService, times(irrelevantCallCount + 3)).findAllBySubmissionId(textSubmission.getId());
 
         Set<TextBlock> textBlocks = textBlockRepository.findAllBySubmissionId(textSubmissionWithoutAssessment.getId());
-        assertThat(textBlocks).allSatisfy(block -> assertThat(block).isEqualToComparingFieldByField(blocksSubmission.get(block.getId())));
+        assertThat(textBlocks).allSatisfy(block -> assertThat(block).usingRecursiveComparison().isEqualTo(blocksSubmission.get(block.getId())));
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
@@ -1337,7 +1337,8 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         verify(textBlockService, times(irrelevantCallCount + 3)).findAllBySubmissionId(textSubmission.getId());
 
         Set<TextBlock> textBlocks = textBlockRepository.findAllBySubmissionId(textSubmissionWithoutAssessment.getId());
-        assertThat(textBlocks).allSatisfy(block -> assertThat(block).usingRecursiveComparison().isEqualTo(blocksSubmission.get(block.getId())));
+        final String[] ignoringFields = { "submission.results", "submission.submissionDate", "submission.participation", "submission.blocks", "submission.versions" };
+        assertThat(textBlocks).allSatisfy(block -> assertThat(block).usingRecursiveComparison().ignoringFields(ignoringFields).isEqualTo(blocksSubmission.get(block.getId())));
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
@@ -277,7 +277,8 @@ class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
         TextSubmission storedSubmission = request.get("/api/exercises/" + finishedTextExercise.getId() + "/text-submission-without-assessment?lock=true", HttpStatus.OK,
                 TextSubmission.class);
 
-        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields("results", "submissionDate", "blocks").isEqualTo(textSubmission);
+        final String[] ignoringFields = { "results", "submissionDate", "blocks", "participation" };
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields(ignoringFields).isEqualTo(textSubmission);
         assertThat(storedSubmission.getSubmissionDate()).as("submission date is correct").isCloseTo(textSubmission.getSubmissionDate(), HalfSecond());
         assertThat(storedSubmission.getLatestResult()).as("result is set").isNotNull();
         assertThat(storedSubmission.getLatestResult().getAssessor()).as("assessor is tutor1").isEqualTo(user);

--- a/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
@@ -277,7 +277,7 @@ class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
         TextSubmission storedSubmission = request.get("/api/exercises/" + finishedTextExercise.getId() + "/text-submission-without-assessment?lock=true", HttpStatus.OK,
                 TextSubmission.class);
 
-        assertThat(storedSubmission).as("submission was found").isEqualToIgnoringGivenFields(textSubmission, "results", "submissionDate", "blocks");
+        assertThat(storedSubmission).as("submission was found").usingRecursiveComparison().ignoringFields("results", "submissionDate", "blocks").isEqualTo(textSubmission);
         assertThat(storedSubmission.getSubmissionDate()).as("submission date is correct").isCloseTo(textSubmission.getSubmissionDate(), HalfSecond());
         assertThat(storedSubmission.getLatestResult()).as("result is set").isNotNull();
         assertThat(storedSubmission.getLatestResult().getAssessor()).as("assessor is tutor1").isEqualTo(user);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Replaces the following deprecated method calls:
- `isEqualToIgnoringGivenFields`
- `isEqualToComparingFieldByField`
- `URL` constructor
- `mvnRequest.setGoals`
- `isEqualToComparingOnlyGivenFields`



### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
