### PR TITLE
`Development`: Fix client warning for competency accordion

### DIFF
--- a/src/main/webapp/app/course/competencies/competency-accordion/competency-accordion.component.ts
+++ b/src/main/webapp/app/course/competencies/competency-accordion/competency-accordion.component.ts
@@ -94,9 +94,9 @@ export class CompetencyAccordionComponent implements OnChanges {
         const courseExercises = this.course?.exercises ?? [];
         const exerciseIdToExercise = Object.fromEntries(courseExercises.map((exercise) => [exercise.id, exercise] as [number, Exercise]));
         const activeCompetencyExercises = (this.metrics.competencyMetrics?.exercises?.[this.competency.id] ?? [])
-            .flatMap((exerciseId) => [exerciseIdToExercise[exerciseId]] ?? [])
-            .filter((exercise) => exercise.releaseDate?.isBefore(dayjs()))
-            .filter((exercise) => exercise.dueDate?.isAfter(dayjs()) || isStartPracticeAvailable(exercise));
+            .flatMap((exerciseId) => [exerciseIdToExercise[exerciseId]])
+            .filter((exercise) => !exercise.releaseDate || exercise.releaseDate.isBefore(dayjs()))
+            .filter((exercise) => !exercise.dueDate || exercise.dueDate.isAfter(dayjs()) || isStartPracticeAvailable(exercise));
 
         const exerciseIdToMaxScore = Object.fromEntries(
             activeCompetencyExercises.map((exercise) => {

--- a/src/main/webapp/app/course/competencies/competency-accordion/competency-accordion.component.ts
+++ b/src/main/webapp/app/course/competencies/competency-accordion/competency-accordion.component.ts
@@ -95,8 +95,8 @@ export class CompetencyAccordionComponent implements OnChanges {
         const exerciseIdToExercise = Object.fromEntries(courseExercises.map((exercise) => [exercise.id, exercise] as [number, Exercise]));
         const activeCompetencyExercises = (this.metrics.competencyMetrics?.exercises?.[this.competency.id] ?? [])
             .flatMap((exerciseId) => [exerciseIdToExercise[exerciseId]])
-            .filter((exercise) => !exercise.releaseDate || exercise.releaseDate.isBefore(dayjs()))
-            .filter((exercise) => !exercise.dueDate || exercise.dueDate.isAfter(dayjs()) || isStartPracticeAvailable(exercise));
+            .filter((exercise) => exercise.releaseDate?.isBefore(dayjs()))
+            .filter((exercise) => exercise.dueDate?.isAfter(dayjs()) || isStartPracticeAvailable(exercise));
 
         const exerciseIdToMaxScore = Object.fromEntries(
             activeCompetencyExercises.map((exercise) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix #8849 

### Description
<!-- Describe your changes in detail -->
Fixes the client warning since the left side of the nullish operator was always defined.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2