### PR TITLE
`Development`: Fix programming exercise assessment e2e test

### DIFF
--- a/src/test/cypress/support/pageobjects/exercises/programming/ProgrammingExerciseFeedbackPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/programming/ProgrammingExerciseFeedbackPage.ts
@@ -6,8 +6,8 @@ import { OnlineEditorPage } from './OnlineEditorPage';
  */
 export class ProgrammingExerciseFeedbackPage extends AbstractExerciseFeedback {
     shouldShowAdditionalFeedback(points: number, feedbackText: string) {
-        cy.reloadUntilFound(this.additionalFeedbackSelector);
-        cy.get(this.additionalFeedbackSelector).contains(`${points} Points: ${feedbackText}`).should('be.visible');
+        cy.reloadUntilFound(this.ADDITIONAL_FEEDBACK_SELECTOR);
+        cy.get(this.ADDITIONAL_FEEDBACK_SELECTOR).contains(`${points} Points: ${feedbackText}`).should('be.visible');
     }
 
     shouldShowCodeFeedback(exerciseID: number, filename: string, feedback: string, points: string, editorPage: OnlineEditorPage) {

--- a/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseFeedbackPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseFeedbackPage.ts
@@ -8,8 +8,8 @@ import { expect } from '@playwright/test';
  */
 export class ProgrammingExerciseFeedbackPage extends AbstractExerciseFeedback {
     async shouldShowAdditionalFeedback(points: number, feedbackText: string) {
-        await Commands.reloadUntilFound(this.page, this.page.locator(this.additionalFeedbackSelector));
-        await expect(this.page.locator(this.additionalFeedbackSelector).getByText(`${points} Points: ${feedbackText}`)).toBeVisible();
+        await Commands.reloadUntilFound(this.page, this.page.locator(this.ADDITIONAL_FEEDBACK_SELECTOR));
+        await expect(this.page.locator(this.ADDITIONAL_FEEDBACK_SELECTOR).getByText(`${points} Points: ${feedbackText}`)).toBeVisible();
     }
 
     async shouldShowCodeFeedback(exerciseID: number, filename: string, feedback: string, points: string, editorPage: OnlineEditorPage) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently one e2e test is failing and should be fixed.

### Description
<!-- Describe your changes in detail -->
#8747 changed all constants to SCREAMING_SNAKE_CASE but missed the occurrences of `ADDITIONAL_FEEDBACK_SELECTOR`/`additionalFeedbackSelector` in the subclasses of `AbstractExerciseFeedback`. This PR fixes the capitalization of the variables in the subclasses.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved selector naming consistency and readability in test automation scripts for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->