### PR TITLE
`Development`: Fix e2e playwright tests that navigate to a course page

### DIFF
--- a/src/test/playwright/e2e/exercise/ExerciseImport.spec.ts
+++ b/src/test/playwright/e2e/exercise/ExerciseImport.spec.ts
@@ -53,7 +53,7 @@ test.describe('Import exercises', () => {
 
             const importResponse = await textExerciseCreation.import();
             const exercise = await importResponse.json();
-            await login(studentOne, `/courses/${secondCourse.id}`);
+            await login(studentOne, `/courses/${secondCourse.id}/exercises/${exercise.id}`);
             await courseOverview.startExercise(exercise.id!);
             await courseOverview.openRunningExercise(exercise.id!);
             const submissionText = await Fixtures.get('loremIpsum-short.txt');
@@ -77,15 +77,12 @@ test.describe('Import exercises', () => {
             await expect(page.locator('#field_title')).toHaveValue(quizExercise.title!);
             await expect(page.locator('#quiz-duration-minutes')).toHaveValue(`${quizExercise.duration! / 60}`);
 
-            // Timeout commented to check if it is necessary
-            // page.waitForTimeout(500);
-
             await quizExerciseCreation.setVisibleFrom(dayjs());
 
             const importResponse = await quizExerciseCreation.import();
             const exercise: QuizExercise = await importResponse.json();
             await courseManagementExercises.startQuiz(exercise.id!);
-            await login(studentOne, `/courses/${secondCourse.id}`);
+            await login(studentOne, `/courses/${secondCourse.id}/exercises/${exercise.id}`);
             await courseOverview.startExercise(exercise.id!);
             await quizExerciseMultipleChoice.tickAnswerOption(exercise.id!, 0);
             await quizExerciseMultipleChoice.tickAnswerOption(exercise.id!, 2);
@@ -110,7 +107,7 @@ test.describe('Import exercises', () => {
 
             const importResponse = await modelingExerciseCreation.import();
             const exercise: ModelingExercise = await importResponse.json();
-            await login(studentOne, `/courses/${secondCourse.id}`);
+            await login(studentOne, `/courses/${secondCourse.id}/exercises/${exercise.id}`);
             await courseOverview.startExercise(exercise.id!);
             await courseOverview.openRunningExercise(exercise.id!);
             await modelingExerciseEditor.addComponentToModel(exercise.id!, 1);
@@ -135,7 +132,7 @@ test.describe('Import exercises', () => {
 
             const importResponse = await programmingExerciseCreation.import();
             const exercise: ProgrammingExercise = await importResponse.json();
-            await login(studentOne, `/courses/${secondCourse.id}`);
+            await login(studentOne, `/courses/${secondCourse.id}/exercises/${exercise.id}`);
             await courseOverview.startExercise(exercise.id!);
             await courseOverview.openRunningExercise(exercise.id!);
             await programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, javaPartiallySuccessfulSubmission, async () => {

--- a/src/test/playwright/e2e/exercise/modeling/ModelingExerciseParticipation.spec.ts
+++ b/src/test/playwright/e2e/exercise/modeling/ModelingExerciseParticipation.spec.ts
@@ -16,7 +16,7 @@ test.describe('Modeling Exercise Participation', () => {
     });
 
     test('Student can start and submit their model', async ({ login, courseOverview, modelingExerciseEditor }) => {
-        await login(studentOne, `/courses/${course.id}`);
+        await login(studentOne, `/courses/${course.id}/exercises/${modelingExercise.id}`);
         await courseOverview.startExercise(modelingExercise.id!);
         await courseOverview.openRunningExercise(modelingExercise.id!);
         await modelingExerciseEditor.addComponentToModel(modelingExercise.id!, 1, 310, 320);

--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseParticipation.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseParticipation.spec.ts
@@ -33,7 +33,7 @@ test.describe('Quiz Exercise Participation', () => {
         test('Student can see a visible quiz', async ({ login, exerciseAPIRequests, courseOverview }) => {
             await login(admin);
             await exerciseAPIRequests.setQuizVisible(quizExercise.id!);
-            await login(studentOne, '/courses/' + course.id);
+            await login(studentOne, `/courses/${course.id}/exercises/${quizExercise.id!}`);
             await courseOverview.openRunningExercise(quizExercise.id!);
         });
 
@@ -41,7 +41,7 @@ test.describe('Quiz Exercise Participation', () => {
             await login(admin);
             await exerciseAPIRequests.setQuizVisible(quizExercise.id!);
             await exerciseAPIRequests.startQuizNow(quizExercise.id!);
-            await login(studentOne, '/courses/' + course.id);
+            await login(studentOne, `/courses/${course.id}/exercises/${quizExercise.id!}`);
             await courseOverview.startExercise(quizExercise.id!);
             await quizExerciseMultipleChoice.tickAnswerOption(quizExercise.id!, 0);
             await quizExerciseMultipleChoice.tickAnswerOption(quizExercise.id!, 2);
@@ -61,13 +61,13 @@ test.describe('Quiz Exercise Participation', () => {
         });
 
         test('Student cannot participate in scheduled quiz before start of working time', async ({ login, courseOverview, quizExerciseParticipation }) => {
-            await login(studentOne, '/courses/' + course.id);
+            await login(studentOne, `/courses/${course.id}/exercises/${quizExercise.id}`);
             await courseOverview.openRunningExercise(quizExercise.id!);
             await expect(quizExerciseParticipation.getWaitingForStartAlert()).toBeVisible();
         });
 
         test('Student can participate in scheduled quiz when working time arrives', async ({ page, login, courseOverview, quizExerciseParticipation }) => {
-            await login(studentOne, `/courses/${course.id}`);
+            await login(studentOne, `/courses/${course.id}/exercises/${quizExercise.id}`);
             await courseOverview.openRunningExercise(quizExercise.id!);
             await page.waitForTimeout(timeUntilQuizStartInSeconds * 1000);
             await expect(quizExerciseParticipation.getWaitingForStartAlert()).not.toBeVisible();
@@ -104,7 +104,7 @@ test.describe('Quiz Exercise Participation', () => {
             await courseManagement.openExercisesOfCourse(course.id!);
             const quizBatch = await quizExerciseOverview.addQuizBatch(quizExercise.id!);
             await quizExerciseOverview.startQuizBatch(quizExercise.id!, quizBatch.id!);
-            await login(studentOne, '/courses/' + course.id);
+            await login(studentOne, `/courses/${course.id}/exercises/${quizExercise.id}`);
             await courseOverview.openRunningExercise(quizExercise.id!);
             await quizExerciseParticipation.joinQuizBatch(quizBatch.password!);
             await expect(quizExerciseParticipation.getQuizQuestion(0)).toBeVisible();
@@ -121,7 +121,7 @@ test.describe('Quiz Exercise Participation', () => {
             await navigationBar.openCourseManagement();
             await courseManagement.openExercisesOfCourse(course.id!);
             await courseManagementExercises.endQuiz(quizExercise);
-            await login(studentOne, '/courses/' + course.id);
+            await login(studentOne, `/courses/${course.id}/exercises/${quizExercise.id}`);
             await expect(courseOverview.getOpenRunningExerciseButton(quizExercise.id!)).not.toBeVisible();
         });
 
@@ -138,7 +138,7 @@ test.describe('Quiz Exercise Participation', () => {
             await courseManagement.openExercisesOfCourse(course.id!);
             await courseManagementExercises.endQuiz(quizExercise);
             await courseManagementExercises.getExercise(quizExercise.id!).locator('button', { hasText: 'Release For Practice' }).click();
-            await login(studentOne, `/courses/${course.id}`);
+            await login(studentOne, `/courses/${course.id}/exercises/${quizExercise.id}`);
             await courseOverview.practiceExercise();
             await expect(quizExerciseParticipation.getQuizQuestion(0)).toBeVisible();
         });
@@ -159,7 +159,7 @@ test.describe('Quiz Exercise Participation', () => {
         });
 
         test('Student can start a batch in an individual quiz', async ({ login, courseOverview, quizExerciseParticipation }) => {
-            await login(studentOne, '/courses/' + course.id);
+            await login(studentOne, `/courses/${course.id}/exercises/${quizExercise.id}`);
             await courseOverview.openRunningExercise(quizExercise.id!);
             await quizExerciseParticipation.startQuizBatch();
             await expect(quizExerciseParticipation.getQuizQuestion(0)).toBeVisible();
@@ -177,9 +177,9 @@ test.describe('Quiz Exercise Participation', () => {
         });
 
         test('Student can participate in SA quiz', async ({ login, courseOverview, quizExerciseShortAnswerQuiz }) => {
-            const quizQuestionId = quizExercise.quizQuestions![0].id!;
-            await login(studentOne, '/courses/' + course.id);
+            await login(studentOne, `/courses/${course.id}/exercises/${quizExercise.id}`);
             await courseOverview.startExercise(quizExercise.id!);
+            const quizQuestionId = quizExercise.quizQuestions![0].id!;
             await quizExerciseShortAnswerQuiz.typeAnswer(0, 1, quizQuestionId, 'give');
             await quizExerciseShortAnswerQuiz.typeAnswer(1, 1, quizQuestionId, 'let');
             await quizExerciseShortAnswerQuiz.typeAnswer(2, 1, quizQuestionId, 'run');
@@ -205,7 +205,7 @@ test.describe('Quiz Exercise Participation', () => {
         });
 
         test('Student can participate in DnD Quiz', async ({ login, courseOverview, quizExerciseDragAndDropQuiz }) => {
-            await login(studentOne, '/courses/' + course.id);
+            await login(studentOne, `/courses/${course.id}/exercises/${quizExercise.id}`);
             await courseOverview.startExercise(quizExercise.id!);
             await quizExerciseDragAndDropQuiz.dragItemIntoDragArea(0);
             await quizExerciseDragAndDropQuiz.submit();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
After changes to course exercises page, directly accessing a course page does not open the first exercise. E2E tests relying on that fail.

### Description
This PR fixes the failing tests by navigating to exercise page instead of the course page.

### Steps for Testing
- **Code Review**: Ensure that tests pass for valid reasons, functionality is adequately tested and check the code quality.
- **Run the tests**: Tests are checked by automatic run in CI environment. You can also run them locally and check if they pass.

**Steps for running the tests:**
1. Navigate to **src/tests/playwright**
2. Configure Playwright using playwright.env file based on your local setup. Current configuration should work for default Artemis setup.
3. Run `npm install && npm run playwright:setup`
4. Run tests with following commands and confirm that they pass:
- `npx playwright test e2e/exercise/modeling/ModelingExerciseParticipation.spec.ts`
- `npx playwright test e2e/exercise/quiz-exercise/QuizExerciseParticipation.spec.ts`
- `npx playwright test e2e/exercise/ExerciseImport.spec.ts`

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated login URLs to include exercise IDs for text, quiz, modeling, and programming exercises in the `Import exercises` test suite.
  - Enhanced login process for modeling and quiz exercises to ensure proper navigation and participation by including exercise IDs in the URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->