### PR TITLE
`Learning paths`: Fix competency graph if no relations exist

### DIFF
--- a/src/main/webapp/app/course/learning-paths/components/competency-graph/competency-graph.component.ts
+++ b/src/main/webapp/app/course/learning-paths/components/competency-graph/competency-graph.component.ts
@@ -25,14 +25,17 @@ export class CompetencyGraphComponent implements OnInit, AfterViewInit {
 
     private readonly competencyGraph: WritableSignal<CompetencyGraphDTO> = signal<CompetencyGraphDTO>({ nodes: [], edges: [] });
     readonly nodes: Signal<CompetencyGraphNodeDTO[]> = computed(() => this.competencyGraph().nodes);
-    readonly edges: Signal<CompetencyGraphEdgeDTO[]> = computed(() =>
-        this.competencyGraph().edges.map((edge) => {
+    readonly edges: Signal<CompetencyGraphEdgeDTO[]> = computed(() => {
+        if (!this.competencyGraph().edges) {
+            return [];
+        }
+        return this.competencyGraph().edges!.map((edge) => {
             return {
                 ...edge,
                 id: `edge-${edge.id}`,
             };
-        }),
-    );
+        });
+    });
 
     readonly layout: WritableSignal<string | Layout> = signal('dagreCluster');
     readonly update$: Subject<boolean> = new Subject<boolean>();

--- a/src/main/webapp/app/course/learning-paths/components/competency-graph/competency-graph.component.ts
+++ b/src/main/webapp/app/course/learning-paths/components/competency-graph/competency-graph.component.ts
@@ -25,17 +25,7 @@ export class CompetencyGraphComponent implements OnInit, AfterViewInit {
 
     private readonly competencyGraph: WritableSignal<CompetencyGraphDTO> = signal<CompetencyGraphDTO>({ nodes: [], edges: [] });
     readonly nodes: Signal<CompetencyGraphNodeDTO[]> = computed(() => this.competencyGraph().nodes);
-    readonly edges: Signal<CompetencyGraphEdgeDTO[]> = computed(() => {
-        if (!this.competencyGraph().edges) {
-            return [];
-        }
-        return this.competencyGraph().edges!.map((edge) => {
-            return {
-                ...edge,
-                id: `edge-${edge.id}`,
-            };
-        });
-    });
+    readonly edges: Signal<CompetencyGraphEdgeDTO[]> = computed(() => this.competencyGraph().edges?.map((edge) => ({ ...edge, id: `edge-${edge.id}` })) || []);
 
     readonly layout: WritableSignal<string | Layout> = signal('dagreCluster');
     readonly update$: Subject<boolean> = new Subject<boolean>();

--- a/src/main/webapp/app/entities/competency/learning-path.model.ts
+++ b/src/main/webapp/app/entities/competency/learning-path.model.ts
@@ -69,7 +69,7 @@ export interface CompetencyGraphEdgeDTO {
 
 export interface CompetencyGraphDTO {
     nodes: CompetencyGraphNodeDTO[];
-    edges: CompetencyGraphEdgeDTO[];
+    edges?: CompetencyGraphEdgeDTO[];
 }
 
 export class NgxLearningPathDTO {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The competency graph of the learning path feature wasn't displayed of no relations between competencies existed.

### Description
<!-- Describe your changes in detail -->
The graph now checks if relations (edges) exist. If not the edges are replaced with an empty array that the competencies are shown anyhow.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 2 competencies **without** relations (each with one lecture unit)

1. Log in to Artemis
2. Navigate to the student learning path UI
3. Open the navigation overview
4. open the competency graph
5. the competencies should be visible without edges between them

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability of the competency graph by handling cases where edges might be null.
	- Enhanced flexibility by making the `edges` property optional in the competency graph model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->