### PR TITLE
`Quiz exercises`: Enable manual quiz evaluation for non-exam exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Result.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Result.java
@@ -48,7 +48,6 @@ import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.hestia.CoverageFileReport;
 import de.tum.in.www1.artemis.domain.participation.Participation;
-import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
 import de.tum.in.www1.artemis.domain.view.QuizView;
@@ -513,17 +512,14 @@ public class Result extends DomainObject implements Comparable<Result> {
         }
     }
 
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
     /**
      * Updates the attributes "score" and "successful" by evaluating its submission.
      * <b>Important</b>: the quizSubmission has to be loaded with eager submitted answers, otherwise this method will not work correctly
+     *
+     * @param quizExercise the quiz exercise for which the submission should be evaluated, must contain access to the course to calculate the score correctly
      */
-    public void evaluateQuizSubmission() {
+    public void evaluateQuizSubmission(@NotNull QuizExercise quizExercise) {
         if (submission instanceof QuizSubmission quizSubmission) {
-            // get the exercise this result belongs to
-            StudentParticipation studentParticipation = (StudentParticipation) getParticipation();
-            QuizExercise quizExercise = (QuizExercise) studentParticipation.getExercise();
             // update score
             setScore(quizExercise.getScoreForSubmission(quizSubmission), quizExercise.getCourseViaExerciseGroupOrCourseMember());
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/UserRoleDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/UserRoleDTO.java
@@ -26,6 +26,6 @@ public record UserRoleDTO(Long userId, String username, UserRole role) {
 
     @SuppressWarnings("unused")
     UserRoleDTO(Long userId, String username, String role) {
-        this(userId, username, UserRole.valueOf(role));
+        this(userId, username, role != null ? UserRole.valueOf(role) : null);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamQuizService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamQuizService.java
@@ -117,7 +117,7 @@ public class ExamQuizService {
                     result.setSubmission(quizSubmission);
                     // calculate scores and update result and submission accordingly
                     quizSubmission.calculateAndUpdateScores(quizExercise.getQuizQuestions());
-                    result.evaluateQuizSubmission();
+                    result.evaluateQuizSubmission(quizExercise);
                     // remove submission to follow save order for ordered collections
                     result.setSubmission(null);
                     if (studentExam.isTestExam()) {
@@ -137,7 +137,7 @@ public class ExamQuizService {
                     quizSubmission.calculateAndUpdateScores(quizExercise.getQuizQuestions());
                     // prevent a lazy exception in the evaluateQuizSubmission method
                     result.setParticipation(participation);
-                    result.evaluateQuizSubmission();
+                    result.evaluateQuizSubmission(quizExercise);
                     if (studentExam.isTestExam()) {
                         result.rated(true);
                     }
@@ -226,7 +226,7 @@ public class ExamQuizService {
                         result.setSubmission(quizSubmission);
                         // calculate scores and update result and submission accordingly
                         quizSubmission.calculateAndUpdateScores(quizExercise.getQuizQuestions());
-                        result.evaluateQuizSubmission();
+                        result.evaluateQuizSubmission(quizExercise);
                         // remove submission to follow save order for ordered collections
                         result.setSubmission(null);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamQuizService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamQuizService.java
@@ -2,15 +2,8 @@ package de.tum.in.www1.artemis.service.exam;
 
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,11 +11,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.Result;
-import de.tum.in.www1.artemis.domain.Submission;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
-import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
-import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
@@ -33,7 +23,6 @@ import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.SubmittedAnswerRepository;
 import de.tum.in.www1.artemis.service.ResultService;
 import de.tum.in.www1.artemis.service.quiz.QuizStatisticService;
-import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 @Profile(PROFILE_CORE)
@@ -45,8 +34,6 @@ public class ExamQuizService {
     private final QuizExerciseRepository quizExerciseRepository;
 
     private final QuizStatisticService quizStatisticService;
-
-    private final ResultService resultService;
 
     private final StudentParticipationRepository studentParticipationRepository;
 
@@ -66,27 +53,8 @@ public class ExamQuizService {
         this.submissionRepository = submissionRepository;
         this.quizExerciseRepository = quizExerciseRepository;
         this.quizStatisticService = quizStatisticService;
-        this.resultService = resultService;
         this.quizSubmissionRepository = quizSubmissionRepository;
         this.submittedAnswerRepository = submittedAnswerRepository;
-    }
-
-    /**
-     * Evaluate the given quiz exercise by evaluate the submission for each participation (there is only one for each participation in exams)
-     * and update the statistics with the generated results.
-     *
-     * @param quizExerciseId the id of the QuizExercise that should be evaluated
-     */
-    public void evaluateQuizAndUpdateStatistics(@NotNull Long quizExerciseId) {
-        long start = System.nanoTime();
-        log.info("Starting quiz evaluation for quiz {}", quizExerciseId);
-        // We have to load the questions and statistics so that we can evaluate and update and we also need the participations and submissions that exist for this exercise so that
-        // they can be evaluated
-        var quizExercise = quizExerciseRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExerciseId);
-        Set<Result> createdResults = evaluateSubmissions(quizExercise);
-        log.info("Quiz evaluation for quiz {} finished after {} with {} created results", quizExercise.getId(), TimeLogUtil.formatDurationFrom(start), createdResults.size());
-        quizStatisticService.updateStatistics(createdResults, quizExercise);
-        log.info("Statistic update for quiz {} finished after {}", quizExercise.getId(), TimeLogUtil.formatDurationFrom(start));
     }
 
     /**
@@ -151,109 +119,5 @@ public class ExamQuizService {
                 submissionRepository.save(quizSubmission);
             }
         }
-    }
-
-    /**
-     * // @formatter:off
-     * Evaluate the given quiz exercise by performing the following actions for each participation:
-     * 1. Get the submission for each participation (there should be only one as in exam mode, the submission gets created upfront and will be updated)
-     * - If no submission is found, print a warning and continue as we cannot evaluate that submission
-     * - If more than one submission is found, select one of them
-     * 2. mark submission and participation as evaluated
-     * 3. Create a new result for the selected submission and calculate scores
-     * 4. Save the updated submission & participation and the newly created result
-     * <p>
-     * After processing all participations, the created results will be returned for further processing
-     * Note: We ignore test run participations
-     * // @formatter:on
-     *
-     * @param quizExercise the id of the QuizExercise that should be evaluated
-     * @return the newly generated results
-     */
-    private Set<Result> evaluateSubmissions(@NotNull QuizExercise quizExercise) {
-        Set<Result> createdResults = new HashSet<>();
-        List<StudentParticipation> studentParticipations = studentParticipationRepository.findAllWithEagerLegalSubmissionsAndEagerResultsByExerciseId(quizExercise.getId());
-        submittedAnswerRepository.loadQuizSubmissionsSubmittedAnswers(studentParticipations);
-
-        for (var participation : studentParticipations) {
-            if (!participation.isTestRun()) {
-                try {
-                    // reconnect so that the quiz questions are available later on (otherwise there will be a org.hibernate.LazyInitializationException)
-                    participation.setExercise(quizExercise);
-                    Set<Submission> submissions = participation.getSubmissions();
-                    QuizSubmission quizSubmission;
-                    if (submissions.isEmpty()) {
-                        log.warn("Found no submissions for participation {} (Participant {}) in quiz {}", participation.getId(), participation.getParticipant().getName(),
-                                quizExercise.getId());
-                        continue;
-                    }
-                    else if (submissions.size() > 1) {
-                        log.warn("Found multiple ({}) submissions for participation {} (Participant {}) in quiz {}, taking the one with highest id", submissions.size(),
-                                participation.getId(), participation.getParticipant().getName(), quizExercise.getId());
-                        List<Submission> submissionsList = new ArrayList<>(submissions);
-
-                        // Load submission with highest id
-                        submissionsList.sort(Comparator.comparing(Submission::getId).reversed());
-                        quizSubmission = (QuizSubmission) submissionsList.getFirst();
-                    }
-                    else {
-                        quizSubmission = (QuizSubmission) submissions.iterator().next();
-                    }
-
-                    participation.setInitializationState(InitializationState.FINISHED);
-
-                    boolean resultExisting = false;
-                    // create new result if none is existing
-                    Result result;
-                    if (participation.getResults().isEmpty()) {
-                        result = new Result().participation(participation);
-                    }
-                    else {
-                        resultExisting = true;
-                        result = participation.getResults().iterator().next();
-                    }
-                    // Only create Results once after the first evaluation
-                    if (!resultExisting) {
-                        // delete result from quizSubmission, to be able to set a new one
-                        if (quizSubmission.getLatestResult() != null) {
-                            resultService.deleteResult(quizSubmission.getLatestResult(), true);
-                        }
-                        result.setRated(true);
-                        result.setAssessmentType(AssessmentType.AUTOMATIC);
-                        result.setCompletionDate(ZonedDateTime.now());
-
-                        // set submission to calculate scores
-                        result.setSubmission(quizSubmission);
-                        // calculate scores and update result and submission accordingly
-                        quizSubmission.calculateAndUpdateScores(quizExercise.getQuizQuestions());
-                        result.evaluateQuizSubmission(quizExercise);
-                        // remove submission to follow save order for ordered collections
-                        result.setSubmission(null);
-
-                        // NOTE: we save participation, submission and result here individually so that one exception (e.g. duplicated key) cannot destroy multiple student answers
-                        submissionRepository.save(quizSubmission);
-                        result = resultRepository.save(result);
-
-                        // add result to participation
-                        participation.addResult(result);
-                        studentParticipationRepository.save(participation);
-
-                        // add result to submission
-                        result.setSubmission(quizSubmission);
-                        quizSubmission.addResult(result);
-                        submissionRepository.save(quizSubmission);
-
-                        // Add result so that it can be returned (and processed later)
-                        createdResults.add(result);
-                    }
-                }
-                catch (Exception e) {
-                    log.error("Exception in evaluateExamQuizExercise() for user {} in quiz {}: {}", participation.getParticipantIdentifier(), quizExercise.getId(), e.getMessage(),
-                            e);
-                }
-            }
-
-        }
-        return createdResults;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -98,6 +98,7 @@ import de.tum.in.www1.artemis.service.messaging.InstanceMessageSendService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationService;
 import de.tum.in.www1.artemis.service.plagiarism.PlagiarismCaseService.PlagiarismMapping;
 import de.tum.in.www1.artemis.service.quiz.QuizPoolService;
+import de.tum.in.www1.artemis.service.quiz.QuizResultService;
 import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 import de.tum.in.www1.artemis.web.rest.dto.BonusExampleDTO;
 import de.tum.in.www1.artemis.web.rest.dto.BonusResultDTO;
@@ -124,6 +125,8 @@ public class ExamService {
 
     private static final int EXAM_ACTIVE_DAYS = 7;
 
+    private final QuizResultService quizResultService;
+
     @Value("${artemis.course-archives-path}")
     private Path examArchivesDirPath;
 
@@ -136,8 +139,6 @@ public class ExamService {
     private final ProgrammingExerciseRepository programmingExerciseRepository;
 
     private final QuizExerciseRepository quizExerciseRepository;
-
-    private final ExamQuizService examQuizService;
 
     private final ExamDateService examDateService;
 
@@ -191,7 +192,7 @@ public class ExamService {
 
     private static final String NOT_ALLOWED_TO_ACCESS_THE_GRADE_SUMMARY = "You are not allowed to access the grade summary of a student exam ";
 
-    public ExamService(ExamDateService examDateService, ExamRepository examRepository, StudentExamRepository studentExamRepository, ExamQuizService examQuizService,
+    public ExamService(ExamDateService examDateService, ExamRepository examRepository, StudentExamRepository studentExamRepository,
             InstanceMessageSendService instanceMessageSendService, TutorLeaderboardService tutorLeaderboardService, StudentParticipationRepository studentParticipationRepository,
             ComplaintRepository complaintRepository, ComplaintResponseRepository complaintResponseRepository, UserRepository userRepository,
             ProgrammingExerciseRepository programmingExerciseRepository, QuizExerciseRepository quizExerciseRepository, ExamLiveEventsService examLiveEventsService,
@@ -199,14 +200,13 @@ public class ExamService {
             GroupNotificationService groupNotificationService, GradingScaleRepository gradingScaleRepository, PlagiarismCaseRepository plagiarismCaseRepository,
             AuthorizationCheckService authorizationCheckService, BonusService bonusService, ExerciseDeletionService exerciseDeletionService,
             SubmittedAnswerRepository submittedAnswerRepository, AuditEventRepository auditEventRepository, CourseScoreCalculationService courseScoreCalculationService,
-            CourseRepository courseRepository, QuizPoolService quizPoolService) {
+            CourseRepository courseRepository, QuizPoolService quizPoolService, QuizResultService quizResultService) {
         this.examDateService = examDateService;
         this.examRepository = examRepository;
         this.studentExamRepository = studentExamRepository;
         this.userRepository = userRepository;
         this.studentParticipationRepository = studentParticipationRepository;
         this.programmingExerciseRepository = programmingExerciseRepository;
-        this.examQuizService = examQuizService;
         this.instanceMessageSendService = instanceMessageSendService;
         this.complaintRepository = complaintRepository;
         this.complaintResponseRepository = complaintResponseRepository;
@@ -229,6 +229,7 @@ public class ExamService {
         this.courseRepository = courseRepository;
         this.quizPoolService = quizPoolService;
         this.defaultObjectMapper = new ObjectMapper();
+        this.quizResultService = quizResultService;
     }
 
     /**
@@ -1138,7 +1139,7 @@ public class ExamService {
         long start = System.nanoTime();
         log.debug("Evaluating {} quiz exercises in exam {}", quizExercises.size(), exam.getId());
         // Evaluate all quizzes for that exercise
-        quizExercises.stream().map(Exercise::getId).forEach(examQuizService::evaluateQuizAndUpdateStatistics);
+        quizExercises.stream().map(Exercise::getId).forEach(quizResultService::evaluateQuizAndUpdateStatistics);
         if (log.isDebugEnabled()) {
             log.debug("Evaluated {} quiz exercises in exam {} in {}", quizExercises.size(), exam.getId(), TimeLogUtil.formatDurationFrom(start));
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizExerciseService.java
@@ -127,7 +127,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
             // update Successful-Flag in Result
             StudentParticipation studentParticipation = (StudentParticipation) result.getParticipation();
             studentParticipation.setExercise(quizExercise);
-            result.evaluateQuizSubmission();
+            result.evaluateQuizSubmission(quizExercise);
 
             submissions.add(quizSubmission);
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizResultService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizResultService.java
@@ -77,7 +77,9 @@ public class QuizResultService {
         var quizExercise = quizExerciseRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExerciseId);
         Set<Result> createdResults = evaluateSubmissions(quizExercise);
         log.info("Quiz evaluation for quiz {} finished after {} with {} created results", quizExercise.getId(), TimeLogUtil.formatDurationFrom(start), createdResults.size());
-        quizStatisticService.recalculateStatistics(quizExercise);
+        if (quizExercise.getQuizPointStatistic() == null) {
+            quizStatisticService.recalculateStatistics(quizExercise);
+        }
         quizStatisticService.updateStatistics(createdResults, quizExercise);
         log.info("Statistic update for quiz {} finished after {}", quizExercise.getId(), TimeLogUtil.formatDurationFrom(start));
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizResultService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizResultService.java
@@ -1,0 +1,187 @@
+package de.tum.in.www1.artemis.service.quiz;
+
+import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import de.tum.in.www1.artemis.domain.Result;
+import de.tum.in.www1.artemis.domain.Submission;
+import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
+import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
+import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
+import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
+import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
+import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
+import de.tum.in.www1.artemis.repository.ResultRepository;
+import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
+import de.tum.in.www1.artemis.repository.SubmissionRepository;
+import de.tum.in.www1.artemis.repository.SubmittedAnswerRepository;
+import de.tum.in.www1.artemis.service.ResultService;
+import de.tum.in.www1.artemis.service.util.TimeLogUtil;
+
+@Profile(PROFILE_CORE)
+@Service
+public class QuizResultService {
+
+    private static final Logger log = LoggerFactory.getLogger(QuizResultService.class);
+
+    private final QuizExerciseRepository quizExerciseRepository;
+
+    private final QuizStatisticService quizStatisticService;
+
+    private final StudentParticipationRepository studentParticipationRepository;
+
+    private final SubmittedAnswerRepository submittedAnswerRepository;
+
+    private final ResultService resultService;
+
+    private final SubmissionRepository submissionRepository;
+
+    private final ResultRepository resultRepository;
+
+    public QuizResultService(QuizExerciseRepository quizExerciseRepository, QuizStatisticService quizStatisticService,
+            StudentParticipationRepository studentParticipationRepository, SubmittedAnswerRepository submittedAnswerRepository, ResultService resultService,
+            SubmissionRepository submissionRepository, ResultRepository resultRepository) {
+        this.quizExerciseRepository = quizExerciseRepository;
+        this.quizStatisticService = quizStatisticService;
+        this.studentParticipationRepository = studentParticipationRepository;
+        this.submittedAnswerRepository = submittedAnswerRepository;
+        this.resultService = resultService;
+        this.submissionRepository = submissionRepository;
+        this.resultRepository = resultRepository;
+    }
+
+    /**
+     * Evaluate the given quiz exercise by evaluate the submission for each participation (there is only one for each participation in exams)
+     * and update the statistics with the generated results.
+     *
+     * @param quizExerciseId the id of the QuizExercise that should be evaluated
+     */
+    public void evaluateQuizAndUpdateStatistics(@NotNull Long quizExerciseId) {
+        long start = System.nanoTime();
+        log.info("Starting quiz evaluation for quiz {}", quizExerciseId);
+        // We have to load the questions and statistics so that we can evaluate and update and we also need the participations and submissions that exist for this exercise so that
+        // they can be evaluated
+        var quizExercise = quizExerciseRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExerciseId);
+        Set<Result> createdResults = evaluateSubmissions(quizExercise);
+        log.info("Quiz evaluation for quiz {} finished after {} with {} created results", quizExercise.getId(), TimeLogUtil.formatDurationFrom(start), createdResults.size());
+        quizStatisticService.updateStatistics(createdResults, quizExercise);
+        log.info("Statistic update for quiz {} finished after {}", quizExercise.getId(), TimeLogUtil.formatDurationFrom(start));
+    }
+
+    /**
+     * // @formatter:off
+     * Evaluate the given quiz exercise by performing the following actions for each participation:
+     * 1. Get the submission for each participation (there should be only one as in exam mode, the submission gets created upfront and will be updated)
+     * - If no submission is found, print a warning and continue as we cannot evaluate that submission
+     * - If more than one submission is found, select one of them
+     * 2. mark submission and participation as evaluated
+     * 3. Create a new result for the selected submission and calculate scores
+     * 4. Save the updated submission & participation and the newly created result
+     * <p>
+     * After processing all participations, the created results will be returned for further processing
+     * Note: We ignore test run participations
+     * // @formatter:on
+     *
+     * @param quizExercise the id of the QuizExercise that should be evaluated
+     * @return the newly generated results
+     */
+    private Set<Result> evaluateSubmissions(@NotNull QuizExercise quizExercise) {
+        Set<Result> createdResults = new HashSet<>();
+        List<StudentParticipation> studentParticipations = studentParticipationRepository.findAllWithEagerLegalSubmissionsAndEagerResultsByExerciseId(quizExercise.getId());
+        submittedAnswerRepository.loadQuizSubmissionsSubmittedAnswers(studentParticipations);
+
+        for (var participation : studentParticipations) {
+            if (!participation.isTestRun()) {
+                try {
+                    // reconnect so that the quiz questions are available later on (otherwise there will be a org.hibernate.LazyInitializationException)
+                    participation.setExercise(quizExercise);
+                    Set<Submission> submissions = participation.getSubmissions();
+                    QuizSubmission quizSubmission;
+                    if (submissions.isEmpty()) {
+                        log.warn("Found no submissions for participation {} (Participant {}) in quiz {}", participation.getId(), participation.getParticipant().getName(),
+                                quizExercise.getId());
+                        continue;
+                    }
+                    else if (submissions.size() > 1) {
+                        log.warn("Found multiple ({}) submissions for participation {} (Participant {}) in quiz {}, taking the one with highest id", submissions.size(),
+                                participation.getId(), participation.getParticipant().getName(), quizExercise.getId());
+                        List<Submission> submissionsList = new ArrayList<>(submissions);
+
+                        // Load submission with highest id
+                        submissionsList.sort(Comparator.comparing(Submission::getId).reversed());
+                        quizSubmission = (QuizSubmission) submissionsList.getFirst();
+                    }
+                    else {
+                        quizSubmission = (QuizSubmission) submissions.iterator().next();
+                    }
+
+                    participation.setInitializationState(InitializationState.FINISHED);
+
+                    boolean resultExisting = false;
+                    // create new result if none is existing
+                    Result result;
+                    if (participation.getResults().isEmpty()) {
+                        result = new Result().participation(participation);
+                    }
+                    else {
+                        resultExisting = true;
+                        result = participation.getResults().iterator().next();
+                    }
+                    // Only create Results once after the first evaluation
+                    if (!resultExisting) {
+                        // delete result from quizSubmission, to be able to set a new one
+                        if (quizSubmission.getLatestResult() != null) {
+                            resultService.deleteResult(quizSubmission.getLatestResult(), true);
+                        }
+                        result.setRated(true);
+                        result.setAssessmentType(AssessmentType.AUTOMATIC);
+                        result.setCompletionDate(ZonedDateTime.now());
+
+                        // set submission to calculate scores
+                        result.setSubmission(quizSubmission);
+                        // calculate scores and update result and submission accordingly
+                        quizSubmission.calculateAndUpdateScores(quizExercise.getQuizQuestions());
+                        result.evaluateQuizSubmission(quizExercise);
+                        // remove submission to follow save order for ordered collections
+                        result.setSubmission(null);
+
+                        // NOTE: we save participation, submission and result here individually so that one exception (e.g. duplicated key) cannot destroy multiple student answers
+                        submissionRepository.save(quizSubmission);
+                        result = resultRepository.save(result);
+
+                        // add result to participation
+                        participation.addResult(result);
+                        studentParticipationRepository.save(participation);
+
+                        // add result to submission
+                        result.setSubmission(quizSubmission);
+                        quizSubmission.addResult(result);
+                        submissionRepository.save(quizSubmission);
+
+                        // Add result so that it can be returned (and processed later)
+                        createdResults.add(result);
+                    }
+                }
+                catch (Exception e) {
+                    log.error("Exception in evaluateExamQuizExercise() for user {} in quiz {}: {}", participation.getParticipantIdentifier(), quizExercise.getId(), e.getMessage(),
+                            e);
+                }
+            }
+
+        }
+        return createdResults;
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizResultService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizResultService.java
@@ -77,6 +77,7 @@ public class QuizResultService {
         var quizExercise = quizExerciseRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExerciseId);
         Set<Result> createdResults = evaluateSubmissions(quizExercise);
         log.info("Quiz evaluation for quiz {} finished after {} with {} created results", quizExercise.getId(), TimeLogUtil.formatDurationFrom(start), createdResults.size());
+        quizStatisticService.recalculateStatistics(quizExercise);
         quizStatisticService.updateStatistics(createdResults, quizExercise);
         log.info("Statistic update for quiz {} finished after {}", quizExercise.getId(), TimeLogUtil.formatDurationFrom(start));
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizSubmissionService.java
@@ -118,7 +118,7 @@ public class QuizSubmissionService extends AbstractQuizSubmissionService<QuizSub
         // setup result - submission relation
         result.setSubmission(quizSubmission);
         // calculate score and update result accordingly
-        result.evaluateQuizSubmission();
+        result.evaluateQuizSubmission(quizExercise);
         quizSubmission.addResult(result);
         quizSubmission.setParticipation(participation);
 
@@ -175,7 +175,7 @@ public class QuizSubmissionService extends AbstractQuizSubmissionService<QuizSub
             result.setSubmission(quizSubmission);
 
             quizSubmission.calculateAndUpdateScores(quizExercise.getQuizQuestions());
-            result.evaluateQuizSubmission();
+            result.evaluateQuizSubmission(quizExercise);
 
             quizSubmissionRepository.save(quizSubmission);
             resultRepository.save(result);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -57,7 +57,6 @@ import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastEditor;
-import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastInstructor;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastStudent;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastTutor;
 import de.tum.in.www1.artemis.security.annotations.enforceRoleInCourse.EnforceAtLeastTutorInCourse;
@@ -613,11 +612,10 @@ public class QuizExerciseResource {
      * @return ResponseEntity void
      */
     @PostMapping("quiz-exercises/{quizExerciseId}/evaluate")
-    @EnforceAtLeastInstructor
-    public ResponseEntity<Void> evaluateQuizExercises(@PathVariable Long quizExerciseId) {
+    @EnforceAtLeastInstructorInExercise(resourceIdFieldName = "quizExerciseId")
+    public ResponseEntity<Long> evaluateQuizExercises(@PathVariable Long quizExerciseId) {
         log.debug("REST request to evaluate quiz exercise {}", quizExerciseId);
         var quizExercise = quizExerciseRepository.findByIdElseThrow(quizExerciseId);
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, quizExercise, null);
         if (!quizExercise.isQuizEnded()) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "quizNotEndedYet", "Quiz hasn't ended yet.")).build();
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -607,12 +607,12 @@ public class QuizExerciseResource {
     }
 
     /**
-     * POST /quiz-exercises/{exerciseId}/evaluate-quiz-exercises : Evaluate the quiz exercise
+     * POST /quiz-exercises/{exerciseId}/evaluate : Evaluate the quiz exercise
      *
      * @param quizExerciseId the id of the quiz exercise
      * @return ResponseEntity void
      */
-    @PostMapping("quiz-exercises/{quizExerciseId}/evaluate-quiz-exercises")
+    @PostMapping("quiz-exercises/{quizExerciseId}/evaluate")
     @EnforceAtLeastInstructor
     public ResponseEntity<Void> evaluateQuizExercises(@PathVariable Long quizExerciseId) {
         log.debug("REST request to evaluate quiz exercise {}", quizExerciseId);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -613,7 +613,7 @@ public class QuizExerciseResource {
      */
     @PostMapping("quiz-exercises/{quizExerciseId}/evaluate")
     @EnforceAtLeastInstructorInExercise(resourceIdFieldName = "quizExerciseId")
-    public ResponseEntity<Long> evaluateQuizExercise(@PathVariable Long quizExerciseId) {
+    public ResponseEntity<Void> evaluateQuizExercise(@PathVariable Long quizExerciseId) {
         log.debug("REST request to evaluate quiz exercise {}", quizExerciseId);
         var quizExercise = quizExerciseRepository.findByIdElseThrow(quizExerciseId);
         if (!quizExercise.isQuizEnded()) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -613,7 +613,7 @@ public class QuizExerciseResource {
      */
     @PostMapping("quiz-exercises/{quizExerciseId}/evaluate")
     @EnforceAtLeastInstructorInExercise(resourceIdFieldName = "quizExerciseId")
-    public ResponseEntity<Long> evaluateQuizExercises(@PathVariable Long quizExerciseId) {
+    public ResponseEntity<Long> evaluateQuizExercise(@PathVariable Long quizExerciseId) {
         log.debug("REST request to evaluate quiz exercise {}", quizExerciseId);
         var quizExercise = quizExerciseRepository.findByIdElseThrow(quizExerciseId);
         if (!quizExercise.isQuizEnded()) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizSubmissionResource.java
@@ -211,7 +211,7 @@ public class QuizSubmissionResource {
         result.setAssessmentType(AssessmentType.AUTOMATIC);
         result.setCompletionDate(ZonedDateTime.now());
         // calculate score and update result accordingly
-        result.evaluateQuizSubmission();
+        result.evaluateQuizSubmission(quizExercise);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-manage-buttons.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-manage-buttons.component.html
@@ -54,6 +54,12 @@
                 <fa-icon [icon]="faWrench" />
                 <span class="d-none d-md-inline" jhiTranslate="entity.action.re-evaluate"></span>
             </a>
+            <button id="evaluateQuizExerciseButton" class="btn btn-primary mt-1" (click)="evaluateQuizExercise()" [disabled]="isEvaluatingQuizExercise || !quizExercise.quizEnded">
+                @if (isEvaluatingQuizExercise) {
+                    <span class="d-none d-md-inline spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                }
+                <span jhiTranslate="artemisApp.studentExams.evaluateQuizExercises"></span>
+            </button>
         }
     </div>
     @if (quizExercise.isAtLeastInstructor) {

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-manage-buttons.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-manage-buttons.component.html
@@ -54,12 +54,16 @@
                 <fa-icon [icon]="faWrench" />
                 <span class="d-none d-md-inline" jhiTranslate="entity.action.re-evaluate"></span>
             </a>
-            <button id="evaluateQuizExerciseButton" class="btn btn-primary mt-1" (click)="evaluateQuizExercise()" [disabled]="isEvaluatingQuizExercise || !quizExercise.quizEnded">
-                @if (isEvaluatingQuizExercise) {
-                    <span class="d-none d-md-inline spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                }
-                <span jhiTranslate="artemisApp.studentExams.evaluateQuizExercises"></span>
-            </button>
+            <jhi-button
+                [btnType]="ButtonType.WARNING"
+                [btnSize]="ButtonSize.SMALL"
+                [title]="'artemisApp.quizExercise.evaluateQuizExercise'"
+                [icon]="faClipboardCheck"
+                [isLoading]="isEvaluatingQuizExercise"
+                (onClick)="evaluateQuizExercise()"
+                [hidden]="!quizExercise.quizEnded"
+                class="me-1 mb-1"
+            />
         }
     </div>
     @if (quizExercise.isAtLeastInstructor) {

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-manage-buttons.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-manage-buttons.component.ts
@@ -7,8 +7,9 @@ import { ActionType } from 'app/shared/delete-dialog/delete-dialog.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { AlertService } from 'app/core/util/alert.service';
 import { EventManager } from 'app/core/util/event-manager.service';
-import { faEye, faFileExport, faListAlt, faSignal, faTable, faTrash, faUndo, faWrench } from '@fortawesome/free-solid-svg-icons';
+import { faClipboardCheck, faEye, faFileExport, faListAlt, faSignal, faTable, faTrash, faUndo, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { Subject } from 'rxjs';
+import { ButtonSize, ButtonType } from 'app/shared/components/button.component';
 
 @Component({
     selector: 'jhi-quiz-exercise-manage-buttons',
@@ -24,6 +25,10 @@ export class QuizExerciseManageButtonsComponent implements OnInit {
     readonly faTrash = faTrash;
     readonly faListAlt = faListAlt;
     readonly faUndo = faUndo;
+    readonly faClipboardCheck = faClipboardCheck;
+
+    readonly ButtonType = ButtonType;
+    readonly ButtonSize = ButtonSize;
 
     protected dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
@@ -119,8 +124,8 @@ export class QuizExerciseManageButtonsComponent implements OnInit {
     evaluateQuizExercise() {
         this.isEvaluatingQuizExercise = true;
         this.exerciseService.evaluateQuizExercise(this.quizExercise.id!).subscribe({
-            next: (res) => {
-                this.alertService.success('artemisApp.quizExercise.evaluateQuizExerciseSuccess', { number: res?.body });
+            next: () => {
+                this.alertService.success('artemisApp.quizExercise.evaluateQuizExerciseSuccess');
                 this.isEvaluatingQuizExercise = false;
             },
             error: (error: HttpErrorResponse) => {

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-manage-buttons.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-manage-buttons.component.ts
@@ -33,6 +33,7 @@ export class QuizExerciseManageButtonsComponent implements OnInit {
     isExamMode: boolean;
 
     baseUrl: string;
+    isEvaluatingQuizExercise: boolean;
 
     constructor(
         private quizExerciseService: QuizExerciseService,
@@ -112,6 +113,20 @@ export class QuizExerciseManageButtonsComponent implements OnInit {
                 this.loadQuizExercises.emit();
             },
             error: (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
+        });
+    }
+
+    evaluateQuizExercise() {
+        this.isEvaluatingQuizExercise = true;
+        this.exerciseService.evaluateQuizExercise(this.quizExercise.id!).subscribe({
+            next: (res) => {
+                this.alertService.success('artemisApp.quizExercise.evaluateQuizExerciseSuccess', { number: res?.body });
+                this.isEvaluatingQuizExercise = false;
+            },
+            error: (error: HttpErrorResponse) => {
+                this.dialogErrorSource.next(error.message);
+                this.isEvaluatingQuizExercise = false;
+            },
         });
     }
 }

--- a/src/main/webapp/app/exercises/shared/exercise/exercise.service.ts
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise.service.ts
@@ -183,6 +183,15 @@ export class ExerciseService {
         return this.http.delete<void>(`${this.resourceUrl}/${exerciseId}/reset`, { observe: 'response' });
     }
 
+    /**
+     * Evaluate the quiz exercise
+     * @param quizExerciseId id of the quiz exercise to be evaluated
+     * @returns void
+     */
+    evaluateQuizExercise(quizExerciseId: number): Observable<HttpResponse<void>> {
+        return this.http.post<any>(`api/quiz-exercises/${quizExerciseId}/evaluate`, {}, { observe: 'response' });
+    }
+
     getUpcomingExercises(): Observable<EntityArrayResponseType> {
         return this.http
             .get<Exercise[]>(`${this.adminResourceUrl}/upcoming`, { observe: 'response' })

--- a/src/main/webapp/i18n/de/quizExercise.json
+++ b/src/main/webapp/i18n/de/quizExercise.json
@@ -138,6 +138,8 @@
             "notParticipatedText": "Das Quiz ist beendet und du hast nicht daran teilgenommen. Es gibt keine Ergebnisse, die angezeigt werden können.",
             "statisticsNotPublished": "Die Übungsleitung hat keine Statistiken freigegeben.",
             "successfullySubmittedText": "Deine Antworten wurden erfolgreich abgegeben.<br><br>Die Ergebnisse werden angezeigt, nachdem das Quiz beendet ist.<br><br>Wenn die Ergebnisse 60 Sekunden nach Quiz Ende nicht automatisch angezeigt werden, dann lade die Seite bitte neu.",
+            "evaluateQuizExercise": "Quiz auswerten",
+            "evaluateQuizExerciseSuccess": "Quiz-Aufgabe erfolgreich ausgewertet!",
             "re-evaluate": {
                 "title": "Quiz für {{ param }} überarbeiten",
                 "resetQuiz": "Setze Quiz zurück",

--- a/src/main/webapp/i18n/en/quizExercise.json
+++ b/src/main/webapp/i18n/en/quizExercise.json
@@ -138,6 +138,8 @@
             "notParticipatedText": "The quiz has ended and you did not participate. There are no results to display.",
             "statisticsNotPublished": "The instructor has not published any statistics.",
             "successfullySubmittedText": "Your answers have been successfully submitted!<br><br>The results will appear after the quiz has ended.<br><br>If the results are not displayed automatically within 60s after the end of the quiz, please reload the page.",
+            "evaluateQuizExercise": "Evaluate quiz",
+            "evaluateQuizExerciseSuccess": "Quiz exercise successfully evaluated!",
             "re-evaluate": {
                 "title": "Re-evaluate Quiz Exercise for {{ param }}",
                 "resetQuiz": "Reset Quiz Exercise",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There was a bug in production that caused the automatic quiz evaluation to fail. Therefore we need a method to evaluate the quiz manually, which is a feature that could be useful as a backup in general.


### Description
<!-- Describe your changes in detail -->
This PR fixes the bug and also adds a button to the quiz detail page to evaluate the quiz. This is different from the re-evaluation, as the evaluation keeps old results and only creates new results for submissions that do not have one yet.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- Local DB access
- If you have a quiz exercise with already existing submissions and results you can skip straight to point 5

1. Log in to Artemis
2. Create a quiz
3. Participate in the quiz
4. Wait for the quiz to end
5. Go to the instructor detail page of the quiz
6. Go to your DB and find your result in the results table. Note it's ID
Go to the participants_score table and delete the entry where the last_result_id is the id of your result
Then delete the entry of your result in the results table
9. Click the "Participations" button
10. Click on your submissions
11. You will see no result
12. Go back to the detail page
13. Press the new evaluate quiz button
14. Now see you submission again and you have a result again.

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 1 Students
- 1 Exam with a Quiz Exercise
- If you have an exam with unevaluated quiz exercises you can skip to point 4

1. Log in to Artemis
2. Participate in the exam as a student
3. Wait for the exam to end
4. Go to the assessment page of the exam
7. Click the "Evaluate quizzes" button
8. If you look into the scores the students have results now

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
TODO

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/ls1intum/Artemis/assets/18218285/10b076ef-48b9-4d06-8709-851b8d0d3a21)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new button to evaluate quiz exercises in the quiz management UI.
  - Introduced a new `QuizResultService` for efficient quiz evaluation and statistics management.

- **Bug Fixes**
  - Improved handling of null values in `UserRoleDTO`.

- **Refactor**
  - Refactored quiz evaluation logic to accept `QuizExercise` as a parameter for accurate score calculation.

- **Documentation**
  - Updated German and English translations for the new quiz evaluation functionality.
  
- **Tests**
  - Added integration tests to ensure correct evaluation and result management of quiz exercises.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->