### PR TITLE
`Learning analytics`: Fix performance issues for dashboard data

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/metrics/ExerciseMetricsRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metrics/ExerciseMetricsRepository.java
@@ -98,7 +98,7 @@ public interface ExerciseMetricsRepository extends JpaRepository<Exercise, Long>
      * @return a set of ResourceTimestampDTO objects containing the exercise id and the latest submission date for the user
      */
     @Query("""
-            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, MAX(s.submissionDate))
+            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, MAX(s.submissionDate)), p.id
             FROM Submission s
                 LEFT JOIN StudentParticipation p ON s.participation.id = p.id
                 LEFT JOIN p.exercise e
@@ -107,7 +107,7 @@ public interface ExerciseMetricsRepository extends JpaRepository<Exercise, Long>
             WHERE e.id IN :exerciseIds
                 AND s.submitted = TRUE
                 AND (p.student.id = :userId OR u.id = :userId)
-            GROUP BY e.id
+            GROUP BY e.id, p.id
             """)
     Set<ResourceTimestampDTO> findLatestSubmissionDatesForUser(@Param("exerciseIds") Set<Long> exerciseIds, @Param("userId") long userId);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/metrics/ExerciseMetricsRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metrics/ExerciseMetricsRepository.java
@@ -98,7 +98,7 @@ public interface ExerciseMetricsRepository extends JpaRepository<Exercise, Long>
      * @return a set of ResourceTimestampDTO objects containing the exercise id and the latest submission date for the user
      */
     @Query("""
-            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, MAX(s.submissionDate))
+            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, MAX(s.submissionDate)), p.id
             FROM Submission s
                 LEFT JOIN StudentParticipation p ON s.participation.id = p.id
                 LEFT JOIN p.exercise e
@@ -107,7 +107,7 @@ public interface ExerciseMetricsRepository extends JpaRepository<Exercise, Long>
             WHERE e.id IN :exerciseIds
                 AND s.submitted = TRUE
                 AND (p.student.id = :userId OR u.id = :userId)
-            GROUP BY p.id
+            GROUP BY e.id, p.id
             """)
     Set<ResourceTimestampDTO> findLatestSubmissionDatesForUser(@Param("exerciseIds") Set<Long> exerciseIds, @Param("userId") long userId);
 
@@ -121,13 +121,13 @@ public interface ExerciseMetricsRepository extends JpaRepository<Exercise, Long>
      * @return a set of ResourceTimestampDTO objects containing the exercise id and the latest submission date for each exercise
      */
     @Query("""
-            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, MAX(s.submissionDate))
+            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, MAX(s.submissionDate)), p.id
             FROM Submission s
-                LEFT JOIN StudentParticipation p ON s.participation.id = p.id
+                LEFT JOIN Participation p ON s.participation.id = p.id
                 LEFT JOIN p.exercise e
             WHERE e.id IN :exerciseIds
                 AND s.submitted = TRUE
-            GROUP BY p.id
+            GROUP BY e.id, p.id
             """)
     Set<ResourceTimestampDTO> findLatestSubmissionDates(@Param("exerciseIds") Set<Long> exerciseIds);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/metrics/ExerciseMetricsRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metrics/ExerciseMetricsRepository.java
@@ -98,7 +98,7 @@ public interface ExerciseMetricsRepository extends JpaRepository<Exercise, Long>
      * @return a set of ResourceTimestampDTO objects containing the exercise id and the latest submission date for the user
      */
     @Query("""
-            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, MAX(s.submissionDate)), p.id
+            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, MAX(s.submissionDate))
             FROM Submission s
                 LEFT JOIN StudentParticipation p ON s.participation.id = p.id
                 LEFT JOIN p.exercise e
@@ -107,7 +107,7 @@ public interface ExerciseMetricsRepository extends JpaRepository<Exercise, Long>
             WHERE e.id IN :exerciseIds
                 AND s.submitted = TRUE
                 AND (p.student.id = :userId OR u.id = :userId)
-            GROUP BY e.id, p.id
+            GROUP BY e.id
             """)
     Set<ResourceTimestampDTO> findLatestSubmissionDatesForUser(@Param("exerciseIds") Set<Long> exerciseIds, @Param("userId") long userId);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/metrics/ExerciseMetricsRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metrics/ExerciseMetricsRepository.java
@@ -89,47 +89,45 @@ public interface ExerciseMetricsRepository extends JpaRepository<Exercise, Long>
 
     /**
      * Get the latest submission dates for a user in a set of exercises.
+     * <p>
+     * This query fetches the latest submission dates for the specified user in the given set of exercises.
+     * It takes into account both individual and team participations.
      *
-     * @param exerciseIds the ids of the exercises
-     * @param userId      the id of the user
-     * @return the latest submission dates for the user in the exercises
+     * @param exerciseIds the ids of the exercises for which to fetch the latest submission dates
+     * @param userId      the id of the user whose submission dates are being fetched
+     * @return a set of ResourceTimestampDTO objects containing the exercise id and the latest submission date for the user
      */
     @Query("""
-            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, s.submissionDate)
+            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, MAX(s.submissionDate))
             FROM Submission s
                 LEFT JOIN StudentParticipation p ON s.participation.id = p.id
                 LEFT JOIN p.exercise e
                 LEFT JOIN p.team t
                 LEFT JOIN t.students u
             WHERE e.id IN :exerciseIds
-                AND s.submissionDate = (
-                    SELECT MAX(s2.submissionDate)
-                    FROM Submission s2
-                    WHERE s2.participation.id = s.participation.id
-                        AND s2.submitted = TRUE
-                )
+                AND s.submitted = TRUE
                 AND (p.student.id = :userId OR u.id = :userId)
+            GROUP BY p.id
             """)
     Set<ResourceTimestampDTO> findLatestSubmissionDatesForUser(@Param("exerciseIds") Set<Long> exerciseIds, @Param("userId") long userId);
 
     /**
      * Get the latest submission dates for a set of exercises.
+     * <p>
+     * This query fetches all latest submission dates for the specified set of exercises.
+     * It considers all participations related to the exercises.
      *
-     * @param exerciseIds the ids of the exercises
-     * @return the latest submission dates for the exercises
+     * @param exerciseIds the ids of the exercises for which to fetch the latest submission dates
+     * @return a set of ResourceTimestampDTO objects containing the exercise id and the latest submission date for each exercise
      */
     @Query("""
-            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, s.submissionDate)
+            SELECT new de.tum.in.www1.artemis.web.rest.dto.metrics.ResourceTimestampDTO(e.id, MAX(s.submissionDate))
             FROM Submission s
                 LEFT JOIN StudentParticipation p ON s.participation.id = p.id
                 LEFT JOIN p.exercise e
             WHERE e.id IN :exerciseIds
-                AND s.submissionDate = (
-                    SELECT MAX(s2.submissionDate)
-                    FROM Submission s2
-                    WHERE s2.participation.id = s.participation.id
-                        AND s2.submitted = TRUE
-                )
+                AND s.submitted = TRUE
+            GROUP BY p.id
             """)
     Set<ResourceTimestampDTO> findLatestSubmissionDates(@Param("exerciseIds") Set<Long> exerciseIds);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
One query is super slow, this PR makes it significantly (20x) faster


### Description
When fetching latest submission dates, sub queries made issues on production courses with many students


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student on TS3 with access to https://artemis-test3.artemis.cit.tum.de/courses/56/dashboard

1. Go the the course dashboard
2. Observe that the loading time of the graphs on the right should be significantly faster (< 10s)
3. Observe that Iris sends you a message (works one time a day, when you go the dashboard for the first time on the day)


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of fetching the latest submission dates for users by considering both individual and team participations in exercises.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->