### PR TITLE
`Communication`: Fix an issue where the client does not keep track of the posts on screen

### DIFF
--- a/src/main/webapp/app/overview/course-conversations/course-wide-search/course-wide-search.component.html
+++ b/src/main/webapp/app/overview/course-conversations/course-wide-search/course-wide-search.component.html
@@ -77,7 +77,7 @@
                 </div>
             }
             <!-- no message exist -->
-            @if (!isFetchingPosts && totalNumberOfPosts === 0) {
+            @if (!isFetchingPosts && posts.length === 0) {
                 <div class="envelope">
                     <fa-icon size="5x" [icon]="faEnvelope" />
                 </div>
@@ -86,7 +86,7 @@
             <div
                 id="scrollableDiv"
                 #container
-                class="{{ totalNumberOfPosts !== 0 ? 'posting-infinite-scroll-container' : '' }}"
+                class="{{ posts.length !== 0 ? 'posting-infinite-scroll-container' : '' }}"
                 infinite-scroll
                 [scrollWindow]="false"
                 (scrolledUp)="fetchNextPage()"

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.html
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.html
@@ -53,7 +53,7 @@
                     </div>
                 }
                 <!-- no message exist -->
-                @if (!isFetchingPosts && (totalNumberOfPosts === 0 || !_activeConversation)) {
+                @if (!isFetchingPosts && (posts.length === 0 || !_activeConversation)) {
                     <div class="envelope">
                         <fa-icon size="5x" [icon]="faEnvelope" />
                     </div>
@@ -62,7 +62,7 @@
                 <div
                     id="scrollableDiv"
                     #container
-                    class="{{ totalNumberOfPosts !== 0 ? 'posting-infinite-scroll-container' : '' }}"
+                    class="{{ posts.length !== 0 ? 'posting-infinite-scroll-container' : '' }}"
                     infinite-scroll
                     [scrollWindow]="false"
                     (scrolledUp)="fetchNextPage()"

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -45,7 +45,7 @@ export class MetisService implements OnDestroy {
     private course: Course;
     private courseId: number;
     private cachedPosts: Post[] = [];
-    private cachedTotalNumberOfPots: number;
+    private cachedTotalNumberOfPosts: number;
     private subscriptionChannel?: string;
 
     private courseWideTopicSubscription: Subscription;
@@ -180,16 +180,16 @@ export class MetisService implements OnDestroy {
                     // if the context changed, we need to fetch posts and dismiss cached posts
                     this.cachedPosts = res.body!;
                 }
-                this.cachedTotalNumberOfPots = Number(res.headers.get('X-Total-Count'));
+                this.cachedTotalNumberOfPosts = Number(res.headers.get('X-Total-Count'));
                 this.posts$.next(this.cachedPosts);
-                this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
+                this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                 this.createSubscriptionFromPostContextFilter();
             });
         } else {
             // if we do not require force update, e.g. because only the post title, tag or content changed,
             // we can emit the previously cached posts
             this.posts$.next(this.cachedPosts);
-            this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
+            this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
         }
     }
 
@@ -207,7 +207,7 @@ export class MetisService implements OnDestroy {
                 if (indexToUpdate === -1) {
                     this.cachedPosts = [createdPost, ...this.cachedPosts];
                     this.posts$.next(this.cachedPosts);
-                    this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
+                    this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                 }
             }),
         );
@@ -233,7 +233,7 @@ export class MetisService implements OnDestroy {
                         }
                         this.cachedPosts[indexOfCachedPost].answers!.push(createdAnswerPost);
                         this.posts$.next(this.cachedPosts);
-                        this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
+                        this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                     }
                 }
             }),
@@ -254,7 +254,7 @@ export class MetisService implements OnDestroy {
                     updatedPost.answers = [...(this.cachedPosts[indexToUpdate].answers ?? [])];
                     this.cachedPosts[indexToUpdate] = updatedPost;
                     this.posts$.next(this.cachedPosts);
-                    this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
+                    this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                 }
             }),
         );
@@ -276,7 +276,7 @@ export class MetisService implements OnDestroy {
                         updatedAnswerPost.post = { ...this.cachedPosts[indexOfCachedPost], answers: [], reactions: [] };
                         this.cachedPosts[indexOfCachedPost].answers![indexOfAnswer] = updatedAnswerPost;
                         this.posts$.next(this.cachedPosts);
-                        this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
+                        this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                     }
                 }
             }),
@@ -307,7 +307,7 @@ export class MetisService implements OnDestroy {
                     if (indexToUpdate > -1) {
                         this.cachedPosts.splice(indexToUpdate, 1);
                         this.posts$.next(this.cachedPosts);
-                        this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
+                        this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                     }
                 }),
             )
@@ -330,7 +330,7 @@ export class MetisService implements OnDestroy {
                         if (indexOfAnswer > -1) {
                             this.cachedPosts[indexOfCachedPost].answers!.splice(indexOfAnswer, 1);
                             this.posts$.next(this.cachedPosts);
-                            this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
+                            this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                         }
                     }
                 }),
@@ -358,7 +358,7 @@ export class MetisService implements OnDestroy {
                         // Need to create a new message object since Angular doesn't detect changes otherwise
                         this.cachedPosts[indexToUpdate] = { ...cachedPost };
                         this.posts$.next(this.cachedPosts);
-                        this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
+                        this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                     }
                 }
             }),
@@ -383,7 +383,7 @@ export class MetisService implements OnDestroy {
                         // Need to create a new message object since Angular doesn't detect changes otherwise
                         this.cachedPosts[indexToUpdate] = { ...cachedPost };
                         this.posts$.next(this.cachedPosts);
-                        this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
+                        this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                     }
                 }
             }),

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -180,7 +180,7 @@ export class MetisService implements OnDestroy {
                     // if the context changed, we need to fetch posts and dismiss cached posts
                     this.cachedPosts = res.body!;
                 }
-                this.cachedTotalNumberOfPosts = Number(res.headers.get('X-Total-Count'));
+                this.cachedTotalNumberOfPosts = Number(res.headers.get('X-Total-Count') ?? '0');
                 this.posts$.next(this.cachedPosts);
                 this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                 this.createSubscriptionFromPostContextFilter();
@@ -328,7 +328,7 @@ export class MetisService implements OnDestroy {
                         // Delete the answer if it still exists (might already be deleted due to WebSocket message)
                         const indexOfAnswer = this.cachedPosts[indexOfCachedPost].answers?.findIndex((answer) => answer.id === answerPost.id) ?? -1;
                         if (indexOfAnswer > -1) {
-                            this.cachedPosts[indexOfCachedPost].answers!.splice(indexOfAnswer, 1);
+                            this.cachedPosts[indexOfCachedPost].answers?.splice(indexOfAnswer, 1);
                             this.posts$.next(this.cachedPosts);
                             this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPosts);
                         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested all changes and their related features with all corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Addresses #8985 

The issue was that the _totalNumberOfPosts_ observable in the metis service did not match the posts visible on screen. This led to unintended behaviour in the client in an empty conversation. The icon showing that the conversation was empty did not dissapear when a new message was created, and did not appear when the last remaining message was deleted.

### Description
Instead of listening to the _totalNumberOfPosts_ variable, in the case of the envelope, I changed it to listen to the .length of the _posts_ variable. The _posts_ variable is the cached posts that are actually visible on screen.

Additionally, I checked all occurences of the _totalNumberOfPosts_ observable in the rest of the code for similar issues. The only other occurence is in a thread or while searching, when comparing it for paging, which I did not see any issue with.

Lastly, i fixed a tiny typo in the metis service. I changed the naming of the local variable _cachedTotalNumberOfPots_ -> _cachedTotalNumberOfPosts_.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Course with communication enabled
- 2 Users

With both users:
1. Log in to Artemis
2. Go to a course with communication enabled
3. Go to the "Communication" tab
4. Go to a conversation without any messages
5. Write the first message with one user
6. Check on the current user if the envelope dissapears (same should apply for the other user that had the conversation open)
7. Delete the message
8. Check if the envelope appears

The same flow should also work for the course wide search form.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of search results display by updating conditions based on the length of the `posts` array.

- **Refactor**
  - Renamed variable for clarity and consistency within the post handling logic.

These changes enhance the reliability and clarity of search result displays and internal logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->