### PR TITLE
`Learning path`: Add learning path explanation for students

### DIFF
--- a/src/main/webapp/app/course/learning-paths/components/competency-graph/competency-graph.component.html
+++ b/src/main/webapp/app/course/learning-paths/components/competency-graph/competency-graph.component.html
@@ -1,7 +1,7 @@
 @if (isLoading()) {
     <div class="row justify-content-center m-4">
         <div class="spinner-border text-primary" role="status">
-            <span class="sr-only">Loading...</span>
+            <span class="sr-only" jhiTranslate="loading"></span>
         </div>
     </div>
 } @else {

--- a/src/main/webapp/app/course/learning-paths/components/competency-graph/competency-graph.component.ts
+++ b/src/main/webapp/app/course/learning-paths/components/competency-graph/competency-graph.component.ts
@@ -5,11 +5,12 @@ import { CompetencyGraphDTO, NodeType } from 'app/entities/competency/learning-p
 import { CompetencyNodeComponent, SizeUpdate } from 'app/course/learning-paths/components/competency-node/competency-node.component';
 import { LearningPathApiService } from 'app/course/learning-paths/services/learning-path-api.service';
 import { AlertService } from 'app/core/util/alert.service';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
 
 @Component({
     selector: 'jhi-competency-graph',
     standalone: true,
-    imports: [CompetencyNodeComponent, NgxGraphModule],
+    imports: [CompetencyNodeComponent, NgxGraphModule, ArtemisSharedModule],
     templateUrl: './competency-graph.component.html',
     styleUrl: './competency-graph.component.scss',
 })

--- a/src/main/webapp/app/course/learning-paths/components/learning-path-lecture-unit/learning-path-lecture-unit.component.html
+++ b/src/main/webapp/app/course/learning-paths/components/learning-path-lecture-unit/learning-path-lecture-unit.component.html
@@ -1,7 +1,7 @@
 @if (isLectureUnitLoading()) {
     <div class="row justify-content-center m-4">
         <div class="spinner-border text-primary" role="status">
-            <span class="sr-only"></span>
+            <span class="sr-only" jhiTranslate="loading"></span>
         </div>
     </div>
 }

--- a/src/main/webapp/app/course/learning-paths/components/learning-path-lecture-unit/learning-path-lecture-unit.component.ts
+++ b/src/main/webapp/app/course/learning-paths/components/learning-path-lecture-unit/learning-path-lecture-unit.component.ts
@@ -7,11 +7,12 @@ import { LectureUnitCompletionEvent } from 'app/overview/course-lectures/course-
 import { LearningPathNavigationService } from 'app/course/learning-paths/services/learning-path-navigation.service';
 import { lastValueFrom, switchMap } from 'rxjs';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
 
 @Component({
     selector: 'jhi-learning-path-lecture-unit',
     standalone: true,
-    imports: [ArtemisLectureUnitsModule],
+    imports: [ArtemisLectureUnitsModule, ArtemisSharedModule],
     templateUrl: './learning-path-lecture-unit.component.html',
 })
 export class LearningPathLectureUnitComponent {

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
@@ -2,7 +2,7 @@
     @if (isLoading()) {
         <div class="row justify-content-center align-items-center h-100">
             <div class="spinner-border text-primary" role="status">
-                <span class="sr-only">Loading...</span>
+                <span class="sr-only" jhiTranslate="loading"></span>
             </div>
         </div>
     } @else if (learningPathId()) {

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
@@ -1,12 +1,31 @@
 <div class="col learning-path-student-page">
-    @if (learningPathId()) {
+    @if (isLoading()) {
+        <div class="row justify-content-center align-items-center h-100">
+            <div class="spinner-border text-primary" role="status">
+                <span class="sr-only">Loading...</span>
+            </div>
+        </div>
+    } @else if (learningPathId()) {
         <jhi-learning-path-student-nav [learningPathId]="learningPathId()!" />
+        <div class="learning-path-student-content">
+            @if (currentLearningObject()?.type === LearningObjectType.LECTURE) {
+                <jhi-learning-path-lecture-unit [lectureUnitId]="currentLearningObject()!.id" />
+            } @else if (currentLearningObject()?.type === LearningObjectType.EXERCISE) {
+                <jhi-learning-path-exercise [courseId]="courseId()" [exerciseId]="currentLearningObject()!.id" />
+            }
+        </div>
+    } @else {
+        <div class="row align-items-center justify-content-center h-100">
+            <div class="learning-path-generation-container">
+                <h3 class="mb-3">Welcome to learning paths</h3>
+                <div>
+                    Welcome to your Learning Path! This feature lets you learn at your own pace with a personalized journey tailored to your performance. It adapts dynamically,
+                    ensuring you always have the most relevant content and challenges. Start now and experience a customized path to success!
+                </div>
+                <button (click)="generateLearningPath(this.courseId())" type="button" class="mt-4 btn btn-primary" id="generate-learning-path-button">
+                    Generate learning path
+                </button>
+            </div>
+        </div>
     }
-    <div class="learning-path-student-content">
-        @if (currentLearningObject()?.type === LearningObjectType.LECTURE) {
-            <jhi-learning-path-lecture-unit [lectureUnitId]="currentLearningObject()!.id" />
-        } @else if (currentLearningObject()?.type === LearningObjectType.EXERCISE) {
-            <jhi-learning-path-exercise [courseId]="courseId()" [exerciseId]="currentLearningObject()!.id" />
-        }
-    </div>
 </div>

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
@@ -17,14 +17,15 @@
     } @else {
         <div class="row align-items-center justify-content-center h-100">
             <div class="learning-path-generation-container">
-                <h3 class="mb-3">Welcome to learning paths</h3>
-                <div>
-                    Welcome to your Learning Path! This feature lets you learn at your own pace with a personalized journey tailored to your performance. It adapts dynamically,
-                    ensuring you always have the most relevant content and challenges. Start now and experience a customized path to success!
-                </div>
-                <button (click)="generateLearningPath(this.courseId())" type="button" class="mt-4 btn btn-primary" id="generate-learning-path-button">
-                    Generate learning path
-                </button>
+                <h3 class="mb-3" jhiTranslate="artemisApp.learningPath.generation.title"></h3>
+                <div jhiTranslate="artemisApp.learningPath.generation.description"></div>
+                <button
+                    (click)="generateLearningPath(this.courseId())"
+                    type="button"
+                    class="mt-4 btn btn-primary"
+                    id="generate-learning-path-button"
+                    jhiTranslate="artemisApp.learningPath.generation.generateButton"
+                ></button>
             </div>
         </div>
     }

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.scss
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.scss
@@ -5,4 +5,9 @@
         height: calc(100vh - var(--sidebar-footer-height-dev) - 10.65rem);
         overflow: auto;
     }
+
+    .learning-path-generation-container {
+        max-width: 500px;
+        text-align: center;
+    }
 }

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.ts
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.ts
@@ -12,13 +12,22 @@ import { LearningPathExerciseComponent } from 'app/course/learning-paths/compone
 import { LearningPathApiService } from 'app/course/learning-paths/services/learning-path-api.service';
 import { LearningPathNavigationService } from 'app/course/learning-paths/services/learning-path-navigation.service';
 import { EntityNotFoundError } from 'app/course/learning-paths/exceptions/entity-not-found.error';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
 
 @Component({
     selector: 'jhi-learning-path-student-page',
     templateUrl: './learning-path-student-page.component.html',
     styleUrl: './learning-path-student-page.component.scss',
     standalone: true,
-    imports: [CommonModule, RouterModule, LearningPathStudentNavComponent, CourseExerciseDetailsModule, LearningPathLectureUnitComponent, LearningPathExerciseComponent],
+    imports: [
+        CommonModule,
+        RouterModule,
+        LearningPathStudentNavComponent,
+        CourseExerciseDetailsModule,
+        LearningPathLectureUnitComponent,
+        LearningPathExerciseComponent,
+        ArtemisSharedModule,
+    ],
 })
 export class LearningPathStudentPageComponent implements OnInit {
     protected readonly LearningObjectType = LearningObjectType;

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.ts
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.ts
@@ -10,8 +10,8 @@ import { CourseExerciseDetailsModule } from 'app/overview/exercise-details/cours
 import { LearningPathLectureUnitComponent } from 'app/course/learning-paths/components/learning-path-lecture-unit/learning-path-lecture-unit.component';
 import { LearningPathExerciseComponent } from 'app/course/learning-paths/components/learning-path-exercise/learning-path-exercise.component';
 import { LearningPathApiService } from 'app/course/learning-paths/services/learning-path-api.service';
-import { EntityNotFoundError } from 'app/course/learning-paths/exceptions/entity-not-found.error';
 import { LearningPathNavigationService } from 'app/course/learning-paths/services/learning-path-navigation.service';
+import { EntityNotFoundError } from 'app/course/learning-paths/exceptions/entity-not-found.error';
 
 @Component({
     selector: 'jhi-learning-path-student-page',
@@ -38,25 +38,29 @@ export class LearningPathStudentPageComponent implements OnInit {
     }
 
     private async loadLearningPathId(courseId: number): Promise<void> {
-        this.isLoading.set(true);
         try {
+            this.isLoading.set(true);
             const learningPathId = await this.learningApiService.getLearningPathId(courseId);
             this.learningPathId.set(learningPathId);
         } catch (error) {
-            if (error instanceof EntityNotFoundError) {
-                await this.generateLearningPath(courseId);
+            // If learning path does not exist (404) ignore the error
+            if (!(error instanceof EntityNotFoundError)) {
+                this.alertService.error(error);
             }
-            this.alertService.error(error);
+        } finally {
+            this.isLoading.set(false);
         }
-        this.isLoading.set(false);
     }
 
-    private async generateLearningPath(courseId: number): Promise<void> {
+    async generateLearningPath(courseId: number): Promise<void> {
         try {
+            this.isLoading.set(true);
             const learningPathId = await this.learningApiService.generateLearningPath(courseId);
             this.learningPathId.set(learningPathId);
         } catch (error) {
             this.alertService.error(error);
+        } finally {
+            this.isLoading.set(false);
         }
     }
 }

--- a/src/main/webapp/i18n/de/learningPath.json
+++ b/src/main/webapp/i18n/de/learningPath.json
@@ -11,6 +11,11 @@
             },
             "competencyGraphModal": {
                 "title": "Abhängigkeiten der Lernpfadkompetenzen"
+            },
+            "generation": {
+                "title": "Willkommen bei deinem Lernpfad!",
+                "description": "Der Lernpfad ermöglicht es dir, in deinem eigenen Tempo zu lernen, mit einer personalisierten Lernreise, die auf deine Leistung zugeschnitten ist. Sie passt sich dynamisch an und stellt sicher, dass du immer die relevantesten Inhalte und Herausforderungen erhältst. Starte jetzt und erlebe deinen individuellen Weg zum Erfolg!",
+                "generateButton": "Meinen Lernfpad starten"
             }
         }
     }

--- a/src/main/webapp/i18n/en/learningPath.json
+++ b/src/main/webapp/i18n/en/learningPath.json
@@ -13,8 +13,8 @@
                 "title": "Learning path competency relations"
             },
             "generation": {
-                "title": "Welcome to learning paths!",
-                "description": "Welcome to your learning path! This feature lets you learn at your own pace with a personalized journey tailored to your performance. It adapts dynamically, ensuring you always have the most relevant content and challenges. Start now and experience a customized path to success!",
+                "title": "Welcome to your learning path!",
+                "description": "This feature lets you learn at your own pace with a personalized journey tailored to your performance. It adapts dynamically, ensuring you always have the most relevant content and challenges. Start now and experience a customized path to success!",
                 "generateButton": "Start my learning path"
             }
         }

--- a/src/main/webapp/i18n/en/learningPath.json
+++ b/src/main/webapp/i18n/en/learningPath.json
@@ -11,6 +11,11 @@
             },
             "competencyGraphModal": {
                 "title": "Learning path competency relations"
+            },
+            "generation": {
+                "title": "Welcome to learning paths!",
+                "description": "Welcome to your learning path! This feature lets you learn at your own pace with a personalized journey tailored to your performance. It adapts dynamically, ensuring you always have the most relevant content and challenges. Start now and experience a customized path to success!",
+                "generateButton": "Start my learning path"
             }
         }
     }

--- a/src/test/javascript/spec/component/learning-paths/pages/learning-path-student-page.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-paths/pages/learning-path-student-page.component.spec.ts
@@ -12,6 +12,7 @@ import { MockTranslateService } from '../../../helpers/mocks/service/mock-transl
 import { LearningPathApiService } from 'app/course/learning-paths/services/learning-path-api.service';
 import { AlertService } from 'app/core/util/alert.service';
 import { MockAlertService } from '../../../helpers/mocks/service/mock-alert.service';
+import { EntityNotFoundError } from 'app/course/learning-paths/exceptions/entity-not-found.error';
 
 describe('LearningPathStudentPageComponent', () => {
     let component: LearningPathStudentPageComponent;
@@ -101,8 +102,38 @@ describe('LearningPathStudentPageComponent', () => {
         expect(alertServiceErrorSpy).toHaveBeenCalledOnce();
     });
 
-    it('should set isLoading correctly during load', async () => {
+    it('should set isLoading correctly during learning path load', async () => {
         jest.spyOn(learningPathApiService, 'getLearningPathId').mockResolvedValue(learningPathId);
+        const loadingSpy = jest.spyOn(component.isLoading, 'set');
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(loadingSpy).toHaveBeenCalledWith(true);
+        expect(loadingSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('should generate learning path on click', async () => {
+        jest.spyOn(learningPathApiService, 'getLearningPathId').mockRejectedValue(new EntityNotFoundError());
+        const generateLearningPathSpy = jest.spyOn(learningPathApiService, 'generateLearningPath').mockResolvedValue(learningPathId);
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const generateLearningPathButton = fixture.debugElement.query(By.css('#generate-learning-path-button'));
+        generateLearningPathButton.nativeElement.click();
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(component.learningPathId()).toEqual(learningPathId);
+        expect(generateLearningPathSpy).toHaveBeenCalledWith(courseId);
+    });
+
+    it('should set isLoading correctly during learning path generation', async () => {
+        jest.spyOn(learningPathApiService, 'getLearningPathId').mockRejectedValue(new EntityNotFoundError());
+        jest.spyOn(learningPathApiService, 'generateLearningPath').mockResolvedValue(learningPathId);
         const loadingSpy = jest.spyOn(component.isLoading, 'set');
 
         fixture.detectChanges();

--- a/src/test/javascript/spec/component/learning-paths/pages/learning-path-student-page.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-paths/pages/learning-path-student-page.component.spec.ts
@@ -109,8 +109,8 @@ describe('LearningPathStudentPageComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        expect(loadingSpy).toHaveBeenCalledWith(true);
-        expect(loadingSpy).toHaveBeenCalledWith(false);
+        expect(loadingSpy).toHaveBeenNthCalledWith(1, true);
+        expect(loadingSpy).toHaveBeenNthCalledWith(2, false);
     });
 
     it('should generate learning path on click', async () => {
@@ -139,7 +139,7 @@ describe('LearningPathStudentPageComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        expect(loadingSpy).toHaveBeenCalledWith(true);
-        expect(loadingSpy).toHaveBeenCalledWith(false);
+        expect(loadingSpy).toHaveBeenNthCalledWith(1, true);
+        expect(loadingSpy).toHaveBeenNthCalledWith(2, false);
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PRs introduces students to the concept of learning paths if they did not use it before.

### Description
<!-- Describe your changes in detail -->
If a learning path has not been generated yet a new welcome text is displayed. The text shortly introduces the student to the concept of learning paths. Additionally the student generates his/her learning path him/herself by clicking on a new generation button.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 student (with no learning path generated yet)
- 1 lecture with learning paths enabled
- at least one Lecture Unit (or Exercise) connected to a competency

1. Log in to Artemis
2. Navigate to the course
3. navigate to learning paths
4. if no learning path has yet been generated a short text should be displayed and a generate button
5. by clicking on the generate button a learning path should be generated and the "normal" learning path UI should be displayed

The following test servers can be used for testing -> Course Johannes Wiest (if you don't want to test locally).
Please mark the user if you tested with it that other testers don't use the same user.
#### [Test Server 1:](https://artemis-test1.artemis.cit.tum.de/)
- [ ] artemis_test_user_2
- [ ] artemis_test_user_4
- [ ] artemis_test_user_5

#### [Test Server 4:](https://artemis-test4.artemis.cit.tum.de/)
- [x] artemis_test_user_2
- [ ] artemis_test_user_3
- [x] artemis_test_user_4
- [x] artemis_test_user_5

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
unchanged

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1512" alt="image" src="https://github.com/ls1intum/Artemis/assets/29427964/e89fdf2c-8f5f-4604-8346-788b472c7d58">
