### PR TITLE
`Tutorial groups`: Fix an issue where tutorial groups are not being displayed

### DIFF
--- a/src/main/webapp/app/overview/course-tutorial-groups/course-tutorial-groups.component.html
+++ b/src/main/webapp/app/overview/course-tutorial-groups/course-tutorial-groups.component.html
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-between gap-3">
     @if (course) {
         <div [ngClass]="{ 'sidebar-collapsed': isCollapsed }">
-            <jhi-sidebar [itemSelected]="tutorialGroupSelected" [courseId]="courseId" [sidebarData]="sidebarData" />
+            <jhi-sidebar [itemSelected]="tutorialGroupSelected" [courseId]="courseId" [sidebarData]="sidebarData" [collapseState]="DEFAULT_COLLAPSE_STATE" />
         </div>
 
         @if (tutorialGroupSelected) {

--- a/src/main/webapp/app/overview/course-tutorial-groups/course-tutorial-groups.component.ts
+++ b/src/main/webapp/app/overview/course-tutorial-groups/course-tutorial-groups.component.ts
@@ -12,7 +12,7 @@ import { AlertService } from 'app/core/util/alert.service';
 import { TutorialGroupFreePeriod } from 'app/entities/tutorial-group/tutorial-group-free-day.model';
 import { CourseStorageService } from 'app/course/manage/course-storage.service';
 import { TutorialGroupsConfiguration } from 'app/entities/tutorial-group/tutorial-groups-configuration.model';
-import { AccordionGroups, SidebarCardElement, SidebarData, TutorialGroupCategory } from 'app/types/sidebar';
+import { AccordionGroups, CollapseState, SidebarCardElement, SidebarData, TutorialGroupCategory } from 'app/types/sidebar';
 import { CourseOverviewService } from '../course-overview.service';
 import { cloneDeep } from 'lodash-es';
 
@@ -20,6 +20,12 @@ const TUTORIAL_UNIT_GROUPS: AccordionGroups = {
     registered: { entityData: [] },
     further: { entityData: [] },
     all: { entityData: [] },
+};
+
+const DEFAULT_COLLAPSE_STATE: CollapseState = {
+    registered: false,
+    all: true,
+    further: true,
 };
 
 @Component({
@@ -42,6 +48,7 @@ export class CourseTutorialGroupsComponent implements OnInit, OnDestroy {
     sidebarData: SidebarData;
     sortedTutorialGroups: TutorialGroup[] = [];
     accordionTutorialGroupsGroups: AccordionGroups = TUTORIAL_UNIT_GROUPS;
+    readonly DEFAULT_COLLAPSE_STATE = DEFAULT_COLLAPSE_STATE;
     sidebarTutorialGroups: SidebarCardElement[] = [];
 
     constructor(
@@ -83,7 +90,7 @@ export class CourseTutorialGroupsComponent implements OnInit, OnDestroy {
     navigateToTutorialGroup() {
         const upcomingTutorialGroup = this.courseOverviewService.getUpcomingTutorialGroup(this.tutorialGroups);
         const lastSelectedTutorialGroup = this.getLastSelectedTutorialGroup();
-        const tutorialGroupId = this.route.firstChild?.snapshot.params.exerciseId;
+        const tutorialGroupId = this.route.firstChild?.snapshot.params.tutorialGroupId;
         if (!tutorialGroupId && lastSelectedTutorialGroup) {
             this.router.navigate([lastSelectedTutorialGroup], { relativeTo: this.route, replaceUrl: true });
             this.tutorialGroupSelected = true;

--- a/src/main/webapp/app/types/sidebar.ts
+++ b/src/main/webapp/app/types/sidebar.ts
@@ -18,7 +18,7 @@ export type ChannelGroupCategory =
 export type SidebarTypes = 'exercise' | 'conversation' | 'default';
 
 export type AccordionGroups = Record<TimeGroupCategory | TutorialGroupCategory | ChannelGroupCategory | string, { entityData: SidebarCardElement[] }>;
-export type CollapseState = Record<TimeGroupCategory, boolean> | Record<ChannelGroupCategory, boolean>;
+export type CollapseState = Record<TimeGroupCategory, boolean> | Record<ChannelGroupCategory, boolean> | Record<TutorialGroupCategory, boolean>;
 export type ChannelAccordionShowAdd = Record<ChannelGroupCategory, boolean>;
 export type ChannelTypeIcons = Record<ChannelGroupCategory, IconProp>;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Description
<!-- Describe your changes in detail -->
Default CollapseState for Tutorial Groups where missing. 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Students
- 1 or more Tutorial Groups

1. Log in to Artemis
2. Navigate to Tutorial Groups
3. Verify that tutorial groups are displayed 


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before: 
<img width="768" alt="image" src="https://github.com/ls1intum/Artemis/assets/75392103/7b72a981-1378-4f58-852c-8779de92f551">

Now: 
<img width="804" alt="image" src="https://github.com/ls1intum/Artemis/assets/75392103/cf895581-7638-45c9-a57f-213f0800613d">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added default collapse state behavior to the sidebar in the course tutorial groups view.

- **Improvements**
  - Sidebar now uses `tutorialGroupId` for navigation instead of `exerciseId`.

- **Bug Fixes**
  - Enhanced collapse state management by extending supported categories in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->