### PR TITLE
`File upload exercises`: Fix an issue when downloading submission files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -437,6 +437,7 @@ dependencies {
     implementation "org.jgrapht:jgrapht-core:1.5.2"
     // use newest version of guava to avoid security issues through outdated dependencies
     implementation "com.google.guava:guava:33.2.1-jre"
+    implementation "com.sun.activation:jakarta.activation:2.0.1"
 
     // use newest version of gson to avoid security issues through outdated dependencies
     implementation "com.google.code.gson:gson:2.11.0"

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
@@ -94,7 +94,7 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
     private StudentParticipation participation;
 
     @BeforeEach
-    void initTestCase() throws Exception {
+    void initTestCase() {
         userUtilService.addUsers(TEST_PREFIX, 3, 1, 0, 1);
         Course course = fileUploadExerciseUtilService.addCourseWithFourFileUploadExercise();
         releasedFileUploadExercise = exerciseUtilService.findFileUploadExerciseWithTitle(course.getExercises(), "released");
@@ -153,7 +153,19 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
         // TODO: upload a real file from the file system twice with the same and with different names and test both works correctly
     }
 
+    @Test
+    @WithMockUser(TEST_PREFIX + "student3")
+    void submitFileSpecialExtensions() throws Exception {
+        releasedFileUploadExercise.setFilePattern("ipynb");
+        exerciseRepository.save(releasedFileUploadExercise);
+        submitFile("test.ipynb", false, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
     private void submitFile(String filename, boolean differentFilePath) throws Exception {
+        submitFile(filename, differentFilePath, MediaType.IMAGE_PNG);
+    }
+
+    private void submitFile(String filename, boolean differentFilePath, MediaType expectedMediaType) throws Exception {
         FileUploadSubmission submission = ParticipationFactory.generateFileUploadSubmission(false);
 
         if (differentFilePath) {
@@ -185,7 +197,7 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
         assertThat(fileBytes.length > 0).as("Stored file has content").isTrue();
         checkDetailsHidden(returnedSubmission, true);
 
-        MvcResult file = request.performMvcRequest(get(returnedSubmission.getFilePath())).andExpect(status().isOk()).andExpect(content().contentType(MediaType.IMAGE_PNG))
+        MvcResult file = request.performMvcRequest(get(returnedSubmission.getFilePath())).andExpect(status().isOk()).andExpect(content().contentType(expectedMediaType))
                 .andReturn();
         assertThat(file.getResponse().getContentAsByteArray()).isEqualTo(validFile.getBytes());
     }


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
There is an internal server error when downloading submission files of non-standard data types.
Fixes #8870


### Description
The fallback solution for determining the media type uses the activation API. Here the necessary dependency got lost, probally during the Spring Boot 3 upgrade due to the package rename


### Steps for Testing
Prerequisites:
- 1 Tutor
- 1 Student
- 1 File Upload Exercise that allows Jupiter Notebook submission ( Add ipynb to the list of allowed file extensions)

1. Submit something as a student
2. As a tutor, download the submitted file
3. See that the download works.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced testing capabilities for file submissions with support for different file paths and expected media types.

- **Chores**
  - Added a new dependency: `jakarta.activation:2.0.1`.
  - Updated other dependencies for security reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->