### PR TITLE
`Programming exercises`: Increase AI feedback request limit

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseCodeReviewFeedbackService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseCodeReviewFeedbackService.java
@@ -232,7 +232,7 @@ public class ProgrammingExerciseCodeReviewFeedbackService {
         if (countOfAthenaResultsInProcessOrSuccessful >= 3) {
             throw new BadRequestAlertException("Cannot send additional AI feedback requests now. Try again later!", "participation", "preconditions not met");
         }
-        if (countOfSuccessfulRequests >= 3) {
+        if (countOfSuccessfulRequests >= 20) {
             throw new BadRequestAlertException("Maximum number of AI feedback requests reached.", "participation", "preconditions not met");
         }
     }

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -328,7 +328,7 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
             const athenaResults = this.gradedParticipation.results.filter((result) => result.assessmentType === 'AUTOMATIC_ATHENA');
             const countOfSuccessfulRequests = athenaResults.filter((result) => result.successful === true).length;
 
-            if (countOfSuccessfulRequests >= 3) {
+            if (countOfSuccessfulRequests >= 20) {
                 const rateLimitExceededWarning = this.translateService.instant('artemisApp.exercise.maxAthenaResultsReached');
                 window.alert(rateLimitExceededWarning);
                 return false;

--- a/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
@@ -573,6 +573,13 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
 
     it('assureConditionsSatisfied should alert and return false if the maximum number of successful Athena results is reached', () => {
         jest.spyOn(window, 'alert').mockImplementation(() => {});
+        const numResults = 20;
+        const results = [];
+
+        for (let i = 0; i < numResults; i++) {
+            results.push({ assessmentType: AssessmentType.AUTOMATIC_ATHENA, successful: true });
+        }
+
         comp.exercise = {
             type: ExerciseType.PROGRAMMING,
             dueDate: dayjs().add(5, 'minutes'),
@@ -585,9 +592,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
                             assessmentType: AssessmentType.AUTOMATIC,
                             score: 100,
                         },
-                        { assessmentType: AssessmentType.AUTOMATIC_ATHENA, successful: true },
-                        { assessmentType: AssessmentType.AUTOMATIC_ATHENA, successful: true },
-                        { assessmentType: AssessmentType.AUTOMATIC_ATHENA, successful: true },
+                        ...results,
                     ],
                 },
             ] as StudentParticipation[],

--- a/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
@@ -574,7 +574,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
     it('assureConditionsSatisfied should alert and return false if the maximum number of successful Athena results is reached', () => {
         jest.spyOn(window, 'alert').mockImplementation(() => {});
         const numResults = 20;
-        const results = [];
+        const results: Array<{ assessmentType: AssessmentType, successful: boolean }> = [];
 
         for (let i = 0; i < numResults; i++) {
             results.push({ assessmentType: AssessmentType.AUTOMATIC_ATHENA, successful: true });

--- a/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
@@ -574,7 +574,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
     it('assureConditionsSatisfied should alert and return false if the maximum number of successful Athena results is reached', () => {
         jest.spyOn(window, 'alert').mockImplementation(() => {});
         const numResults = 20;
-        const results: Array<{ assessmentType: AssessmentType, successful: boolean }> = [];
+        const results: Array<{ assessmentType: AssessmentType; successful: boolean }> = [];
 
         for (let i = 0; i < numResults; i++) {
             results.push({ assessmentType: AssessmentType.AUTOMATIC_ATHENA, successful: true });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, a student can only do three feedback request. For an experiment that we want to conduct, the number needs to be increased to 20.
In the future, there will be a follow-up PR that let the instructor set the limit: <PR>

### Description
<!-- Describe your changes in detail -->
Hardcodes the limit to 20 requests per exercise.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2