### PR TITLE
Feature/iris/add button to ingest one lecture

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/iris/settings/IrisLectureIngestionSubSettings.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/iris/settings/IrisLectureIngestionSubSettings.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.iris.settings;
 
-import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
@@ -16,16 +15,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class IrisLectureIngestionSubSettings extends IrisSubSettings {
 
-    @Nullable
     @Column(name = "auto_ingest_on_lecture_attachment_upload")
-    private Boolean autoIngestOnLectureAttachmentUpload;
+    private boolean autoIngestOnLectureAttachmentUpload;
 
-    @Nullable
-    public Boolean getAutoIngestOnLectureAttachmentUpload() {
+    public boolean getAutoIngestOnLectureAttachmentUpload() {
         return autoIngestOnLectureAttachmentUpload;
     }
 
-    public void setAutoIngestOnLectureAttachmentUpload(@Nullable Boolean autoIngestOnLectureAttachmentUpload) {
+    public void setAutoIngestOnLectureAttachmentUpload(boolean autoIngestOnLectureAttachmentUpload) {
         this.autoIngestOnLectureAttachmentUpload = autoIngestOnLectureAttachmentUpload;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
@@ -105,7 +105,7 @@ public class LectureImportService {
         // Send lectures to pyris
         if (pyrisWebhookService.isPresent() && irisSettingsRepository.isPresent()) {
             pyrisWebhookService.get().autoUpdateAttachmentUnitsInPyris(irisSettingsRepository.get(), lecture.getCourse().getId(),
-                    lectureUnits.stream().map(lectureUnit -> (AttachmentUnit) lectureUnit).toList());
+                    lectureUnits.stream().filter(lectureUnit -> lectureUnit instanceof AttachmentUnit).map(lectureUnit -> (AttachmentUnit) lectureUnit).toList());
         }
         // Save again to establish the ordered list relationship
         return lectureRepository.save(lecture);

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureService.java
@@ -35,6 +35,8 @@ import de.tum.in.www1.artemis.web.rest.util.PageUtil;
 @Service
 public class LectureService {
 
+    private static final Logger log = LoggerFactory.getLogger(LoggingAspect.class);
+
     private final LectureRepository lectureRepository;
 
     private final AuthorizationCheckService authCheckService;
@@ -44,8 +46,6 @@ public class LectureService {
     private final ChannelService channelService;
 
     private final Optional<PyrisWebhookService> pyrisWebhookService;
-
-    private static final Logger log = LoggerFactory.getLogger(LoggingAspect.class);
 
     public LectureService(LectureRepository lectureRepository, AuthorizationCheckService authCheckService, ChannelRepository channelRepository, ChannelService channelService,
             Optional<PyrisWebhookService> pyrisWebhookService) {
@@ -146,8 +146,7 @@ public class LectureService {
     public void delete(Lecture lecture) {
         if (pyrisWebhookService.isPresent()) {
             Lecture lectureWithAttachmentUnits = lectureRepository.findByIdWithLectureUnitsAndAttachmentsElseThrow(lecture.getId());
-            List<AttachmentUnit> attachmentUnitList = lectureWithAttachmentUnits.getLectureUnits().stream()
-                    .filter(lectureUnit -> lectureUnit instanceof AttachmentUnit && ((AttachmentUnit) lectureUnit).getAttachment().getLink().endsWith(".pdf"))
+            List<AttachmentUnit> attachmentUnitList = lectureWithAttachmentUnits.getLectureUnits().stream().filter(lectureUnit -> lectureUnit instanceof AttachmentUnit)
                     .map(lectureUnit -> (AttachmentUnit) lectureUnit).toList();
             if (!attachmentUnitList.isEmpty()) {
                 pyrisWebhookService.get().deleteLectureFromPyrisDB(attachmentUnitList);
@@ -170,7 +169,7 @@ public class LectureService {
                     .map(unit -> (AttachmentUnit) unit).toList();
             if (!attachmentUnitList.isEmpty()) {
                 log.info("Send Lectures To Iris executed successfully.");
-                return pyrisWebhookService.get().addLectureToPyrisDB(attachmentUnitList) != null;
+                return pyrisWebhookService.get().addLectureUnitsToPyrisDB(attachmentUnitList) != null;
             }
         }
         return false;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/lectureingestionwebhook/PyrisLectureUnitWebhookDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/dto/lectureingestionwebhook/PyrisLectureUnitWebhookDTO.java
@@ -8,6 +8,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * providing necessary details such as lecture and course identifiers, names, and descriptions.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PyrisLectureUnitWebhookDTO(Boolean toUpdate, String artemisBaseUrl, String pdfFile, int lectureUnitId, String lectureUnitName, int lectureId, String lectureName,
-        int courseId, String courseName, String courseDescription) {
+public record PyrisLectureUnitWebhookDTO(Boolean toUpdate, String artemisBaseUrl, String pdfFile, Long lectureUnitId, String lectureUnitName, Long lectureId, String lectureName,
+        Long courseId, String courseName, String courseDescription) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/job/IngestionWebhookJob.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/pyris/job/IngestionWebhookJob.java
@@ -4,8 +4,8 @@ import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 
 /**
- * An implementation of a PyrisJob for tutor chat messages.
- * This job is used to reference the details of a tutor chat session when Pyris sends a status update.
+ * An implementation of a PyrisJob for Lecture Ingestion in Pyris.
+ * This job is used to reference the details of then Ingestion when Pyris sends a status update.
  */
 public record IngestionWebhookJob(String jobId) implements PyrisJob {
 

--- a/src/main/java/de/tum/in/www1/artemis/service/iris/settings/IrisSettingsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/iris/settings/IrisSettingsService.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
@@ -139,41 +140,37 @@ public class IrisSettingsService {
         }
     }
 
+    private static <T extends IrisSubSettings> T initializeSettings(T settings, Supplier<T> constructor) {
+        if (settings == null) {
+            settings = constructor.get();
+            settings.setEnabled(false);
+        }
+        return settings;
+    }
+
     private void initializeIrisChatSettings(IrisGlobalSettings settings) {
         var irisChatSettings = settings.getIrisChatSettings();
-        if (irisChatSettings == null) {
-            irisChatSettings = new IrisChatSubSettings();
-            irisChatSettings.setEnabled(false);
-        }
+        irisChatSettings = initializeSettings(irisChatSettings, IrisChatSubSettings::new);
         irisChatSettings.setTemplate(loadDefaultChatTemplate());
         settings.setIrisChatSettings(irisChatSettings);
     }
 
     private void initializeIrisLectureIngestionSettings(IrisGlobalSettings settings) {
         var irisLectureIngestionSettings = settings.getIrisLectureIngestionSettings();
-        if (irisLectureIngestionSettings == null) {
-            irisLectureIngestionSettings = new IrisLectureIngestionSubSettings();
-            irisLectureIngestionSettings.setEnabled(false);
-        }
+        irisLectureIngestionSettings = initializeSettings(irisLectureIngestionSettings, IrisLectureIngestionSubSettings::new);
         settings.setIrisLectureIngestionSettings(irisLectureIngestionSettings);
     }
 
     private void initializeIrisHestiaSettings(IrisGlobalSettings settings) {
         var irisHestiaSettings = settings.getIrisHestiaSettings();
-        if (irisHestiaSettings == null) {
-            irisHestiaSettings = new IrisHestiaSubSettings();
-            irisHestiaSettings.setEnabled(false);
-        }
+        irisHestiaSettings = initializeSettings(irisHestiaSettings, IrisHestiaSubSettings::new);
         irisHestiaSettings.setTemplate(loadDefaultHestiaTemplate());
         settings.setIrisHestiaSettings(irisHestiaSettings);
     }
 
     private void initializeIrisCompetencyGenerationSettings(IrisGlobalSettings settings) {
         var irisCompetencyGenerationSettings = settings.getIrisCompetencyGenerationSettings();
-        if (irisCompetencyGenerationSettings == null) {
-            irisCompetencyGenerationSettings = new IrisCompetencyGenerationSubSettings();
-            irisCompetencyGenerationSettings.setEnabled(false);
-        }
+        irisCompetencyGenerationSettings = initializeSettings(irisCompetencyGenerationSettings, IrisCompetencyGenerationSubSettings::new);
         irisCompetencyGenerationSettings.setTemplate(loadDefaultCompetencyGenerationTemplate());
         settings.setIrisCompetencyGenerationSettings(irisCompetencyGenerationSettings);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
@@ -263,7 +263,8 @@ public class LectureResource {
     /**
      * POST /courses/{courseId}/ingest
      *
-     * @param courseId the ID of the course for which all lectures should be ingested in pyris
+     * @param courseId  the ID of the course for which all lectures should be ingested in pyris
+     * @param lectureId If this id is present then only ingest this one lecture of the respective course
      * @return the ResponseEntity with status 200 (OK) and a message success or null if the operation failed
      */
     @PostMapping("courses/{courseId}/ingest")

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
@@ -4,6 +4,7 @@ import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -266,9 +267,20 @@ public class LectureResource {
      * @return the ResponseEntity with status 200 (OK) and a message success or null if the operation failed
      */
     @PostMapping("courses/{courseId}/ingest")
-    public ResponseEntity<Boolean> ingestLectures(@PathVariable Long courseId) {
+    public ResponseEntity<Boolean> ingestLectures(@PathVariable Long courseId, @RequestParam(required = false) Optional<Long> lectureId) {
         log.debug("REST request to ingest lectures of course : {}", courseId);
         Course course = courseRepository.findByIdWithLecturesAndLectureUnitsElseThrow(courseId);
+        if (lectureId.isPresent()) {
+            Optional<Lecture> lectureToIngest = course.getLectures().stream().filter(lecture -> lecture.getId().equals(lectureId.get())).findFirst();
+            if (lectureToIngest.isPresent()) {
+                Set<Lecture> lecturesToIngest = new HashSet<>();
+                lecturesToIngest.add(lectureToIngest.get());
+                return ResponseEntity.ok().body(lectureService.ingestLecturesInPyris(lecturesToIngest));
+            }
+            return ResponseEntity.badRequest()
+                    .headers(HeaderUtil.createAlert(applicationName, "Could not send lecture to Iris, no lecture found with the provided id.", "idExists")).body(null);
+
+        }
         return ResponseEntity.ok().body(lectureService.ingestLecturesInPyris(course.getLectures()));
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LectureResource.java
@@ -168,7 +168,7 @@ public class LectureResource {
      * @param courseId         the courseId of the course for which all lectures should be returned
      * @return the ResponseEntity with status 200 (OK) and the list of lectures in body
      */
-    @GetMapping(value = "courses/{courseId}/lectures")
+    @GetMapping("courses/{courseId}/lectures")
     @EnforceAtLeastEditor
     public ResponseEntity<Set<Lecture>> getLecturesForCourse(@PathVariable Long courseId, @RequestParam(required = false, defaultValue = "false") boolean withLectureUnits) {
         log.debug("REST request to get all Lectures for the course with id : {}", courseId);

--- a/src/main/webapp/app/lecture/lecture-detail.component.html
+++ b/src/main/webapp/app/lecture/lecture-detail.component.html
@@ -21,6 +21,12 @@
                         <span jhiTranslate="entity.action.units"></span>
                     </a>
                 }
+                @if (lecture.course?.isAtLeastInstructor && lectureIngestionEnabled) {
+                    <button (click)="ingestLectureInPyris()" class="btn btn-primary">
+                        <fa-icon [icon]="faFileExport" />
+                        <span jhiTranslate="entity.action.sendToIris"></span>
+                    </button>
+                }
             </div>
         }
     </div>

--- a/src/main/webapp/app/lecture/lecture-detail.component.ts
+++ b/src/main/webapp/app/lecture/lecture-detail.component.ts
@@ -1,27 +1,32 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { faFile, faPencilAlt, faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
+import { faFile, faFileExport, faPencilAlt, faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
 import { Lecture } from 'app/entities/lecture.model';
 import { DetailOverviewSection, DetailType } from 'app/detail-overview-list/detail-overview-list.component';
 import { ArtemisMarkdownService } from 'app/shared/markdown.service';
-
+import { LectureService } from 'app/lecture/lecture.service';
+import { IrisSettingsService } from 'app/iris/settings/shared/iris-settings.service';
 @Component({
     selector: 'jhi-lecture-detail',
     templateUrl: './lecture-detail.component.html',
 })
 export class LectureDetailComponent implements OnInit {
     lecture: Lecture;
+    lectureIngestionEnabled = false;
 
     // Icons
     faPencilAlt = faPencilAlt;
     faFile = faFile;
     faPuzzlePiece = faPuzzlePiece;
+    faFileExport = faFileExport;
 
     detailSections: DetailOverviewSection[];
 
     constructor(
         private activatedRoute: ActivatedRoute,
         private artemisMarkdown: ArtemisMarkdownService,
+        protected lectureService: LectureService,
+        private irisSettingsService: IrisSettingsService,
     ) {}
 
     /**
@@ -31,6 +36,13 @@ export class LectureDetailComponent implements OnInit {
         this.activatedRoute.data.subscribe(({ lecture }) => {
             this.lecture = lecture;
             this.getLectureDetailSections();
+            if (this.lecture.course?.id) {
+                this.irisSettingsService.getCombinedCourseSettings(this.lecture.course?.id).subscribe((settings) => {
+                    if (settings) {
+                        this.lectureIngestionEnabled = settings.irisLectureIngestionSettings?.enabled || false;
+                    }
+                });
+            }
         });
     }
 
@@ -64,5 +76,11 @@ export class LectureDetailComponent implements OnInit {
                 },
             ];
         }
+    }
+    /**
+     * Trigger the Ingeston of this Lecture in Iris.
+     */
+    ingestLectureInPyris() {
+        this.lectureService.ingestLecturesInPyris(this.lecture.course!.id!, this.lecture.id);
     }
 }

--- a/src/main/webapp/app/lecture/lecture.component.ts
+++ b/src/main/webapp/app/lecture/lecture.component.ts
@@ -70,9 +70,7 @@ export class LectureComponent implements OnInit {
         this.courseId = Number(this.route.snapshot.paramMap.get('courseId'));
         this.loadAll();
         this.irisSettingsService.getCombinedCourseSettings(this.courseId).subscribe((settings) => {
-            if (settings) {
-                this.lectureIngestionEnabled = settings.irisLectureIngestionSettings?.enabled || false;
-            }
+            this.lectureIngestionEnabled = settings?.irisLectureIngestionSettings?.enabled || false;
         });
     }
 

--- a/src/main/webapp/app/lecture/lecture.component.ts
+++ b/src/main/webapp/app/lecture/lecture.component.ts
@@ -188,7 +188,7 @@ export class LectureComponent implements OnInit {
     }
 
     /**
-     * Trigger the IngestFix failing testion of all Lectures in the course.
+     * Trigger the Ingestion of all Lectures in the course.
      */
     ingestLecturesInPyris() {
         if (this.lectures.first()) {

--- a/src/main/webapp/app/lecture/lecture.service.ts
+++ b/src/main/webapp/app/lecture/lecture.service.ts
@@ -111,9 +111,18 @@ export class LectureService {
                 tap((res: EntityArrayResponseType) => res?.body?.forEach(this.sendTitlesToEntityTitleService.bind(this))),
             );
     }
-
-    ingestLecturesInPyris(courseId: number) {
-        this.http.post(`api/courses/${courseId}/ingest`, { observe: 'response' }).subscribe({
+    /**
+     * triggers the ingestion of All the lectures inside the course specified or one lecture inside of the course
+     *
+     * @param courseId Course containing the lecture(s)
+     * @param lectureId The lecture to be ingested in pyris
+     */
+    ingestLecturesInPyris(courseId: number, lectureId?: number): void {
+        let params = new HttpParams();
+        if (lectureId) {
+            params = params.set('lectureId', lectureId.toString()); // Ensure the parameter name matches what the server expects
+        }
+        this.http.post(`api/courses/${courseId}/ingest`, { params: params, observe: 'response' }).subscribe({
             error: (error) => console.error(`Failed to send Ingestion request`, error),
         });
     }

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -264,7 +264,8 @@
             "discardChanges": "Änderungen verwerfen",
             "goBack": "Zurück",
             "search": "Suchen",
-            "select": "Auswählen"
+            "select": "Auswählen",
+            "sendToIris": "Zu Iris Schicken"
         },
         "detail": {
             "field": "Feld",

--- a/src/main/webapp/i18n/de/iris.json
+++ b/src/main/webapp/i18n/de/iris.json
@@ -22,7 +22,7 @@
                 "subSettings": {
                     "chatSettings": "Chat Einstellungen",
                     "lectureIngestionSettings": {
-                        "title": "Vorlesung Erfassung Einstellungen",
+                        "title": "Vorlesungerfassungseinstellungen",
                         "autoIngestOnAttachmentUpload": "Vorlesungen automatisch an Pyris senden"
                     },
                     "hestiaSettings": "Hestia Einstellungen",

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -266,7 +266,8 @@
             "discardChanges": "Discard changes",
             "goBack": "Go back",
             "search": "Search",
-            "select": "Select"
+            "select": "Select",
+            "sendToIris": "Send To Iris"
         },
         "detail": {
             "field": "Field",

--- a/src/test/java/de/tum/in/www1/artemis/iris/PyrisLectureIngestionTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/iris/PyrisLectureIngestionTest.java
@@ -127,9 +127,9 @@ class PyrisLectureIngestionTest extends AbstractIrisIntegrationTest {
         irisRequestMockProvider.mockIngestionWebhookRunResponse(dto -> {
             assertThat(dto.settings().authenticationToken()).isNotNull();
         });
-        String jobToken = pyrisWebhookService.addLectureToPyrisDB(List.of((AttachmentUnit) lecture1.getLectureUnits().getFirst()));
+        String jobToken = pyrisWebhookService.addLectureUnitsToPyrisDB(List.of((AttachmentUnit) lecture1.getLectureUnits().getFirst()));
         assertThat(jobToken).isNull();
-        jobToken = pyrisWebhookService.addLectureToPyrisDB(List.of((AttachmentUnit) lecture1.getLectureUnits().getLast()));
+        jobToken = pyrisWebhookService.addLectureUnitsToPyrisDB(List.of((AttachmentUnit) lecture1.getLectureUnits().getLast()));
         assertThat(jobToken).isNull();
     }
 
@@ -182,9 +182,9 @@ class PyrisLectureIngestionTest extends AbstractIrisIntegrationTest {
         irisRequestMockProvider.mockIngestionWebhookRunResponse(dto -> {
             assertThat(dto.settings().authenticationToken()).isNotNull();
         });
-        String jobToken = pyrisWebhookService.addLectureToPyrisDB(List.of((AttachmentUnit) lecture1.getLectureUnits().getFirst()));
+        String jobToken = pyrisWebhookService.addLectureUnitsToPyrisDB(List.of((AttachmentUnit) lecture1.getLectureUnits().getFirst()));
         assertThat(jobToken).isNotNull();
-        jobToken = pyrisWebhookService.addLectureToPyrisDB(List.of((AttachmentUnit) lecture1.getLectureUnits().getLast()));
+        jobToken = pyrisWebhookService.addLectureUnitsToPyrisDB(List.of((AttachmentUnit) lecture1.getLectureUnits().getLast()));
         assertThat(jobToken).isNull();
     }
 
@@ -196,7 +196,7 @@ class PyrisLectureIngestionTest extends AbstractIrisIntegrationTest {
             assertThat(dto.settings().authenticationToken()).isNotNull();
         });
         if (lecture1.getLectureUnits().getFirst() instanceof AttachmentUnit attachmentUnit) {
-            String jobToken = pyrisWebhookService.addLectureToPyrisDB(List.of(attachmentUnit));
+            String jobToken = pyrisWebhookService.addLectureUnitsToPyrisDB(List.of(attachmentUnit));
             PyrisStageDTO doneStage = new PyrisStageDTO("done", 1, PyrisStageState.DONE, "Stage completed successfully.");
             PyrisLectureIngestionStatusUpdateDTO statusUpdate = new PyrisLectureIngestionStatusUpdateDTO("Success", List.of(doneStage));
             var headers = new HttpHeaders(new LinkedMultiValueMap<>(Map.of("Authorization", List.of("Bearer " + jobToken))));
@@ -229,7 +229,7 @@ class PyrisLectureIngestionTest extends AbstractIrisIntegrationTest {
             assertThat(dto.settings().authenticationToken()).isNotNull();
         });
         if (lecture1.getLectureUnits().getFirst() instanceof AttachmentUnit attachmentUnit) {
-            String jobToken = pyrisWebhookService.addLectureToPyrisDB(List.of(attachmentUnit));
+            String jobToken = pyrisWebhookService.addLectureUnitsToPyrisDB(List.of(attachmentUnit));
             PyrisStageDTO doneStage = new PyrisStageDTO("done", 1, PyrisStageState.DONE, "Stage completed successfully.");
             PyrisStageDTO inProgressStage = new PyrisStageDTO("inProgressStage", 1, PyrisStageState.IN_PROGRESS, "Stage completed successfully.");
             PyrisLectureIngestionStatusUpdateDTO statusUpdate = new PyrisLectureIngestionStatusUpdateDTO("Success", List.of(doneStage, inProgressStage));
@@ -279,7 +279,7 @@ class PyrisLectureIngestionTest extends AbstractIrisIntegrationTest {
             assertThat(dto.settings().authenticationToken()).isNotNull();
         });
         if (lecture1.getLectureUnits().getFirst() instanceof AttachmentUnit attachmentUnit) {
-            String jobToken = pyrisWebhookService.addLectureToPyrisDB(List.of(attachmentUnit));
+            String jobToken = pyrisWebhookService.addLectureUnitsToPyrisDB(List.of(attachmentUnit));
             PyrisStageDTO errorStage = new PyrisStageDTO("error", 1, PyrisStageState.ERROR, "Stage not broke due to error.");
             PyrisLectureIngestionStatusUpdateDTO statusUpdate = new PyrisLectureIngestionStatusUpdateDTO("Success", List.of(errorStage));
             var headers = new HttpHeaders(new LinkedMultiValueMap<>(Map.of("Authorization", List.of("Bearer " + jobToken))));

--- a/src/test/javascript/spec/component/lecture/lecture-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture/lecture-detail.component.spec.ts
@@ -14,6 +14,7 @@ import { MockLocalStorageService } from '../../helpers/mocks/service/mock-local-
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { TranslateService } from '@ngx-translate/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { LectureService } from 'app/lecture/lecture.service';
 
 const mockLecture = {
     title: 'Test Lecture',
@@ -31,6 +32,7 @@ describe('LectureDetailComponent', () => {
     let component: LectureDetailComponent;
     let fixture: ComponentFixture<LectureDetailComponent>;
     let mockActivatedRoute: any;
+    let lectureService: LectureService;
 
     beforeEach(async () => {
         mockActivatedRoute = {
@@ -53,6 +55,7 @@ describe('LectureDetailComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(LectureDetailComponent);
         component = fixture.componentInstance;
+        lectureService = TestBed.inject(LectureService);
         fixture.detectChanges();
     });
 
@@ -83,5 +86,12 @@ describe('LectureDetailComponent', () => {
                 expect(detail).toBeTruthy();
             }
         }
+    });
+    it('should call the service to ingest lectures when ingestLecturesInPyris is called', () => {
+        component.lecture = mockLecture;
+        const ingestSpy = jest.spyOn(lectureService, 'ingestLecturesInPyris').mockImplementation(() => of(null));
+        component.ingestLectureInPyris();
+        expect(ingestSpy).toHaveBeenCalledWith(mockLecture.course?.id, mockLecture.id);
+        expect(ingestSpy).toHaveBeenCalledOnce();
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.


#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [ ] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We need a button to ingest only one lecture thus their PR.

### Description
<!-- Describe your changes in detail -->
Added a button to send one Lecture to Iris, when the lecture ingestion settings is on. 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Steps for Testing
Prerequisites:

1 Instructor / Admin
use Test Course Yassine Souissi on test server 3.
Pyris and Artemis running.
Log in to Grafana through this link( should take you directly to ts3 logs): https://grafana.gchq.ase.in.tum.de/d/uBBKO8qnk/nodes-detailed-view?orgId=1&refresh=1m&var-DS_PROMETHEUS=default&var-job=artemis_test&var-name=artemis-test3.artemis.cit.tum.de&var-node=artemis-test-vm3.artemis.cit.tum.de&var-port=9100
Test as an admin(only people with admin rights can test on ts3):

Log in to Artemis as an Admin
Go to the course page
Test as an INSTRUCTOR/Admin:
-diable iris lecture ingestion settings, check if the button is not there.
- enable iris lecture ingestion settings, check if the button is there. 
- click on the button then check the logs on grafana, after 5 minutes you should find this log with ctrl+f : Slides ingestion:Lecture Ingestion Finished.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)


### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

