### PR TITLE
`Programming exercises`: Fix the diff editor layout

### DIFF
--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-line-stat.component.html
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-line-stat.component.html
@@ -2,10 +2,10 @@
     <span class="text-success">+{{ addedLineCount }}</span>
     <span class="text-danger">-{{ removedLineCount }}</span>
     <span class="diff-block-bar">
-        @for (i of [].constructor(addedSquareCount); track i) {
+        @for (i of [].constructor(addedSquareCount); track $index) {
             <span class="diff-block bg-success"></span>
         }
-        @for (i of [].constructor(removedSquareCount); track i) {
+        @for (i of [].constructor(removedSquareCount); track $index) {
             <span class="diff-block bg-danger"></span>
         }
     </span>

--- a/src/main/webapp/app/shared/monaco-editor/monaco-diff-editor.component.ts
+++ b/src/main/webapp/app/shared/monaco-editor/monaco-diff-editor.component.ts
@@ -120,7 +120,7 @@ export class MonacoDiffEditorComponent implements OnInit, OnDestroy {
 
     /**
      * Adjusts the height of the editor to fit the new content height.
-     * @param newContentHeight
+     * @param newContentHeight The new content height of the editor.
      */
     adjustHeightAndLayout(newContentHeight: number) {
         this.monacoDiffEditorContainerElement.style.height = newContentHeight + 'px';
@@ -131,7 +131,9 @@ export class MonacoDiffEditorComponent implements OnInit, OnDestroy {
      * Adjusts this editor to fit its container.
      */
     layout(): void {
-        this._editor.layout();
+        const width = this.monacoDiffEditorContainerElement.clientWidth;
+        const height = this.monacoDiffEditorContainerElement.clientHeight;
+        this._editor.layout({ width, height });
     }
 
     /**


### PR DESCRIPTION
### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There is a bug where the diff editor becomes 5px tall.

### Description
<!-- Describe your changes in detail -->
- Fixed the bug by specifying the height and width explicitly
- Also silenced some warnings by using a proper tracking expression

### Steps for Testing
Prerequisites: LocalVC test server + Programming exercise with one submission

1. Instructor: View the diff between the template & solution. Verify that the files are displayed and that you can interact normally with the diff editor.
2. Instructor or student: Go to Open repository > Commit history > any commit and verify that all files are displayed normally.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage

Only trivial changes

### Screenshots

No UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved tracking and control flow in the HTML template for displaying added and removed line counts in the Git Diff Report.
  - Enhanced Monaco editor to dynamically adjust its height based on new content and ensure it fits its container properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->