### PR TITLE
`Development`: Add scheduling profile to local vc run configuration

### DIFF
--- a/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI_.xml
+++ b/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI_.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artemis (Server, LocalVC &amp; LocalCI)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="dev,localci,localvc,artemis,buildagent,core,ldap-only,local" />
+    <option name="ACTIVE_PROFILES" value="dev,localci,localvc,artemis,buildagent,core,ldap-only,local,scheduling" />
     <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <module name="Artemis.main" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />

--- a/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI_.xml
+++ b/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI_.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artemis (Server, LocalVC &amp; LocalCI)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="dev,localci,localvc,artemis,buildagent,core,ldap-only,local,scheduling" />
+    <option name="ACTIVE_PROFILES" value="dev,localci,localvc,artemis,scheduling,buildagent,core,ldap-only,local" />
     <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <module name="Artemis.main" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Almost all other run configurations include the "scheduling" profile and there is no reason why the configuration `Server, LocalVC, LocalCI` should not have it.

### Description
<!-- Describe your changes in detail -->
Adds the profile "scheduling" to the `Server, LocalVC, LocalCI` profile.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
1. Start Artemis locally with the `Server, LocalVC, LocalCI` profile 
2. Look at the beans (see screenshot)
3. Make sure that beans with scheduling exist. For example the `AccountResource` has the `dataExportScheduleService` (see second screenshot)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
#### Reviews
- [x] Review 1
- [x] Review 2
- [x] Review 3

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Finding Beans:
![Bildschirmfoto 2024-06-05 um 12 44 59](https://github.com/ls1intum/Artemis/assets/38322605/e8eeb198-2a80-4682-970b-abe03881a546)
Example (`AccountResource` has `dataExportScheduleService`):
![Bildschirmfoto 2024-06-05 um 12 52 02](https://github.com/ls1intum/Artemis/assets/38322605/6a047ca2-c4e0-4446-9b7e-ff0505847f54)
