### PR TITLE
`Assessment`: Improve layout in scores overview

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
@@ -155,11 +155,6 @@
                     [rowClass]="settings.rowClass"
                     [scrollbarH]="settings.scrollbarH"
                 >
-                    <ngx-datatable-column prop="" [minWidth]="50" [width]="60">
-                        <ng-template ngx-datatable-cell-template let-rowIndex="rowIndex">
-                            {{ rowIndex + 1 }}
-                        </ng-template>
-                    </ngx-datatable-column>
                     <ngx-datatable-column prop="" [sortable]="true" [minWidth]="100" [width]="180">
                         <ng-template ngx-datatable-header-template>
                             <span class="datatable-header-cell-wrapper" (click)="controls.onSort(exercise.teamMode ? 'team.name' : 'student.name')">

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
@@ -238,27 +238,29 @@
                             </ng-template>
                         </ngx-datatable-column>
                     }
-                    <ngx-datatable-column prop="" [sortable]="true" [minWidth]="100" [width]="100">
-                        <ng-template ngx-datatable-header-template>
-                            <span class="datatable-header-cell-wrapper d-inline-block w-100 text-center" (click)="controls.onSort('results?.last()?.assessmentNote?.note')">
-                                <fa-icon [icon]="faComment" [ngbTooltip]="'artemisApp.assessment.assessmentNote' | artemisTranslate" />
-                                <fa-icon [icon]="controls.iconForSortPropField('results?.last()?.assessmentNote?.note')" />
-                            </span>
-                        </ng-template>
-                        <ng-template ngx-datatable-cell-template let-value="value">
-                            @if (value.results?.last()?.assessmentNote?.note?.trim()) {
-                                <span class="w-100 text-center">
-                                    <fa-icon
-                                        [ngbPopover]="value.results?.last()?.assessmentNote.note"
-                                        [triggers]="'hover'"
-                                        [icon]="faComment"
-                                        [container]="'body'"
-                                        [popoverClass]="'max-vw-30 popover-text-truncate-4-lines'"
-                                    />
+                    @if (exercise.assessmentType === AssessmentType.MANUAL || exercise.assessmentType === AssessmentType.SEMI_AUTOMATIC) {
+                        <ngx-datatable-column prop="" [sortable]="true" [minWidth]="100" [width]="100">
+                            <ng-template ngx-datatable-header-template>
+                                <span class="datatable-header-cell-wrapper d-inline-block w-100 text-center" (click)="controls.onSort('results?.last()?.assessmentNote?.note')">
+                                    <fa-icon [icon]="faComment" [ngbTooltip]="'artemisApp.assessment.assessmentNote' | artemisTranslate" />
+                                    <fa-icon [icon]="controls.iconForSortPropField('results?.last()?.assessmentNote?.note')" />
                                 </span>
-                            }
-                        </ng-template>
-                    </ngx-datatable-column>
+                            </ng-template>
+                            <ng-template ngx-datatable-cell-template let-value="value">
+                                @if (value.results?.last()?.assessmentNote?.note?.trim()) {
+                                    <span class="w-100 text-center">
+                                        <fa-icon
+                                            [ngbPopover]="value.results?.last()?.assessmentNote.note"
+                                            [triggers]="'hover'"
+                                            [icon]="faComment"
+                                            [container]="'body'"
+                                            [popoverClass]="'max-vw-30 popover-text-truncate-4-lines'"
+                                        />
+                                    </span>
+                                }
+                            </ng-template>
+                        </ngx-datatable-column>
+                    }
                     @if (exercise.type === ExerciseType.PROGRAMMING && afterDueDate) {
                         <ngx-datatable-column prop="" [minWidth]="100" [width]="110">
                             <ng-template ngx-datatable-header-template>


### PR DESCRIPTION
@coderabbitai ignore

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The scores table takes up a lot of vertical space. We want to reduce this if possible to support smaller window sizes.

### Description
<!-- Describe your changes in detail -->
Two main changes:

- Remove the index column
  - The index does not really contribute relevant information. It depends on the order of the results as returned by the database query, or the sorting order. E.g. if `StudentA` is listed in row `1` by default, some other student `StudentD` might end up being numbered `1` when sorting by submission date, and `StudentG` might be numbered `1` when sorting by score.
  - The student name/login serves as easily recognisable identifier column.
- Only show the assessment note column if the exercise has manual assessment enabled
  - For other exercises this column would always be empty otherwise.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Exercise

1. Go to the exercise details page for an exercise.
2. Go to the ‘Scores’ table for this exercise.
3. If manual assessment is enabled, the assessment note column ( :left_speech_bubble:  ) should be shown. Otherwise not.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
unchanged

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
