### PR TITLE
`Integrated code lifecycle`: Fix an issue when parsing fixed tests with messages

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/TestResultXmlParser.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/TestResultXmlParser.java
@@ -87,7 +87,8 @@ class TestResultXmlParser {
         }
     }
 
-    // Intentionally empty record to represent the skipped tag (</skipped>)
+    // Intentionally empty record to represent the skipped tag (<skipped/>)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     record Skip() {
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/TestResultXmlParserTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/TestResultXmlParserTest.java
@@ -149,7 +149,7 @@ class TestResultXmlParserTest {
         String input = """
                 <testsuite>
                     <testcase name="testBubbleSort()" classname="testpackage.SortingExampleBehaviorTest" time="0.000306">
-                        <skipped/>
+                        <skipped message="This test was skipped."/>
                     </testcase>
                 </testsuite>
                 """;


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
Maven adds a reason to the result file why a test git skipped. #8718 missed the annotation to ignore such additional properties.


### Steps for Testing
Create a Maven Programming Exercise that uses Assumptions for skipping test cases, for example a test like this:

```java
MergeSort mergeSort = new MergeSort();
mergeSort.performSort(dates);
Assumptions.assumeTrue(datesWithCorrectOrder.equals(dates));
```

Check that the test passes for the solution, but is skipped for the template / student submission.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved XML parsing logic to handle unknown properties in skipped test results, ensuring better compatibility with various XML formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->