### PR TITLE
`Exam mode`: Fix displaying exam grade with and without bonus

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/result-overview/exam-result-overview.component.html
+++ b/src/main/webapp/app/exam/participate/summary/result-overview/exam-result-overview.component.html
@@ -133,6 +133,21 @@
                             }}
                         }
                     </div>
+                    @if (studentExamWithGrade?.studentResult?.gradeWithBonus?.finalGrade) {
+                        <div class="h5">
+                            <span jhiTranslate="artemisApp.exam.examSummary.gradeBeforeBonus"></span>
+                            {{ studentExamWithGrade.studentResult.overallGrade }}
+                        </div>
+                        <div class="h5">
+                            <span jhiTranslate="artemisApp.exam.examSummary.gradeAfterBonus"></span>
+                            {{ studentExamWithGrade.studentResult.gradeWithBonus?.finalGrade }}
+                        </div>
+                    } @else {
+                        <div class="h5">
+                            <span jhiTranslate="artemisApp.exam.examSummary.grade"></span>
+                            {{ studentExamWithGrade.studentResult.overallGrade }}
+                        </div>
+                    }
                 </div>
             </div>
         </jhi-collapsible-card>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client

- [x] I added multiple screenshots/screencasts of my UI changes.



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Students should be able to see their final grade when viewing the exam results.

### Description
<!-- Describe your changes in detail -->

Fixes https://github.com/ls1intum/Artemis/issues/8909

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Fixes https://github.com/ls1intum/Artemis/issues/8909


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
![image](https://github.com/ls1intum/Artemis/assets/33342534/55974b09-b963-4c00-b163-c85194c55967)

With no grade bonus:
![image](https://github.com/ls1intum/Artemis/assets/33342534/5b691539-469f-4bd2-969b-431f9e05dc3c)

With grade bonus enabled:
![image](https://github.com/ls1intum/Artemis/assets/33342534/b3cd487a-9563-47ed-a87f-50fcc4e4d6e8)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced conditional rendering for exam result overview. Now displays grade information differently based on the presence of a final grade, showing grades before and after any bonus application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->