### PR TITLE
`Integrade code lifecycle`: Change priority of test exams and practice exercises

### DIFF
--- a/docs/dev/system-design/integrated-code-lifecycle/integrated-code-lifecycle-system-design.inc
+++ b/docs/dev/system-design/integrated-code-lifecycle/integrated-code-lifecycle-system-design.inc
@@ -80,7 +80,7 @@ The CI Management has access to the database and the file system.
 
 The CI Management subsystem implements the ``ContinuousIntegrationTriggerService`` interface, the ``LocalCITriggerService`` which provides the ``triggerBuild`` method. This method gets called whenever a repository needs to be tested, i.e. after creating a programming exercise or when a student submits code.
 When the ``triggerBuild`` method is called, all necessary information necessary to execute the build job is prepared and used to create a ``LocalCIBuildJobQueueItem`` object. The object contains, among other things, repository URIs, the build configuration, a user-defined build script (prepared by the ``LocalCIScriptService``) and a priority value.
-This object is then added to the job queue where it will then be retrieved by a build agent to execute the build job. The following diagram shows the structure of the ``LocalCIBuildJobQueueItem``:
+The priority value is determined based on whether the programming exercise is part of an exam or not. The exercise due date is also taken into account. This object is then added to the job queue where it will then be retrieved by a build agent to execute the build job. The following diagram shows the structure of the ``LocalCIBuildJobQueueItem``:
 
 .. figure:: /dev/system-design/integrated-code-lifecycle/Integrated_Code_Lifecycle_Build_Job_Item.svg
    :align: center

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -142,8 +142,9 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
 
         long courseId = programmingExercise.getCourseViaExerciseGroupOrCourseMember().getId();
 
-        // Exam exercises have a higher priority than normal exercises
-        int priority = programmingExercise.isExamExercise() ? 1 : 2;
+        // Exam exercises have highest priority, Exercises with due date in the past have lowest priority
+        int priority = programmingExercise.isExamExercise() ? 1
+                : (programmingExercise.getDueDate() != null && programmingExercise.getDueDate().isBefore(ZonedDateTime.now())) ? 3 : 2;
 
         ZonedDateTime submissionDate = ZonedDateTime.now();
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -283,7 +283,7 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
         if (programmingExercise.isExamExercise()) {
             boolean isTestExam = programmingExercise.getExerciseGroup().getExam().isTestExam();
             if (isTestExam) {
-                return 3;
+                return 2;
             }
             if (participation instanceof ProgrammingExerciseStudentParticipation studentParticipation) {
                 return examDateService.isIndividualExerciseWorkingPeriodOver(programmingExercise.getExamViaExerciseGroupOrCourseMember(), studentParticipation) ? 3 : 1;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -143,8 +143,7 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
         long courseId = programmingExercise.getCourseViaExerciseGroupOrCourseMember().getId();
 
         // Exam exercises have highest priority, Exercises with due date in the past have lowest priority
-        int priority = programmingExercise.isExamExercise() ? 1
-                : (programmingExercise.getDueDate() != null && programmingExercise.getDueDate().isBefore(ZonedDateTime.now())) ? 3 : 2;
+        int priority = determinePriority(programmingExercise);
 
         ZonedDateTime submissionDate = ZonedDateTime.now();
 
@@ -273,5 +272,18 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
 
         return new BuildConfig(buildScript, dockerImage, commitHashToBuild, assignmentCommitHash, testCommitHash, branch, programmingLanguage, projectType,
                 staticCodeAnalysisEnabled, sequentialTestRunsEnabled, testwiseCoverageEnabled, resultPaths);
+    }
+
+    private int determinePriority(ProgrammingExercise programmingExercise) {
+        if (programmingExercise.isExamExercise()) {
+            boolean isTestExam = programmingExercise.getExerciseGroup().getExam().isTestExam();
+            return isTestExam ? 2 : 1;
+        }
+        else if (programmingExercise.getDueDate() != null && programmingExercise.getDueDate().isBefore(ZonedDateTime.now())) {
+            return 3;
+        }
+        else {
+            return 2;
+        }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/LocalCITriggerService.java
@@ -281,6 +281,10 @@ public class LocalCITriggerService implements ContinuousIntegrationTriggerServic
 
     private int determinePriority(ProgrammingExercise programmingExercise, ProgrammingExerciseParticipation participation) {
         if (programmingExercise.isExamExercise()) {
+            boolean isTestExam = programmingExercise.getExerciseGroup().getExam().isTestExam();
+            if (isTestExam) {
+                return 3;
+            }
             if (participation instanceof ProgrammingExerciseStudentParticipation studentParticipation) {
                 return examDateService.isIndividualExerciseWorkingPeriodOver(programmingExercise.getExamViaExerciseGroupOrCourseMember(), studentParticipation) ? 3 : 1;
             }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Changed priority depending on the programming exercise.
- Real exam: priority 1
- Test exam: priority 2
- Graded course exercise (i.e. before due date): priority 2
- Practice exercise or non-running exams (i.e. after due date): priority 3


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

You can thoroughly test this locally, follow the steps below, otherwise you can just make sure that everything works on TS3: Use [Test Course Mohamed Bilel Besrour](https://artemis-test3.artemis.cit.tum.de/courses/48). Exams and exercises will be prepared.

Easy testing:
- Go to TS3, use one of the student test users (artemis_test_user_1-5)
- Go to course [Test Course Mohamed Bilel Besrour](https://artemis-test3.artemis.cit.tum.de/courses/48)
- Make a submission for a test exam, real exam, exercise with past due data, exercise with future due date. The exams and exercises should already be there
- Check that the submission worked and you get a result for your submission

Thorough testing (locally):
Prerequisites:
- 1 Admin
- 1 Programming Exercise with due date already passed
- 1 Programming Exercise with due data in the future
- 1 TestExam with programming exercise
- 1 Real Exam with programming exercise

1. Start artemis with these profiles: `dev,localci,localvc,artemis,scheduling,core,ldap-only,local` (we removed buildagent so that buildjobs stay in the queue and are not processed)
2. Make a submission foreach of the programming exercises stated in the prerequisites 
3. Navigate to `Build Overview`
4. Under `Queued Build Jobs`, Make sure that each submission has the correct priority (as stated in the description)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved priority calculation for programming exercises in Continuous Integration (CI) management. Exam exercises now have the highest priority, and exercises with past due dates have the lowest priority.

- **Bug Fixes**
  - Enhanced the functionality of test cases by introducing checks and mechanisms for setting build priorities based on specific conditions related to programming exercises and exams.

- **Documentation**
  - Updated system design documentation to reflect changes in priority determination logic for CI build jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->