### PR TITLE
`Development`: Reduce redundant autowires in server tests

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractArtemisIntegrationTest.java
@@ -26,10 +26,12 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUri;
+import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.MockDelegate;
 import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
+import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.FileService;
 import de.tum.in.www1.artemis.service.ModelingSubmissionService;
 import de.tum.in.www1.artemis.service.TextBlockService;
@@ -169,6 +171,12 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
 
     @Autowired
     protected CourseUtilService courseUtilService;
+
+    @Autowired
+    protected ExerciseUtilService exerciseUtilService;
+
+    @Autowired
+    protected UserRepository userRepository;
 
     @Autowired
     protected ExerciseRepository exerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractArtemisIntegrationTest.java
@@ -27,6 +27,7 @@ import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUri;
 import de.tum.in.www1.artemis.exercise.programming.MockDelegate;
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.service.FileService;
@@ -174,6 +175,9 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
 
     @Autowired
     protected ResultRepository resultRepository;
+
+    @Autowired
+    protected CourseRepository courseRepository;
 
     @BeforeEach
     void mockMailService() {

--- a/src/test/java/de/tum/in/www1/artemis/BuildPlanIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/BuildPlanIntegrationTest.java
@@ -33,8 +33,7 @@ class BuildPlanIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTes
     @Autowired
     private ProgrammingTriggerService programmingTriggerService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/BuildPlanIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/BuildPlanIntegrationTest.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.BuildPlan;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
@@ -18,7 +17,6 @@ import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilServic
 import de.tum.in.www1.artemis.repository.BuildPlanRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.programming.ProgrammingTriggerService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class BuildPlanIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
@@ -32,11 +30,6 @@ class BuildPlanIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTes
 
     @Autowired
     private ProgrammingTriggerService programmingTriggerService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/BuildPlanIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/BuildPlanIntegrationTest.java
@@ -16,7 +16,6 @@ import de.tum.in.www1.artemis.domain.enumeration.ProjectType;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.repository.BuildPlanRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
-import de.tum.in.www1.artemis.service.programming.ProgrammingTriggerService;
 
 class BuildPlanIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
@@ -27,9 +26,6 @@ class BuildPlanIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTes
 
     @Autowired
     private BuildPlanRepository buildPlanRepository;
-
-    @Autowired
-    private ProgrammingTriggerService programmingTriggerService;
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/ContentVersionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ContentVersionIntegrationTest.java
@@ -19,8 +19,7 @@ class ContentVersionIntegrationTest extends AbstractSpringIntegrationIndependent
 
     private static final String TEST_PREFIX = "contentversion";
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @BeforeEach
     void initTestCase() {

--- a/src/test/java/de/tum/in/www1/artemis/ContentVersionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ContentVersionIntegrationTest.java
@@ -6,20 +6,16 @@ import java.net.URI;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.filter.ApiVersionFilter;
 
 class ContentVersionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "contentversion";
-
-
 
     @BeforeEach
     void initTestCase() {

--- a/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
@@ -59,8 +59,7 @@ class FileIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private LectureRepository lectureRepo;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
@@ -25,7 +25,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Attachment;
 import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.User;
@@ -40,7 +39,6 @@ import de.tum.in.www1.artemis.repository.AttachmentRepository;
 import de.tum.in.www1.artemis.repository.AttachmentUnitRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.LectureUnitCompletionRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.ExamUserDTO;
 
 class FileIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -59,16 +57,11 @@ class FileIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private LectureRepository lectureRepo;
 
-
-
     @Autowired
     private LectureUtilService lectureUtilService;
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/LongFeedbackResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LongFeedbackResourceIntegrationTest.java
@@ -24,8 +24,7 @@ class LongFeedbackResourceIntegrationTest extends AbstractSpringIntegrationIndep
 
     private static final String LONG_FEEDBACK = "a".repeat(Constants.FEEDBACK_DETAIL_TEXT_DATABASE_MAX_LENGTH + 10);
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/LongFeedbackResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LongFeedbackResourceIntegrationTest.java
@@ -16,15 +16,12 @@ import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class LongFeedbackResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "longfeedbackintegration";
 
     private static final String LONG_FEEDBACK = "a".repeat(Constants.FEEDBACK_DETAIL_TEXT_DATABASE_MAX_LENGTH + 10);
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/LongFeedbackResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LongFeedbackResourceIntegrationTest.java
@@ -13,7 +13,6 @@ import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Feedback;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.Result;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 
@@ -25,9 +24,6 @@ class LongFeedbackResourceIntegrationTest extends AbstractSpringIntegrationIndep
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/Lti13LaunchIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/Lti13LaunchIntegrationTest.java
@@ -23,7 +23,6 @@ import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import io.jsonwebtoken.Jwts;
 
 /**
@@ -50,8 +49,6 @@ class Lti13LaunchIntegrationTest extends AbstractSpringIntegrationIndependentTes
     private static final String VALID_STATE = "validState";
 
     private static final String TEST_PREFIX = "lti13launchintegrationtest";
-
-
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/Lti13LaunchIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/Lti13LaunchIntegrationTest.java
@@ -17,12 +17,10 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import de.tum.in.www1.artemis.repository.UserRepository;
 import io.jsonwebtoken.Jwts;
 
 /**
@@ -49,9 +47,6 @@ class Lti13LaunchIntegrationTest extends AbstractSpringIntegrationIndependentTes
     private static final String VALID_STATE = "validState";
 
     private static final String TEST_PREFIX = "lti13launchintegrationtest";
-
-    @Autowired
-    private UserRepository userRepository;
 
     @BeforeEach
     void init() {

--- a/src/test/java/de/tum/in/www1/artemis/Lti13LaunchIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/Lti13LaunchIntegrationTest.java
@@ -51,8 +51,7 @@ class Lti13LaunchIntegrationTest extends AbstractSpringIntegrationIndependentTes
 
     private static final String TEST_PREFIX = "lti13launchintegrationtest";
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/LtiDeepLinkingIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LtiDeepLinkingIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.lti.Claims;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import io.jsonwebtoken.Jwts;
@@ -53,9 +52,6 @@ class LtiDeepLinkingIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private CourseUtilService courseUtilService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     private Course course;
 

--- a/src/test/java/de/tum/in/www1/artemis/LtiDeepLinkingIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LtiDeepLinkingIntegrationTest.java
@@ -32,15 +32,11 @@ import de.tum.in.www1.artemis.config.lti.CustomLti13Configurer;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.lti.Claims;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import io.jsonwebtoken.Jwts;
 
 class LtiDeepLinkingIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "ltideeplinkingintegrationtest";
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/LtiDeepLinkingIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LtiDeepLinkingIntegrationTest.java
@@ -44,8 +44,7 @@ class LtiDeepLinkingIntegrationTest extends AbstractSpringIntegrationIndependent
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/LtiDeepLinkingIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LtiDeepLinkingIntegrationTest.java
@@ -29,12 +29,10 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.RSAKey;
 
 import de.tum.in.www1.artemis.config.lti.CustomLti13Configurer;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.lti.Claims;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import io.jsonwebtoken.Jwts;
 
 class LtiDeepLinkingIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -44,13 +42,8 @@ class LtiDeepLinkingIntegrationTest extends AbstractSpringIntegrationIndependent
     @Autowired
     private UserRepository userRepository;
 
-
-
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     private Course course;
 

--- a/src/test/java/de/tum/in/www1/artemis/LtiQuizIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LtiQuizIntegrationTest.java
@@ -66,8 +66,7 @@ class LtiQuizIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private CourseUtilService courseUtilService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/LtiQuizIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LtiQuizIntegrationTest.java
@@ -37,7 +37,6 @@ import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
 import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.service.quiz.QuizExerciseService;
@@ -48,9 +47,6 @@ import de.tum.in.www1.artemis.util.RequestUtilService;
 class LtiQuizIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "ltiquizsubmissiontest";
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private QuizExerciseService quizExerciseService;

--- a/src/test/java/de/tum/in/www1/artemis/LtiQuizIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LtiQuizIntegrationTest.java
@@ -38,7 +38,6 @@ import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
 import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
@@ -51,9 +50,6 @@ import de.tum.in.www1.artemis.util.RequestUtilService;
 class LtiQuizIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "ltiquizsubmissiontest";
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ExerciseRepository exerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/LtiQuizIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LtiQuizIntegrationTest.java
@@ -28,7 +28,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.QuizMode;
@@ -43,7 +42,6 @@ import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.service.quiz.QuizExerciseService;
 import de.tum.in.www1.artemis.service.quiz.QuizSubmissionService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 
 @Isolated
@@ -62,11 +60,6 @@ class LtiQuizIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
-
-
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/ManagementResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ManagementResourceIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.connectors.ci.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.feature.Feature;
 import de.tum.in.www1.artemis.service.feature.FeatureToggleService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ManagementResourceIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCTest {
 
@@ -47,8 +46,6 @@ class ManagementResourceIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     private FeatureToggleService featureToggleService;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/ManagementResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ManagementResourceIntegrationTest.java
@@ -24,7 +24,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.domain.PersistentAuditEvent;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseFactory;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
@@ -49,9 +48,6 @@ class ManagementResourceIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/ManagementResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ManagementResourceIntegrationTest.java
@@ -48,8 +48,7 @@ class ManagementResourceIntegrationTest extends AbstractSpringIntegrationLocalCI
     @Autowired
     private FeatureToggleService featureToggleService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/MetricsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/MetricsIntegrationTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -31,9 +30,6 @@ import de.tum.in.www1.artemis.web.rest.dto.metrics.StudentMetricsDTO;
 class MetricsIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "metricsintegration";
-
-    @Autowired
-    private ParticipantScoreScheduleService participantScoreScheduleService;
 
     private Course course;
 

--- a/src/test/java/de/tum/in/www1/artemis/OAuth2JWKSIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/OAuth2JWKSIntegrationTest.java
@@ -14,15 +14,11 @@ import de.tum.in.www1.artemis.course.CourseFactory;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.LtiPlatformConfiguration;
 import de.tum.in.www1.artemis.domain.OnlineCourseConfiguration;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.OnlineCourseConfigurationRepository;
 
 class OAuth2JWKSIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "oauth2jwksintegrationtest";
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private OnlineCourseConfigurationRepository onlineCourseConfigurationRepository;

--- a/src/test/java/de/tum/in/www1/artemis/StatisticsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StatisticsIntegrationTest.java
@@ -40,7 +40,6 @@ import de.tum.in.www1.artemis.repository.GradingScaleRepository;
 import de.tum.in.www1.artemis.repository.ParticipantScoreRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.AnswerPostRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.web.rest.dto.CourseManagementStatisticsDTO;
@@ -52,9 +51,6 @@ class StatisticsIntegrationTest extends AbstractSpringIntegrationIndependentTest
 
     @Autowired
     private TextExerciseRepository textExerciseRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private PostRepository postRepository;

--- a/src/test/java/de/tum/in/www1/artemis/StatisticsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StatisticsIntegrationTest.java
@@ -43,7 +43,6 @@ import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.AnswerPostRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.CourseManagementStatisticsDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ExerciseManagementStatisticsDTO;
 
@@ -71,8 +70,6 @@ class StatisticsIntegrationTest extends AbstractSpringIntegrationIndependentTest
 
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
-
-
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/StatisticsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StatisticsIntegrationTest.java
@@ -72,8 +72,7 @@ class StatisticsIntegrationTest extends AbstractSpringIntegrationIndependentTest
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/StatisticsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StatisticsIntegrationTest.java
@@ -31,7 +31,6 @@ import de.tum.in.www1.artemis.domain.enumeration.SpanType;
 import de.tum.in.www1.artemis.domain.enumeration.StatisticsView;
 import de.tum.in.www1.artemis.domain.metis.AnswerPost;
 import de.tum.in.www1.artemis.domain.metis.Post;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
@@ -75,9 +74,6 @@ class StatisticsIntegrationTest extends AbstractSpringIntegrationIndependentTest
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     private Course course;
 

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -47,7 +47,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ComplaintResponseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.service.dto.ComplaintAction;
 import de.tum.in.www1.artemis.service.dto.ComplaintRequestDTO;
@@ -62,9 +61,6 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
 
     @Autowired
     private SubmissionRepository submissionRepo;
-
-    @Autowired
-    private ResultRepository resultRepo;
 
     @Autowired
     private ComplaintRepository complaintRepo;
@@ -126,7 +122,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         exerciseUtilService.updateExerciseDueDate(modelingExercise.getId(), ZonedDateTime.now().minusDays(2));
         exerciseUtilService.updateAssessmentDueDate(modelingExercise.getId(), ZonedDateTime.now().minusDays(1));
         modelingAssessment.setCompletionDate(modelingExercise.getDueDate().minusDays(1));
-        resultRepo.save(modelingAssessment);
+        resultRepository.save(modelingAssessment);
 
         verifySuccessfulComplaint();
     }
@@ -137,7 +133,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         exerciseUtilService.updateExerciseDueDate(modelingExercise.getId(), ZonedDateTime.now().minusDays(3));
         exerciseUtilService.updateAssessmentDueDate(modelingExercise.getId(), ZonedDateTime.now().minusDays(1));
         modelingAssessment.setCompletionDate(modelingExercise.getAssessmentDueDate().minusDays(1));
-        resultRepo.save(modelingAssessment);
+        resultRepository.save(modelingAssessment);
 
         verifySuccessfulComplaint();
     }
@@ -148,7 +144,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         exerciseUtilService.updateExerciseDueDate(modelingExercise.getId(), ZonedDateTime.now().minusDays(3));
         exerciseUtilService.updateAssessmentDueDate(modelingExercise.getId(), ZonedDateTime.now().minusDays(2));
         modelingAssessment.setCompletionDate(modelingExercise.getAssessmentDueDate().plusDays(1));
-        resultRepo.save(modelingAssessment);
+        resultRepository.save(modelingAssessment);
 
         verifySuccessfulComplaint();
     }
@@ -160,7 +156,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         assertThat(storedComplaint).as("complaint is saved").isPresent();
         assertThat(storedComplaint.orElseThrow().getComplaintText()).as("complaint text got correctly saved").isEqualTo(complaint.getComplaintText());
         assertThat(storedComplaint.orElseThrow().isAccepted()).as("accepted flag of complaint is not set").isNull();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is true").isTrue();
         Result result = storedComplaint.orElseThrow().getResult();
         assertThat(result.getId()).isEqualTo(storedResult.getId());
@@ -181,7 +177,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         request.post("/api/complaints", complaintRequest, HttpStatus.CREATED);
 
         assertThat(complaintRepo.findByResultId(modelingAssessment.getId())).as("complaint is saved").isPresent();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is true").isTrue();
     }
 
@@ -193,7 +189,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         request.post("/api/complaints", complaintRequest, HttpStatus.BAD_REQUEST);
 
         assertThat(complaintRepo.findByResultId(modelingAssessment.getId())).as("complaint is not saved").isNotPresent();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is false").isFalse();
     }
 
@@ -208,7 +204,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         request.post("/api/complaints", complaintRequest, HttpStatus.CREATED);
 
         assertThat(complaintRepo.findByResultId(modelingAssessment.getId())).as("complaint is saved").isPresent();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is true").isTrue();
 
         // Only one complaint is possible for exercise regardless of its type
@@ -231,7 +227,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         request.post("/api/complaints", complaintRequest, HttpStatus.CREATED);
 
         assertThat(complaintRepo.findByResultId(modelingAssessment.getId())).as("complaint is saved").isPresent();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is true").isTrue();
     }
 
@@ -246,7 +242,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         request.post("/api/complaints", complaintRequest, HttpStatus.BAD_REQUEST);
 
         assertThat(complaintRepo.findByResultId(modelingAssessment.getId())).as("complaint is not saved").isNotPresent();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is false").isFalse();
     }
 
@@ -262,7 +258,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
 
         Complaint storedComplaint = complaintRepo.findByResultId(modelingAssessment.getId()).orElseThrow();
         assertThat(storedComplaint.isAccepted()).as("complaint is not accepted").isFalse();
-        Result storedResult = resultRepo.findWithBidirectionalSubmissionAndFeedbackAndAssessorAndAssessmentNoteAndTeamStudentsByIdElseThrow(modelingAssessment.getId());
+        Result storedResult = resultRepository.findWithBidirectionalSubmissionAndFeedbackAndAssessorAndAssessmentNoteAndTeamStudentsByIdElseThrow(modelingAssessment.getId());
         Result updatedResult = storedResult.getSubmission().getLatestResult();
         participationUtilService.checkFeedbackCorrectlyStored(modelingAssessment.getFeedbacks(), updatedResult.getFeedbacks(), FeedbackType.MANUAL);
         final String[] ignoringFields = { "feedbacks", "submission", "participation", "assessor" };
@@ -291,8 +287,8 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         // set dates to UTC and round to milliseconds for comparison
         result.setCompletionDate(ZonedDateTime.ofInstant(result.getCompletionDate().truncatedTo(ChronoUnit.MILLIS).toInstant(), ZoneId.of("UTC")));
         modelingAssessment.setCompletionDate(ZonedDateTime.ofInstant(modelingAssessment.getCompletionDate().truncatedTo(ChronoUnit.MILLIS).toInstant(), ZoneId.of("UTC")));
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
-        Result resultAfterComplaintResponse = resultRepo.findByIdWithEagerFeedbacksAndAssessor(receivedResult.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result resultAfterComplaintResponse = resultRepository.findByIdWithEagerFeedbacksAndAssessor(receivedResult.getId()).orElseThrow();
         participationUtilService.checkFeedbackCorrectlyStored(feedbacks, resultAfterComplaintResponse.getFeedbacks(), FeedbackType.MANUAL);
         assertThat(storedResult.getAssessor()).as("assessor is still the original one").isEqualTo(modelingAssessment.getAssessor());
     }
@@ -474,7 +470,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void getComplaintsByCourseId_tutor_allComplaintsForTutor() throws Exception {
         complaint.getResult().setAssessor(userUtilService.getUserByLogin(TEST_PREFIX + "instructor1"));
-        resultRepo.save(complaint.getResult());
+        resultRepository.save(complaint.getResult());
         complaintRepo.save(complaint);
         final var params = new LinkedMultiValueMap<String, String>();
         params.add("complaintType", ComplaintType.COMPLAINT.name());
@@ -512,7 +508,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         complaint.setParticipant(userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         complaintRepo.save(complaint);
         complaint.getResult().setHasComplaint(true);
-        resultRepo.save(complaint.getResult());
+        resultRepository.save(complaint.getResult());
 
         final var params = new LinkedMultiValueMap<String, String>();
         params.add("complaintType", ComplaintType.COMPLAINT.name());
@@ -536,7 +532,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         User instructor = userUtilService.getUserByLogin(TEST_PREFIX + "instructor1");
         complaint.setParticipant(instructor);
         complaint.getResult().setAssessor(instructor);
-        resultRepo.save(complaint.getResult());
+        resultRepository.save(complaint.getResult());
         complaint = complaintRepo.save(complaint);
         course.setInstructorGroupName("test");
         course.setTeachingAssistantGroupName("test");
@@ -554,7 +550,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         User instructor = userUtilService.getUserByLogin(TEST_PREFIX + "instructor1");
         complaint.setParticipant(instructor);
         complaint.getResult().setAssessor(instructor);
-        resultRepo.save(complaint.getResult());
+        resultRepository.save(complaint.getResult());
         complaint = complaintRepo.save(complaint);
 
         final var params = new LinkedMultiValueMap<String, String>();
@@ -800,7 +796,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         assertThat(storedComplaint).as("complaint is saved").isPresent();
         assertThat(storedComplaint.orElseThrow().getComplaintText()).as("complaint text got correctly saved").isEqualTo(examExerciseComplaint.complaintText());
         assertThat(storedComplaint.get().isAccepted()).as("accepted flag of complaint is not set").isNull();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(textSubmission.getLatestResult().getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(textSubmission.getLatestResult().getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is true").isTrue();
         // set date to UTC for comparison
         storedResult.setCompletionDate(ZonedDateTime.ofInstant(storedResult.getCompletionDate().toInstant(), ZoneId.of("UTC")));

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -17,7 +17,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Complaint;
 import de.tum.in.www1.artemis.domain.ComplaintResponse;
 import de.tum.in.www1.artemis.domain.Course;
@@ -53,7 +52,6 @@ import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.service.dto.ComplaintAction;
 import de.tum.in.www1.artemis.service.dto.ComplaintRequestDTO;
 import de.tum.in.www1.artemis.service.dto.ComplaintResponseUpdateDTO;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 import de.tum.in.www1.artemis.web.rest.dto.AssessmentUpdateDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SubmissionWithComplaintDTO;
@@ -76,11 +74,6 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
 
     @Autowired
     private ExamRepository examRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -47,7 +47,6 @@ import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ComplaintResponseRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
@@ -74,9 +73,6 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
 
     @Autowired
     private ComplaintResponseRepository complaintResponseRepo;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ExamRepository examRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -77,8 +77,7 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
     @Autowired
     private ExamRepository examRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -37,7 +37,6 @@ import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exam.ExamFactory;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.fileupload.FileUploadExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
@@ -70,9 +69,6 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
 
     @Autowired
     private ExamRepository examRepository;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentTeamComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentTeamComplaintIntegrationTest.java
@@ -40,7 +40,6 @@ import de.tum.in.www1.artemis.service.dto.ComplaintAction;
 import de.tum.in.www1.artemis.service.dto.ComplaintRequestDTO;
 import de.tum.in.www1.artemis.service.dto.ComplaintResponseUpdateDTO;
 import de.tum.in.www1.artemis.team.TeamUtilService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 import de.tum.in.www1.artemis.web.rest.dto.AssessmentUpdateDTO;
 
@@ -59,8 +58,6 @@ class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIn
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentTeamComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentTeamComplaintIntegrationTest.java
@@ -28,7 +28,6 @@ import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
@@ -56,9 +55,6 @@ class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIn
 
     @Autowired
     private TeamUtilService teamUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentTeamComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentTeamComplaintIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.service.dto.ComplaintAction;
 import de.tum.in.www1.artemis.service.dto.ComplaintRequestDTO;
@@ -45,9 +44,6 @@ import de.tum.in.www1.artemis.web.rest.dto.AssessmentUpdateDTO;
 class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "assmentteamcomplaint"; // only lower case is supported
-
-    @Autowired
-    private ResultRepository resultRepo;
 
     @Autowired
     private ComplaintRepository complaintRepo;
@@ -115,7 +111,7 @@ class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIn
         request.post(resourceUrl, complaintRequest, HttpStatus.CREATED);
 
         assertThat(complaintRepo.findByResultId(modelingAssessment.getId())).as("complaint is saved").isPresent();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is true").isTrue();
     }
 
@@ -127,7 +123,7 @@ class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIn
         request.post(resourceUrl, complaintRequest, HttpStatus.BAD_REQUEST);
 
         assertThat(complaintRepo.findByResultId(modelingAssessment.getId())).as("complaint is not saved").isNotPresent();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is false").isFalse();
     }
 
@@ -141,7 +137,7 @@ class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIn
         request.post(resourceUrl, complaintRequest, HttpStatus.CREATED);
 
         assertThat(complaintRepo.findByResultId(modelingAssessment.getId())).as("complaint is saved").isPresent();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is true").isTrue();
 
         // Only one complaint is possible for exercise regardless of its type
@@ -162,7 +158,7 @@ class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIn
         request.post(resourceUrl, complaintRequest, HttpStatus.CREATED);
 
         assertThat(complaintRepo.findByResultId(modelingAssessment.getId())).as("complaint is saved").isPresent();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is true").isTrue();
     }
 
@@ -177,7 +173,7 @@ class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIn
         request.post(resourceUrl, complaintRequest, HttpStatus.BAD_REQUEST);
 
         assertThat(complaintRepo.findByResultId(modelingAssessment.getId())).as("complaint is not saved").isNotPresent();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).orElseThrow();
         assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is false").isFalse();
     }
 
@@ -193,7 +189,7 @@ class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIn
         assertThat(complaintResponse.getComplaint().getParticipant()).isNull();
         Complaint storedComplaint = complaintRepo.findByResultId(modelingAssessment.getId()).orElseThrow();
         assertThat(storedComplaint.isAccepted()).as("complaint is not accepted").isFalse();
-        Result storedResult = resultRepo.findWithBidirectionalSubmissionAndFeedbackAndAssessorAndAssessmentNoteAndTeamStudentsByIdElseThrow(modelingAssessment.getId());
+        Result storedResult = resultRepository.findWithBidirectionalSubmissionAndFeedbackAndAssessorAndAssessmentNoteAndTeamStudentsByIdElseThrow(modelingAssessment.getId());
         participationUtilService.checkFeedbackCorrectlyStored(modelingAssessment.getFeedbacks(), storedResult.getFeedbacks(), FeedbackType.MANUAL);
         assertThat(storedResult.getSubmission()).isEqualTo(modelingAssessment.getSubmission());
         assertThat(storedResult.getAssessor()).isEqualTo(modelingAssessment.getAssessor());

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentTeamComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentTeamComplaintIntegrationTest.java
@@ -60,8 +60,7 @@ class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIn
     @Autowired
     private SubmissionRepository submissionRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentTeamComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/AssessmentTeamComplaintIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.service.dto.ComplaintAction;
@@ -46,9 +45,6 @@ import de.tum.in.www1.artemis.web.rest.dto.AssessmentUpdateDTO;
 class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "assmentteamcomplaint"; // only lower case is supported
-
-    @Autowired
-    private ExerciseRepository exerciseRepo;
 
     @Autowired
     private ResultRepository resultRepo;
@@ -99,7 +95,7 @@ class AssessmentTeamComplaintIntegrationTest extends AbstractSpringIntegrationIn
         course = modelingExerciseUtilService.addCourseWithOneModelingExercise();
         modelingExercise = (ModelingExercise) course.getExercises().iterator().next();
         modelingExercise.setMode(ExerciseMode.TEAM);
-        modelingExercise = exerciseRepo.save(modelingExercise);
+        modelingExercise = exerciseRepository.save(modelingExercise);
         team = teamUtilService.addTeamForExercise(modelingExercise, userUtilService.getUserByLogin(TEST_PREFIX + "tutor1"), TEST_PREFIX);
         saveModelingSubmissionAndAssessment();
         complaint = new Complaint().result(modelingAssessment).complaintText("This is not fair").complaintType(ComplaintType.COMPLAINT);

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ComplaintResponseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ComplaintResponseIntegrationTest.java
@@ -30,7 +30,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ComplaintResponseRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
@@ -46,9 +45,6 @@ class ComplaintResponseIntegrationTest extends AbstractSpringIntegrationIndepend
 
     @Autowired
     private UserRepository userRepository;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private ParticipationService participationService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ComplaintResponseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ComplaintResponseIntegrationTest.java
@@ -67,8 +67,7 @@ class ComplaintResponseIntegrationTest extends AbstractSpringIntegrationIndepend
     @Autowired
     private ComplaintResponseRepository complaintResponseRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ComplaintResponseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ComplaintResponseIntegrationTest.java
@@ -31,7 +31,6 @@ import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ComplaintResponseRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.service.dto.ComplaintAction;
 import de.tum.in.www1.artemis.service.dto.ComplaintResponseUpdateDTO;
@@ -41,9 +40,6 @@ class ComplaintResponseIntegrationTest extends AbstractSpringIntegrationIndepend
     private static final Logger log = LoggerFactory.getLogger(ComplaintResponseIntegrationTest.class);
 
     private static final String TEST_PREFIX = "complaintresponseintegration";
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ParticipationService participationService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ComplaintResponseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ComplaintResponseIntegrationTest.java
@@ -16,7 +16,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.config.Constants;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Complaint;
 import de.tum.in.www1.artemis.domain.ComplaintResponse;
 import de.tum.in.www1.artemis.domain.Course;
@@ -38,7 +37,6 @@ import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.service.dto.ComplaintAction;
 import de.tum.in.www1.artemis.service.dto.ComplaintResponseUpdateDTO;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ComplaintResponseIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -66,11 +64,6 @@ class ComplaintResponseIntegrationTest extends AbstractSpringIntegrationIndepend
 
     @Autowired
     private ComplaintResponseRepository complaintResponseRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     private Complaint complaint;
 

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ComplaintResponseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ComplaintResponseIntegrationTest.java
@@ -30,7 +30,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ComplaintResponseRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.ParticipationService;
@@ -51,9 +50,6 @@ class ComplaintResponseIntegrationTest extends AbstractSpringIntegrationIndepend
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private ComplaintRepository complaintRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
@@ -42,7 +42,6 @@ import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
@@ -65,9 +64,6 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
 
     @Autowired
     private ExampleSubmissionRepository exampleSubmissionRepo;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ExerciseRepository exerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
@@ -20,7 +20,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ExampleSubmission;
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -46,7 +45,6 @@ import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 import de.tum.in.www1.artemis.web.rest.dto.TextAssessmentDTO;
 
@@ -67,11 +65,6 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
 
     @Autowired
     private ExerciseRepository exerciseRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
@@ -68,8 +68,7 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
     @Autowired
     private ExerciseRepository exerciseRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
@@ -36,7 +36,6 @@ import de.tum.in.www1.artemis.domain.enumeration.Language;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.participation.TutorParticipation;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
@@ -57,9 +56,6 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
 
     @Autowired
     private ExampleSubmissionRepository exampleSubmissionRepo;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
@@ -42,7 +42,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
@@ -62,9 +61,6 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
 
     @Autowired
     private ExampleSubmissionRepository exampleSubmissionRepo;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExampleSubmissionIntegrationTest.java
@@ -43,7 +43,6 @@ import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 import de.tum.in.www1.artemis.web.rest.dto.TextAssessmentDTO;
 
@@ -52,9 +51,6 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
     private static final Logger log = LoggerFactory.getLogger(ExampleSubmissionIntegrationTest.class);
 
     private static final String TEST_PREFIX = "examplesubmissionintegration";
-
-    @Autowired
-    private ResultRepository resultRepo;
 
     @Autowired
     private GradingCriterionRepository gradingCriterionRepo;
@@ -223,7 +219,7 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
 
         request.putWithResponseBody("/api/modeling-submissions/" + storedExampleSubmission.getId() + "/example-assessment", feedbacks, Result.class, HttpStatus.OK);
 
-        Result storedResult = resultRepo.findDistinctWithFeedbackBySubmissionId(storedExampleSubmission.getSubmission().getId()).orElseThrow();
+        Result storedResult = resultRepository.findDistinctWithFeedbackBySubmissionId(storedExampleSubmission.getSubmission().getId()).orElseThrow();
         participationUtilService.checkFeedbackCorrectlyStored(feedbacks, storedResult.getFeedbacks(), FeedbackType.MANUAL);
         assertThat(storedResult.isExampleResult()).as("stored result is flagged as example result").isTrue();
     }
@@ -280,7 +276,7 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
         dto.setFeedbacks(feedbacks);
         request.putWithResponseBody("/api/exercises/" + textExercise.getId() + "/example-submissions/" + storedExampleSubmission.getId() + "/example-text-assessment", dto,
                 Result.class, HttpStatus.OK);
-        Result storedResult = resultRepo.findDistinctWithFeedbackBySubmissionId(storedExampleSubmission.getSubmission().getId()).orElseThrow();
+        Result storedResult = resultRepository.findDistinctWithFeedbackBySubmissionId(storedExampleSubmission.getSubmission().getId()).orElseThrow();
         participationUtilService.checkFeedbackCorrectlyStored(feedbacks, storedResult.getFeedbacks(), FeedbackType.MANUAL);
         assertThat(storedResult.isExampleResult()).as("stored result is flagged as example result").isTrue();
     }
@@ -391,7 +387,7 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
         gradingCriterionRepo.saveAll(gradingCriteria);
         var studentParticipation = participationUtilService.addAssessmentWithFeedbackWithGradingInstructionsForExercise(exercise, TEST_PREFIX + "instructor1");
         Submission originalSubmission = studentParticipation.findLatestSubmission().orElseThrow();
-        Optional<Result> orginalResult = resultRepo.findDistinctWithFeedbackBySubmissionId(originalSubmission.getId());
+        Optional<Result> orginalResult = resultRepository.findDistinctWithFeedbackBySubmissionId(originalSubmission.getId());
 
         ExampleSubmission exampleSubmission = importExampleSubmission(exercise.getId(), originalSubmission.getId(), HttpStatus.OK);
         assertThat(exampleSubmission.getSubmission().getResults().get(0).getFeedbacks().get(0).getGradingInstruction().getId())

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExerciseScoresChartIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExerciseScoresChartIntegrationTest.java
@@ -38,8 +38,7 @@ class ExerciseScoresChartIntegrationTest extends AbstractSpringIntegrationIndepe
 
     private static final String TEST_PREFIX = "exercisescoreschart";
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExerciseScoresChartIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExerciseScoresChartIntegrationTest.java
@@ -18,7 +18,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Team;
@@ -31,17 +30,11 @@ import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 import de.tum.in.www1.artemis.team.TeamUtilService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.ExerciseScoresDTO;
 
 class ExerciseScoresChartIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "exercisescoreschart";
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ExerciseScoresChartIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ExerciseScoresChartIntegrationTest.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ParticipantScoreRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 import de.tum.in.www1.artemis.team.TeamUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.ExerciseScoresDTO;
@@ -52,9 +51,6 @@ class ExerciseScoresChartIntegrationTest extends AbstractSpringIntegrationIndepe
     private Long idOfIndividualTextExerciseWithoutParticipants;
 
     private Long idOfTeamTextExercise;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private TeamRepository teamRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/GradeStepIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/GradeStepIntegrationTest.java
@@ -50,8 +50,7 @@ class GradeStepIntegrationTest extends AbstractSpringIntegrationIndependentTest 
     @Autowired
     private PlagiarismCaseRepository plagiarismCaseRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/GradeStepIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/GradeStepIntegrationTest.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.web.rest.dto.GradeDTO;
 import de.tum.in.www1.artemis.web.rest.dto.GradeStepsDTO;
@@ -41,9 +40,6 @@ class GradeStepIntegrationTest extends AbstractSpringIntegrationIndependentTest 
 
     @Autowired
     private ExamRepository examRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private PlagiarismCaseRepository plagiarismCaseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/GradeStepIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/GradeStepIntegrationTest.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.GradeStep;
 import de.tum.in.www1.artemis.domain.GradeType;
@@ -30,7 +29,6 @@ import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.GradeDTO;
 import de.tum.in.www1.artemis.web.rest.dto.GradeStepsDTO;
 
@@ -49,11 +47,6 @@ class GradeStepIntegrationTest extends AbstractSpringIntegrationIndependentTest 
 
     @Autowired
     private PlagiarismCaseRepository plagiarismCaseRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/GradingScaleIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/GradingScaleIntegrationTest.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.GradeStep;
 import de.tum.in.www1.artemis.domain.GradeType;
@@ -24,7 +23,6 @@ import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 
 class GradingScaleIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -39,11 +37,6 @@ class GradingScaleIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private UserRepository userRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/GradingScaleIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/GradingScaleIntegrationTest.java
@@ -40,8 +40,7 @@ class GradingScaleIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/GradingScaleIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/GradingScaleIntegrationTest.java
@@ -22,7 +22,6 @@ import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 
 class GradingScaleIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -34,9 +33,6 @@ class GradingScaleIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private ExamRepository examRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/GradingScaleIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/GradingScaleIntegrationTest.java
@@ -21,7 +21,6 @@ import de.tum.in.www1.artemis.domain.GradingScale;
 import de.tum.in.www1.artemis.domain.enumeration.SortingOrder;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
@@ -40,9 +39,6 @@ class GradingScaleIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private UserRepository userRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
@@ -42,7 +42,6 @@ import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 import de.tum.in.www1.artemis.team.TeamUtilService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.score.ScoreDTO;
 
 class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCTest {
@@ -85,8 +84,6 @@ class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationLocalCILo
 
     @Autowired
     private GradingScaleRepository gradingScaleRepository;
-
-
 
     @Autowired
     private CompetencyUtilService competencyUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
 import de.tum.in.www1.artemis.repository.LectureUnitRepository;
@@ -68,9 +67,6 @@ class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationLocalCILo
 
     @Autowired
     private ExerciseRepository exerciseRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
@@ -38,7 +38,6 @@ import de.tum.in.www1.artemis.repository.LectureUnitRepository;
 import de.tum.in.www1.artemis.repository.ParticipantScoreRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 import de.tum.in.www1.artemis.team.TeamUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.score.ScoreDTO;
@@ -62,9 +61,6 @@ class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationLocalCILo
     private Exam exam;
 
     private User student1;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private TeamRepository teamRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
@@ -86,8 +86,7 @@ class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationLocalCILo
     @Autowired
     private GradingScaleRepository gradingScaleRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CompetencyUtilService competencyUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ParticipantScoreIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
 import de.tum.in.www1.artemis.repository.LectureUnitRepository;
 import de.tum.in.www1.artemis.repository.ParticipantScoreRepository;
@@ -63,9 +62,6 @@ class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationLocalCILo
     private Exam exam;
 
     private User student1;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/RatingResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/RatingResourceIntegrationTest.java
@@ -20,7 +20,6 @@ import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.domain.TextSubmission;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
@@ -35,9 +34,6 @@ class RatingResourceIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/RatingResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/RatingResourceIntegrationTest.java
@@ -25,7 +25,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.service.RatingService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class RatingResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -33,8 +32,6 @@ class RatingResourceIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private RatingService ratingService;
-
-
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/RatingResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/RatingResourceIntegrationTest.java
@@ -34,8 +34,7 @@ class RatingResourceIntegrationTest extends AbstractSpringIntegrationIndependent
     @Autowired
     private RatingService ratingService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ResultServiceIntegrationTest.java
@@ -26,7 +26,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationLocalCILocalVCTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Feedback;
 import de.tum.in.www1.artemis.domain.FileUploadExercise;
@@ -75,7 +74,6 @@ import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.ResultWithPointsPerGradingCriterionDTO;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
@@ -125,8 +123,6 @@ class ResultServiceIntegrationTest extends AbstractSpringIntegrationLocalCILocal
     @Autowired
     private GradingCriterionRepository gradingCriterionRepository;
 
-
-
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
 
@@ -141,9 +137,6 @@ class ResultServiceIntegrationTest extends AbstractSpringIntegrationLocalCILocal
 
     @Autowired
     private ExamUtilService examUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     private Course course;
 

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ResultServiceIntegrationTest.java
@@ -50,7 +50,6 @@ import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentPar
 import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.GradingCriterionUtil;
 import de.tum.in.www1.artemis.exercise.fileupload.FileUploadExerciseFactory;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseFactory;
@@ -117,9 +116,6 @@ class ResultServiceIntegrationTest extends AbstractSpringIntegrationLocalCILocal
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ResultServiceIntegrationTest.java
@@ -68,7 +68,6 @@ import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SolutionProgrammingExerciseParticipationRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
@@ -110,9 +109,6 @@ class ResultServiceIntegrationTest extends AbstractSpringIntegrationLocalCILocal
 
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private SubmissionRepository submissionRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ResultServiceIntegrationTest.java
@@ -72,7 +72,6 @@ import de.tum.in.www1.artemis.repository.SolutionProgrammingExerciseParticipatio
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.web.rest.dto.ResultWithPointsPerGradingCriterionDTO;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
@@ -100,9 +99,6 @@ class ResultServiceIntegrationTest extends AbstractSpringIntegrationLocalCILocal
 
     @Autowired
     private TextExerciseRepository textExerciseRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/ResultServiceIntegrationTest.java
@@ -125,8 +125,7 @@ class ResultServiceIntegrationTest extends AbstractSpringIntegrationLocalCILocal
     @Autowired
     private GradingCriterionRepository gradingCriterionRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorEffortIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorEffortIntegrationTest.java
@@ -47,8 +47,7 @@ class TutorEffortIntegrationTest extends AbstractSpringIntegrationIndependentTes
     @Autowired
     private CourseUtilService courseUtilService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorEffortIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorEffortIntegrationTest.java
@@ -14,7 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.TextSubmission;
@@ -26,7 +25,6 @@ import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.TextAssessmentEventRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class TutorEffortIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -43,11 +41,6 @@ class TutorEffortIntegrationTest extends AbstractSpringIntegrationIndependentTes
 
     @Autowired
     private TextAssessmentEventRepository textAssessmentEventRepository;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
-
-
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorEffortIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorEffortIntegrationTest.java
@@ -24,14 +24,10 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.TextAssessmentEventRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 
 class TutorEffortIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "tutoreffort"; // only lower case is supported
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private TextSubmissionRepository textSubmissionRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorLeaderboardServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorLeaderboardServiceIntegrationTest.java
@@ -19,7 +19,6 @@ import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.TutorLeaderboardService;
 import de.tum.in.www1.artemis.user.UserUtilService;
@@ -34,9 +33,6 @@ class TutorLeaderboardServiceIntegrationTest extends AbstractSpringIntegrationIn
 
     @Autowired
     private UserRepository userRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorLeaderboardServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorLeaderboardServiceIntegrationTest.java
@@ -21,7 +21,6 @@ import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.TutorLeaderboardService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.TutorLeaderboardDTO;
 
 class TutorLeaderboardServiceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -33,8 +32,6 @@ class TutorLeaderboardServiceIntegrationTest extends AbstractSpringIntegrationIn
 
     @Autowired
     private UserRepository userRepository;
-
-
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorLeaderboardServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorLeaderboardServiceIntegrationTest.java
@@ -19,7 +19,6 @@ import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.TutorLeaderboardService;
 import de.tum.in.www1.artemis.web.rest.dto.TutorLeaderboardDTO;
 
@@ -29,9 +28,6 @@ class TutorLeaderboardServiceIntegrationTest extends AbstractSpringIntegrationIn
 
     @Autowired
     private TutorLeaderboardService tutorLeaderboardService;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorLeaderboardServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorLeaderboardServiceIntegrationTest.java
@@ -34,8 +34,7 @@ class TutorLeaderboardServiceIntegrationTest extends AbstractSpringIntegrationIn
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationIntegrationTest.java
@@ -31,7 +31,6 @@ import de.tum.in.www1.artemis.domain.participation.TutorParticipation;
 import de.tum.in.www1.artemis.exercise.ExerciseFactory;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
 import de.tum.in.www1.artemis.repository.GradingInstructionRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
@@ -45,9 +44,6 @@ import de.tum.in.www1.artemis.util.TestResourceUtils;
 class TutorParticipationIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "tutorparticipationintegration";
-
-    @Autowired
-    private ExerciseRepository exerciseRepo;
 
     @Autowired
     private SubmissionService submissionService;
@@ -99,7 +95,7 @@ class TutorParticipationIntegrationTest extends AbstractSpringIntegrationIndepen
 
         for (Exercise exercise : new Exercise[] { textExercise, modelingExercise }) {
             exercise.setTitle("exercise name");
-            exerciseRepo.save(exercise);
+            exerciseRepository.save(exercise);
             path = "/api/exercises/" + exercise.getId() + "/assess-example-submission";
         }
 

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
 import de.tum.in.www1.artemis.repository.GradingInstructionRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.service.ExampleSubmissionService;
 import de.tum.in.www1.artemis.service.ResultService;
@@ -47,9 +46,6 @@ class TutorParticipationIntegrationTest extends AbstractSpringIntegrationIndepen
 
     @Autowired
     private SubmissionService submissionService;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private ExampleSubmissionService exampleSubmissionService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationIntegrationTest.java
@@ -17,7 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ExampleSubmission;
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -41,7 +40,6 @@ import de.tum.in.www1.artemis.service.ExampleSubmissionService;
 import de.tum.in.www1.artemis.service.ResultService;
 import de.tum.in.www1.artemis.service.SubmissionService;
 import de.tum.in.www1.artemis.service.TutorParticipationService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 
 class TutorParticipationIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -68,11 +66,6 @@ class TutorParticipationIntegrationTest extends AbstractSpringIntegrationIndepen
 
     @Autowired
     private GradingCriterionRepository gradingCriterionRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationIntegrationTest.java
@@ -69,8 +69,7 @@ class TutorParticipationIntegrationTest extends AbstractSpringIntegrationIndepen
     @Autowired
     private GradingCriterionRepository gradingCriterionRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationResourceIntegrationTest.java
@@ -18,15 +18,11 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.participation.TutorParticipation;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.TutorParticipationRepository;
 
 class TutorParticipationResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "tutorparticipationresource";
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private TutorParticipationRepository tutorParticipationRepository;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationResourceIntegrationTest.java
@@ -11,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ExampleSubmission;
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -21,7 +20,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.TutorParticipationRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class TutorParticipationResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -35,11 +33,6 @@ class TutorParticipationResourceIntegrationTest extends AbstractSpringIntegratio
 
     @Autowired
     private ExampleSubmissionRepository exampleSubmissionRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/assessment/TutorParticipationResourceIntegrationTest.java
@@ -36,8 +36,7 @@ class TutorParticipationResourceIntegrationTest extends AbstractSpringIntegratio
     @Autowired
     private ExampleSubmissionRepository exampleSubmissionRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.domain.Authority;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.repository.AuthorityRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
@@ -62,9 +61,6 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private TutorialGroupUtilService tutorialGroupUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -66,8 +66,7 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
     @Autowired
     private GitlabRequestMockProvider gitlabRequestMockProvider;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -29,7 +29,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
 import de.tum.in.www1.artemis.connector.GitlabRequestMockProvider;
 import de.tum.in.www1.artemis.course.CourseFactory;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Authority;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
@@ -43,7 +42,6 @@ import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.user.PasswordService;
 import de.tum.in.www1.artemis.tutorialgroups.TutorialGroupUtilService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.vm.LoginVM;
 import de.tum.in.www1.artemis.web.rest.vm.ManagedUserVM;
 
@@ -66,13 +64,8 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
     @Autowired
     private GitlabRequestMockProvider gitlabRequestMockProvider;
 
-
-
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -37,7 +37,6 @@ import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.repository.AuthorityRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.user.PasswordService;
@@ -54,9 +53,6 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private AuthorityRepository authorityRepository;

--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -37,7 +37,6 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.repository.AuthorityRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.security.Role;
@@ -54,9 +53,6 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
 
     @Autowired
     private PasswordService passwordService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/authentication/LdapAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/LdapAuthenticationIntegrationTest.java
@@ -26,7 +26,6 @@ import de.tum.in.www1.artemis.domain.Authority;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.repository.AuthorityRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
@@ -56,9 +55,6 @@ class LdapAuthenticationIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     protected CourseUtilService courseUtilService;
-
-    @Autowired
-    protected ExerciseUtilService exerciseUtilService;
 
     private static final String NON_EXISTING_USERNAME = TEST_PREFIX + "na";
 

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserJenkinsGitlabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserJenkinsGitlabIntegrationTest.java
@@ -18,7 +18,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.User;
@@ -30,7 +29,6 @@ import de.tum.in.www1.artemis.service.connectors.jenkins.JenkinsUserManagementSe
 import de.tum.in.www1.artemis.service.user.PasswordService;
 import de.tum.in.www1.artemis.user.UserFactory;
 import de.tum.in.www1.artemis.user.UserTestService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.vm.ManagedUserVM;
 
 class UserJenkinsGitlabIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
@@ -60,11 +58,6 @@ class UserJenkinsGitlabIntegrationTest extends AbstractSpringIntegrationJenkinsG
 
     @Autowired
     private GitLabUserManagementService gitLabUserManagementService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserJenkinsGitlabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserJenkinsGitlabIntegrationTest.java
@@ -51,9 +51,6 @@ class UserJenkinsGitlabIntegrationTest extends AbstractSpringIntegrationJenkinsG
     private PasswordService passwordService;
 
     @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
     private JenkinsUserManagementService jenkinsUserManagementService;
 
     @Autowired

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserJenkinsGitlabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserJenkinsGitlabIntegrationTest.java
@@ -61,8 +61,7 @@ class UserJenkinsGitlabIntegrationTest extends AbstractSpringIntegrationJenkinsG
     @Autowired
     private GitLabUserManagementService gitLabUserManagementService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserSaml2IntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserSaml2IntegrationTest.java
@@ -24,7 +24,6 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.connectors.SAML2Service;
 import de.tum.in.www1.artemis.service.user.PasswordService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.open.PublicUserJwtResource;
 import de.tum.in.www1.artemis.web.rest.vm.LoginVM;
 
@@ -44,8 +43,6 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationGitlabCIGitlabSa
 
     @Autowired
     private PasswordService passwordService;
-
-
 
     @BeforeEach
     void setup() {

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserSaml2IntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserSaml2IntegrationTest.java
@@ -21,7 +21,6 @@ import org.springframework.security.test.context.TestSecurityContextHolder;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationGitlabCIGitlabSamlTest;
 import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.connectors.SAML2Service;
 import de.tum.in.www1.artemis.service.user.PasswordService;
 import de.tum.in.www1.artemis.web.rest.open.PublicUserJwtResource;
@@ -37,9 +36,6 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationGitlabCIGitlabSa
     private static final String STUDENT_PASSWORD = "test1234";
 
     private static final String STUDENT_REGISTRATION_NUMBER = "12345678";
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private PasswordService passwordService;

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserSaml2IntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserSaml2IntegrationTest.java
@@ -45,8 +45,7 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationGitlabCIGitlabSa
     @Autowired
     private PasswordService passwordService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @BeforeEach
     void setup() {

--- a/src/test/java/de/tum/in/www1/artemis/bonus/BonusIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/bonus/BonusIntegrationTest.java
@@ -51,8 +51,7 @@ class BonusIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private GradingScaleRepository gradingScaleRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/bonus/BonusIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/bonus/BonusIntegrationTest.java
@@ -19,7 +19,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.assessment.GradingScaleFactory;
 import de.tum.in.www1.artemis.assessment.GradingScaleUtilService;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Bonus;
 import de.tum.in.www1.artemis.domain.BonusStrategy;
 import de.tum.in.www1.artemis.domain.Course;
@@ -35,7 +34,6 @@ import de.tum.in.www1.artemis.repository.BonusRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.BonusExampleDTO;
 
 class BonusIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -50,11 +48,6 @@ class BonusIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private GradingScaleRepository gradingScaleRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/bonus/BonusIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/bonus/BonusIntegrationTest.java
@@ -32,7 +32,6 @@ import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.repository.BonusRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
@@ -45,9 +44,6 @@ class BonusIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private BonusRepository bonusRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ExamRepository examRepository;

--- a/src/test/java/de/tum/in/www1/artemis/bonus/BonusIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/bonus/BonusIntegrationTest.java
@@ -32,7 +32,6 @@ import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.repository.BonusRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
 import de.tum.in.www1.artemis.web.rest.dto.BonusExampleDTO;
 
@@ -54,9 +53,6 @@ class BonusIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private GradingScaleUtilService gradingScaleUtilService;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     private Bonus courseBonus;
 

--- a/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
@@ -37,7 +37,6 @@ import de.tum.in.www1.artemis.domain.competency.LearningPath;
 import de.tum.in.www1.artemis.domain.competency.RelationType;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.domain.lecture.TextUnit;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.repository.CompetencyProgressRepository;
@@ -72,9 +71,6 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private LearningPathRepository learningPathRepository;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
@@ -45,7 +45,6 @@ import de.tum.in.www1.artemis.repository.CompetencyRelationRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
 import de.tum.in.www1.artemis.repository.LearningPathRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.LectureUnitService;
 import de.tum.in.www1.artemis.service.competency.CompetencyProgressService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
@@ -64,9 +63,6 @@ import de.tum.in.www1.artemis.web.rest.dto.competency.NgxLearningPathDTO;
 class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "learningpathintegration";
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private CompetencyUtilService competencyUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
@@ -23,7 +23,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.StudentScoreUtilService;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.GradingCriterion;
@@ -49,7 +48,6 @@ import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.LectureUnitService;
 import de.tum.in.www1.artemis.service.competency.CompetencyProgressService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 import de.tum.in.www1.artemis.web.rest.LearningPathResource;
 import de.tum.in.www1.artemis.web.rest.dto.competency.CompetencyGraphNodeDTO;
@@ -69,9 +67,6 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private UserRepository userRepository;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private CompetencyUtilService competencyUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
@@ -43,7 +43,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.repository.CompetencyProgressRepository;
 import de.tum.in.www1.artemis.repository.CompetencyRelationRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
 import de.tum.in.www1.artemis.repository.LearningPathRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
@@ -67,9 +66,6 @@ import de.tum.in.www1.artemis.web.rest.dto.competency.NgxLearningPathDTO;
 class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "learningpathintegration";
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
@@ -71,9 +71,6 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     private UserRepository userRepository;
 
     @Autowired
-    private UserUtilService userUtilService;
-
-    @Autowired
     private CourseUtilService courseUtilService;
 
     @Autowired

--- a/src/test/java/de/tum/in/www1/artemis/competency/StandardizedCompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/StandardizedCompetencyIntegrationTest.java
@@ -56,8 +56,7 @@ class StandardizedCompetencyIntegrationTest extends AbstractSpringIntegrationInd
     @Autowired
     private SourceRepository sourceRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private StandardizedCompetencyUtilService standardizedCompetencyUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/competency/StandardizedCompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/StandardizedCompetencyIntegrationTest.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.repository.CompetencyRepository;
 import de.tum.in.www1.artemis.repository.SourceRepository;
 import de.tum.in.www1.artemis.repository.competency.KnowledgeAreaRepository;
 import de.tum.in.www1.artemis.repository.competency.StandardizedCompetencyRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.standardizedCompetency.KnowledgeAreaRequestDTO;
 import de.tum.in.www1.artemis.web.rest.dto.standardizedCompetency.KnowledgeAreaResultDTO;
 import de.tum.in.www1.artemis.web.rest.dto.standardizedCompetency.SourceDTO;
@@ -55,8 +54,6 @@ class StandardizedCompetencyIntegrationTest extends AbstractSpringIntegrationInd
 
     @Autowired
     private SourceRepository sourceRepository;
-
-
 
     @Autowired
     private StandardizedCompetencyUtilService standardizedCompetencyUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/config/MetricsBeanTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/config/MetricsBeanTest.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExamUserRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
@@ -79,9 +78,6 @@ class MetricsBeanTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ExamRepository examRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private SubmissionRepository submissionRepository;

--- a/src/test/java/de/tum/in/www1/artemis/dataexport/DataExportResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/dataexport/DataExportResourceIntegrationTest.java
@@ -31,7 +31,6 @@ import de.tum.in.www1.artemis.domain.DataExport;
 import de.tum.in.www1.artemis.domain.enumeration.DataExportState;
 import de.tum.in.www1.artemis.repository.DataExportRepository;
 import de.tum.in.www1.artemis.service.export.DataExportService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.DataExportDTO;
 import de.tum.in.www1.artemis.web.rest.dto.RequestDataExportDTO;
 
@@ -44,8 +43,6 @@ class DataExportResourceIntegrationTest extends AbstractSpringIntegrationIndepen
 
     @Autowired
     private DataExportRepository dataExportRepository;
-
-
 
     @Autowired
     private DataExportService dataExportService;

--- a/src/test/java/de/tum/in/www1/artemis/dataexport/DataExportResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/dataexport/DataExportResourceIntegrationTest.java
@@ -45,8 +45,7 @@ class DataExportResourceIntegrationTest extends AbstractSpringIntegrationIndepen
     @Autowired
     private DataExportRepository dataExportRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private DataExportService dataExportService;

--- a/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
@@ -20,7 +20,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationLocalCILocalVCTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Result;
@@ -44,7 +43,6 @@ import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.ResultService;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 import de.tum.in.www1.artemis.team.TeamUtilService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCTest {
 
@@ -81,11 +79,6 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
 
     @Autowired
     private ResultService resultService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.domain.scores.TeamScore;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ParticipantScoreRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.StudentScoreRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
@@ -54,9 +53,6 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
     private Long idOfTeam1;
 
     private Long idOfStudent1;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;

--- a/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
@@ -36,7 +36,6 @@ import de.tum.in.www1.artemis.repository.ParticipantScoreRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.StudentScoreRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.ResultService;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
@@ -65,9 +64,6 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
 
     @Autowired
     private TeamRepository teamRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ResultService resultService;

--- a/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
@@ -32,7 +32,6 @@ import de.tum.in.www1.artemis.domain.scores.StudentScore;
 import de.tum.in.www1.artemis.domain.scores.TeamScore;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ParticipantScoreRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
@@ -55,9 +54,6 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
     private Long idOfTeam1;
 
     private Long idOfStudent1;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private ResultRepository resultRepository;

--- a/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/entitylistener/ResultListenerIntegrationTest.java
@@ -82,8 +82,7 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
     @Autowired
     private ResultService resultService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -70,7 +70,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ExamLiveEventRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExamUserRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.QuizPoolRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
@@ -107,9 +106,6 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
     @Autowired
     private QuizExerciseRepository quizExerciseRepository;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -75,10 +75,8 @@ import de.tum.in.www1.artemis.repository.QuizPoolRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
 import de.tum.in.www1.artemis.service.dto.StudentDTO;
-import de.tum.in.www1.artemis.service.exam.ExamAccessService;
 import de.tum.in.www1.artemis.service.exam.ExamDateService;
 import de.tum.in.www1.artemis.service.exam.ExamService;
 import de.tum.in.www1.artemis.service.quiz.QuizPoolService;
@@ -108,9 +106,6 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
     private QuizExerciseRepository quizExerciseRepository;
 
     @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
     private ExamRepository examRepository;
 
     @Autowired
@@ -136,9 +131,6 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
     @Autowired
     private ZipFileTestUtilService zipFileTestUtilService;
-
-    @Autowired
-    private ExamAccessService examAccessService;
 
     @Autowired
     private ChannelRepository channelRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -41,7 +41,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.FileUploadSubmission;
@@ -87,7 +86,6 @@ import de.tum.in.www1.artemis.service.quiz.QuizPoolService;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 import de.tum.in.www1.artemis.service.user.PasswordService;
 import de.tum.in.www1.artemis.user.UserFactory;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 import de.tum.in.www1.artemis.util.ZipFileTestUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.CourseWithIdDTO;
@@ -148,11 +146,6 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
     @Autowired
     private ChannelRepository channelRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -68,7 +68,6 @@ import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamLiveEventRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExamUserRepository;
@@ -110,9 +109,6 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
     @Autowired
     private QuizExerciseRepository quizExerciseRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ExerciseRepository exerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -62,7 +62,6 @@ import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizGroup;
 import de.tum.in.www1.artemis.domain.quiz.QuizPool;
 import de.tum.in.www1.artemis.domain.quiz.QuizQuestion;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
@@ -143,9 +142,6 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private PageableSearchUtilService pageableSearchUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -149,8 +149,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
     @Autowired
     private ChannelRepository channelRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
@@ -76,7 +76,6 @@ import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.service.exam.ExamService;
 import de.tum.in.www1.artemis.service.exam.StudentExamService;
@@ -104,9 +103,6 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
 
     @Autowired
     private QuizSubmissionService quizSubmissionService;
-
-    @Autowired
-    private UserRepository userRepo;
 
     @Autowired
     private ExamRepository examRepository;
@@ -463,8 +459,8 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
         log.debug("testGetStatsForExamAssessmentDashboard: step 1 done");
         doNothing().when(gitService).combineAllCommitsOfRepositoryIntoOne(any());
 
-        User examTutor1 = userRepo.findOneByLogin(TEST_PREFIX + "tutor1").orElseThrow();
-        User examTutor2 = userRepo.findOneByLogin(TEST_PREFIX + "tutor2").orElseThrow();
+        User examTutor1 = userRepository.findOneByLogin(TEST_PREFIX + "tutor1").orElseThrow();
+        User examTutor2 = userRepository.findOneByLogin(TEST_PREFIX + "tutor2").orElseThrow();
 
         var examVisibleDate = ZonedDateTime.now().minusMinutes(5);
         var examStartDate = ZonedDateTime.now().plusMinutes(5);
@@ -671,8 +667,8 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
     private void lockAndAssessForSecondCorrection(Exam exam, Course course, List<StudentExam> studentExams, List<Exercise> exercisesInExam, int numberOfCorrectionRounds)
             throws Exception {
         // Lock all submissions
-        User examInstructor = userRepo.findOneByLogin(TEST_PREFIX + "instructor1").orElseThrow();
-        User examTutor2 = userRepo.findOneByLogin(TEST_PREFIX + "tutor2").orElseThrow();
+        User examInstructor = userRepository.findOneByLogin(TEST_PREFIX + "instructor1").orElseThrow();
+        User examTutor2 = userRepository.findOneByLogin(TEST_PREFIX + "tutor2").orElseThrow();
 
         for (var exercise : exercisesInExam) {
             for (var participation : exercise.getStudentParticipations()) {
@@ -970,7 +966,7 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
         // Compare StudentResult with the generated results
         for (var studentResult : examScores.studentResults()) {
             // Find the original user using the id in StudentResult
-            User originalUser = userRepo.findByIdElseThrow(studentResult.userId());
+            User originalUser = userRepository.findByIdElseThrow(studentResult.userId());
             StudentExam studentExamOfUser = studentExams.stream().filter(studentExam -> studentExam.getUser().equals(originalUser)).findFirst().orElseThrow();
 
             assertThat(studentResult.name()).isEqualTo(originalUser.getName());
@@ -1112,12 +1108,12 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
         textExerciseUtilService.createIndividualTextExercise(course, pastTimestamp, pastTimestamp, pastTimestamp);
 
         Exercise teamExercise = textExerciseUtilService.createTeamTextExercise(course, pastTimestamp, pastTimestamp, pastTimestamp);
-        User tutor1 = userRepo.findOneByLogin(TEST_PREFIX + "tutor1").orElseThrow();
+        User tutor1 = userRepository.findOneByLogin(TEST_PREFIX + "tutor1").orElseThrow();
         Long teamTextExerciseId = teamExercise.getId();
         Long team1Id = teamUtilService.createTeam(Set.of(student1), tutor1, teamExercise, TEST_PREFIX + "team1").getId();
-        User student2 = userRepo.findOneByLogin(TEST_PREFIX + "student2").orElseThrow();
-        User student3 = userRepo.findOneByLogin(TEST_PREFIX + "student3").orElseThrow();
-        User tutor2 = userRepo.findOneByLogin(TEST_PREFIX + "tutor2").orElseThrow();
+        User student2 = userRepository.findOneByLogin(TEST_PREFIX + "student2").orElseThrow();
+        User student3 = userRepository.findOneByLogin(TEST_PREFIX + "student3").orElseThrow();
+        User tutor2 = userRepository.findOneByLogin(TEST_PREFIX + "tutor2").orElseThrow();
         Long team2Id = teamUtilService.createTeam(Set.of(student2, student3), tutor2, teamExercise, TEST_PREFIX + "team2").getId();
 
         participationUtilService.createParticipationSubmissionAndResult(individualTextExerciseId, student1, 10.0, 10.0, 50, true);

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
@@ -160,8 +160,7 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
     @Autowired
     private ProgrammingExerciseTestService programmingExerciseTestService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
@@ -35,7 +35,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
 import de.tum.in.www1.artemis.assessment.GradingScaleUtilService;
 import de.tum.in.www1.artemis.bonus.BonusFactory;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.BonusStrategy;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.DomainObject;
@@ -86,7 +85,6 @@ import de.tum.in.www1.artemis.service.exam.StudentExamService;
 import de.tum.in.www1.artemis.service.quiz.QuizSubmissionService;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 import de.tum.in.www1.artemis.team.TeamUtilService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.ExamPrepareExercisesTestUtil;
 import de.tum.in.www1.artemis.util.LocalRepository;
 import de.tum.in.www1.artemis.web.rest.dto.DueDateStat;
@@ -159,11 +157,6 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
 
     @Autowired
     private ProgrammingExerciseTestService programmingExerciseTestService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
@@ -66,7 +66,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.BonusRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExamUserRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
@@ -109,9 +108,6 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
 
     @Autowired
     private QuizSubmissionService quizSubmissionService;
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private ExerciseRepository exerciseRepo;
@@ -1183,7 +1179,7 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
 
         course.setMaxPoints(100);
         course.setPresentationScore(null);
-        courseRepo.save(course);
+        courseRepository.save(course);
 
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
@@ -72,7 +72,6 @@ import de.tum.in.www1.artemis.repository.ParticipantScoreRepository;
 import de.tum.in.www1.artemis.repository.ParticipationTestRepository;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.QuizSubmissionRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
@@ -129,9 +128,6 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private ParticipationTestRepository participationTestRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamParticipationIntegrationTest.java
@@ -67,7 +67,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.BonusRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExamUserRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
 import de.tum.in.www1.artemis.repository.ParticipantScoreRepository;
 import de.tum.in.www1.artemis.repository.ParticipationTestRepository;
@@ -106,9 +105,6 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
 
     @Autowired
     private QuizSubmissionService quizSubmissionService;
-
-    @Autowired
-    private ExerciseRepository exerciseRepo;
 
     @Autowired
     private UserRepository userRepo;
@@ -828,7 +824,7 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
 
         if (withSecondCorrectionAndStarted) {
             exercisesInExam.forEach(exercise -> exercise.setSecondCorrectionEnabled(true));
-            exerciseRepo.saveAll(exercisesInExam);
+            exerciseRepository.saveAll(exercisesInExam);
         }
 
         // Scores used for all exercise results
@@ -888,7 +884,7 @@ class ExamParticipationIntegrationTest extends AbstractSpringIntegrationJenkinsG
         // explicitly set the user again to prevent issues in the following server call due to the use of SecurityUtils.setAuthorizationObject();
         userUtilService.changeUser(TEST_PREFIX + "instructor1");
         final var exerciseWithNoUsers = TextExerciseFactory.generateTextExerciseForExam(exam.getExerciseGroups().get(0));
-        exerciseRepo.save(exerciseWithNoUsers);
+        exerciseRepository.save(exerciseWithNoUsers);
 
         GradingScale gradingScale = gradingScaleUtilService.generateGradingScaleWithStickyStep(new double[] { 60, 25, 15, 50 },
                 Optional.of(new String[] { "5.0", "3.0", "1.0", "1.0" }), true, 1);

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamRegistrationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamRegistrationIntegrationTest.java
@@ -19,7 +19,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationLocalCILocalVCTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.Exam;
@@ -36,7 +35,6 @@ import de.tum.in.www1.artemis.service.ldap.LdapUserDto;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 import de.tum.in.www1.artemis.service.user.PasswordService;
 import de.tum.in.www1.artemis.user.UserFactory;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 
 class ExamRegistrationIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCTest {
@@ -65,11 +63,6 @@ class ExamRegistrationIntegrationTest extends AbstractSpringIntegrationLocalCILo
 
     @Autowired
     private ChannelRepository channelRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamRegistrationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamRegistrationIntegrationTest.java
@@ -66,8 +66,7 @@ class ExamRegistrationIntegrationTest extends AbstractSpringIntegrationLocalCILo
     @Autowired
     private ChannelRepository channelRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamRegistrationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamRegistrationIntegrationTest.java
@@ -26,10 +26,8 @@ import de.tum.in.www1.artemis.domain.exam.ExamUser;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExamUserRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
 import de.tum.in.www1.artemis.service.dto.StudentDTO;
-import de.tum.in.www1.artemis.service.exam.ExamAccessService;
 import de.tum.in.www1.artemis.service.exam.ExamRegistrationService;
 import de.tum.in.www1.artemis.service.ldap.LdapUserDto;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
@@ -44,9 +42,6 @@ class ExamRegistrationIntegrationTest extends AbstractSpringIntegrationLocalCILo
     public static final String STUDENT_111 = TEST_PREFIX + "student111";
 
     @Autowired
-    private UserRepository userRepo;
-
-    @Autowired
     private ExamRepository examRepository;
 
     @Autowired
@@ -57,9 +52,6 @@ class ExamRegistrationIntegrationTest extends AbstractSpringIntegrationLocalCILo
 
     @Autowired
     private PasswordService passwordService;
-
-    @Autowired
-    private ExamAccessService examAccessService;
 
     @Autowired
     private ChannelRepository channelRepository;
@@ -108,9 +100,9 @@ class ExamRegistrationIntegrationTest extends AbstractSpringIntegrationLocalCILo
     void testRegisterUserInExam_addedToCourseStudentsGroup() throws Exception {
         User student42 = userUtilService.getUserByLogin(TEST_PREFIX + "student42");
 
-        Set<User> studentsInCourseBefore = userRepo.findAllWithGroupsAndAuthoritiesByIsDeletedIsFalseAndGroupsContains(course1.getStudentGroupName());
+        Set<User> studentsInCourseBefore = userRepository.findAllWithGroupsAndAuthoritiesByIsDeletedIsFalseAndGroupsContains(course1.getStudentGroupName());
         request.postWithoutLocation("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/students/" + TEST_PREFIX + "student42", null, HttpStatus.OK, null);
-        Set<User> studentsInCourseAfter = userRepo.findAllWithGroupsAndAuthoritiesByIsDeletedIsFalseAndGroupsContains(course1.getStudentGroupName());
+        Set<User> studentsInCourseAfter = userRepository.findAllWithGroupsAndAuthoritiesByIsDeletedIsFalseAndGroupsContains(course1.getStudentGroupName());
         studentsInCourseBefore.add(student42);
         assertThat(studentsInCourseBefore).containsExactlyInAnyOrderElementsOf(studentsInCourseAfter);
     }
@@ -158,7 +150,7 @@ class ExamRegistrationIntegrationTest extends AbstractSpringIntegrationLocalCILo
         userUtilService.createAndSaveUser("student99"); // not registered for the course
         userUtilService.setRegistrationNumberOfUserAndSave("student99", registrationNumber99);
 
-        User student99 = userRepo.findOneWithGroupsAndAuthoritiesByLogin("student99").orElseThrow();
+        User student99 = userRepository.findOneWithGroupsAndAuthoritiesByLogin("student99").orElseThrow();
         assertThat(student99.getGroups()).doesNotContain(course1.getStudentGroupName());
 
         // Note: student111 is not yet a user of Artemis and should be retrieved from the LDAP
@@ -209,7 +201,7 @@ class ExamRegistrationIntegrationTest extends AbstractSpringIntegrationLocalCILo
 
         for (var examUser : storedExam.getExamUsers()) {
             // all registered users must have access to the course
-            var user = userRepo.findOneWithGroupsAndAuthoritiesByLogin(examUser.getUser().getLogin()).orElseThrow();
+            var user = userRepository.findOneWithGroupsAndAuthoritiesByLogin(examUser.getUser().getLogin()).orElseThrow();
             assertThat(user.getGroups()).contains(course1.getStudentGroupName());
         }
 
@@ -277,7 +269,7 @@ class ExamRegistrationIntegrationTest extends AbstractSpringIntegrationLocalCILo
     void testAddAllRegisteredUsersToExam() throws Exception {
         Exam exam = examUtilService.addExam(course1);
         Channel channel = examUtilService.addExamChannel(exam, "testchannel");
-        int numberOfStudentsInCourse = userRepo.findAllByIsDeletedIsFalseAndGroupsContains(course1.getStudentGroupName()).size();
+        int numberOfStudentsInCourse = userRepository.findAllByIsDeletedIsFalseAndGroupsContains(course1.getStudentGroupName()).size();
 
         User student99 = userUtilService.createAndSaveUser(TEST_PREFIX + "student99"); // not registered for the course
         student99.setGroups(Collections.singleton("tumuser"));

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamSessionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamSessionIntegrationTest.java
@@ -8,14 +8,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
 import de.tum.in.www1.artemis.repository.ExamSessionRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.service.exam.ExamSessionService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import inet.ipaddr.IPAddressString;
 
 class ExamSessionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -30,11 +28,6 @@ class ExamSessionIntegrationTest extends AbstractSpringIntegrationIndependentTes
 
     @Autowired
     private ExamSessionService examSessionService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamSessionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamSessionIntegrationTest.java
@@ -31,8 +31,7 @@ class ExamSessionIntegrationTest extends AbstractSpringIntegrationIndependentTes
     @Autowired
     private ExamSessionService examSessionService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
@@ -32,7 +32,6 @@ import org.springframework.util.ResourceUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.Exam;
@@ -42,7 +41,6 @@ import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseTestServic
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.LocalRepository;
 import de.tum.in.www1.artemis.web.rest.dto.ExamUserAttendanceCheckDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ExamUserDTO;
@@ -66,11 +64,6 @@ class ExamUserIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest
 
     @Autowired
     private ProgrammingExerciseTestService programmingExerciseTestService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
@@ -40,7 +40,6 @@ import de.tum.in.www1.artemis.domain.exam.StudentExam;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseTestService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.util.LocalRepository;
 import de.tum.in.www1.artemis.web.rest.dto.ExamUserAttendanceCheckDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ExamUserDTO;
@@ -55,9 +54,6 @@ class ExamUserIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest
 
     @Autowired
     private ObjectMapper mapper;
-
-    @Autowired
-    private UserRepository userRepo;
 
     @Autowired
     private StudentExamRepository studentExamRepository;
@@ -93,16 +89,16 @@ class ExamUserIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest
 
         // same registration number as in test pdf file
         student1.setRegistrationNumber("03756882");
-        userRepo.save(student1);
+        userRepository.save(student1);
 
         student2.setRegistrationNumber("03756883");
-        userRepo.save(student2);
+        userRepository.save(student2);
 
         student3.setRegistrationNumber("03756884");
-        userRepo.save(student3);
+        userRepository.save(student3);
 
         student4.setRegistrationNumber("03756885");
-        userRepo.save(student4);
+        userRepository.save(student4);
 
         exam1 = examUtilService.addActiveExamWithRegisteredUser(course1, student2);
         exam1 = examUtilService.addExerciseGroupsAndExercisesToExam(exam1, false);

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamUserIntegrationTest.java
@@ -67,8 +67,7 @@ class ExamUserIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest
     @Autowired
     private ProgrammingExerciseTestService programmingExerciseTestService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ProgrammingExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ProgrammingExamIntegrationTest.java
@@ -40,7 +40,6 @@ import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseTestServic
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
@@ -49,9 +48,6 @@ import de.tum.in.www1.artemis.util.ExamPrepareExercisesTestUtil;
 class ProgrammingExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
     private static final String TEST_PREFIX = "programmingexamtest";
-
-    @Autowired
-    private ExerciseRepository exerciseRepo;
 
     @Autowired
     private ExamRepository examRepository;
@@ -331,7 +327,7 @@ class ProgrammingExamIntegrationTest extends AbstractSpringIntegrationJenkinsGit
         exam.setId(null);
         ProgrammingExercise programming = ProgrammingExerciseFactory.generateProgrammingExerciseForExam(programmingGroup, ProgrammingLanguage.JAVA);
         programmingGroup.addExercise(programming);
-        exerciseRepo.save(programming);
+        exerciseRepository.save(programming);
 
         doReturn(true).when(versionControlService).checkIfProjectExists(any(), any());
         doReturn(null).when(continuousIntegrationService).checkIfProjectExists(any(), any());

--- a/src/test/java/de/tum/in/www1/artemis/exam/ProgrammingExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ProgrammingExamIntegrationTest.java
@@ -28,7 +28,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.User;
@@ -45,7 +44,6 @@ import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.ExamPrepareExercisesTestUtil;
 
 class ProgrammingExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
@@ -69,11 +67,6 @@ class ProgrammingExamIntegrationTest extends AbstractSpringIntegrationJenkinsGit
 
     @Autowired
     private ProgrammingExerciseTestService programmingExerciseTestService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/ProgrammingExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ProgrammingExamIntegrationTest.java
@@ -70,8 +70,7 @@ class ProgrammingExamIntegrationTest extends AbstractSpringIntegrationJenkinsGit
     @Autowired
     private ProgrammingExerciseTestService programmingExerciseTestService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/QuizPoolIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/QuizPoolIntegrationTest.java
@@ -24,7 +24,6 @@ import de.tum.in.www1.artemis.domain.quiz.QuizQuestion;
 import de.tum.in.www1.artemis.domain.quiz.ShortAnswerQuestion;
 import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseFactory;
 import de.tum.in.www1.artemis.service.quiz.QuizPoolService;
-import de.tum.in.www1.artemis.util.RequestUtilService;
 
 class QuizPoolIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -35,9 +34,6 @@ class QuizPoolIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ExamUtilService examUtilService;
-
-    @Autowired
-    private RequestUtilService request;
 
     private Course course;
 

--- a/src/test/java/de/tum/in/www1/artemis/exam/QuizPoolIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/QuizPoolIntegrationTest.java
@@ -41,8 +41,7 @@ class QuizPoolIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private ExamUtilService examUtilService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private RequestUtilService request;

--- a/src/test/java/de/tum/in/www1/artemis/exam/QuizPoolIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/QuizPoolIntegrationTest.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.Exam;
@@ -25,7 +24,6 @@ import de.tum.in.www1.artemis.domain.quiz.QuizQuestion;
 import de.tum.in.www1.artemis.domain.quiz.ShortAnswerQuestion;
 import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseFactory;
 import de.tum.in.www1.artemis.service.quiz.QuizPoolService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 
 class QuizPoolIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -36,12 +34,7 @@ class QuizPoolIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     private QuizPoolService quizPoolService;
 
     @Autowired
-    private CourseUtilService courseUtilService;
-
-    @Autowired
     private ExamUtilService examUtilService;
-
-
 
     @Autowired
     private RequestUtilService request;

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -116,7 +116,6 @@ import de.tum.in.www1.artemis.repository.ExamUserRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
 import de.tum.in.www1.artemis.repository.QuizSubmissionRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
@@ -150,9 +149,6 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabT
 
     @Autowired
     private ExamUserRepository examUserRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private SubmissionRepository submissionRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -104,7 +104,6 @@ import de.tum.in.www1.artemis.domain.quiz.ShortAnswerSubmittedText;
 import de.tum.in.www1.artemis.domain.quiz.SubmittedAnswer;
 import de.tum.in.www1.artemis.domain.submissionpolicy.LockRepositoryPolicy;
 import de.tum.in.www1.artemis.domain.submissionpolicy.SubmissionPolicy;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseTestService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
@@ -194,9 +193,6 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabT
 
     @Autowired
     private ExamUtilService examUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -202,8 +202,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabT
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -61,7 +61,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
 import de.tum.in.www1.artemis.assessment.GradingScaleUtilService;
 import de.tum.in.www1.artemis.bonus.BonusFactory;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.BonusStrategy;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -129,7 +128,6 @@ import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.service.exam.ExamQuizService;
 import de.tum.in.www1.artemis.service.exam.StudentExamService;
 import de.tum.in.www1.artemis.service.util.RoundingUtil;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.ExamPrepareExercisesTestUtil;
 import de.tum.in.www1.artemis.util.LocalRepository;
 import de.tum.in.www1.artemis.web.rest.dto.StudentExamWithGradeDTO;
@@ -201,11 +199,6 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabT
 
     @Autowired
     private ObjectMapper objectMapper;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -113,7 +113,6 @@ import de.tum.in.www1.artemis.repository.BonusRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExamSessionRepository;
 import de.tum.in.www1.artemis.repository.ExamUserRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingScaleRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
 import de.tum.in.www1.artemis.repository.QuizSubmissionRepository;
@@ -148,9 +147,6 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabT
 
     @Autowired
     private ExamRepository examRepository;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private ExamUserRepository examUserRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exam/TestExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/TestExamIntegrationTest.java
@@ -23,7 +23,6 @@ import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExamUserRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
-import de.tum.in.www1.artemis.service.exam.ExamAccessService;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 import de.tum.in.www1.artemis.service.user.PasswordService;
 import de.tum.in.www1.artemis.user.UserFactory;
@@ -40,9 +39,6 @@ class TestExamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private PasswordService passwordService;
-
-    @Autowired
-    private ExamAccessService examAccessService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/TestExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/TestExamIntegrationTest.java
@@ -14,7 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.Exam;
@@ -28,7 +27,6 @@ import de.tum.in.www1.artemis.service.exam.ExamAccessService;
 import de.tum.in.www1.artemis.service.scheduled.ParticipantScoreScheduleService;
 import de.tum.in.www1.artemis.service.user.PasswordService;
 import de.tum.in.www1.artemis.user.UserFactory;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class TestExamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -45,11 +43,6 @@ class TestExamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ExamAccessService examAccessService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exam/TestExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/TestExamIntegrationTest.java
@@ -46,8 +46,7 @@ class TestExamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private ExamAccessService examAccessService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/AthenaExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/AthenaExerciseIntegrationTest.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.in.www1.artemis.AbstractAthenaTest;
 import de.tum.in.www1.artemis.course.CourseTestService;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.TextExercise;
@@ -32,7 +31,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class AthenaExerciseIntegrationTest extends AbstractAthenaTest {
 
@@ -41,16 +39,11 @@ class AthenaExerciseIntegrationTest extends AbstractAthenaTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-
-
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/AthenaExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/AthenaExerciseIntegrationTest.java
@@ -30,7 +30,6 @@ import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
@@ -59,9 +58,6 @@ class AthenaExerciseIntegrationTest extends AbstractAthenaTest {
 
     @Autowired
     private CourseTestService courseTestService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/AthenaExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/AthenaExerciseIntegrationTest.java
@@ -41,8 +41,7 @@ class AthenaExerciseIntegrationTest extends AbstractAthenaTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/AthenaResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/AthenaResourceIntegrationTest.java
@@ -82,8 +82,7 @@ class AthenaResourceIntegrationTest extends AbstractAthenaTest {
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ResultRepository resultRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/AthenaResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/AthenaResourceIntegrationTest.java
@@ -40,7 +40,6 @@ import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.FeedbackRepository;
 import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ModelingSubmissionRepository;
@@ -100,9 +99,6 @@ class AthenaResourceIntegrationTest extends AbstractAthenaTest {
 
     @Autowired
     private FeedbackRepository feedbackRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     private TextExercise textExercise;
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/AthenaResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/AthenaResourceIntegrationTest.java
@@ -45,7 +45,6 @@ import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ModelingSubmissionRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
@@ -80,9 +79,6 @@ class AthenaResourceIntegrationTest extends AbstractAthenaTest {
 
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/AthenaResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/AthenaResourceIntegrationTest.java
@@ -66,9 +66,6 @@ class AthenaResourceIntegrationTest extends AbstractAthenaTest {
     private ModelingExerciseUtilService modelingExerciseUtilService;
 
     @Autowired
-    private ExerciseUtilService exerciseUtilService;
-
-    @Autowired
     private TextSubmissionRepository textSubmissionRepository;
 
     @Autowired

--- a/src/test/java/de/tum/in/www1/artemis/exercise/AthenaResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/AthenaResourceIntegrationTest.java
@@ -49,7 +49,6 @@ import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class AthenaResourceIntegrationTest extends AbstractAthenaTest {
 
@@ -81,8 +80,6 @@ class AthenaResourceIntegrationTest extends AbstractAthenaTest {
 
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
-
-
 
     @Autowired
     private ResultRepository resultRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
@@ -50,7 +50,6 @@ import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilServic
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.TutorParticipationRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
@@ -66,9 +65,6 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private UserRepository userRepository;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private ExamRepository examRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
@@ -84,8 +84,7 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private ExerciseService exerciseService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
@@ -75,9 +75,6 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     private ExerciseService exerciseService;
 
     @Autowired
-    private ExerciseUtilService exerciseUtilService;
-
-    @Autowired
     private ParticipationUtilService participationUtilService;
 
     @Autowired

--- a/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
@@ -50,7 +50,6 @@ import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
@@ -78,9 +77,6 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ParticipationRepository participationRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private TutorParticipationRepository tutorParticipationRepo;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
@@ -22,7 +22,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.FileUploadExercise;
@@ -56,7 +55,6 @@ import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.TutorParticipationRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.ExerciseService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 import de.tum.in.www1.artemis.web.rest.dto.ExerciseDetailsDTO;
 import de.tum.in.www1.artemis.web.rest.dto.StatsForDashboardDTO;
@@ -83,11 +81,6 @@ class ExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ExerciseService exerciseService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/ExerciseIntegrationTest.java
@@ -52,7 +52,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.TutorParticipationRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.ExerciseService;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 import de.tum.in.www1.artemis.web.rest.dto.ExerciseDetailsDTO;
@@ -62,9 +61,6 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 class ExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "exerciseintegration";
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ExamRepository examRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
@@ -56,7 +56,6 @@ import de.tum.in.www1.artemis.repository.FileUploadExerciseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.AssessmentUpdateDTO;
 import de.tum.in.www1.artemis.web.rest.dto.FileUploadAssessmentDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ResultDTO;
@@ -88,8 +87,6 @@ class FileUploadAssessmentIntegrationTest extends AbstractSpringIntegrationIndep
 
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
-
-
 
     @Autowired
     private FileUploadExerciseUtilService fileUploadExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
@@ -52,7 +52,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.FileUploadExerciseRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.web.rest.dto.AssessmentUpdateDTO;
@@ -65,9 +64,6 @@ class FileUploadAssessmentIntegrationTest extends AbstractSpringIntegrationIndep
     private static final String TEST_PREFIX = "fileuploadassessment";
 
     public static final String API_FILE_UPLOAD_SUBMISSIONS = "/api/file-upload-submissions/";
-
-    @Autowired
-    private ResultRepository resultRepo;
 
     @Autowired
     private ComplaintRepository complaintRepo;
@@ -373,7 +369,7 @@ class FileUploadAssessmentIntegrationTest extends AbstractSpringIntegrationIndep
         fileUploadSubmission = fileUploadExerciseUtilService.saveFileUploadSubmissionWithResultAndAssessor(afterReleaseFileUploadExercise, fileUploadSubmission, student,
                 originalAssessor);
         fileUploadSubmission.getLatestResult().setCompletionDate(originalAssessmentSubmitted ? ZonedDateTime.now() : null);
-        resultRepo.save(fileUploadSubmission.getLatestResult());
+        resultRepository.save(fileUploadSubmission.getLatestResult());
         var params = new LinkedMultiValueMap<String, String>();
         params.add("submit", submit);
         List<Feedback> feedbacks = ParticipationFactory.generateFeedback();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
@@ -89,8 +89,7 @@ class FileUploadAssessmentIntegrationTest extends AbstractSpringIntegrationIndep
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private FileUploadExerciseUtilService fileUploadExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
@@ -46,7 +46,6 @@ import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
@@ -82,9 +81,6 @@ class FileUploadAssessmentIntegrationTest extends AbstractSpringIntegrationIndep
 
     @Autowired
     private FileUploadExerciseUtilService fileUploadExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadAssessmentIntegrationTest.java
@@ -51,7 +51,6 @@ import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.FileUploadExerciseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
@@ -75,9 +74,6 @@ class FileUploadAssessmentIntegrationTest extends AbstractSpringIntegrationIndep
 
     @Autowired
     private FileUploadExerciseRepository fileUploadExerciseRepository;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private SubmissionRepository submissionRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
@@ -45,7 +45,6 @@ import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.GradingCriterionUtil;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.FeedbackRepository;
 import de.tum.in.www1.artemis.repository.FileUploadExerciseRepository;
@@ -62,9 +61,6 @@ import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "fileuploaderxercise";
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private ExerciseRepository exerciseRepo;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
@@ -80,8 +80,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
     @Autowired
     private ChannelRepository channelRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private FileUploadExerciseUtilService fileUploadExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
@@ -44,7 +44,6 @@ import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.GradingCriterionUtil;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.FeedbackRepository;
 import de.tum.in.www1.artemis.repository.FileUploadExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
@@ -59,9 +58,6 @@ import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
 class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "fileuploaderxercise";
-
-    @Autowired
-    private ExerciseRepository exerciseRepo;
 
     @Autowired
     private FeedbackRepository feedbackRepository;
@@ -350,7 +346,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
         for (var exercise : course.getExercises()) {
             request.delete("/api/file-upload-exercises/" + exercise.getId(), HttpStatus.OK);
         }
-        assertThat(exerciseRepo.findByCourseIdWithCategories(course.getId())).isEmpty();
+        assertThat(exerciseRepository.findByCourseIdWithCategories(course.getId())).isEmpty();
     }
 
     @Test
@@ -374,7 +370,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
             request.delete("/api/file-upload-exercises/" + exercise.getId(), HttpStatus.FORBIDDEN);
         }
 
-        assertThat(exerciseRepo.findByCourseIdWithCategories(course.getId())).hasSize(course.getExercises().size());
+        assertThat(exerciseRepository.findByCourseIdWithCategories(course.getId())).hasSize(course.getExercises().size());
     }
 
     @Test
@@ -393,7 +389,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
         for (var exercise : course.getExercises()) {
             request.delete("/api/file-upload-exercises/" + exercise.getId(), HttpStatus.FORBIDDEN);
         }
-        assertThat(exerciseRepo.findByCourseIdWithCategories(course.getId())).hasSize(3);
+        assertThat(exerciseRepository.findByCourseIdWithCategories(course.getId())).hasSize(3);
     }
 
     @Test
@@ -401,7 +397,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
     void deleteExamFileUploadExercise() throws Exception {
         FileUploadExercise fileUploadExercise = fileUploadExerciseUtilService.addCourseExamExerciseGroupWithOneFileUploadExercise();
         request.delete("/api/file-upload-exercises/" + fileUploadExercise.getId(), HttpStatus.OK);
-        assertThat(exerciseRepo.findByCourseIdWithCategories(fileUploadExercise.getCourseViaExerciseGroupOrCourseMember().getId())).isEmpty();
+        assertThat(exerciseRepository.findByCourseIdWithCategories(fileUploadExercise.getCourseViaExerciseGroupOrCourseMember().getId())).isEmpty();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
@@ -27,7 +27,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Feedback;
@@ -51,7 +50,6 @@ import de.tum.in.www1.artemis.repository.FileUploadExerciseRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.InvalidExamExerciseDatesArgumentProvider;
 import de.tum.in.www1.artemis.util.InvalidExamExerciseDatesArgumentProvider.InvalidExamExerciseDateConfiguration;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
@@ -80,8 +78,6 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
     @Autowired
     private ChannelRepository channelRepository;
 
-
-
     @Autowired
     private FileUploadExerciseUtilService fileUploadExerciseUtilService;
 
@@ -93,9 +89,6 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
 
     @Autowired
     private ParticipationUtilService participationUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private PageableSearchUtilService pageableSearchUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
@@ -145,7 +145,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
         // make sure the instructor is not instructor for this course anymore by changing the courses' instructor group name
         var course = fileUploadExercise.getCourseViaExerciseGroupOrCourseMember();
         course.setInstructorGroupName("new-instructor-group-name");
-        courseRepo.save(course);
+        courseRepository.save(course);
         fileUploadExercise.setFilePattern(creationFilePattern);
         gradingCriteria = exerciseUtilService.addGradingInstructionsToExercise(fileUploadExercise);
         request.postWithResponseBody("/api/file-upload-exercises", fileUploadExercise, FileUploadExercise.class, HttpStatus.FORBIDDEN);
@@ -327,7 +327,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
     void getExamFileUploadExercise_InstructorNotInGroup() throws Exception {
         Course course = fileUploadExerciseUtilService.addCourseWithThreeFileUploadExercise();
         course.setInstructorGroupName("new-instructor-group-name");
-        courseRepo.save(course);
+        courseRepository.save(course);
         for (var exercise : course.getExercises()) {
             request.get("/api/file-upload-exercises/" + exercise.getId(), HttpStatus.FORBIDDEN, FileUploadExercise.class);
         }
@@ -397,7 +397,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
     void deleteFileUploadExerciseFails_InstructorNotInGroup() throws Exception {
         Course course = fileUploadExerciseUtilService.addCourseWithThreeFileUploadExercise();
         course.setInstructorGroupName("new-instructor-group-name");
-        courseRepo.save(course);
+        courseRepository.save(course);
         for (var exercise : course.getExercises()) {
             request.delete("/api/file-upload-exercises/" + exercise.getId(), HttpStatus.FORBIDDEN);
         }
@@ -439,7 +439,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
         fileUploadExercise.setDueDate(ZonedDateTime.now().plusDays(10));
         fileUploadExercise.setAssessmentDueDate(ZonedDateTime.now().plusDays(11));
         course.setInstructorGroupName("new-instructor-group-name");
-        courseRepo.save(course);
+        courseRepository.save(course);
         request.putWithResponseBody("/api/file-upload-exercises/" + fileUploadExercise.getId(), fileUploadExercise, FileUploadExercise.class, HttpStatus.FORBIDDEN);
     }
 
@@ -556,7 +556,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
     void getAllFileUploadExercisesForCourseFails_InstructorNotInGroup() throws Exception {
         var course = fileUploadExerciseUtilService.addCourseWithThreeFileUploadExercise();
         course.setInstructorGroupName("new-instructor-group-name");
-        courseRepo.save(course);
+        courseRepository.save(course);
         request.getList("/api/courses/" + course.getId() + "/file-upload-exercises", HttpStatus.FORBIDDEN, FileUploadExercise.class);
     }
 
@@ -624,7 +624,7 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
         Course course = fileUploadExerciseUtilService.addCourseWithThreeFileUploadExercise();
         FileUploadExercise fileUploadExercise = exerciseUtilService.findFileUploadExerciseWithTitle(course.getExercises(), "released");
         course.setInstructorGroupName("test");
-        courseRepo.save(course);
+        courseRepository.save(course);
 
         request.putWithResponseBody("/api/file-upload-exercises/" + fileUploadExercise.getId() + "/re-evaluate", fileUploadExercise, FileUploadExercise.class,
                 HttpStatus.FORBIDDEN);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadExerciseIntegrationTest.java
@@ -40,7 +40,6 @@ import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.GradingCriterionUtil;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
@@ -76,9 +75,6 @@ class FileUploadExerciseIntegrationTest extends AbstractSpringIntegrationIndepen
 
     @Autowired
     private FileUploadExerciseUtilService fileUploadExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
@@ -47,7 +47,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.FileUploadSubmissionRepository;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.service.FilePathService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -59,8 +58,6 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
 
     @Autowired
     private ParticipationRepository participationRepository;
-
-
 
     @Autowired
     private FileUploadExerciseUtilService fileUploadExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
@@ -40,7 +40,6 @@ import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
@@ -61,9 +60,6 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
 
     @Autowired
     private FileUploadExerciseUtilService fileUploadExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/fileupload/FileUploadSubmissionIntegrationTest.java
@@ -60,8 +60,7 @@ class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrationIndep
     @Autowired
     private ParticipationRepository participationRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private FileUploadExerciseUtilService fileUploadExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ApollonDiagramResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ApollonDiagramResourceIntegrationTest.java
@@ -19,7 +19,6 @@ import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.enumeration.DiagramType;
 import de.tum.in.www1.artemis.domain.modeling.ApollonDiagram;
 import de.tum.in.www1.artemis.repository.ApollonDiagramRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ApollonDiagramResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -28,9 +27,6 @@ class ApollonDiagramResourceIntegrationTest extends AbstractSpringIntegrationInd
 
     @Autowired
     private ApollonDiagramRepository apollonDiagramRepository;
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ApollonDiagramResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ApollonDiagramResourceIntegrationTest.java
@@ -19,7 +19,6 @@ import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.enumeration.DiagramType;
 import de.tum.in.www1.artemis.domain.modeling.ApollonDiagram;
 import de.tum.in.www1.artemis.repository.ApollonDiagramRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ApollonDiagramResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -27,8 +26,6 @@ class ApollonDiagramResourceIntegrationTest extends AbstractSpringIntegrationInd
 
     @Autowired
     private ApollonDiagramRepository apollonDiagramRepository;
-
-
 
     private ApollonDiagram apollonDiagram;
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ApollonDiagramResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ApollonDiagramResourceIntegrationTest.java
@@ -28,8 +28,7 @@ class ApollonDiagramResourceIntegrationTest extends AbstractSpringIntegrationInd
     @Autowired
     private ApollonDiagramRepository apollonDiagramRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     private ApollonDiagram apollonDiagram;
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ApollonDiagramResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ApollonDiagramResourceIntegrationTest.java
@@ -47,8 +47,8 @@ class ApollonDiagramResourceIntegrationTest extends AbstractSpringIntegrationInd
 
         course1 = CourseFactory.generateCourse(null, ZonedDateTime.now(), ZonedDateTime.now(), new HashSet<>(), "tumuser", "tutor", "editor", "instructor");
         course2 = CourseFactory.generateCourse(null, ZonedDateTime.now(), ZonedDateTime.now(), new HashSet<>(), "tumuser", "tutor", "editor", "instructor");
-        courseRepo.save(course1);
-        courseRepo.save(course2);
+        courseRepository.save(course1);
+        courseRepository.save(course2);
     }
 
     @AfterEach

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
@@ -72,7 +72,6 @@ import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.AssessmentService;
 import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.service.compass.CompassService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.AssessmentUpdateDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ModelingAssessmentDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ResultDTO;
@@ -131,8 +130,6 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     private ModelClusterRepository modelClusterRepository;
-
-
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
@@ -132,8 +132,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
     @Autowired
     private ModelClusterRepository modelClusterRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
@@ -53,7 +53,6 @@ import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismComparison;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismStatus;
 import de.tum.in.www1.artemis.domain.plagiarism.modeling.ModelingSubmissionElement;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.plagiarism.PlagiarismUtilService;
@@ -118,9 +117,6 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
@@ -64,7 +64,6 @@ import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
 import de.tum.in.www1.artemis.repository.ModelClusterRepository;
 import de.tum.in.www1.artemis.repository.ModelElementRepository;
 import de.tum.in.www1.artemis.repository.ModelingSubmissionRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
@@ -87,9 +86,6 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     private ModelingSubmissionRepository modelingSubmissionRepo;
-
-    @Autowired
-    private ResultRepository resultRepo;
 
     @Autowired
     private ParticipationService participationService;
@@ -294,7 +290,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
                 TEST_PREFIX + "student1");
         List<Feedback> feedbacks = participationUtilService.loadAssessmentFomResources("test-data/model-assessment/assessment.54727.json");
         createAssessment(submission, feedbacks, "/assessment?submit=true", HttpStatus.FORBIDDEN);
-        Optional<Result> storedResult = resultRepo.findDistinctBySubmissionId(submission.getId());
+        Optional<Result> storedResult = resultRepository.findDistinctBySubmissionId(submission.getId());
         assertThat(storedResult).as("result is not saved").isNotPresent();
     }
 
@@ -310,7 +306,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         createAssessment(submission, feedbacks, "/assessment", HttpStatus.OK);
 
         ModelingSubmission storedSubmission = modelingSubmissionRepo.findWithEagerResultById(submission.getId()).orElseThrow();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
         participationUtilService.checkFeedbackCorrectlyStored(feedbacks, storedResult.getFeedbacks(), FeedbackType.MANUAL);
         checkAssessmentNotFinished(storedResult, assessor);
         assertThat(storedResult.getParticipation()).isNotNull();
@@ -339,7 +335,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         createAssessment(submission, feedbacks, "/assessment?submit=true", HttpStatus.OK);
 
         ModelingSubmission storedSubmission = modelingSubmissionRepo.findWithEagerResultById(submission.getId()).orElseThrow();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
         participationUtilService.checkFeedbackCorrectlyStored(feedbacks, storedResult.getFeedbacks(), FeedbackType.MANUAL);
         checkAssessmentFinished(storedResult, assessor);
         assertThat(storedResult.getParticipation()).isNotNull();
@@ -361,7 +357,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         createAssessment(submission, feedbacks, "/assessment?submit=true", HttpStatus.OK);
 
         ModelingSubmission storedSubmission = modelingSubmissionRepo.findWithEagerResultById(submission.getId()).orElseThrow();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
         participationUtilService.checkFeedbackCorrectlyStored(feedbacks, storedResult.getFeedbacks(), FeedbackType.MANUAL);
         checkAssessmentFinished(storedResult, assessor);
         assertThat(storedResult.getParticipation()).isNotNull();
@@ -378,7 +374,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         createAssessment(submission, feedbacks, "/assessment?submit=true", HttpStatus.OK);
 
         ModelingSubmission storedSubmission = modelingSubmissionRepo.findWithEagerResultById(submission.getId()).orElseThrow();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
         participationUtilService.checkFeedbackCorrectlyStored(feedbacks, storedResult.getFeedbacks(), FeedbackType.MANUAL);
         checkAssessmentFinished(storedResult, assessor);
     }
@@ -394,7 +390,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         createAssessment(submission, feedbacks, "/assessment?submit=true", HttpStatus.OK);
 
         ModelingSubmission storedSubmission = modelingSubmissionRepo.findWithEagerResultById(submission.getId()).orElseThrow();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
         participationUtilService.checkFeedbackCorrectlyStored(feedbacks, storedResult.getFeedbacks(), FeedbackType.MANUAL);
         checkAssessmentFinished(storedResult, assessor);
         assertThat(storedResult.getParticipation()).isNotNull();
@@ -411,7 +407,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         createAssessment(submission, feedbacks, "/assessment", HttpStatus.OK);
 
         ModelingSubmission storedSubmission = modelingSubmissionRepo.findWithEagerResultById(submission.getId()).orElseThrow();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
         participationUtilService.checkFeedbackCorrectlyStored(feedbacks, storedResult.getFeedbacks(), FeedbackType.MANUAL);
         checkAssessmentNotFinished(storedResult, assessor);
 
@@ -419,7 +415,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         createAssessment(submission, feedbacks, "/assessment?submit=true", HttpStatus.OK);
 
         storedSubmission = modelingSubmissionRepo.findWithEagerResultById(submission.getId()).orElseThrow();
-        storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
+        storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
         participationUtilService.checkFeedbackCorrectlyStored(feedbacks, storedResult.getFeedbacks(), FeedbackType.MANUAL);
         checkAssessmentFinished(storedResult, assessor);
         assertThat(storedResult.getParticipation()).isNotNull();
@@ -457,7 +453,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         feedbacks.add(new Feedback().credits(pointsAwarded).type(FeedbackType.MANUAL_UNREFERENCED).detailText("gj"));
         createAssessment(submission, feedbacks, "/assessment?submit=true", HttpStatus.OK);
         ModelingSubmission storedSubmission = modelingSubmissionRepo.findWithEagerResultById(submission.getId()).orElseThrow();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
         assertThat(storedResult.getScore()).isEqualTo(expectedScore, Offset.offset(offsetByTenThousandth));
     }
 
@@ -476,7 +472,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         createAssessment(submission, feedbacks, "/assessment?submit=true", HttpStatus.OK);
 
         ModelingSubmission storedSubmission = modelingSubmissionRepo.findWithEagerResultById(submission.getId()).orElseThrow();
-        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
+        Result storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
 
         assertThat(storedResult.getScore()).isEqualTo(105);
 
@@ -486,7 +482,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         createAssessment(submission, feedbacks, "/assessment?submit=true", HttpStatus.OK);
 
         storedSubmission = modelingSubmissionRepo.findWithEagerResultById(submission.getId()).orElseThrow();
-        storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
+        storedResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(storedSubmission.getLatestResult().getId()).orElseThrow();
 
         assertThat(storedResult.getScore()).isEqualTo(110, Offset.offset(offsetByTenThousandth));
     }
@@ -627,7 +623,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         ModelingSubmission storedSubmission = request.postWithResponseBody("/api/exercises/" + classExercise.getId() + "/modeling-submissions", submission,
                 ModelingSubmission.class, HttpStatus.OK);
 
-        Optional<Result> automaticResult = resultRepo.findDistinctWithFeedbackBySubmissionId(storedSubmission.getId());
+        Optional<Result> automaticResult = resultRepository.findDistinctWithFeedbackBySubmissionId(storedSubmission.getId());
         assertThat(automaticResult).as("automatic result not stored in database").isNotPresent();
     }
 
@@ -923,7 +919,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
 
         createAssessment(submission1, feedbacks, "/assessment?submit=true", HttpStatus.OK);
 
-        Optional<Result> automaticResult = resultRepo.findDistinctWithFeedbackBySubmissionId(submission2.getId());
+        Optional<Result> automaticResult = resultRepository.findDistinctWithFeedbackBySubmissionId(submission2.getId());
         assertThat(automaticResult).as("automatic result not stored in database").isNotPresent();
     }
 
@@ -1041,11 +1037,11 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
 
         createAssessment(modelingSubmission2, Collections.singletonList(changedFeedback), "/assessment?submit=true", HttpStatus.OK);
 
-        modelingAssessment = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission2.getId()).orElseThrow();
+        modelingAssessment = resultRepository.findDistinctWithFeedbackBySubmissionId(modelingSubmission2.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("assessment is correctly stored").hasSize(1);
         assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("feedback credits are correct").isEqualTo(changedFeedback.getCredits());
         assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("feedback text are correct").isEqualTo(changedFeedback.getText());
-        modelingAssessment = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
+        modelingAssessment = resultRepository.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("existing manual assessment has correct amount of feedback").hasSize(1);
         assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("existing manual assessment did not change credits").isEqualTo(originalFeedback.getCredits());
         assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("existing manual assessment did not change text").isEqualTo(originalFeedback.getText());
@@ -1064,12 +1060,12 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
 
         createAssessment(modelingSubmission, Collections.singletonList(originalFeedback), "/assessment?submit=true", HttpStatus.OK);
 
-        Result originalResult = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
+        Result originalResult = resultRepository.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
         Feedback changedFeedback = originalResult.getFeedbacks().get(0).credits(2.0).text("another text");
         ModelingAssessmentDTO body = new ModelingAssessmentDTO(Collections.singletonList(changedFeedback), "text");
         request.put(API_MODELING_SUBMISSIONS + modelingSubmission.getId() + "/result/" + originalResult.getId() + "/assessment?submit=true", body, HttpStatus.OK);
 
-        modelingAssessment = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
+        modelingAssessment = resultRepository.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("overridden assessment has correct amount of feedback").hasSize(1);
         assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("feedback credits are properly overridden").isEqualTo(changedFeedback.getCredits());
         assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("feedback text is properly overridden").isEqualTo(changedFeedback.getText());
@@ -1096,17 +1092,17 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         createAssessment(modelingSubmission, Arrays.asList(originalFeedback, originalFeedbackWithoutReference), "/assessment?submit=true", HttpStatus.OK);
         createAssessment(modelingSubmission2, Arrays.asList(originalFeedback, originalFeedbackWithoutReference), "/assessment?submit=true", HttpStatus.OK);
 
-        Result originalResult = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
+        Result originalResult = resultRepository.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
         Feedback changedFeedback = originalResult.getFeedbacks().get(0).credits(2.0).text("another text");
         Feedback feedbackWithoutReference = new Feedback().credits(1.0).text("another feedback text again").reference(null).type(FeedbackType.MANUAL_UNREFERENCED);
         ModelingAssessmentDTO body = new ModelingAssessmentDTO(Arrays.asList(changedFeedback, feedbackWithoutReference), "text");
         request.put(API_MODELING_SUBMISSIONS + modelingSubmission.getId() + "/result/" + originalResult.getId() + "/assessment?submit=true", body, HttpStatus.OK);
 
-        modelingAssessment = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
+        modelingAssessment = resultRepository.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("overridden assessment has correct amount of feedback").hasSize(2);
         assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("feedback credits are properly overridden").isEqualTo(changedFeedback.getCredits());
         assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("feedback text is properly overridden").isEqualTo(changedFeedback.getText());
-        modelingAssessment = resultRepo.findDistinctWithFeedbackBySubmissionId(modelingSubmission2.getId()).orElseThrow();
+        modelingAssessment = resultRepository.findDistinctWithFeedbackBySubmissionId(modelingSubmission2.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("existing submitted assessment still exists").hasSize(2);
         assertThat(modelingAssessment.getFeedbacks().getFirst().getCredits()).as("existing feedback credits are still the same").isEqualTo(originalFeedback.getCredits());
         assertThat(modelingAssessment.getFeedbacks().getFirst().getText()).as("existing feedback text is still the same").isEqualTo(originalFeedback.getText());
@@ -1446,7 +1442,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         ModelingSubmission submission = ParticipationFactory.generateModelingSubmission(loadFileFromResources("test-data/model-submission/model.54727.json"), true);
         submission = modelingExerciseUtilService.addModelingSubmissionWithResultAndAssessor(classExercise, submission, student, originalAssessor);
         submission.getLatestResult().setCompletionDate(originalAssessmentSubmitted ? ZonedDateTime.now() : null);
-        resultRepo.save(submission.getLatestResult());
+        resultRepository.save(submission.getLatestResult());
         var params = new LinkedMultiValueMap<String, String>();
         params.add("submit", submit);
         List<Feedback> feedbacks = participationUtilService.loadAssessmentFomResources("test-data/model-assessment/assessment.54727.json");
@@ -1469,7 +1465,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         Result newResult = participationUtilService
                 .addResultToSubmission(submission, AssessmentType.MANUAL, userUtilService.getUserByLogin(TEST_PREFIX + "tutor2"), null, true, null).getLatestResult();
 
-        resultRepo.save(submission.getLatestResult());
+        resultRepository.save(submission.getLatestResult());
         var params = new LinkedMultiValueMap<String, String>();
         params.add("submit", submit);
         List<Feedback> feedbacks = participationUtilService.loadAssessmentFomResources("test-data/model-assessment/assessment.54727.json");
@@ -1510,7 +1506,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         firstResult.setAssessor(tutor1);
         firstResult.setHasComplaint(true);
         firstResult.setParticipation(studentParticipation);
-        firstResult = resultRepo.saveAndFlush(firstResult);
+        firstResult = resultRepository.saveAndFlush(firstResult);
 
         submission.addResult(firstResult);
         firstResult.setSubmission(submission);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
@@ -61,7 +61,6 @@ import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ComplaintResponseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ModelClusterRepository;
 import de.tum.in.www1.artemis.repository.ModelElementRepository;
 import de.tum.in.www1.artemis.repository.ModelingSubmissionRepository;
@@ -84,9 +83,6 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
     public static final String API_MODELING_SUBMISSIONS = "/api/modeling-submissions/";
 
     @Autowired
-    private ExerciseRepository exerciseRepo;
-
-    @Autowired
     private UserRepository userRepo;
 
     @Autowired
@@ -106,9 +102,6 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     private AssessmentService assessmentService;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private ExamRepository examRepository;
@@ -327,7 +320,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testManualAssessmentSave_noCourse() throws Exception {
         classExercise.setCourse(null);
-        exerciseRepo.save(classExercise);
+        exerciseRepository.save(classExercise);
         ModelingSubmission submission = modelingExerciseUtilService.addModelingSubmissionFromResources(classExercise, "test-data/model-submission/model.54727.json",
                 TEST_PREFIX + "student1");
 
@@ -440,7 +433,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         useCaseExercise.setIncludedInOverallScore(includedInOverallScore);
         useCaseExercise.setMaxPoints(10.0);
         useCaseExercise.setBonusPoints(bonus ? 10.0 : 0.0);
-        exerciseRepo.save(useCaseExercise);
+        exerciseRepository.save(useCaseExercise);
 
         // setting up student submission
         ModelingSubmission submission = modelingExerciseUtilService.addModelingSubmissionFromResources(useCaseExercise, "test-data/model-submission/use-case-model.json",
@@ -980,7 +973,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testOverrideAutomaticAssessment() throws Exception {
         classExercise.setDueDate(ZonedDateTime.now().minusHours(1));
-        exerciseRepo.save(classExercise);
+        exerciseRepository.save(classExercise);
         modelingSubmission = modelingExerciseUtilService.addModelingSubmissionFromResources(classExercise, "test-data/model-submission/model.54727.partial.json",
                 TEST_PREFIX + "student1");
         modelingAssessment = modelingExerciseUtilService.addModelingAssessmentForSubmission(classExercise, modelingSubmission,
@@ -1305,7 +1298,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         Exam examWithExerciseGroups = examRepository.findWithExerciseGroupsAndExercisesById(exam.getId()).orElseThrow();
         exerciseGroup1 = examWithExerciseGroups.getExerciseGroups().get(0);
         ModelingExercise exercise = ModelingExerciseFactory.generateModelingExerciseForExam(DiagramType.ClassDiagram, exerciseGroup1);
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
         exerciseGroup1.addExercise(exercise);
 
         // add student submission
@@ -1497,7 +1490,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
                 ZonedDateTime.now().plusDays(8), DiagramType.ClassDiagram, course);
         modelingExercise.setMaxPoints(10.0);
         modelingExercise.setBonusPoints(0.0);
-        modelingExercise = exerciseRepo.saveAndFlush(modelingExercise);
+        modelingExercise = exerciseRepository.saveAndFlush(modelingExercise);
 
         // creating participation of student1 by starting the exercise
         User student1 = userRepo.findOneByLogin(TEST_PREFIX + "student1").orElse(null);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingAssessmentIntegrationTest.java
@@ -66,7 +66,6 @@ import de.tum.in.www1.artemis.repository.ModelElementRepository;
 import de.tum.in.www1.artemis.repository.ModelingSubmissionRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.AssessmentService;
 import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.service.compass.CompassService;
@@ -80,9 +79,6 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
     private static final String TEST_PREFIX = "modelingassessment";
 
     public static final String API_MODELING_SUBMISSIONS = "/api/modeling-submissions/";
-
-    @Autowired
-    private UserRepository userRepo;
 
     @Autowired
     private ModelingSubmissionRepository modelingSubmissionRepo;
@@ -1489,7 +1485,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         modelingExercise = exerciseRepository.saveAndFlush(modelingExercise);
 
         // creating participation of student1 by starting the exercise
-        User student1 = userRepo.findOneByLogin(TEST_PREFIX + "student1").orElse(null);
+        User student1 = userRepository.findOneByLogin(TEST_PREFIX + "student1").orElse(null);
         StudentParticipation studentParticipation = participationService.startExercise(modelingExercise, student1, false);
 
         // creating submission of student1
@@ -1501,7 +1497,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         submission = submissionRepository.saveAndFlush(submission);
 
         // creating assessment by tutor1
-        User tutor1 = userRepo.findOneByLogin("tutor1").orElse(null);
+        User tutor1 = userRepository.findOneByLogin("tutor1").orElse(null);
         Result firstResult = ParticipationFactory.generateResult(true, 50);
         firstResult.setAssessor(tutor1);
         firstResult.setHasComplaint(true);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseIntegrationTest.java
@@ -104,8 +104,7 @@ class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationLocalCILo
     @Autowired
     private ChannelRepository channelRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseIntegrationTest.java
@@ -48,7 +48,6 @@ import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.participation.TutorParticipation;
 import de.tum.in.www1.artemis.domain.plagiarism.modeling.ModelingPlagiarismResult;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.GradingCriterionUtil;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
@@ -101,9 +100,6 @@ class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationLocalCILo
 
     @Autowired
     private ChannelRepository channelRepository;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseIntegrationTest.java
@@ -53,7 +53,6 @@ import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.GradingCriterionUtil;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.FeedbackRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
 import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;
@@ -92,9 +91,6 @@ class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationLocalCILo
 
     @Autowired
     private GradingCriterionRepository gradingCriterionRepository;
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
@@ -924,7 +920,7 @@ class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationLocalCILo
         Course course = modelingExerciseUtilService.addCourseWithOneModelingExercise();
         classExercise = (ModelingExercise) course.getExercises().iterator().next();
         course.setInstructorGroupName("test");
-        courseRepo.save(course);
+        courseRepository.save(course);
         request.put("/api/modeling-exercises/" + classExercise.getId() + "/re-evaluate", classExercise, HttpStatus.FORBIDDEN);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseIntegrationTest.java
@@ -27,7 +27,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationLocalCILocalVCTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ExampleSubmission;
 import de.tum.in.www1.artemis.domain.Feedback;
@@ -61,7 +60,6 @@ import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.TutorParticipationRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.ExerciseIntegrationTestService;
 import de.tum.in.www1.artemis.util.InvalidExamExerciseDatesArgumentProvider;
 import de.tum.in.www1.artemis.util.InvalidExamExerciseDatesArgumentProvider.InvalidExamExerciseDateConfiguration;
@@ -104,13 +102,8 @@ class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationLocalCILo
     @Autowired
     private ChannelRepository channelRepository;
 
-
-
     @Autowired
     private ExerciseUtilService exerciseUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseUtilService.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -35,6 +34,7 @@ import de.tum.in.www1.artemis.domain.plagiarism.modeling.ModelingPlagiarismResul
 import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.FeedbackRepository;
 import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseUtilService.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -57,6 +58,9 @@ public class ModelingExerciseUtilService {
     private static final ZonedDateTime futureTimestamp = ZonedDateTime.now().plusDays(1);
 
     private static final ZonedDateTime futureFutureTimestamp = ZonedDateTime.now().plusDays(2);
+
+    @Autowired
+    private CourseRepository courseRepo;
 
     @Autowired
     private ExerciseRepository exerciseRepo;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingExerciseUtilService.java
@@ -34,7 +34,6 @@ import de.tum.in.www1.artemis.domain.plagiarism.modeling.ModelingPlagiarismResul
 import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.FeedbackRepository;
 import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;
@@ -58,9 +57,6 @@ public class ModelingExerciseUtilService {
     private static final ZonedDateTime futureTimestamp = ZonedDateTime.now().plusDays(1);
 
     private static final ZonedDateTime futureFutureTimestamp = ZonedDateTime.now().plusDays(2);
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private ExerciseRepository exerciseRepo;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
@@ -42,7 +42,6 @@ import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismComparison;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismSubmission;
 import de.tum.in.www1.artemis.domain.plagiarism.modeling.ModelingSubmissionElement;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
@@ -99,9 +98,6 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
@@ -53,7 +53,6 @@ import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionVersionRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismComparisonRepository;
@@ -64,9 +63,6 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCTest {
 
     private static final String TEST_PREFIX = "modelingsubmissionintegration";
-
-    @Autowired
-    private UserRepository userRepo;
 
     @Autowired
     private TeamRepository teamRepository;
@@ -281,8 +277,8 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         team.setName("Team");
         team.setShortName(TEST_PREFIX + "team");
         team.setExercise(useCaseExercise);
-        team.addStudents(userRepo.findOneByLogin(TEST_PREFIX + "student1").orElseThrow());
-        team.addStudents(userRepo.findOneByLogin(TEST_PREFIX + "student2").orElseThrow());
+        team.addStudents(userRepository.findOneByLogin(TEST_PREFIX + "student1").orElseThrow());
+        team.addStudents(userRepository.findOneByLogin(TEST_PREFIX + "student2").orElseThrow());
         teamRepository.save(useCaseExercise, team);
 
         participationUtilService.addTeamParticipationForExercise(useCaseExercise, team.getId());
@@ -471,7 +467,7 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         plagiarismCase.setExercise(classExercise);
         plagiarismCase = plagiarismCaseRepository.save(plagiarismCase);
         Post post = new Post();
-        post.setAuthor(userRepo.getUserByLoginElseThrow(TEST_PREFIX + "instructor1"));
+        post.setAuthor(userRepository.getUserByLoginElseThrow(TEST_PREFIX + "instructor1"));
         post.setTitle("Title Plagiarism Case Post");
         post.setContent("Content Plagiarism Case Post");
         post.setVisibleForStudents(true);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
@@ -106,8 +106,7 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
     @Autowired
     private PostRepository postRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
@@ -48,7 +48,6 @@ import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExerciseGroupRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ModelingSubmissionRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
@@ -65,9 +64,6 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCTest {
 
     private static final String TEST_PREFIX = "modelingsubmissionintegration";
-
-    @Autowired
-    private ExerciseRepository exerciseRepo;
 
     @Autowired
     private UserRepository userRepo;
@@ -280,7 +276,7 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
     @WithMockUser(username = TEST_PREFIX + "student1")
     void saveAndSubmitModelingSubmission_isTeamMode() throws Exception {
         useCaseExercise.setMode(ExerciseMode.TEAM);
-        exerciseRepo.save(useCaseExercise);
+        exerciseRepository.save(useCaseExercise);
         Team team = new Team();
         team.setName("Team");
         team.setShortName(TEST_PREFIX + "team");
@@ -773,7 +769,7 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         ModelingExercise modelingExercise = ModelingExerciseFactory.generateModelingExerciseForExam(DiagramType.ActivityDiagram, exerciseGroup);
         exerciseGroup.addExercise(modelingExercise);
         exerciseGroupRepository.save(exerciseGroup);
-        modelingExercise = exerciseRepo.save(modelingExercise);
+        modelingExercise = exerciseRepository.save(modelingExercise);
 
         examRepository.save(exam);
 
@@ -796,7 +792,7 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         ModelingExercise modelingExercise = ModelingExerciseFactory.generateModelingExerciseForExam(DiagramType.ActivityDiagram, exerciseGroup);
         exerciseGroup.addExercise(modelingExercise);
         exerciseGroupRepository.save(exerciseGroup);
-        modelingExercise = exerciseRepo.save(modelingExercise);
+        modelingExercise = exerciseRepository.save(modelingExercise);
 
         exam = examRepository.save(exam);
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/modeling/ModelingSubmissionIntegrationTest.java
@@ -59,7 +59,6 @@ import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismComparisonRepository;
 import de.tum.in.www1.artemis.service.compass.CompassService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
@@ -105,8 +104,6 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     private PostRepository postRepository;
-
-
 
     @Autowired
     private ModelingExerciseUtilService modelingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/CourseGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/CourseGitlabJenkinsIntegrationTest.java
@@ -48,8 +48,7 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @BeforeEach
     void setup() {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/CourseGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/CourseGitlabJenkinsIntegrationTest.java
@@ -25,7 +25,6 @@ import de.tum.in.www1.artemis.course.CourseFactory;
 import de.tum.in.www1.artemis.course.CourseTestService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
@@ -39,9 +38,6 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private UserRepository userRepo;
@@ -579,7 +575,7 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testRemoveTutorFromCourse_removeUserFromGitlabGroupFails() throws Exception {
         Course course = CourseFactory.generateCourse(null, null, null, new HashSet<>(), "tumuser", "tutor", "editor", "instructor");
-        course = courseRepo.save(course);
+        course = courseRepository.save(course);
         programmingExerciseUtilService.addProgrammingExerciseToCourse(course);
 
         Optional<User> optionalTutor = userRepo.findOneWithGroupsByLogin(TEST_PREFIX + "tutor1");
@@ -603,7 +599,7 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
     @WithMockUser(username = "admin", roles = "ADMIN")
     void testUpdateCourse_withExternalUserManagement_vcsUserManagementHasNotBeenCalled() throws Exception {
         var course = CourseFactory.generateCourse(1L, null, null, new HashSet<>(), "tumuser", "tutor", "editor", "instructor");
-        course = courseRepo.save(course);
+        course = courseRepository.save(course);
 
         request.performMvcRequest(courseTestService.buildUpdateCourse(1, course)).andExpect(status().isOk()).andReturn();
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/CourseGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/CourseGitlabJenkinsIntegrationTest.java
@@ -26,7 +26,6 @@ import de.tum.in.www1.artemis.course.CourseTestService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 
 class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
@@ -37,9 +36,6 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
-
-    @Autowired
-    private UserRepository userRepo;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -228,15 +224,15 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
         // Create editor in the course
         User user = userUtilService.createAndSaveUser("new-editor");
         user.setGroups(Set.of("new-editor-group"));
-        userRepo.save(user);
+        userRepository.save(user);
 
         user = userUtilService.createAndSaveUser("new-ta");
         user.setGroups(Set.of("new-ta-group"));
-        userRepo.save(user);
+        userRepository.save(user);
 
         user = userUtilService.createAndSaveUser("new-instructor");
         user.setGroups(Set.of("new-instructor-group"));
-        userRepo.save(user);
+        userRepository.save(user);
 
         gitlabRequestMockProvider.mockUpdateCoursePermissions(course, oldInstructorGroup, oldEditorGroup, oldTaGroup);
         jenkinsRequestMockProvider.mockUpdateCoursePermissions(course, oldInstructorGroup, course.getEditorGroupName(), course.getTeachingAssistantGroupName(), false, false);
@@ -257,7 +253,7 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
         // Create editor in the course
         User user = userUtilService.createAndSaveUser("new-editor");
         user.setGroups(Set.of("new-instructor-group"));
-        user = userRepo.save(user);
+        user = userRepository.save(user);
 
         gitlabRequestMockProvider.mockGetUserId(user.getLogin(), true, true);
         request.performMvcRequest(courseTestService.buildUpdateCourse(course.getId(), course)).andExpect(status().isInternalServerError()).andReturn();
@@ -272,7 +268,7 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
         // Create editor in the course
         User user = userUtilService.createAndSaveUser("new-editor");
         user.setGroups(Set.of("new-instructor-group"));
-        user = userRepo.save(user);
+        user = userRepository.save(user);
 
         gitlabRequestMockProvider.mockFailOnGetUserById(user.getLogin());
         request.performMvcRequest(courseTestService.buildUpdateCourse(course.getId(), course)).andExpect(status().isInternalServerError()).andReturn();
@@ -290,7 +286,7 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
         var exercise = courseExercise.stream().findFirst();
         assertThat(exercise).isPresent();
 
-        var user = userRepo.findAllWithGroupsAndAuthoritiesByIsDeletedIsFalseAndGroupsContains(course.getTeachingAssistantGroupName()).stream().findFirst();
+        var user = userRepository.findAllWithGroupsAndAuthoritiesByIsDeletedIsFalseAndGroupsContains(course.getTeachingAssistantGroupName()).stream().findFirst();
         assertThat(user).isPresent();
 
         gitlabRequestMockProvider.mockFailToUpdateOldGroupMembers(exercise.get(), user.get());
@@ -304,13 +300,13 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
      * @param groups    the groups to change
      */
     private void changeUserGroup(String userLogin, Set<String> groups) {
-        Optional<User> user = userRepo.findOneWithGroupsByLogin(userLogin);
+        Optional<User> user = userRepository.findOneWithGroupsByLogin(userLogin);
         assertThat(user).isPresent();
 
         User updatedUser = user.get();
         updatedUser.setGroups(groups);
 
-        userRepo.save(updatedUser);
+        userRepository.save(updatedUser);
     }
 
     @Test
@@ -319,7 +315,7 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
         Course course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         course.setInstructorGroupName("new-instructor-group");
 
-        Optional<User> user = userRepo.findOneWithGroupsByLogin(TEST_PREFIX + "instructor1");
+        Optional<User> user = userRepository.findOneWithGroupsByLogin(TEST_PREFIX + "instructor1");
         assertThat(user).isPresent();
 
         gitlabRequestMockProvider.mockFailToGetUserWhenUpdatingOldMembers(user.get());
@@ -332,7 +328,7 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
         Course course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         course.setInstructorGroupName("new-instructor-group");
 
-        Optional<User> user = userRepo.findOneWithGroupsByLogin(TEST_PREFIX + "instructor1");
+        Optional<User> user = userRepository.findOneWithGroupsByLogin(TEST_PREFIX + "instructor1");
         assertThat(user).isPresent();
 
         var exercise = programmingExerciseRepository.findAllProgrammingExercisesInCourseOrInExamsOfCourse(course).stream().findFirst();
@@ -574,7 +570,7 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
         course = courseRepository.save(course);
         programmingExerciseUtilService.addProgrammingExerciseToCourse(course);
 
-        Optional<User> optionalTutor = userRepo.findOneWithGroupsByLogin(TEST_PREFIX + "tutor1");
+        Optional<User> optionalTutor = userRepository.findOneWithGroupsByLogin(TEST_PREFIX + "tutor1");
         assertThat(optionalTutor).isPresent();
 
         String tutorGroup = course.getTeachingAssistantGroupName();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/CourseGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/CourseGitlabJenkinsIntegrationTest.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
@@ -47,8 +46,6 @@ class CourseGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkin
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-
 
     @BeforeEach
     void setup() {

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/PlantUmlIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/PlantUmlIntegrationTest.java
@@ -27,8 +27,7 @@ class PlantUmlIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "plantumlintegration";
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     private static final String UML_DIAGRAM_STRING = "@somePlantUml";
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/PlantUmlIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/PlantUmlIntegrationTest.java
@@ -13,21 +13,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import net.sourceforge.plantuml.SourceStringReader;
 import net.sourceforge.plantuml.core.DiagramDescription;
 
 class PlantUmlIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "plantumlintegration";
-
-
 
     private static final String UML_DIAGRAM_STRING = "@somePlantUml";
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
@@ -62,7 +62,6 @@ import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 import de.tum.in.www1.artemis.web.rest.dto.AssessmentUpdateDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ResultDTO;
@@ -101,8 +100,6 @@ class ProgrammingAssessmentIntegrationTest extends AbstractSpringIntegrationInde
 
     @Autowired
     private UserRepository userRepository;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
@@ -102,8 +102,7 @@ class ProgrammingAssessmentIntegrationTest extends AbstractSpringIntegrationInde
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
@@ -55,7 +55,6 @@ import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
@@ -85,9 +84,6 @@ class ProgrammingAssessmentIntegrationTest extends AbstractSpringIntegrationInde
 
     @Autowired
     private ProgrammingSubmissionTestRepository programmingSubmissionRepository;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private ExamRepository examRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
@@ -57,7 +57,6 @@ import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
@@ -78,9 +77,6 @@ class ProgrammingAssessmentIntegrationTest extends AbstractSpringIntegrationInde
 
     @Autowired
     private ComplaintRepository complaintRepo;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private ProgrammingSubmissionTestRepository programmingSubmissionRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
@@ -50,7 +50,6 @@ import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
@@ -91,9 +90,6 @@ class ProgrammingAssessmentIntegrationTest extends AbstractSpringIntegrationInde
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingAssessmentIntegrationTest.java
@@ -59,7 +59,6 @@ import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 import de.tum.in.www1.artemis.web.rest.dto.AssessmentUpdateDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ResultDTO;
@@ -89,9 +88,6 @@ class ProgrammingAssessmentIntegrationTest extends AbstractSpringIntegrationInde
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseGitIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.connectors.GitService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.GitUtilService;
 import de.tum.in.www1.artemis.util.LocalRepository;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
@@ -49,8 +48,6 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractSpringIntegrationInd
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseGitIntegrationTest.java
@@ -29,7 +29,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUri;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.connectors.GitService;
@@ -51,9 +50,6 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractSpringIntegrationInd
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseGitIntegrationTest.java
@@ -50,8 +50,7 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractSpringIntegrationInd
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseIntegrationTestService.java
@@ -95,7 +95,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.plagiarism.PlagiarismUtilService;
 import de.tum.in.www1.artemis.repository.AuxiliaryRepositoryRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
@@ -145,9 +144,6 @@ class ProgrammingExerciseIntegrationTestService {
 
     @Autowired
     private GitUtilService gitUtilService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseIntegrationTestService.java
@@ -40,7 +40,6 @@ import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 import java.util.zip.ZipFile;
 
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.io.FileUtils;
@@ -96,6 +95,7 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.plagiarism.PlagiarismUtilService;
 import de.tum.in.www1.artemis.repository.AuxiliaryRepositoryRepository;
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseIntegrationTestService.java
@@ -40,6 +40,7 @@ import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 import java.util.zip.ZipFile;
 
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.io.FileUtils;
@@ -144,6 +145,9 @@ class ProgrammingExerciseIntegrationTestService {
 
     @Autowired
     private GitUtilService gitUtilService;
+
+    @Autowired
+    private CourseRepository courseRepository;
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
@@ -34,7 +34,6 @@ import de.tum.in.www1.artemis.domain.enumeration.ProjectType;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.TemplateProgrammingExerciseParticipation;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCRepositoryUri;
 import de.tum.in.www1.artemis.util.LocalRepository;
@@ -47,9 +46,6 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractSpringInt
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
@@ -27,7 +27,6 @@ import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationLocalCILocalVCTest;
 import de.tum.in.www1.artemis.connector.AeolusRequestMockProvider;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.enumeration.AeolusTarget;
@@ -54,9 +53,6 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractSpringInt
 
     @Autowired
     private ParticipationUtilService participationUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private AeolusRequestMockProvider aeolusRequestMockProvider;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
@@ -70,8 +70,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @Autowired
     private ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
@@ -37,7 +37,6 @@ import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentPar
 import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.TemplateProgrammingExerciseParticipation;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
@@ -67,9 +66,6 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
@@ -44,7 +44,6 @@ import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.CommitInfoDTO;
 
 class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -69,8 +68,6 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Autowired
     private ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
@@ -42,7 +42,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.web.rest.dto.CommitInfoDTO;
 
@@ -62,9 +61,6 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Autowired
     private ParticipationRepository participationRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseServiceIntegrationTest.java
@@ -53,8 +53,7 @@ class ProgrammingExerciseServiceIntegrationTest extends AbstractSpringIntegratio
     @Autowired
     private ExerciseIntegrationTestService exerciseIntegrationTestService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseServiceIntegrationTest.java
@@ -17,7 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationLocalCILocalVCTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.ProgrammingExerciseTestCase;
@@ -31,7 +30,6 @@ import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseImportBasicService;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.ExerciseIntegrationTestService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 
@@ -52,11 +50,6 @@ class ProgrammingExerciseServiceIntegrationTest extends AbstractSpringIntegratio
 
     @Autowired
     private ExerciseIntegrationTestService exerciseIntegrationTestService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseServiceIntegrationTest.java
@@ -26,7 +26,6 @@ import de.tum.in.www1.artemis.domain.hestia.ExerciseHint;
 import de.tum.in.www1.artemis.domain.submissionpolicy.LockRepositoryPolicy;
 import de.tum.in.www1.artemis.domain.submissionpolicy.SubmissionPenaltyPolicy;
 import de.tum.in.www1.artemis.domain.submissionpolicy.SubmissionPolicy;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseImportBasicService;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseService;
@@ -53,9 +52,6 @@ class ProgrammingExerciseServiceIntegrationTest extends AbstractSpringIntegratio
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private PageableSearchUtilService pageableSearchUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseTemplateIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseTemplateIntegrationTest.java
@@ -52,7 +52,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
@@ -74,9 +73,6 @@ class ProgrammingExerciseTemplateIntegrationTest extends AbstractSpringIntegrati
 
     @Autowired
     private ProgrammingLanguageFeatureService programmingLanguageFeatureService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     private ProgrammingExercise exercise;
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest.java
@@ -40,7 +40,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.BuildLogStatisticsEntryRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.connectors.ci.notification.dto.CommitDTO;
 import de.tum.in.www1.artemis.service.connectors.ci.notification.dto.TestCaseDTO;
@@ -62,9 +61,6 @@ class ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest extends Abstrac
 
     @Autowired
     private BuildLogStatisticsEntryRepository buildLogStatisticsEntryRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest.java
@@ -67,8 +67,7 @@ class ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest extends Abstrac
     @Autowired
     private ResultRepository resultRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest.java
@@ -46,7 +46,6 @@ import de.tum.in.www1.artemis.service.connectors.ci.notification.dto.CommitDTO;
 import de.tum.in.www1.artemis.service.connectors.ci.notification.dto.TestCaseDTO;
 import de.tum.in.www1.artemis.service.connectors.ci.notification.dto.TestCaseDetailMessageDTO;
 import de.tum.in.www1.artemis.service.connectors.ci.notification.dto.TestResultsDTO;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
@@ -66,8 +65,6 @@ class ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest extends Abstrac
 
     @Autowired
     private ResultRepository resultRepository;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest.java
@@ -35,7 +35,6 @@ import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 import de.tum.in.www1.artemis.domain.enumeration.ProjectType;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.BuildLogStatisticsEntryRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
@@ -64,9 +63,6 @@ class ProgrammingSubmissionAndResultGitlabJenkinsIntegrationTest extends Abstrac
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionIntegrationTest.java
@@ -61,7 +61,6 @@ import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.TestConstants;
 import de.tum.in.www1.artemis.util.TestResourceUtils;
 import de.tum.in.www1.artemis.web.rest.dto.SubmissionDTO;
@@ -88,8 +87,6 @@ class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrationJenk
 
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionIntegrationTest.java
@@ -89,8 +89,7 @@ class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrationJenk
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingSubmissionIntegrationTest.java
@@ -53,7 +53,6 @@ import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipat
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exception.ContinuousIntegrationException;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
@@ -90,9 +89,6 @@ class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrationJenk
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryIntegrationTest.java
@@ -72,7 +72,6 @@ import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismStatus;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismSubmission;
 import de.tum.in.www1.artemis.domain.plagiarism.text.TextSubmissionElement;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
@@ -131,9 +130,6 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTe
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryIntegrationTest.java
@@ -53,7 +53,6 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.BuildLogEntry;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.FileType;
@@ -88,7 +87,6 @@ import de.tum.in.www1.artemis.service.BuildLogEntryService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.vcs.VersionControlRepositoryPermission;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseParticipationService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.GitUtilService;
 import de.tum.in.www1.artemis.util.LocalRepository;
 import de.tum.in.www1.artemis.util.TestConstants;
@@ -134,8 +132,6 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTe
     @Autowired
     private ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository;
 
-
-
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
 
@@ -150,9 +146,6 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTe
 
     @Autowired
     private ExamUtilService examUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     private ProgrammingExercise programmingExercise;
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryIntegrationTest.java
@@ -134,8 +134,7 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTe
     @Autowired
     private ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryIntegrationTest.java
@@ -115,9 +115,6 @@ class RepositoryIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTe
     private StudentExamRepository studentExamRepository;
 
     @Autowired
-    private ProgrammingExerciseParticipationService programmingExerciseParticipationService;
-
-    @Autowired
     private PlagiarismComparisonRepository plagiarismComparisonRepository;
 
     @Autowired

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest.java
@@ -28,7 +28,6 @@ import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.TestConstants;
 
 class RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
@@ -37,8 +36,6 @@ class RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest extends A
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest.java
@@ -38,8 +38,7 @@ class RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest extends A
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest.java
@@ -25,7 +25,6 @@ import de.tum.in.www1.artemis.domain.BuildLogEntry;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.util.TestConstants;
@@ -39,9 +38,6 @@ class RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest extends A
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/StaticCodeAnalysisIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/StaticCodeAnalysisIntegrationTest.java
@@ -57,8 +57,7 @@ class StaticCodeAnalysisIntegrationTest extends AbstractSpringIntegrationLocalCI
     @Autowired
     private ProgrammingExerciseFeedbackCreationService feedbackCreationService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/StaticCodeAnalysisIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/StaticCodeAnalysisIntegrationTest.java
@@ -34,7 +34,6 @@ import de.tum.in.www1.artemis.domain.StaticCodeAnalysisCategory;
 import de.tum.in.www1.artemis.domain.enumeration.CategoryState;
 import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.StaticCodeAnalysisCategoryRepository;
 import de.tum.in.www1.artemis.service.StaticCodeAnalysisService;
@@ -54,9 +53,6 @@ class StaticCodeAnalysisIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     private StaticCodeAnalysisCategoryRepository staticCodeAnalysisCategoryRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ProgrammingExerciseFeedbackCreationService feedbackCreationService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/StaticCodeAnalysisIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/StaticCodeAnalysisIntegrationTest.java
@@ -39,7 +39,6 @@ import de.tum.in.www1.artemis.repository.StaticCodeAnalysisCategoryRepository;
 import de.tum.in.www1.artemis.service.StaticCodeAnalysisService;
 import de.tum.in.www1.artemis.service.dto.StaticCodeAnalysisIssue;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseFeedbackCreationService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class StaticCodeAnalysisIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCTest {
 
@@ -56,8 +55,6 @@ class StaticCodeAnalysisIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Autowired
     private ProgrammingExerciseFeedbackCreationService feedbackCreationService;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/SubmissionPolicyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/SubmissionPolicyIntegrationTest.java
@@ -30,7 +30,6 @@ import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentPar
 import de.tum.in.www1.artemis.domain.submissionpolicy.LockRepositoryPolicy;
 import de.tum.in.www1.artemis.domain.submissionpolicy.SubmissionPenaltyPolicy;
 import de.tum.in.www1.artemis.domain.submissionpolicy.SubmissionPolicy;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.connectors.ci.notification.dto.CommitDTO;
@@ -48,9 +47,6 @@ class SubmissionPolicyIntegrationTest extends AbstractSpringIntegrationJenkinsGi
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/SubmissionPolicyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/SubmissionPolicyIntegrationTest.java
@@ -51,8 +51,7 @@ class SubmissionPolicyIntegrationTest extends AbstractSpringIntegrationJenkinsGi
     @Autowired
     private ProgrammingExerciseGradingService gradingService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/SubmissionPolicyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/SubmissionPolicyIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.domain.submissionpolicy.SubmissionPolicy;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.connectors.ci.notification.dto.CommitDTO;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseGradingService;
 
@@ -43,9 +42,6 @@ class SubmissionPolicyIntegrationTest extends AbstractSpringIntegrationJenkinsGi
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ProgrammingExerciseGradingService gradingService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/SubmissionPolicyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/SubmissionPolicyIntegrationTest.java
@@ -36,7 +36,6 @@ import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.connectors.ci.notification.dto.CommitDTO;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseGradingService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class SubmissionPolicyIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
@@ -50,8 +49,6 @@ class SubmissionPolicyIntegrationTest extends AbstractSpringIntegrationJenkinsGi
 
     @Autowired
     private ProgrammingExerciseGradingService gradingService;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/TestRepositoryResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/TestRepositoryResourceIntegrationTest.java
@@ -32,7 +32,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.File;
 import de.tum.in.www1.artemis.domain.FileType;
@@ -40,7 +39,6 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.Repository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.connectors.GitService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.GitUtilService;
 import de.tum.in.www1.artemis.util.LocalRepository;
 import de.tum.in.www1.artemis.web.rest.dto.FileMove;
@@ -53,11 +51,6 @@ class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegrationJen
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     private final String testRepoBaseUrl = "/api/test-repository/";
 

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/TestRepositoryResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/TestRepositoryResourceIntegrationTest.java
@@ -54,8 +54,7 @@ class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegrationJen
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizExerciseIntegrationTest.java
@@ -72,7 +72,6 @@ import de.tum.in.www1.artemis.domain.quiz.ShortAnswerQuestionStatistic;
 import de.tum.in.www1.artemis.domain.quiz.ShortAnswerSolution;
 import de.tum.in.www1.artemis.domain.quiz.ShortAnswerSpot;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.QuizSubmissionRepository;
@@ -126,9 +125,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private ExamUtilService examUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private QuizExerciseUtilService quizExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizExerciseIntegrationTest.java
@@ -130,8 +130,7 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @Autowired
     private ChannelRepository channelRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizExerciseIntegrationTest.java
@@ -42,7 +42,6 @@ import org.springframework.util.MultiValueMap;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Team;
 import de.tum.in.www1.artemis.domain.TeamAssignmentConfig;
@@ -85,7 +84,6 @@ import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.ExerciseService;
 import de.tum.in.www1.artemis.service.quiz.QuizExerciseService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.ExerciseIntegrationTestService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.QuizBatchJoinDTO;
@@ -130,8 +128,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @Autowired
     private ChannelRepository channelRepository;
 
-
-
     @Autowired
     private ExamUtilService examUtilService;
 
@@ -140,9 +136,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private QuizExerciseUtilService quizExerciseUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private PageableSearchUtilService pageableSearchUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizExerciseIntegrationTest.java
@@ -76,7 +76,6 @@ import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.QuizSubmissionRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmittedAnswerRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
@@ -100,9 +99,6 @@ class QuizExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private QuizExerciseRepository quizExerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizSubmissionIntegrationTest.java
@@ -62,7 +62,6 @@ import de.tum.in.www1.artemis.domain.quiz.ShortAnswerSubmittedText;
 import de.tum.in.www1.artemis.domain.quiz.SubmittedAnswer;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
@@ -84,9 +83,6 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCILoca
     private static final int NUMBER_OF_STUDENTS = 4;
 
     private static final int NUMBER_OF_TUTORS = 1;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ExerciseRepository exerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizSubmissionIntegrationTest.java
@@ -64,7 +64,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.QuizSubmissionRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.service.quiz.QuizBatchService;
 import de.tum.in.www1.artemis.service.quiz.QuizExerciseService;
@@ -95,9 +94,6 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCILoca
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private QuizBatchService quizBatchService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizSubmissionIntegrationTest.java
@@ -61,7 +61,6 @@ import de.tum.in.www1.artemis.domain.quiz.ShortAnswerSubmittedText;
 import de.tum.in.www1.artemis.domain.quiz.SubmittedAnswer;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.QuizSubmissionRepository;
@@ -81,9 +80,6 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCILoca
     private static final int NUMBER_OF_STUDENTS = 4;
 
     private static final int NUMBER_OF_TUTORS = 1;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private QuizExerciseService quizExerciseService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizSubmissionIntegrationTest.java
@@ -108,8 +108,7 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCILoca
     @Autowired
     private QuizBatchService quizBatchService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private QuizExerciseUtilService quizExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/quiz/QuizSubmissionIntegrationTest.java
@@ -35,7 +35,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationLocalCILocalVCTest;
 import de.tum.in.www1.artemis.config.Constants;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
@@ -71,7 +70,6 @@ import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.service.quiz.QuizBatchService;
 import de.tum.in.www1.artemis.service.quiz.QuizExerciseService;
 import de.tum.in.www1.artemis.service.quiz.QuizStatisticService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.QuizBatchJoinDTO;
 
 class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCTest {
@@ -108,13 +106,8 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCILoca
     @Autowired
     private QuizBatchService quizBatchService;
 
-
-
     @Autowired
     private QuizExerciseUtilService quizExerciseUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/CodeHintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/CodeHintIntegrationTest.java
@@ -24,7 +24,6 @@ import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilServic
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.hestia.CodeHintRepository;
 import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseSolutionEntryRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class CodeHintIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -38,8 +37,6 @@ class CodeHintIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ProgrammingExerciseSolutionEntryRepository solutionEntryRepository;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/CodeHintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/CodeHintIntegrationTest.java
@@ -39,8 +39,7 @@ class CodeHintIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private ProgrammingExerciseSolutionEntryRepository solutionEntryRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/CodeHintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/CodeHintIntegrationTest.java
@@ -19,7 +19,6 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.ProgrammingExerciseTestCase;
 import de.tum.in.www1.artemis.domain.hestia.CodeHint;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseSolutionEntry;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.hestia.CodeHintRepository;
@@ -40,9 +39,6 @@ class CodeHintIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     private ProgrammingExercise exercise;
 

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ExerciseHintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ExerciseHintIntegrationTest.java
@@ -35,7 +35,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.hestia.ExerciseHintActivationRepository;
 import de.tum.in.www1.artemis.repository.hestia.ExerciseHintRepository;
@@ -47,9 +46,6 @@ class ExerciseHintIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private UserRepository userRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private ExerciseHintRepository exerciseHintRepository;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ExerciseHintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ExerciseHintIntegrationTest.java
@@ -35,7 +35,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.hestia.ExerciseHintActivationRepository;
 import de.tum.in.www1.artemis.repository.hestia.ExerciseHintRepository;
 import de.tum.in.www1.artemis.service.hestia.ProgrammingExerciseTaskService;
@@ -43,9 +42,6 @@ import de.tum.in.www1.artemis.service.hestia.ProgrammingExerciseTaskService;
 class ExerciseHintIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "exercisehintintegration";
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ExerciseHintRepository exerciseHintRepository;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ExerciseHintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ExerciseHintIntegrationTest.java
@@ -29,7 +29,6 @@ import de.tum.in.www1.artemis.domain.hestia.ExerciseHint;
 import de.tum.in.www1.artemis.domain.hestia.ExerciseHintActivation;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseTask;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
@@ -63,9 +62,6 @@ class ExerciseHintIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ExerciseHintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ExerciseHintIntegrationTest.java
@@ -40,7 +40,6 @@ import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.hestia.ExerciseHintActivationRepository;
 import de.tum.in.www1.artemis.repository.hestia.ExerciseHintRepository;
 import de.tum.in.www1.artemis.service.hestia.ProgrammingExerciseTaskService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ExerciseHintIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -75,8 +74,6 @@ class ExerciseHintIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;
-
-
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ExerciseHintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ExerciseHintIntegrationTest.java
@@ -76,8 +76,7 @@ class ExerciseHintIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @Autowired
     private ExerciseUtilService exerciseUtilService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffEntry;
@@ -19,7 +18,6 @@ import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffReport;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseFactory;
 import de.tum.in.www1.artemis.localvcci.AbstractLocalCILocalVCIntegrationTest;
 import de.tum.in.www1.artemis.service.hestia.ProgrammingExerciseGitDiffReportService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.HestiaUtilTestService;
 import de.tum.in.www1.artemis.util.LocalRepository;
 
@@ -29,11 +27,6 @@ import de.tum.in.www1.artemis.util.LocalRepository;
 class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractLocalCILocalVCIntegrationTest {
 
     private static final String TEST_PREFIX = "progexgitdiffreport";
-
-    @Autowired
-    private CourseUtilService courseUtilService;
-
-
 
     private static final String FILE_NAME = "test.java";
 

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
@@ -33,8 +33,7 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractLocalCILoc
     @Autowired
     private CourseUtilService courseUtilService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     private static final String FILE_NAME = "test.java";
 

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseSolutionEntryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseSolutionEntryIntegrationTest.java
@@ -45,8 +45,7 @@ class ProgrammingExerciseSolutionEntryIntegrationTest extends AbstractSpringInte
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseSolutionEntryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseSolutionEntryIntegrationTest.java
@@ -18,7 +18,6 @@ import de.tum.in.www1.artemis.domain.ProgrammingExerciseTestCase;
 import de.tum.in.www1.artemis.domain.hestia.CodeHint;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseSolutionEntry;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseTask;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.hestia.CodeHintRepository;
@@ -43,9 +42,6 @@ class ProgrammingExerciseSolutionEntryIntegrationTest extends AbstractSpringInte
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     private ProgrammingExercise programmingExercise;
 

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseSolutionEntryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseSolutionEntryIntegrationTest.java
@@ -24,7 +24,6 @@ import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.hestia.CodeHintRepository;
 import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseSolutionEntryRepository;
 import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseTaskRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ProgrammingExerciseSolutionEntryIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -44,8 +43,6 @@ class ProgrammingExerciseSolutionEntryIntegrationTest extends AbstractSpringInte
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseTaskIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseTaskIntegrationTest.java
@@ -28,7 +28,6 @@ import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseSolutionEntryRepository;
 import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseTaskRepository;
 import de.tum.in.www1.artemis.service.hestia.ProgrammingExerciseTaskService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ProgrammingExerciseTaskIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -48,8 +47,6 @@ class ProgrammingExerciseTaskIntegrationTest extends AbstractSpringIntegrationIn
 
     @Autowired
     private ProgrammingExerciseTaskService programmingExerciseTaskService;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseTaskIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseTaskIntegrationTest.java
@@ -21,7 +21,6 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.ProgrammingExerciseTestCase;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseSolutionEntry;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseTask;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
@@ -50,9 +49,6 @@ class ProgrammingExerciseTaskIntegrationTest extends AbstractSpringIntegrationIn
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     private ProgrammingExercise programmingExercise;
 

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseTaskIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseTaskIntegrationTest.java
@@ -49,8 +49,7 @@ class ProgrammingExerciseTaskIntegrationTest extends AbstractSpringIntegrationIn
     @Autowired
     private ProgrammingExerciseTaskService programmingExerciseTaskService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/TestwiseCoverageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/TestwiseCoverageIntegrationTest.java
@@ -28,7 +28,6 @@ import de.tum.in.www1.artemis.repository.SolutionProgrammingExerciseParticipatio
 import de.tum.in.www1.artemis.repository.hestia.CoverageFileReportRepository;
 import de.tum.in.www1.artemis.repository.hestia.CoverageReportRepository;
 import de.tum.in.www1.artemis.repository.hestia.TestwiseCoverageReportEntryRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 
 class TestwiseCoverageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -55,8 +54,6 @@ class TestwiseCoverageIntegrationTest extends AbstractSpringIntegrationIndepende
 
     @Autowired
     private RequestUtilService request;
-
-
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/TestwiseCoverageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/TestwiseCoverageIntegrationTest.java
@@ -56,8 +56,7 @@ class TestwiseCoverageIntegrationTest extends AbstractSpringIntegrationIndepende
     @Autowired
     private RequestUtilService request;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/TestwiseCoverageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/TestwiseCoverageIntegrationTest.java
@@ -28,7 +28,6 @@ import de.tum.in.www1.artemis.repository.SolutionProgrammingExerciseParticipatio
 import de.tum.in.www1.artemis.repository.hestia.CoverageFileReportRepository;
 import de.tum.in.www1.artemis.repository.hestia.CoverageReportRepository;
 import de.tum.in.www1.artemis.repository.hestia.TestwiseCoverageReportEntryRepository;
-import de.tum.in.www1.artemis.util.RequestUtilService;
 
 class TestwiseCoverageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -51,9 +50,6 @@ class TestwiseCoverageIntegrationTest extends AbstractSpringIntegrationIndepende
 
     @Autowired
     private SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseRepository;
-
-    @Autowired
-    private RequestUtilService request;
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/hestia/TestwiseCoverageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/TestwiseCoverageIntegrationTest.java
@@ -20,7 +20,6 @@ import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 import de.tum.in.www1.artemis.domain.hestia.CoverageFileReport;
 import de.tum.in.www1.artemis.domain.hestia.CoverageReport;
 import de.tum.in.www1.artemis.domain.hestia.TestwiseCoverageReportEntry;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionTestRepository;
@@ -53,9 +52,6 @@ class TestwiseCoverageIntegrationTest extends AbstractSpringIntegrationIndepende
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     private ProgrammingExercise programmingExercise;
 

--- a/src/test/java/de/tum/in/www1/artemis/iris/AbstractIrisIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/iris/AbstractIrisIntegrationTest.java
@@ -23,19 +23,13 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.iris.IrisTemplate;
 import de.tum.in.www1.artemis.domain.iris.session.IrisExerciseChatSession;
 import de.tum.in.www1.artemis.domain.iris.settings.IrisSubSettings;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.iris.IrisSettingsRepository;
 import de.tum.in.www1.artemis.repository.iris.IrisTemplateRepository;
 import de.tum.in.www1.artemis.service.iris.settings.IrisSettingsService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 public abstract class AbstractIrisIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCTest {
-
-    @Autowired
-    protected CourseRepository courseRepository;
 
     @Autowired
     protected IrisSettingsService irisSettingsService;
@@ -49,12 +43,6 @@ public abstract class AbstractIrisIntegrationTest extends AbstractSpringIntegrat
 
     @Autowired
     protected ProgrammingExerciseRepository programmingExerciseRepository;
-
-    @Autowired
-    protected UserUtilService userUtilService;
-
-    @Autowired
-    protected ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private IrisSettingsRepository irisSettingsRepository;

--- a/src/test/java/de/tum/in/www1/artemis/iris/IrisCompetencyGenerationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/iris/IrisCompetencyGenerationIntegrationTest.java
@@ -8,11 +8,9 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.competency.Competency;
 import de.tum.in.www1.artemis.domain.competency.CompetencyTaxonomy;
@@ -20,9 +18,6 @@ import de.tum.in.www1.artemis.domain.competency.CompetencyTaxonomy;
 class IrisCompetencyGenerationIntegrationTest extends AbstractIrisIntegrationTest {
 
     private static final String TEST_PREFIX = "iriscompetencyintegration";
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     private Course course;
 

--- a/src/test/java/de/tum/in/www1/artemis/iris/PyrisLectureIngestionTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/iris/PyrisLectureIngestionTest.java
@@ -21,7 +21,6 @@ import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.iris.settings.IrisCourseSettings;
 import de.tum.in.www1.artemis.domain.lecture.AttachmentUnit;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.iris.IrisSettingsRepository;
 import de.tum.in.www1.artemis.service.connectors.pyris.PyrisJobService;
@@ -38,9 +37,6 @@ class PyrisLectureIngestionTest extends AbstractIrisIntegrationTest {
 
     @Autowired
     private PyrisWebhookService pyrisWebhookService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private LectureRepository lectureRepository;

--- a/src/test/java/de/tum/in/www1/artemis/learninganalytics/StudentLearningAnalyticsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/learninganalytics/StudentLearningAnalyticsIntegrationTest.java
@@ -15,16 +15,12 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.course.CourseTestService;
 import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 
 class StudentLearningAnalyticsIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "studentlearninganalytics";
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     protected RequestUtilService request;

--- a/src/test/java/de/tum/in/www1/artemis/learninganalytics/StudentLearningAnalyticsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/learninganalytics/StudentLearningAnalyticsIntegrationTest.java
@@ -28,8 +28,7 @@ class StudentLearningAnalyticsIntegrationTest extends AbstractSpringIntegrationI
     @Autowired
     private CourseTestService courseTestService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/learninganalytics/StudentLearningAnalyticsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/learninganalytics/StudentLearningAnalyticsIntegrationTest.java
@@ -13,9 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.course.CourseTestService;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 
 class StudentLearningAnalyticsIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -27,11 +25,6 @@ class StudentLearningAnalyticsIntegrationTest extends AbstractSpringIntegrationI
 
     @Autowired
     private CourseTestService courseTestService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
@@ -39,8 +39,7 @@ class AttachmentResourceIntegrationTest extends AbstractSpringIntegrationIndepen
     @Autowired
     private LectureRepository lectureRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.AttachmentRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class AttachmentResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -38,8 +37,6 @@ class AttachmentResourceIntegrationTest extends AbstractSpringIntegrationIndepen
 
     @Autowired
     private LectureRepository lectureRepository;
-
-
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
@@ -26,16 +26,12 @@ import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.AttachmentRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 
 class AttachmentResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "attachmentresourceintegrationtest";
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private AttachmentRepository attachmentRepository;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
@@ -23,7 +23,6 @@ import de.tum.in.www1.artemis.domain.Attachment;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.TextExercise;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.AttachmentRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
@@ -40,9 +39,6 @@ class AttachmentResourceIntegrationTest extends AbstractSpringIntegrationIndepen
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     private Attachment attachment;
 

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentResourceIntegrationTest.java
@@ -164,7 +164,7 @@ class AttachmentResourceIntegrationTest extends AbstractSpringIntegrationIndepen
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void deleteAttachment_notInstructorInACourse() throws Exception {
-        var course = courseRepo.save(new Course());
+        var course = courseRepository.save(new Course());
         attachment = attachmentRepository.save(attachment);
         lecture.setCourse(course);
         lectureRepository.save(lecture);

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitIntegrationTest.java
@@ -41,7 +41,6 @@ import de.tum.in.www1.artemis.repository.AttachmentUnitRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.SlideRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class AttachmentUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -60,8 +59,6 @@ class AttachmentUnitIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private SlideRepository slideRepository;
-
-
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitIntegrationTest.java
@@ -61,8 +61,7 @@ class AttachmentUnitIntegrationTest extends AbstractSpringIntegrationIndependent
     @Autowired
     private SlideRepository slideRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitsIntegrationTest.java
@@ -34,7 +34,6 @@ import de.tum.in.www1.artemis.domain.lecture.AttachmentUnit;
 import de.tum.in.www1.artemis.repository.AttachmentUnitRepository;
 import de.tum.in.www1.artemis.repository.SlideRepository;
 import de.tum.in.www1.artemis.service.LectureUnitProcessingService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.LectureUnitInformationDTO;
 import de.tum.in.www1.artemis.web.rest.dto.LectureUnitSplitDTO;
@@ -51,8 +50,6 @@ class AttachmentUnitsIntegrationTest extends AbstractSpringIntegrationIndependen
 
     @Autowired
     private RequestUtilService request;
-
-
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitsIntegrationTest.java
@@ -34,7 +34,6 @@ import de.tum.in.www1.artemis.domain.lecture.AttachmentUnit;
 import de.tum.in.www1.artemis.repository.AttachmentUnitRepository;
 import de.tum.in.www1.artemis.repository.SlideRepository;
 import de.tum.in.www1.artemis.service.LectureUnitProcessingService;
-import de.tum.in.www1.artemis.util.RequestUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.LectureUnitInformationDTO;
 import de.tum.in.www1.artemis.web.rest.dto.LectureUnitSplitDTO;
 
@@ -47,9 +46,6 @@ class AttachmentUnitsIntegrationTest extends AbstractSpringIntegrationIndependen
 
     @Autowired
     private SlideRepository slideRepository;
-
-    @Autowired
-    private RequestUtilService request;
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/AttachmentUnitsIntegrationTest.java
@@ -52,8 +52,7 @@ class AttachmentUnitsIntegrationTest extends AbstractSpringIntegrationIndependen
     @Autowired
     private RequestUtilService request;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
@@ -134,8 +134,7 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
     @Autowired
     private LectureUnitService lectureUnitService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
@@ -70,7 +70,6 @@ import de.tum.in.www1.artemis.repository.LectureUnitRepository;
 import de.tum.in.www1.artemis.repository.PrerequisiteRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.TextUnitRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.LectureUnitService;
 import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.team.TeamUtilService;
@@ -93,9 +92,6 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
 
     @Autowired
     private ParticipationUtilService participationUtilService;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private SubmissionRepository submissionRepository;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
@@ -29,7 +29,6 @@ import de.tum.in.www1.artemis.competency.CompetencyProgressUtilService;
 import de.tum.in.www1.artemis.competency.CompetencyUtilService;
 import de.tum.in.www1.artemis.competency.PrerequisiteUtilService;
 import de.tum.in.www1.artemis.competency.StandardizedCompetencyUtilService;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -77,7 +76,6 @@ import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.LectureUnitService;
 import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.team.TeamUtilService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.CourseCompetencyProgressDTO;
 import de.tum.in.www1.artemis.web.rest.dto.SearchResultPageDTO;
@@ -133,11 +131,6 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
 
     @Autowired
     private LectureUnitService lectureUnitService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private TeamUtilService teamUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
@@ -64,7 +64,6 @@ import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.AttachmentUnitRepository;
 import de.tum.in.www1.artemis.repository.CompetencyRelationRepository;
 import de.tum.in.www1.artemis.repository.CompetencyRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseUnitRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.LectureUnitRepository;
@@ -89,9 +88,6 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
 
     @Autowired
     private LectureRepository lectureRepository;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private ParticipationService participationService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/CompetencyIntegrationTest.java
@@ -68,7 +68,6 @@ import de.tum.in.www1.artemis.repository.ExerciseUnitRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.LectureUnitRepository;
 import de.tum.in.www1.artemis.repository.PrerequisiteRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.TextUnitRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
@@ -100,9 +99,6 @@ class CompetencyIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCT
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private TextUnitRepository textUnitRepository;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/ExerciseUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/ExerciseUnitIntegrationTest.java
@@ -24,7 +24,6 @@ import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.domain.lecture.ExerciseUnit;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.FileUploadExerciseRepository;
 import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
@@ -35,9 +34,6 @@ import de.tum.in.www1.artemis.user.UserUtilService;
 class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "exerciseunitintegration";
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private TextExerciseRepository textExerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/ExerciseUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/ExerciseUnitIntegrationTest.java
@@ -14,7 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.FileUploadExercise;
@@ -29,7 +28,6 @@ import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -49,11 +47,6 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private FileUploadExerciseRepository fileUploadExerciseRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     private Course course1;
 

--- a/src/test/java/de/tum/in/www1/artemis/lecture/ExerciseUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/ExerciseUnitIntegrationTest.java
@@ -50,8 +50,7 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @Autowired
     private FileUploadExerciseRepository fileUploadExerciseRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
@@ -18,7 +18,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Attachment;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Lecture;
@@ -35,7 +34,6 @@ import de.tum.in.www1.artemis.repository.AttachmentRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 
 class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -53,11 +51,6 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     ChannelRepository channelRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
@@ -32,7 +32,6 @@ import de.tum.in.www1.artemis.domain.lecture.VideoUnit;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
 import de.tum.in.www1.artemis.repository.AttachmentRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
@@ -45,9 +44,6 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private LectureRepository lectureRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private TextExerciseRepository textExerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureIntegrationTest.java
@@ -54,8 +54,7 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     ChannelRepository channelRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureUnitIntegrationTest.java
@@ -29,15 +29,11 @@ import de.tum.in.www1.artemis.domain.lecture.TextUnit;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.LectureUnitCompletionRepository;
 import de.tum.in.www1.artemis.repository.TextUnitRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.web.rest.dto.lectureunit.LectureUnitForLearningPathNodeDetailsDTO;
 
 class LectureUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "lectureunitintegration";
-
-    @Autowired
-    private UserRepository userRepo;
 
     @Autowired
     private TextUnitRepository textUnitRepository;
@@ -230,7 +226,7 @@ class LectureUnitIntegrationTest extends AbstractSpringIntegrationIndependentTes
         LectureUnit lectureUnit = this.lecture1.getLectureUnits().get(0);
 
         assertThat(lectureUnit.getCompletedUsers()).isNotEmpty();
-        assertThat(lectureUnit.isCompletedFor(userRepo.getUser())).isTrue();
+        assertThat(lectureUnit.isCompletedFor(userRepository.getUser())).isTrue();
 
         // Set lecture unit as uncompleted for user
         request.postWithoutLocation("/api/lectures/" + lecture1.getId() + "/lecture-units/" + lecture1.getLectureUnits().get(0).getId() + "/completion?completed=false", null,
@@ -240,7 +236,7 @@ class LectureUnitIntegrationTest extends AbstractSpringIntegrationIndependentTes
         lectureUnit = this.lecture1.getLectureUnits().get(0);
 
         assertThat(lectureUnit.getCompletedUsers()).isEmpty();
-        assertThat(lectureUnit.isCompletedFor(userRepo.getUser())).isFalse();
+        assertThat(lectureUnit.isCompletedFor(userRepository.getUser())).isFalse();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureUnitIntegrationTest.java
@@ -18,7 +18,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.competency.CompetencyUtilService;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.Lecture;
@@ -31,7 +30,6 @@ import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.LectureUnitCompletionRepository;
 import de.tum.in.www1.artemis.repository.TextUnitRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.lectureunit.LectureUnitForLearningPathNodeDetailsDTO;
 
 class LectureUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -49,11 +47,6 @@ class LectureUnitIntegrationTest extends AbstractSpringIntegrationIndependentTes
 
     @Autowired
     private LectureUnitCompletionRepository lectureUnitCompletionRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureUnitIntegrationTest.java
@@ -50,8 +50,7 @@ class LectureUnitIntegrationTest extends AbstractSpringIntegrationIndependentTes
     @Autowired
     private LectureUnitCompletionRepository lectureUnitCompletionRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureUnitIntegrationTest.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnitCompletion;
 import de.tum.in.www1.artemis.domain.lecture.OnlineUnit;
 import de.tum.in.www1.artemis.domain.lecture.TextUnit;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.LectureUnitCompletionRepository;
 import de.tum.in.www1.artemis.repository.TextUnitRepository;
@@ -38,9 +37,6 @@ import de.tum.in.www1.artemis.web.rest.dto.lectureunit.LectureUnitForLearningPat
 class LectureUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "lectureunitintegration";
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserRepository userRepo;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureUtilService.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import org.apache.commons.io.FileUtils;
 import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,6 +58,9 @@ public class LectureUtilService {
     private static final ZonedDateTime pastTimestamp = ZonedDateTime.now().minusDays(1);
 
     private static final ZonedDateTime futureFutureTimestamp = ZonedDateTime.now().plusDays(2);
+
+    @Autowired
+    private CourseRepository courseRepo;
 
     @Autowired
     private LectureRepository lectureRepo;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureUtilService.java
@@ -9,7 +9,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import org.apache.commons.io.FileUtils;
 import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +36,7 @@ import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.post.ConversationFactory;
 import de.tum.in.www1.artemis.repository.AttachmentRepository;
 import de.tum.in.www1.artemis.repository.AttachmentUnitRepository;
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseUnitRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.LectureUnitCompletionRepository;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LectureUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LectureUtilService.java
@@ -36,7 +36,6 @@ import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.post.ConversationFactory;
 import de.tum.in.www1.artemis.repository.AttachmentRepository;
 import de.tum.in.www1.artemis.repository.AttachmentUnitRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseUnitRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.LectureUnitCompletionRepository;
@@ -58,9 +57,6 @@ public class LectureUtilService {
     private static final ZonedDateTime pastTimestamp = ZonedDateTime.now().minusDays(1);
 
     private static final ZonedDateTime futureFutureTimestamp = ZonedDateTime.now().plusDays(2);
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private LectureRepository lectureRepo;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/OnlineUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/OnlineUnitIntegrationTest.java
@@ -29,7 +29,6 @@ import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.domain.lecture.OnlineUnit;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.OnlineUnitRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.OnlineResourceDTO;
 
 class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -41,8 +40,6 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
 
     @Autowired
     private LectureRepository lectureRepository;
-
-
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/OnlineUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/OnlineUnitIntegrationTest.java
@@ -42,8 +42,7 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
     @Autowired
     private LectureRepository lectureRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/PrerequisiteIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/PrerequisiteIntegrationTest.java
@@ -13,24 +13,17 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.competency.PrerequisiteUtilService;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.competency.CompetencyTaxonomy;
 import de.tum.in.www1.artemis.domain.competency.Prerequisite;
 import de.tum.in.www1.artemis.repository.PrerequisiteRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.competency.PrerequisiteRequestDTO;
 import de.tum.in.www1.artemis.web.rest.dto.competency.PrerequisiteResponseDTO;
 
 class PrerequisiteIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "prerequisiteintegrationtest";
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private PrerequisiteUtilService prerequisiteUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/PrerequisiteIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/PrerequisiteIntegrationTest.java
@@ -27,8 +27,7 @@ class PrerequisiteIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     private static final String TEST_PREFIX = "prerequisiteintegrationtest";
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/PrerequisiteIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/PrerequisiteIntegrationTest.java
@@ -18,7 +18,6 @@ import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.competency.CompetencyTaxonomy;
 import de.tum.in.www1.artemis.domain.competency.Prerequisite;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.PrerequisiteRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.competency.PrerequisiteRequestDTO;
@@ -39,9 +38,6 @@ class PrerequisiteIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private PrerequisiteRepository prerequisiteRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     private Course course;
 

--- a/src/test/java/de/tum/in/www1/artemis/lecture/TextUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/TextUnitIntegrationTest.java
@@ -16,7 +16,6 @@ import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.domain.lecture.TextUnit;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.TextUnitRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -27,8 +26,6 @@ class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private LectureRepository lectureRepository;
-
-
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/TextUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/TextUnitIntegrationTest.java
@@ -28,8 +28,7 @@ class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private LectureRepository lectureRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/VideoUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/VideoUnitIntegrationTest.java
@@ -28,8 +28,7 @@ class VideoUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest 
     @Autowired
     private LectureRepository lectureRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/lecture/VideoUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/VideoUnitIntegrationTest.java
@@ -16,7 +16,6 @@ import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.domain.lecture.VideoUnit;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.VideoUnitRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class VideoUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -27,8 +26,6 @@ class VideoUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest 
 
     @Autowired
     private LectureRepository lectureRepository;
-
-
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/AbstractLocalCILocalVCIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/AbstractLocalCILocalVCIntegrationTest.java
@@ -19,7 +19,6 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.ProjectType;
 import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.TemplateProgrammingExerciseParticipation;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.repository.AuxiliaryRepositoryRepository;
@@ -52,9 +51,6 @@ public class AbstractLocalCILocalVCIntegrationTest extends AbstractSpringIntegra
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     protected ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/AbstractLocalCILocalVCIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/AbstractLocalCILocalVCIntegrationTest.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExerciseGroupRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.StaticCodeAnalysisService;
 import de.tum.in.www1.artemis.service.connectors.aeolus.AeolusTemplateService;
 import de.tum.in.www1.artemis.user.UserUtilService;
@@ -62,9 +61,6 @@ public class AbstractLocalCILocalVCIntegrationTest extends AbstractSpringIntegra
 
     @Autowired
     private StaticCodeAnalysisService staticCodeAnalysisService;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     protected AuxiliaryRepositoryRepository auxiliaryRepositoryRepository;

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCIResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalCIResourceIntegrationTest.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.BuildStatus;
 import de.tum.in.www1.artemis.domain.enumeration.RepositoryType;
 import de.tum.in.www1.artemis.repository.BuildJobRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.service.BuildLogEntryService;
 import de.tum.in.www1.artemis.service.connectors.localci.buildagent.SharedQueueProcessingService;
 import de.tum.in.www1.artemis.service.connectors.localci.dto.BuildAgentInformation;
@@ -72,9 +71,6 @@ class LocalCIResourceIntegrationTest extends AbstractLocalCILocalVCIntegrationTe
 
     @Autowired
     private PageableSearchUtilService pageableSearchUtilService;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @BeforeEach
     void createJobs() {

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCIIntegrationTest.java
@@ -49,7 +49,6 @@ import de.tum.in.www1.artemis.domain.submissionpolicy.LockRepositoryPolicy;
 import de.tum.in.www1.artemis.domain.submissionpolicy.SubmissionPolicy;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.repository.BuildJobRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.service.ldap.LdapUserDto;
 import de.tum.in.www1.artemis.util.LocalRepository;
 
@@ -62,9 +61,6 @@ class LocalVCLocalCIIntegrationTest extends AbstractLocalCILocalVCIntegrationTes
 
     @Autowired
     private ExamUtilService examUtilService;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private BuildJobRepository buildJobRepository;

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCIParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCLocalCIParticipationIntegrationTest.java
@@ -15,7 +15,6 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.TemplateProgrammingExerciseParticipation;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.service.connectors.localvc.LocalVCRepositoryUri;
 import de.tum.in.www1.artemis.util.LocalRepository;
@@ -26,9 +25,6 @@ class LocalVCLocalCIParticipationIntegrationTest extends AbstractSpringIntegrati
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")

--- a/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCSshIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/localvcci/LocalVCSshIntegrationTest.java
@@ -30,7 +30,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.config.icl.ssh.HashUtils;
 import de.tum.in.www1.artemis.config.icl.ssh.SshGitCommand;
 import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.icl.SshGitCommandFactoryService;
 
 @Profile(PROFILE_LOCALVC)
@@ -39,9 +38,6 @@ class LocalVCSshIntegrationTest extends LocalVCIntegrationTest {
     private final String hostname = "localhost";
 
     private final int port = 7921;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private SshServer sshServer;

--- a/src/test/java/de/tum/in/www1/artemis/metis/AnswerMessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/AnswerMessageIntegrationTest.java
@@ -41,7 +41,6 @@ import de.tum.in.www1.artemis.exam.ExamUtilService;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.metis.AnswerPostRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationMessageRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
@@ -53,9 +52,6 @@ class AnswerMessageIntegrationTest extends AbstractSpringIntegrationIndependentT
 
     @Autowired
     private AnswerPostRepository answerPostRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/metis/AnswerMessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/AnswerMessageIntegrationTest.java
@@ -25,7 +25,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Lecture;
@@ -43,7 +42,6 @@ import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
 import de.tum.in.www1.artemis.repository.metis.AnswerPostRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationMessageRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.websocket.dto.metis.PostDTO;
 
 class AnswerMessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -52,11 +50,6 @@ class AnswerMessageIntegrationTest extends AbstractSpringIntegrationIndependentT
 
     @Autowired
     private AnswerPostRepository answerPostRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ConversationUtilService conversationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/metis/AnswerMessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/AnswerMessageIntegrationTest.java
@@ -53,8 +53,7 @@ class AnswerMessageIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Autowired
     private AnswerPostRepository answerPostRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/metis/AnswerMessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/AnswerMessageIntegrationTest.java
@@ -37,7 +37,6 @@ import de.tum.in.www1.artemis.domain.metis.Post;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.notification.SingleUserNotification;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
 import de.tum.in.www1.artemis.repository.metis.AnswerPostRepository;
@@ -59,9 +58,6 @@ class AnswerMessageIntegrationTest extends AbstractSpringIntegrationIndependentT
 
     @Autowired
     private LectureUtilService lectureUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/metis/ChannelIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ChannelIntegrationTest.java
@@ -26,7 +26,6 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.CourseInformationSharingConfiguration;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
@@ -63,9 +62,6 @@ class ChannelIntegrationTest extends AbstractConversationTest {
 
     @Autowired
     private ConversationUtilService conversationUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @BeforeEach
     @Override

--- a/src/test/java/de/tum/in/www1/artemis/metis/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/MessageIntegrationTest.java
@@ -92,8 +92,7 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ConversationUtilService conversationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/metis/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/MessageIntegrationTest.java
@@ -60,7 +60,6 @@ import de.tum.in.www1.artemis.domain.notification.ConversationNotification;
 import de.tum.in.www1.artemis.domain.notification.Notification;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismCase;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationMessageRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationParticipantRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ConversationNotificationRepository;
@@ -77,9 +76,6 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ConversationMessageRepository conversationMessageRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private OneToOneChatRepository oneToOneChatRepository;

--- a/src/test/java/de/tum/in/www1/artemis/metis/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/MessageIntegrationTest.java
@@ -45,7 +45,6 @@ import org.springframework.util.MultiValueMap;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.User;
@@ -67,7 +66,6 @@ import de.tum.in.www1.artemis.repository.metis.ConversationParticipantRepository
 import de.tum.in.www1.artemis.repository.metis.conversation.ConversationNotificationRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.OneToOneChatRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.PostContextFilterDTO;
 import de.tum.in.www1.artemis.web.websocket.dto.metis.PostDTO;
 
@@ -92,13 +90,8 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-
-
     @Autowired
     private ConversationUtilService conversationUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ConversationNotificationRepository conversationNotificationRepository;

--- a/src/test/java/de/tum/in/www1/artemis/metis/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/MessageIntegrationTest.java
@@ -61,7 +61,6 @@ import de.tum.in.www1.artemis.domain.notification.ConversationNotification;
 import de.tum.in.www1.artemis.domain.notification.Notification;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismCase;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationMessageRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationParticipantRepository;
@@ -92,9 +91,6 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
@@ -33,7 +33,6 @@ import de.tum.in.www1.artemis.domain.metis.Post;
 import de.tum.in.www1.artemis.domain.metis.PostSortCriterion;
 import de.tum.in.www1.artemis.domain.metis.Reaction;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationMessageRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.metis.ReactionRepository;
@@ -50,9 +49,6 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ConversationMessageRepository conversationMessageRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private ConversationUtilService conversationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
@@ -56,8 +56,7 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
@@ -34,7 +34,6 @@ import de.tum.in.www1.artemis.domain.metis.Post;
 import de.tum.in.www1.artemis.domain.metis.PostSortCriterion;
 import de.tum.in.www1.artemis.domain.metis.Reaction;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationMessageRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
@@ -65,9 +64,6 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ConversationUtilService conversationUtilService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     private List<Post> existingPostsWithAnswers;
 

--- a/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
@@ -24,7 +24,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.CourseInformationSharingConfiguration;
@@ -38,7 +37,6 @@ import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationMessageRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.metis.ReactionRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -55,11 +53,6 @@ class ReactionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private UserRepository userRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ConversationUtilService conversationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/metis/linkpreview/LinkPreviewIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/linkpreview/LinkPreviewIntegrationTest.java
@@ -22,7 +22,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.LinkPreviewDTO;
 
 class LinkPreviewIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -33,8 +32,6 @@ class LinkPreviewIntegrationTest extends AbstractSpringIntegrationIndependentTes
     private static final String GOOGLE_URL = "https://google.com";
 
     private static final String MOCK_FILE_PATH_PREFIX = "src/test/java/de/tum/in/www1/artemis/metis/linkpreview/mockFiles/";
-
-
 
     @Autowired
     private CacheManager cacheManager;

--- a/src/test/java/de/tum/in/www1/artemis/metis/linkpreview/LinkPreviewIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/linkpreview/LinkPreviewIntegrationTest.java
@@ -34,8 +34,7 @@ class LinkPreviewIntegrationTest extends AbstractSpringIntegrationIndependentTes
 
     private static final String MOCK_FILE_PATH_PREFIX = "src/test/java/de/tum/in/www1/artemis/metis/linkpreview/mockFiles/";
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CacheManager cacheManager;

--- a/src/test/java/de/tum/in/www1/artemis/notification/NotificationResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/NotificationResourceIntegrationTest.java
@@ -26,7 +26,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.NotificationRepository;
 import de.tum.in.www1.artemis.repository.NotificationSettingRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class NotificationResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -38,8 +37,6 @@ class NotificationResourceIntegrationTest extends AbstractSpringIntegrationIndep
 
     @Autowired
     private NotificationSettingRepository notificationSettingRepository;
-
-
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/notification/NotificationResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/NotificationResourceIntegrationTest.java
@@ -23,16 +23,12 @@ import de.tum.in.www1.artemis.domain.notification.Notification;
 import de.tum.in.www1.artemis.domain.notification.NotificationConstants;
 import de.tum.in.www1.artemis.domain.notification.SingleUserNotification;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.NotificationRepository;
 import de.tum.in.www1.artemis.repository.NotificationSettingRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 
 class NotificationResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/notification/NotificationResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/NotificationResourceIntegrationTest.java
@@ -25,12 +25,8 @@ import de.tum.in.www1.artemis.domain.notification.SingleUserNotification;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.NotificationRepository;
 import de.tum.in.www1.artemis.repository.NotificationSettingRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 
 class NotificationResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private NotificationRepository notificationRepository;

--- a/src/test/java/de/tum/in/www1/artemis/notification/NotificationResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/NotificationResourceIntegrationTest.java
@@ -39,8 +39,7 @@ class NotificationResourceIntegrationTest extends AbstractSpringIntegrationIndep
     @Autowired
     private NotificationSettingRepository notificationSettingRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/notification/NotificationSettingsResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/NotificationSettingsResourceIntegrationTest.java
@@ -13,14 +13,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.NotificationSetting;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
 import de.tum.in.www1.artemis.repository.NotificationSettingRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class NotificationSettingsResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -28,11 +26,6 @@ class NotificationSettingsResourceIntegrationTest extends AbstractSpringIntegrat
 
     @Autowired
     private NotificationSettingRepository notificationSettingRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ConversationUtilService conversationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/notification/NotificationSettingsResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/NotificationSettingsResourceIntegrationTest.java
@@ -29,8 +29,7 @@ class NotificationSettingsResourceIntegrationTest extends AbstractSpringIntegrat
     @Autowired
     private NotificationSettingRepository notificationSettingRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
@@ -68,8 +68,8 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
         course2.setEnrollmentEndDate(futureTimestamp);
         course1.setOrganizations(organizations);
 
-        course1 = courseRepo.save(course1);
-        course2 = courseRepo.save(course2);
+        course1 = courseRepository.save(course1);
+        course2 = courseRepository.save(course2);
 
         List<Course> coursesToEnroll = request.getList("/api/courses/for-enrollment", HttpStatus.OK, Course.class);
         assertThat(coursesToEnroll).contains(course1).contains(course2);
@@ -106,9 +106,9 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
         course1.setOrganizations(organizations);
         course3.setOrganizations(otherOrganizations);
 
-        course1 = courseRepo.save(course1);
-        course2 = courseRepo.save(course2);
-        course3 = courseRepo.save(course3);
+        course1 = courseRepository.save(course1);
+        course2 = courseRepository.save(course2);
+        course3 = courseRepository.save(course3);
 
         Set<String> updatedGroups = request.postWithResponseBody("/api/courses/" + course1.getId() + "/enroll", null, Set.class, HttpStatus.OK);
         assertThat(updatedGroups).as("User is enrolled in course").contains(course1.getStudentGroupName());
@@ -129,7 +129,7 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
         organization = organizationRepo.save(organization);
 
         Course course1 = CourseFactory.generateCourse(null, ZonedDateTime.now(), ZonedDateTime.now(), new HashSet<>(), "testcourse1", "tutor", "editor", "instructor");
-        course1 = courseRepo.save(course1);
+        course1 = courseRepository.save(course1);
 
         request.postWithoutLocation("/api/admin/organizations/" + organization.getId() + "/courses/" + course1.getId(), null, HttpStatus.OK, null);
 
@@ -144,10 +144,10 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = "admin", roles = "ADMIN")
     void testRemoveCourseToOrganization() throws Exception {
         Course course1 = CourseFactory.generateCourse(null, ZonedDateTime.now(), ZonedDateTime.now(), new HashSet<>(), "testcourse1", "tutor", "editor", "instructor");
-        course1 = courseRepo.save(course1);
+        course1 = courseRepository.save(course1);
 
         Organization organization = organizationUtilService.createOrganization();
-        courseRepo.addOrganizationToCourse(course1.getId(), organization);
+        courseRepository.addOrganizationToCourse(course1.getId(), organization);
 
         Organization originalOrganization = request.get("/api/admin/organizations/" + organization.getId() + "/full", HttpStatus.OK, Organization.class);
         assertThat(originalOrganization.getCourses()).contains(course1);
@@ -264,12 +264,12 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = "admin", roles = "ADMIN")
     void testDeleteOrganization() throws Exception {
         Course course1 = CourseFactory.generateCourse(null, ZonedDateTime.now(), ZonedDateTime.now(), new HashSet<>(), "testcourse1", "tutor", "editor", "instructor");
-        course1 = courseRepo.save(course1);
+        course1 = courseRepository.save(course1);
 
         Organization organization = organizationUtilService.createOrganization();
         organization = organizationRepo.save(organization);
 
-        courseRepo.addOrganizationToCourse(course1.getId(), organization);
+        courseRepository.addOrganizationToCourse(course1.getId(), organization);
 
         request.delete("/api/admin/organizations/" + organization.getId(), HttpStatus.OK);
         request.get("/api/admin/organizations/" + organization.getId(), HttpStatus.NOT_FOUND, Organization.class);
@@ -297,12 +297,12 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = "admin", roles = "ADMIN")
     void testGetNumberOfUsersAndCoursesOfAllOrganizations() throws Exception {
         Course course1 = CourseFactory.generateCourse(null, ZonedDateTime.now(), ZonedDateTime.now(), new HashSet<>(), "testcourse1", "tutor", "editor", "instructor");
-        course1 = courseRepo.save(course1);
+        course1 = courseRepository.save(course1);
 
         Organization organization = organizationUtilService.createOrganization();
         organization = organizationRepo.save(organization);
 
-        courseRepo.addOrganizationToCourse(course1.getId(), organization);
+        courseRepository.addOrganizationToCourse(course1.getId(), organization);
         User student = userUtilService.createAndSaveUser(TEST_PREFIX + "testGetNumberOfUsersOfAll_");
 
         userRepo.addOrganizationToUser(student.getId(), organization);
@@ -322,12 +322,12 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = "admin", roles = "ADMIN")
     void testGetNumberOfUsersAndCoursesOfOrganization() throws Exception {
         Course course1 = CourseFactory.generateCourse(null, ZonedDateTime.now(), ZonedDateTime.now(), new HashSet<>(), "testcourse1", "tutor", "editor", "instructor");
-        course1 = courseRepo.save(course1);
+        course1 = courseRepository.save(course1);
 
         Organization organization = organizationUtilService.createOrganization();
         organization = organizationRepo.save(organization);
 
-        courseRepo.addOrganizationToCourse(course1.getId(), organization);
+        courseRepository.addOrganizationToCourse(course1.getId(), organization);
         User student = userUtilService.createAndSaveUser(TEST_PREFIX + "testGetNumberOfUsers_");
 
         userRepo.addOrganizationToUser(student.getId(), organization);
@@ -348,8 +348,8 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
         organization = organizationRepo.save(organization);
 
         Course course1 = CourseFactory.generateCourse(null, ZonedDateTime.now(), ZonedDateTime.now(), new HashSet<>(), "testcourse1", "tutor", "editor", "instructor");
-        course1 = courseRepo.save(course1);
-        courseRepo.addOrganizationToCourse(course1.getId(), organization);
+        course1 = courseRepository.save(course1);
+        courseRepository.addOrganizationToCourse(course1.getId(), organization);
 
         User student = userUtilService.createAndSaveUser(TEST_PREFIX + "testGetOrganizationById");
 
@@ -376,12 +376,12 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetAllOrganizationByCourse() throws Exception {
         Course course1 = CourseFactory.generateCourse(null, ZonedDateTime.now(), ZonedDateTime.now(), new HashSet<>(), "testcourse1", "tutor", "editor", "instructor");
-        course1 = courseRepo.save(course1);
+        course1 = courseRepository.save(course1);
 
         Organization organization = organizationUtilService.createOrganization();
         organization = organizationRepo.save(organization);
 
-        courseRepo.addOrganizationToCourse(course1.getId(), organization);
+        courseRepository.addOrganizationToCourse(course1.getId(), organization);
 
         List<Organization> result = request.getList("/api/organizations/courses/" + course1.getId(), HttpStatus.OK, Organization.class);
         assertThat(result).contains(organization);

--- a/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
@@ -18,7 +18,6 @@ import de.tum.in.www1.artemis.course.CourseFactory;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Organization;
 import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.OrganizationRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
@@ -28,9 +27,6 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "organizationtest";
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private UserRepository userRepo;

--- a/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
@@ -19,16 +19,12 @@ import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Organization;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.OrganizationRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.web.rest.dto.OrganizationCountDTO;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "organizationtest";
-
-    @Autowired
-    private UserRepository userRepo;
 
     @Autowired
     private OrganizationRepository organizationRepo;
@@ -50,7 +46,7 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
         User student = userUtilService.createAndSaveUser(TEST_PREFIX + "login2");
         student.setOrganizations(organizations);
-        userRepo.save(student);
+        userRepository.save(student);
 
         ZonedDateTime pastTimestamp = ZonedDateTime.now().minusDays(5);
         ZonedDateTime futureTimestamp = ZonedDateTime.now().plusDays(5);
@@ -85,7 +81,7 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
         User student = userUtilService.createAndSaveUser(TEST_PREFIX + "login1");
         student.setOrganizations(organizations);
-        userRepo.save(student);
+        userRepository.save(student);
 
         ZonedDateTime pastTimestamp = ZonedDateTime.now().minusDays(5);
         ZonedDateTime futureTimestamp = ZonedDateTime.now().plusDays(5);
@@ -301,7 +297,7 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
         courseRepository.addOrganizationToCourse(course1.getId(), organization);
         User student = userUtilService.createAndSaveUser(TEST_PREFIX + "testGetNumberOfUsersOfAll_");
 
-        userRepo.addOrganizationToUser(student.getId(), organization);
+        userRepository.addOrganizationToUser(student.getId(), organization);
 
         List<OrganizationCountDTO> result = request.getList("/api/admin/organizations/count-all", HttpStatus.OK, OrganizationCountDTO.class);
 
@@ -326,7 +322,7 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
         courseRepository.addOrganizationToCourse(course1.getId(), organization);
         User student = userUtilService.createAndSaveUser(TEST_PREFIX + "testGetNumberOfUsers_");
 
-        userRepo.addOrganizationToUser(student.getId(), organization);
+        userRepository.addOrganizationToUser(student.getId(), organization);
 
         OrganizationCountDTO result = request.get("/api/admin/organizations/" + organization.getId() + "/count", HttpStatus.OK, OrganizationCountDTO.class);
 
@@ -349,10 +345,10 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
         User student = userUtilService.createAndSaveUser(TEST_PREFIX + "testGetOrganizationById");
 
-        userRepo.addOrganizationToUser(student.getId(), organization);
+        userRepository.addOrganizationToUser(student.getId(), organization);
         // invoked remove to make sure it works correctly
-        userRepo.removeOrganizationFromUser(student.getId(), organization);
-        userRepo.addOrganizationToUser(student.getId(), organization);
+        userRepository.removeOrganizationFromUser(student.getId(), organization);
+        userRepository.addOrganizationToUser(student.getId(), organization);
 
         Organization result = request.get("/api/admin/organizations/" + organization.getId(), HttpStatus.OK, Organization.class);
         Organization resultWithCoursesAndUsers = request.get("/api/admin/organizations/" + organization.getId() + "/full", HttpStatus.OK, Organization.class);
@@ -393,7 +389,7 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
         organization = organizationRepo.save(organization);
         User student = userUtilService.createAndSaveUser(TEST_PREFIX + "testGetAllOrganizationByUser");
 
-        userRepo.addOrganizationToUser(student.getId(), organization);
+        userRepository.addOrganizationToUser(student.getId(), organization);
 
         List<Organization> result = request.getList("/api/admin/organizations/users/" + student.getId(), HttpStatus.OK, Organization.class);
 

--- a/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
@@ -20,7 +20,6 @@ import de.tum.in.www1.artemis.domain.Organization;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.OrganizationRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.OrganizationCountDTO;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
@@ -36,8 +35,6 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private OrganizationUtilService organizationUtilService;
-
-
 
     /**
      * Test if getting courses a user can enroll in works with multi organization and

--- a/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/organization/OrganizationIntegrationTest.java
@@ -37,8 +37,7 @@ class OrganizationIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @Autowired
     private OrganizationUtilService organizationUtilService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     /**
      * Test if getting courses a user can enroll in works with multi organization and

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
@@ -43,7 +43,6 @@ import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractAthenaTest;
 import de.tum.in.www1.artemis.assessment.GradingScaleUtilService;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.FileUploadExercise;
@@ -95,7 +94,6 @@ import de.tum.in.www1.artemis.service.feature.Feature;
 import de.tum.in.www1.artemis.service.feature.FeatureToggleService;
 import de.tum.in.www1.artemis.service.quiz.QuizBatchService;
 import de.tum.in.www1.artemis.service.quiz.QuizScheduleService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.LocalRepository;
 import de.tum.in.www1.artemis.web.rest.dto.QuizBatchJoinDTO;
 
@@ -135,11 +133,6 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
     @Autowired
     private GradingScaleService gradingScaleService;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
@@ -83,7 +83,6 @@ import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseFactory;
 import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
@@ -103,9 +102,6 @@ import de.tum.in.www1.artemis.web.rest.dto.QuizBatchJoinDTO;
 class ParticipationIntegrationTest extends AbstractAthenaTest {
 
     private static final String TEST_PREFIX = "participationintegration";
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private ExerciseRepository exerciseRepo;
@@ -205,7 +201,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         programmingExercise = ProgrammingExerciseFactory.generateProgrammingExercise(ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1), course);
         programmingExercise = exerciseRepo.save(programmingExercise);
         course.addExercises(programmingExercise);
-        course = courseRepo.save(course);
+        course = courseRepository.save(course);
 
         doReturn(defaultBranch).when(versionControlService).getDefaultBranchOfRepository(any());
         doReturn("Success").when(continuousIntegrationService).copyBuildPlan(any(), any(), any(), any(), any(), anyBoolean());
@@ -584,7 +580,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         var course = programmingExercise.getCourseViaExerciseGroupOrCourseMember();
         course.setRestrictedAthenaModulesAccess(true);
-        this.courseRepo.save(course);
+        this.courseRepository.save(course);
 
         this.programmingExercise.setFeedbackSuggestionModule(ATHENA_MODULE_PROGRAMMING_TEST);
         this.exerciseRepo.save(programmingExercise);
@@ -631,7 +627,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         var course = programmingExercise.getCourseViaExerciseGroupOrCourseMember();
         course.setRestrictedAthenaModulesAccess(true);
-        this.courseRepo.save(course);
+        this.courseRepository.save(course);
 
         this.programmingExercise.setFeedbackSuggestionModule(ATHENA_MODULE_PROGRAMMING_TEST);
         this.exerciseRepo.save(programmingExercise);
@@ -773,7 +769,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void getAllParticipationsForExercise_withLatestResults_forQuizExercise() throws Exception {
         var quizExercise = QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1), QuizMode.INDIVIDUAL, course);
         course.addExercises(quizExercise);
-        courseRepo.save(course);
+        courseRepository.save(course);
         exerciseRepo.save(quizExercise);
 
         var participation = participationUtilService.createAndSaveParticipationForExercise(quizExercise, TEST_PREFIX + "student1");
@@ -1472,7 +1468,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var exerciseGroup1 = examWithExerciseGroups.getExerciseGroups().get(0);
         programmingExercise = exerciseRepo.save(ProgrammingExerciseFactory.generateProgrammingExerciseForExam(exerciseGroup1));
         course.addExercises(programmingExercise);
-        course = courseRepo.save(course);
+        course = courseRepository.save(course);
 
         var participation = ParticipationFactory.generateProgrammingExerciseStudentParticipation(InitializationState.INACTIVE, programmingExercise,
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
@@ -83,7 +83,6 @@ import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
@@ -100,9 +99,6 @@ import de.tum.in.www1.artemis.web.rest.dto.QuizBatchJoinDTO;
 class ParticipationIntegrationTest extends AbstractAthenaTest {
 
     private static final String TEST_PREFIX = "participationintegration";
-
-    @Autowired
-    private ExerciseRepository exerciseRepo;
 
     @Autowired
     private StudentParticipationRepository participationRepo;
@@ -188,10 +184,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
             }
         }
         modelingExercise.setTitle("UML Class Diagram");
-        exerciseRepo.save(modelingExercise);
+        exerciseRepository.save(modelingExercise);
 
         programmingExercise = ProgrammingExerciseFactory.generateProgrammingExercise(ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1), course);
-        programmingExercise = exerciseRepo.save(programmingExercise);
+        programmingExercise = exerciseRepository.save(programmingExercise);
         course.addExercises(programmingExercise);
         course = courseRepository.save(course);
 
@@ -260,7 +256,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @WithMockUser(username = TEST_PREFIX + "student2")
     void participateInTextExercise_releaseDateNotReached() throws Exception {
         textExercise.setReleaseDate(ZonedDateTime.now().plusHours(2));
-        exerciseRepo.save(textExercise);
+        exerciseRepository.save(textExercise);
         request.post("/api/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.FORBIDDEN);
     }
 
@@ -269,7 +265,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void participateInTextExercise_noReleaseDateStartDateNotReached() throws Exception {
         textExercise.setReleaseDate(null);
         textExercise.setStartDate(ZonedDateTime.now().plusHours(2));
-        exerciseRepo.save(textExercise);
+        exerciseRepository.save(textExercise);
         request.post("/api/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.FORBIDDEN);
     }
 
@@ -278,7 +274,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void participateInTextExercise_releaseDateReachedStartDateNotReached() throws Exception {
         textExercise.setReleaseDate(ZonedDateTime.now().minusMinutes(1));
         textExercise.setStartDate(ZonedDateTime.now().plusHours(2));
-        exerciseRepo.save(textExercise);
+        exerciseRepository.save(textExercise);
         request.post("/api/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.FORBIDDEN);
     }
 
@@ -287,7 +283,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void participateInTextExercise_releaseDateReachedStartDateNotReachedAsTutor() throws Exception {
         textExercise.setReleaseDate(ZonedDateTime.now().minusMinutes(1));
         textExercise.setStartDate(ZonedDateTime.now().plusHours(2));
-        exerciseRepo.save(textExercise);
+        exerciseRepository.save(textExercise);
         request.post("/api/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.CREATED);
     }
 
@@ -296,7 +292,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void participateInTextExercise_releaseDateReachedStartDateReached() throws Exception {
         textExercise.setReleaseDate(ZonedDateTime.now().minusMinutes(2));
         textExercise.setStartDate(ZonedDateTime.now().minusMinutes(1));
-        exerciseRepo.save(textExercise);
+        exerciseRepository.save(textExercise);
         request.post("/api/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.CREATED);
     }
 
@@ -330,7 +326,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @WithMockUser(username = TEST_PREFIX + "student1")
     void participateInProgrammingExercise_dueDatePassed() throws Exception {
         programmingExercise.setDueDate(ZonedDateTime.now().minusHours(2));
-        exerciseRepo.save(programmingExercise);
+        exerciseRepository.save(programmingExercise);
         request.post("/api/exercises/" + programmingExercise.getId() + "/participations", null, HttpStatus.FORBIDDEN);
     }
 
@@ -355,7 +351,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @WithMockUser(username = TEST_PREFIX + "student1")
     void practiceProgrammingExercise_beforeDatePassed() throws Exception {
         programmingExercise.setDueDate(ZonedDateTime.now().plusHours(2));
-        exerciseRepo.save(programmingExercise);
+        exerciseRepository.save(programmingExercise);
         request.post("/api/exercises/" + programmingExercise.getId() + "/participations/practice", null, HttpStatus.FORBIDDEN);
     }
 
@@ -363,7 +359,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @WithMockUser(username = TEST_PREFIX + "student1")
     void participateInProgrammingTeamExercise_withoutAssignedTeam() throws Exception {
         programmingExercise.setMode(ExerciseMode.TEAM);
-        exerciseRepo.save(programmingExercise);
+        exerciseRepository.save(programmingExercise);
         request.post("/api/exercises/" + programmingExercise.getId() + "/participations", null, HttpStatus.BAD_REQUEST);
     }
 
@@ -371,7 +367,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @WithMockUser(username = TEST_PREFIX + "student1")
     void practiceProgrammingExercise_successful() throws Exception {
         programmingExercise.setDueDate(ZonedDateTime.now().minusHours(1));
-        exerciseRepo.save(programmingExercise);
+        exerciseRepository.save(programmingExercise);
 
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
         prepareMocksForProgrammingExercise(user.getLogin(), true);
@@ -404,7 +400,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @WithMockUser(username = TEST_PREFIX + "student1")
     void practiceProgrammingTeamExercise_Forbidden() throws Exception {
         programmingExercise.setMode(ExerciseMode.TEAM);
-        exerciseRepo.save(programmingExercise);
+        exerciseRepository.save(programmingExercise);
         request.post("/api/exercises/" + programmingExercise.getId() + "/participations/practice", null, HttpStatus.BAD_REQUEST);
     }
 
@@ -544,7 +540,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void requestFeedbackExerciseNotPossibleIfOnlyAutomaticFeedbacks() throws Exception {
         programmingExercise.setAssessmentType(AssessmentType.AUTOMATIC);
-        exerciseRepo.save(programmingExercise);
+        exerciseRepository.save(programmingExercise);
 
         var participation = ParticipationFactory.generateProgrammingExerciseStudentParticipation(InitializationState.INITIALIZED, programmingExercise,
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
@@ -575,7 +571,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         this.courseRepository.save(course);
 
         this.programmingExercise.setFeedbackSuggestionModule(ATHENA_MODULE_PROGRAMMING_TEST);
-        this.exerciseRepo.save(programmingExercise);
+        this.exerciseRepository.save(programmingExercise);
 
         athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("programming");
 
@@ -622,7 +618,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         this.courseRepository.save(course);
 
         this.programmingExercise.setFeedbackSuggestionModule(ATHENA_MODULE_PROGRAMMING_TEST);
-        this.exerciseRepo.save(programmingExercise);
+        this.exerciseRepository.save(programmingExercise);
         this.athenaRequestMockProvider.mockGetFeedbackSuggestionsWithFailure("programming");
 
         var participation = ParticipationFactory.generateProgrammingExerciseStudentParticipation(InitializationState.INACTIVE, programmingExercise,
@@ -689,7 +685,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void resumeProgrammingExerciseParticipation_forbidden() throws Exception {
         var exercise = ProgrammingExerciseFactory.generateProgrammingExercise(ZonedDateTime.now().minusDays(2), ZonedDateTime.now().minusDays(1), course);
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
         var participation = ParticipationFactory.generateProgrammingExerciseStudentParticipation(InitializationState.INACTIVE, exercise,
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         participationRepo.save(participation);
@@ -762,7 +758,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var quizExercise = QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1), QuizMode.INDIVIDUAL, course);
         course.addExercises(quizExercise);
         courseRepository.save(course);
-        exerciseRepo.save(quizExercise);
+        exerciseRepository.save(quizExercise);
 
         var participation = participationUtilService.createAndSaveParticipationForExercise(quizExercise, TEST_PREFIX + "student1");
         var result1 = participationUtilService.createSubmissionAndResult(participation, 42, true);
@@ -820,7 +816,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participationUtilService.createAndSaveParticipationForExercise(textExercise, TEST_PREFIX + "student2");
         participationUtilService.createAndSaveParticipationForExercise(modelingExercise, TEST_PREFIX + "student1");
         var quizEx = QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1), QuizMode.SYNCHRONIZED, course);
-        exerciseRepo.save(quizEx);
+        exerciseRepository.save(quizEx);
         participationUtilService.createAndSaveParticipationForExercise(quizEx, TEST_PREFIX + "student2");
 
         var participations = request.getList("/api/courses/" + course.getId() + "/participations", HttpStatus.OK, StudentParticipation.class);
@@ -1012,7 +1008,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         final var course = fileUploadExerciseUtilService.addCourseWithFileUploadExercise();
         var exercise = (FileUploadExercise) course.getExercises().stream().findAny().orElseThrow();
         exercise.setDueDate(ZonedDateTime.now().plusHours(2));
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
 
         var submission = fileUploadExerciseUtilService.addFileUploadSubmission(exercise, ParticipationFactory.generateFileUploadSubmission(true), TEST_PREFIX + "student1");
         submission.getParticipation().setIndividualDueDate(ZonedDateTime.now().plusDays(1));
@@ -1033,7 +1029,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         final var course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         var exercise = (ProgrammingExercise) course.getExercises().stream().findAny().orElseThrow();
         exercise.setDueDate(ZonedDateTime.now().plusHours(2));
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
 
         final var participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
         participation.setIndividualDueDate(ZonedDateTime.now().plusHours(20));
@@ -1062,7 +1058,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         final var course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         var exercise = (ProgrammingExercise) course.getExercises().stream().findAny().orElseThrow();
         exercise.setDueDate(ZonedDateTime.now().plusHours(2));
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
 
         final var participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
         final var participationsToUpdate = new StudentParticipationList(participation);
@@ -1080,7 +1076,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         final var course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         var exercise = (ProgrammingExercise) course.getExercises().stream().findAny().orElseThrow();
         exercise.setDueDate(null);
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
 
         var participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
         participation.setIndividualDueDate(ZonedDateTime.now().plusHours(4));
@@ -1100,7 +1096,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         final var course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         var exercise = (ProgrammingExercise) course.getExercises().stream().findAny().orElseThrow();
         exercise.setDueDate(ZonedDateTime.now().minusHours(4));
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
 
         var participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
         participation.setIndividualDueDate(ZonedDateTime.now().plusHours(6));
@@ -1126,7 +1122,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         final var course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         var exercise = (ProgrammingExercise) course.getExercises().stream().findAny().orElseThrow();
         exercise.setDueDate(ZonedDateTime.now().minusHours(4));
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
 
         var participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
         participation.setIndividualDueDate(ZonedDateTime.now().plusHours(4));
@@ -1203,7 +1199,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participationRepo.save(participation);
         if (afterDueDate) {
             programmingExercise.setDueDate(ZonedDateTime.now().minusHours(1));
-            exerciseRepo.save(programmingExercise);
+            exerciseRepository.save(programmingExercise);
         }
         jenkinsRequestMockProvider.enableMockingOfRequests(jenkinsServer);
         mockDeleteBuildPlan(programmingExercise.getProjectKey(), participation.getBuildPlanId(), false);
@@ -1227,7 +1223,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var now = ZonedDateTime.now();
         var exercise = TextExerciseFactory.generateTextExercise(now.minusDays(2), now.plusDays(2), now.plusDays(4), course);
         exercise.setMode(ExerciseMode.TEAM);
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
 
         var student = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
 
@@ -1236,7 +1232,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var teams = new HashSet<Team>();
         teams.add(team);
         exercise.setTeams(teams);
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
 
         var participation = participationUtilService.addTeamParticipationForExercise(exercise, team.getId());
         var actualParticipation = request.get("/api/exercises/" + exercise.getId() + "/participation", HttpStatus.OK, StudentParticipation.class);
@@ -1333,7 +1329,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var now = ZonedDateTime.now();
         var exercise = TextExerciseFactory.generateTextExercise(now.minusDays(2), now.plusDays(2), now.plusDays(4), course);
         exercise.setMode(ExerciseMode.TEAM);
-        return exerciseRepo.save(exercise);
+        return exerciseRepository.save(exercise);
     }
 
     private Team createTeamForExercise(User student, Exercise exercise) {
@@ -1348,7 +1344,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var teams = new HashSet<Team>();
         teams.add(team);
         exercise.setTeams(teams);
-        return exerciseRepo.save(exercise);
+        return exerciseRepository.save(exercise);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
@@ -1356,7 +1352,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @EnumSource(QuizMode.class)
     void getParticipation_quizExerciseNotStarted(QuizMode quizMode) throws Exception {
         var quizEx = QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().plusHours(2), ZonedDateTime.now().plusDays(1), quizMode, course);
-        quizEx = exerciseRepo.save(quizEx);
+        quizEx = exerciseRepository.save(quizEx);
         request.get("/api/exercises/" + quizEx.getId() + "/participation", HttpStatus.FORBIDDEN, StudentParticipation.class);
     }
 
@@ -1365,7 +1361,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @EnumSource(QuizMode.class)
     void getParticipation_quizExerciseStartedAndNoParticipation(QuizMode quizMode) throws Exception {
         var quizEx = QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().minusMinutes(2), ZonedDateTime.now().minusMinutes(1), quizMode, course);
-        quizEx = exerciseRepo.save(quizEx);
+        quizEx = exerciseRepository.save(quizEx);
         request.getNullable("/api/exercises/" + quizEx.getId() + "/participation", HttpStatus.NO_CONTENT, StudentParticipation.class);
     }
 
@@ -1373,7 +1369,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void getParticipation_quizBatchNotPresent() throws Exception {
         var quizEx = QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().minusMinutes(1), ZonedDateTime.now().plusMinutes(5), QuizMode.INDIVIDUAL, course).duration(360);
-        quizEx = exerciseRepo.save(quizEx);
+        quizEx = exerciseRepository.save(quizEx);
         var participation = request.get("/api/exercises/" + quizEx.getId() + "/participation", HttpStatus.OK, StudentParticipation.class);
         quizEx.setRemainingNumberOfAttempts(1);
         assertThat(participation.getExercise()).as("Participation contains exercise").isEqualTo(quizEx);
@@ -1386,7 +1382,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @EnumSource(QuizMode.class)
     void getParticipation_quizExerciseFinished(QuizMode quizMode) throws Exception {
         var quizEx = QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().minusMinutes(20), ZonedDateTime.now().minusMinutes(20), quizMode, course);
-        quizEx = exerciseRepo.save(quizEx);
+        quizEx = exerciseRepository.save(quizEx);
         var participation = participationUtilService.createAndSaveParticipationForExercise(quizEx, TEST_PREFIX + "student1");
         var submission = participationUtilService.addSubmission(participation, new QuizSubmission().scoreInPoints(11D).submitted(true));
         participationUtilService.addResultToParticipation(participation, submission);
@@ -1414,7 +1410,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         quizExercise.addQuestions(QuizExerciseFactory.createShortAnswerQuestion());
         quizExercise.setDuration(600);
         quizExercise.setQuizPointStatistic(new QuizPointStatistic());
-        quizExercise = exerciseRepo.save(quizExercise);
+        quizExercise = exerciseRepository.save(quizExercise);
 
         ShortAnswerQuestion saQuestion = (ShortAnswerQuestion) quizExercise.getQuizQuestions().get(0);
         List<ShortAnswerSpot> spots = saQuestion.getSpots();
@@ -1458,7 +1454,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         Exam examWithExerciseGroups = ExamFactory.generateExamWithExerciseGroup(course, false);
         examRepository.save(examWithExerciseGroups);
         var exerciseGroup1 = examWithExerciseGroups.getExerciseGroups().get(0);
-        programmingExercise = exerciseRepo.save(ProgrammingExerciseFactory.generateProgrammingExerciseForExam(exerciseGroup1));
+        programmingExercise = exerciseRepository.save(ProgrammingExerciseFactory.generateProgrammingExerciseForExam(exerciseGroup1));
         course.addExercises(programmingExercise);
         course = courseRepository.save(course);
 
@@ -1487,7 +1483,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void whenFeedbackRequestedAndDeadlinePassed_thenFail() throws Exception {
 
         programmingExercise.setDueDate(ZonedDateTime.now().minusDays(100));
-        programmingExercise = exerciseRepo.save(programmingExercise);
+        programmingExercise = exerciseRepository.save(programmingExercise);
 
         var participation = ParticipationFactory.generateProgrammingExerciseStudentParticipation(InitializationState.INACTIVE, programmingExercise,
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
@@ -1514,7 +1510,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void whenFeedbackRequestedAndRateLimitExceeded_thenFail() throws Exception {
 
         programmingExercise.setDueDate(ZonedDateTime.now().plusDays(100));
-        programmingExercise = exerciseRepo.save(programmingExercise);
+        programmingExercise = exerciseRepository.save(programmingExercise);
 
         var participation = ParticipationFactory.generateProgrammingExerciseStudentParticipation(InitializationState.INACTIVE, programmingExercise,
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
@@ -1549,7 +1545,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void whenFeedbackRequestedAndRateLimitStillUnknownDueRequestsInProgress_thenFail() throws Exception {
 
         programmingExercise.setDueDate(ZonedDateTime.now().plusDays(100));
-        programmingExercise = exerciseRepo.save(programmingExercise);
+        programmingExercise = exerciseRepository.save(programmingExercise);
 
         var participation = ParticipationFactory.generateProgrammingExerciseStudentParticipation(InitializationState.INACTIVE, programmingExercise,
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
@@ -1589,7 +1585,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         @EnumSource(QuizMode.class)
         void getParticipation_quizExerciseStartedAndSubmissionAllowed(QuizMode quizMode) throws Exception {
             var quizEx = QuizExerciseFactory.generateQuizExercise(ZonedDateTime.now().minusMinutes(1), ZonedDateTime.now().plusMinutes(5), quizMode, course).duration(360);
-            quizEx = exerciseRepo.save(quizEx);
+            quizEx = exerciseRepository.save(quizEx);
 
             request.postWithResponseBody("/api/quiz-exercises/" + quizEx.getId() + "/start-participation", null, StudentParticipation.class, HttpStatus.OK);
 

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
@@ -83,7 +83,6 @@ import de.tum.in.www1.artemis.exercise.quiz.QuizExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ExamRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
@@ -105,9 +104,6 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private FeatureToggleService featureToggleService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationIntegrationTest.java
@@ -136,8 +136,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @Autowired
     private GradingScaleService gradingScaleService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationSubmissionIntegrationTest.java
@@ -31,8 +31,7 @@ class ParticipationSubmissionIntegrationTest extends AbstractSpringIntegrationIn
     @Autowired
     private ResultRepository resultRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationSubmissionIntegrationTest.java
@@ -15,7 +15,6 @@ import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Submission;
 import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.domain.TextSubmission;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 
@@ -28,9 +27,6 @@ class ParticipationSubmissionIntegrationTest extends AbstractSpringIntegrationIn
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationSubmissionIntegrationTest.java
@@ -17,7 +17,6 @@ import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.domain.TextSubmission;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 
 class ParticipationSubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -26,9 +25,6 @@ class ParticipationSubmissionIntegrationTest extends AbstractSpringIntegrationIn
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/ParticipationSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/ParticipationSubmissionIntegrationTest.java
@@ -19,7 +19,6 @@ import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ParticipationSubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -30,8 +29,6 @@ class ParticipationSubmissionIntegrationTest extends AbstractSpringIntegrationIn
 
     @Autowired
     private ResultRepository resultRepository;
-
-
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/SubmissionExportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/SubmissionExportIntegrationTest.java
@@ -19,7 +19,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.FileUploadExercise;
@@ -34,17 +33,11 @@ import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exercise.fileupload.FileUploadExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.SubmissionExportOptionsDTO;
 
 class SubmissionExportIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "submissionexportintegration";
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/SubmissionExportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/SubmissionExportIntegrationTest.java
@@ -41,8 +41,7 @@ class SubmissionExportIntegrationTest extends AbstractSpringIntegrationIndepende
 
     private static final String TEST_PREFIX = "submissionexportintegration";
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
@@ -12,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.Submission;
@@ -27,7 +26,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.SubmissionVersionRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.SubmissionVersionDTO;
 import de.tum.in.www1.artemis.web.rest.dto.pageablesearch.SearchTermPageableSearchDTO;
@@ -41,11 +39,6 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest
 
     @Autowired
     private ResultRepository resultRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
@@ -23,7 +23,6 @@ import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.SubmissionVersionRepository;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
@@ -36,9 +35,6 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-    @Autowired
-    private ResultRepository resultRepository;
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
@@ -24,7 +24,6 @@ import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.SubmissionVersionRepository;
@@ -42,9 +41,6 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest
 
     @Autowired
     private ResultRepository resultRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
@@ -42,8 +42,7 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest
     @Autowired
     private ResultRepository resultRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/participation/SubmissionIntegrationTest.java
@@ -21,7 +21,6 @@ import de.tum.in.www1.artemis.domain.TextSubmission;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.SubmissionVersionRepository;
@@ -35,9 +34,6 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest
 
     @Autowired
     private SubmissionRepository submissionRepository;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismAnswerPostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismAnswerPostIntegrationTest.java
@@ -16,7 +16,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.enumeration.CourseInformationSharingConfiguration;
 import de.tum.in.www1.artemis.domain.metis.AnswerPost;
@@ -24,7 +23,6 @@ import de.tum.in.www1.artemis.domain.metis.Post;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
 import de.tum.in.www1.artemis.repository.metis.AnswerPostRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class PlagiarismAnswerPostIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -35,11 +33,6 @@ class PlagiarismAnswerPostIntegrationTest extends AbstractSpringIntegrationIndep
 
     @Autowired
     private PostRepository postRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ConversationUtilService conversationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismAnswerPostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismAnswerPostIntegrationTest.java
@@ -36,8 +36,7 @@ class PlagiarismAnswerPostIntegrationTest extends AbstractSpringIntegrationIndep
     @Autowired
     private PostRepository postRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismAnswerPostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismAnswerPostIntegrationTest.java
@@ -22,7 +22,6 @@ import de.tum.in.www1.artemis.domain.enumeration.CourseInformationSharingConfigu
 import de.tum.in.www1.artemis.domain.metis.AnswerPost;
 import de.tum.in.www1.artemis.domain.metis.Post;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.metis.AnswerPostRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
@@ -36,9 +35,6 @@ class PlagiarismAnswerPostIntegrationTest extends AbstractSpringIntegrationIndep
 
     @Autowired
     private PostRepository postRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
@@ -56,8 +56,7 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
     @Autowired
     private PlagiarismComparisonRepository plagiarismComparisonRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
@@ -29,7 +29,6 @@ import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismResult;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismSubmission;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismVerdict;
 import de.tum.in.www1.artemis.domain.plagiarism.text.TextSubmissionElement;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
@@ -52,9 +51,6 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     private Course course;
 

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
@@ -31,7 +31,6 @@ import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismVerdict;
 import de.tum.in.www1.artemis.domain.plagiarism.text.TextSubmissionElement;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismComparisonRepository;
@@ -47,9 +46,6 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private PostRepository postRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private PlagiarismComparisonRepository plagiarismComparisonRepository;

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
@@ -16,7 +16,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Team;
@@ -36,7 +35,6 @@ import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismComparisonRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.plagiarism.PlagiarismCaseInfoDTO;
 import de.tum.in.www1.artemis.web.rest.dto.plagiarism.PlagiarismVerdictDTO;
 
@@ -56,16 +54,11 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
     @Autowired
     private PlagiarismComparisonRepository plagiarismComparisonRepository;
 
-
-
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     private Course course;
 

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismIntegrationTest.java
@@ -14,7 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.domain.enumeration.ExerciseMode;
@@ -31,7 +30,6 @@ import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismComparisonRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismResultRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.plagiarism.PlagiarismComparisonStatusDTO;
 
 class PlagiarismIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -50,13 +48,8 @@ class PlagiarismIntegrationTest extends AbstractSpringIntegrationIndependentTest
     @Autowired
     private PlagiarismResultRepository plagiarismResultRepository;
 
-
-
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismIntegrationTest.java
@@ -50,8 +50,7 @@ class PlagiarismIntegrationTest extends AbstractSpringIntegrationIndependentTest
     @Autowired
     private PlagiarismResultRepository plagiarismResultRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismPostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismPostIntegrationTest.java
@@ -55,8 +55,7 @@ class PlagiarismPostIntegrationTest extends AbstractSpringIntegrationLocalCILoca
     @Autowired
     private PlagiarismCaseRepository plagiarismCaseRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ConversationUtilService conversationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismPostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismPostIntegrationTest.java
@@ -34,7 +34,6 @@ import de.tum.in.www1.artemis.domain.metis.UserRole;
 import de.tum.in.www1.artemis.domain.metis.conversation.Channel;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismCase;
 import de.tum.in.www1.artemis.post.ConversationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.metis.ConversationMessageRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
@@ -55,9 +54,6 @@ class PlagiarismPostIntegrationTest extends AbstractSpringIntegrationLocalCILoca
 
     @Autowired
     private PlagiarismCaseRepository plagiarismCaseRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismPostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/plagiarism/PlagiarismPostIntegrationTest.java
@@ -38,7 +38,6 @@ import de.tum.in.www1.artemis.repository.metis.ConversationMessageRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.PostContextFilterDTO;
 import de.tum.in.www1.artemis.web.websocket.dto.metis.PostDTO;
 
@@ -54,8 +53,6 @@ class PlagiarismPostIntegrationTest extends AbstractSpringIntegrationLocalCILoca
 
     @Autowired
     private PlagiarismCaseRepository plagiarismCaseRepository;
-
-
 
     @Autowired
     private ConversationUtilService conversationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/science/ScienceSettingsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/science/ScienceSettingsIntegrationTest.java
@@ -15,7 +15,6 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.science.ScienceSetting;
 import de.tum.in.www1.artemis.repository.science.ScienceSettingRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ScienceSettingsIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -23,8 +22,6 @@ class ScienceSettingsIntegrationTest extends AbstractSpringIntegrationIndependen
 
     @Autowired
     private ScienceSettingRepository scienceSettingRepository;
-
-
 
     private ScienceSetting settingA;
 

--- a/src/test/java/de/tum/in/www1/artemis/science/ScienceSettingsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/science/ScienceSettingsIntegrationTest.java
@@ -24,8 +24,7 @@ class ScienceSettingsIntegrationTest extends AbstractSpringIntegrationIndependen
     @Autowired
     private ScienceSettingRepository scienceSettingRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     private ScienceSetting settingA;
 

--- a/src/test/java/de/tum/in/www1/artemis/service/AssessmentServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/AssessmentServiceTest.java
@@ -39,7 +39,6 @@ import de.tum.in.www1.artemis.exercise.fileupload.FileUploadExerciseFactory;
 import de.tum.in.www1.artemis.exercise.modeling.ModelingExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
@@ -51,9 +50,6 @@ class AssessmentServiceTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ExerciseRepository exerciseRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ResultRepository resultRepository;

--- a/src/test/java/de/tum/in/www1/artemis/service/ConductAgreementServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ConductAgreementServiceTest.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.course.CourseFactory;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 
 class ConductAgreementServiceTest extends AbstractSpringIntegrationIndependentTest {
@@ -21,9 +20,6 @@ class ConductAgreementServiceTest extends AbstractSpringIntegrationIndependentTe
     private static final ZonedDateTime PAST_TIMESTAMP = ZonedDateTime.now().minusDays(1);
 
     private static final ZonedDateTime FUTURE_TIMESTAMP = ZonedDateTime.now().plusDays(1);
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ConductAgreementService conductAgreementService;

--- a/src/test/java/de/tum/in/www1/artemis/service/CourseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/CourseServiceTest.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.domain.TextSubmission;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
@@ -43,9 +42,6 @@ class CourseServiceTest extends AbstractSpringIntegrationLocalCILocalVCTest {
 
     @Autowired
     private CourseService courseService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/service/EmailSummaryServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/EmailSummaryServiceTest.java
@@ -29,7 +29,6 @@ import de.tum.in.www1.artemis.domain.NotificationSetting;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.DifficultyLevel;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.NotificationSettingRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
@@ -46,9 +45,6 @@ class EmailSummaryServiceTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private NotificationSettingRepository notificationSettingRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/service/LearningPathServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/LearningPathServiceTest.java
@@ -38,7 +38,6 @@ import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.repository.CompetencyRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.learningpath.LearningPathNgxService;
@@ -64,9 +63,6 @@ class LearningPathServiceTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private UserUtilService userUtilService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private CompetencyUtilService competencyUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/service/LectureImportServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/LectureImportServiceTest.java
@@ -18,7 +18,6 @@ import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.lecture.ExerciseUnit;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 
@@ -28,9 +27,6 @@ class LectureImportServiceTest extends AbstractSpringIntegrationIndependentTest 
 
     @Autowired
     private LectureImportService lectureImportService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private LectureRepository lectureRepository;

--- a/src/test/java/de/tum/in/www1/artemis/service/LectureServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/LectureServiceTest.java
@@ -21,7 +21,6 @@ import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.lecture.LectureFactory;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.PageableSearchUtilService;
@@ -34,9 +33,6 @@ class LectureServiceTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private LectureService lectureService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private LectureRepository lectureRepository;

--- a/src/test/java/de/tum/in/www1/artemis/service/TitleCacheEvictionServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/TitleCacheEvictionServiceTest.java
@@ -20,7 +20,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.lecture.LectureUtilService;
 import de.tum.in.www1.artemis.organization.OrganizationUtilService;
 import de.tum.in.www1.artemis.repository.ApollonDiagramRepository;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
@@ -39,9 +38,6 @@ class TitleCacheEvictionServiceTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private CacheManager cacheManager;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ExerciseRepository exerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/service/exam/ExamAccessServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/exam/ExamAccessServiceTest.java
@@ -23,7 +23,6 @@ import de.tum.in.www1.artemis.domain.exam.ExamUser;
 import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExamUserRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
@@ -39,9 +38,6 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 class ExamAccessServiceTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "examaccessservicetest";
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ExamRepository examRepository;

--- a/src/test/java/de/tum/in/www1/artemis/service/exam/StudentExamAccessServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/exam/StudentExamAccessServiceTest.java
@@ -17,7 +17,6 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
@@ -33,9 +32,6 @@ class StudentExamAccessServiceTest extends AbstractSpringIntegrationIndependentT
 
     @Autowired
     private StudentExamRepository studentExamRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/service/export/CourseExamExportServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/export/CourseExamExportServiceTest.java
@@ -17,7 +17,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
@@ -38,9 +37,6 @@ class CourseExamExportServiceTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private UserUtilService userUtilService;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private ExerciseRepository exerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/TutorialGroupNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/TutorialGroupNotificationServiceTest.java
@@ -36,7 +36,6 @@ import de.tum.in.www1.artemis.domain.notification.Notification;
 import de.tum.in.www1.artemis.domain.notification.TutorialGroupNotification;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroup;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupRegistration;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.NotificationSettingRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupNotificationRepository;
@@ -54,9 +53,6 @@ class TutorialGroupNotificationServiceTest extends AbstractSpringIntegrationInde
 
     @Autowired
     private TutorialGroupNotificationRepository tutorialGroupNotificationRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private TutorialGroupRepository tutorialGroupRepository;

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
@@ -42,8 +42,7 @@ class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest
     @Autowired
     private UserRepository userRepo;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
@@ -25,14 +25,10 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.ExerciseMode;
 import de.tum.in.www1.artemis.domain.enumeration.TeamImportStrategyType;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 
 class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest {
-
-    @Autowired
-    private ExerciseRepository exerciseRepo;
 
     @Autowired
     private TeamRepository teamRepo;
@@ -106,10 +102,10 @@ class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest
         // Make both source and destination exercise team exercises
         sourceExercise = exerciseUtilService.findModelingExerciseWithTitle(course.getExercises(), "Modeling");
         sourceExercise.setMode(ExerciseMode.TEAM);
-        sourceExercise = exerciseRepo.save(sourceExercise);
+        sourceExercise = exerciseRepository.save(sourceExercise);
         destinationExercise = exerciseUtilService.findTextExerciseWithTitle(course.getExercises(), "Text");
         destinationExercise.setMode(ExerciseMode.TEAM);
-        destinationExercise = exerciseRepo.save(destinationExercise);
+        destinationExercise = exerciseRepository.save(destinationExercise);
         Pair<List<Team>, List<Team>> importedTeamsWithBody = getImportedTeamsAndBody("import", TEST_PREFIX + "student", REGISTRATION_NUMBER_PREFIX + "R");
         importedTeams = importedTeamsWithBody.getFirst();
         importedTeamsBody = importedTeamsWithBody.getSecond();
@@ -270,14 +266,14 @@ class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest
 
         // If the destination exercise is not a team exercise, the request should fail
         destinationExercise.setMode(ExerciseMode.INDIVIDUAL);
-        exerciseRepo.save(destinationExercise);
+        exerciseRepository.save(destinationExercise);
         request.put(importFromSourceExerciseUrl(), null, HttpStatus.BAD_REQUEST);
 
         destinationExercise.setMode(ExerciseMode.TEAM);
-        exerciseRepo.save(destinationExercise);
+        exerciseRepository.save(destinationExercise);
         // If the source exercise is not a team exercise, the request should fail
         sourceExercise.setMode(ExerciseMode.INDIVIDUAL);
-        exerciseRepo.save(sourceExercise);
+        exerciseRepository.save(sourceExercise);
         request.put(importFromSourceExerciseUrl(), null, HttpStatus.BAD_REQUEST);
     }
 
@@ -286,10 +282,10 @@ class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest
     void testImportTeamsFromListBadRequests() throws Exception {
         // If the destination exercise is not a team exercise, the request should fail
         destinationExercise.setMode(ExerciseMode.INDIVIDUAL);
-        exerciseRepo.save(destinationExercise);
+        exerciseRepository.save(destinationExercise);
         request.put(importFromListUrl(), importedTeamsBody, HttpStatus.BAD_REQUEST);
         destinationExercise.setMode(ExerciseMode.TEAM);
-        exerciseRepo.save(destinationExercise);
+        exerciseRepository.save(destinationExercise);
 
         // If user with given registration number does not exist, the request should fail
         List<Team> teams = new ArrayList<>();

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
@@ -24,16 +24,12 @@ import de.tum.in.www1.artemis.domain.Team;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.ExerciseMode;
 import de.tum.in.www1.artemis.domain.enumeration.TeamImportStrategyType;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.repository.TeamRepository;
 
 class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private TeamRepository teamRepo;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private TeamUtilService teamUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
@@ -333,7 +333,7 @@ class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest
     void testImportTeamsFromExerciseForbiddenAsInstructorOfOtherCourse() throws Exception {
         // If the instructor is not part of the correct course instructor group anymore, he should not be able to import teams
         course.setInstructorGroupName("Different group name");
-        courseRepo.save(course);
+        courseRepository.save(course);
 
         request.put(importFromSourceExerciseUrl(), null, HttpStatus.FORBIDDEN);
     }
@@ -343,7 +343,7 @@ class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest
     void testImportTeamsFromListForbiddenAsInstructorOfOtherCourse() throws Exception {
         // If the instructor is not part of the correct course instructor group anymore, he should not be able to import teams
         course.setInstructorGroupName("Different group name");
-        courseRepo.save(course);
+        courseRepository.save(course);
 
         request.put(importFromListUrl(), importedTeamsBody, HttpStatus.FORBIDDEN);
     }

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
@@ -26,15 +26,11 @@ import de.tum.in.www1.artemis.domain.enumeration.ExerciseMode;
 import de.tum.in.www1.artemis.domain.enumeration.TeamImportStrategyType;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.repository.TeamRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 
 class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private TeamRepository teamRepo;
-
-    @Autowired
-    private UserRepository userRepo;
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;
@@ -110,7 +106,7 @@ class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest
         importedTeams = importedTeamsWithBody.getFirst();
         importedTeamsBody = importedTeamsWithBody.getSecond();
         // Select a tutor for the teams
-        tutor = userRepo.findOneByLogin(TEST_PREFIX + "tutor1").orElseThrow();
+        tutor = userRepository.findOneByLogin(TEST_PREFIX + "tutor1").orElseThrow();
     }
 
     private void testImportTeamsIntoExercise(ImportType type, TeamImportStrategyType importStrategyType, List<Team> body, List<Team> addedTeams) throws Exception {
@@ -298,7 +294,7 @@ class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest
         request.put(importFromListUrl(), getTeamsIntoLoginOnlyTeams(teams), HttpStatus.BAD_REQUEST);
 
         // If user does not have an identifier: registration number or login, the request should fail
-        userRepo.saveAll(teams.stream().map(Team::getStudents).flatMap(Collection::stream).toList());
+        userRepository.saveAll(teams.stream().map(Team::getStudents).flatMap(Collection::stream).toList());
         request.put(importFromListUrl(), getTeamsIntoOneIdentifierTeams(teams, null), HttpStatus.BAD_REQUEST);
 
         // If user's registration number points to same user with a login in request, it should fail
@@ -360,7 +356,7 @@ class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest
                 registrationPrefix);
         var users = generatedTeams.stream().map(Team::getStudents).flatMap(Collection::stream).toList();
         users.forEach(u -> userUtilService.cleanUpRegistrationNumberForUser(u));
-        userRepo.saveAll(users);
+        userRepository.saveAll(users);
         List<Team> teamsWithLogins = getTeamsIntoLoginOnlyTeams(generatedTeams.subList(0, 2));
         List<Team> teamsWithRegistrationNumbers = getTeamsIntoRegistrationNumberOnlyTeams(generatedTeams.subList(2, 3));
         List<Team> body = Stream.concat(teamsWithLogins.stream(), teamsWithRegistrationNumbers.stream()).toList();

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
@@ -26,16 +26,12 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.ExerciseMode;
 import de.tum.in.www1.artemis.domain.enumeration.TeamImportStrategyType;
 import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.user.UserUtilService;
 
 class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest {
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private ExerciseRepository exerciseRepo;

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamImportIntegrationTest.java
@@ -18,7 +18,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Team;
@@ -29,7 +28,6 @@ import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -41,11 +39,6 @@ class TeamImportIntegrationTest extends AbstractSpringIntegrationIndependentTest
 
     @Autowired
     private UserRepository userRepo;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
@@ -54,8 +54,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private UserRepository userRepo;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
@@ -34,7 +34,6 @@ import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilServic
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.dto.TeamSearchUserDTO;
@@ -42,9 +41,6 @@ import de.tum.in.www1.artemis.web.rest.dto.CoursesForDashboardDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ExerciseDetailsDTO;
 
 class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
-
-    @Autowired
-    private ExerciseRepository exerciseRepo;
 
     @Autowired
     private TeamRepository teamRepo;
@@ -90,7 +86,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         exercise = course.getExercises().iterator().next();
         exercise.setMode(ExerciseMode.TEAM);
         exercise.setReleaseDate(ZonedDateTime.now().minusDays(1));
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
         students = new HashSet<>(userRepo.searchByLoginOrNameInGroup("tumuser", TEST_PREFIX + "student"));
         tutor = userRepo.findOneByLogin(TEST_PREFIX + "tutor1").orElseThrow();
     }
@@ -124,8 +120,8 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         teamAssignmentConfig.setMinTeamSize(1);
         teamAssignmentConfig.setMaxTeamSize(10);
         exercise.setTeamAssignmentConfig(teamAssignmentConfig);
-        exercise = exerciseRepo.save(exercise);
-        exercise = exerciseRepo.findWithEagerCategoriesAndTeamAssignmentConfigById(exercise.getId()).orElseThrow();
+        exercise = exerciseRepository.save(exercise);
+        exercise = exerciseRepository.findWithEagerCategoriesAndTeamAssignmentConfigById(exercise.getId()).orElseThrow();
         assertThat(exercise.getTeamAssignmentConfig().getMinTeamSize()).isEqualTo(1);
         assertThat(exercise.getTeamAssignmentConfig().getMaxTeamSize()).isEqualTo(10);
         assertThat(exercise.getTeamAssignmentConfig().getId()).isNotNull();
@@ -516,7 +512,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         // make exercises team-based
         Stream.of(programmingExercise, textExercise, modelingExercise).forEach(exercise -> {
             exercise.setMode(ExerciseMode.TEAM);
-            exerciseRepo.save(exercise);
+            exerciseRepository.save(exercise);
         });
 
         String shortNamePrefix1 = TEST_PREFIX + "team";

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
@@ -35,7 +35,6 @@ import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilServic
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
@@ -45,9 +44,6 @@ import de.tum.in.www1.artemis.web.rest.dto.CoursesForDashboardDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ExerciseDetailsDTO;
 
 class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private ExerciseRepository exerciseRepo;

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
@@ -17,7 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
@@ -39,7 +38,6 @@ import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.dto.TeamSearchUserDTO;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.CoursesForDashboardDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ExerciseDetailsDTO;
 
@@ -54,8 +52,6 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private UserRepository userRepo;
 
-
-
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
 
@@ -64,9 +60,6 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
@@ -190,7 +190,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     void testCreateTeam_Forbidden_AsTutorOfDifferentCourse() throws Exception {
         // If the TA is not part of the correct course TA group anymore, he should not be able to create a team for an exercise of that course
         course.setTeachingAssistantGroupName("Different group name");
-        courseRepo.save(course);
+        courseRepository.save(course);
 
         Team team = new Team();
         team.setName("Team");
@@ -273,7 +273,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     void testUpdateTeam_Forbidden_AsTutorOfDifferentCourse() throws Exception {
         // If the TA is not part of the correct course TA group anymore, he should not be able to update a team for an exercise of that course
         course.setTeachingAssistantGroupName("Different group name");
-        courseRepo.save(course);
+        courseRepository.save(course);
 
         Team team = teamUtilService.addTeamForExercise(exercise, tutor);
         team.setName("Updated Team Name");
@@ -344,7 +344,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     void testGetTeamsForExercise_Forbidden() throws Exception {
         // If the TA is not part of the correct course TA group anymore, he should not be able to get the teams for an exercise of that course
         course.setTeachingAssistantGroupName("Different group name");
-        courseRepo.save(course);
+        courseRepository.save(course);
         teamUtilService.addTeamsForExercise(exercise, 3, tutor);
         request.getList(resourceUrl(), HttpStatus.FORBIDDEN, Team.class);
     }
@@ -374,7 +374,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         // If the instructor is not part of the correct course instructor group anymore,
         // he should not be able to delete a team for an exercise of that course
         course.setInstructorGroupName("Different group name");
-        courseRepo.save(course);
+        courseRepository.save(course);
 
         Team team = teamUtilService.addTeamForExercise(exercise, tutor);
         request.delete(resourceUrl() + "/" + team.getId(), HttpStatus.FORBIDDEN);
@@ -445,7 +445,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     void testSearchUsersInCourse_Forbidden_AsTutorOfDifferentCourse() throws Exception {
         // If the TA is not part of the correct course TA group anymore, he should not be able to search for users in the course
         course.setTeachingAssistantGroupName("Different group name");
-        courseRepo.save(course);
+        courseRepository.save(course);
 
         request.getList(resourceUrlSearchUsersInCourse(TEST_PREFIX + "student"), HttpStatus.FORBIDDEN, TeamSearchUserDTO.class);
     }
@@ -480,7 +480,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         userRepo.save(student);
 
         course.setStudentGroupName(TEST_PREFIX + "student" + "assignedTeam");
-        courseRepo.save(course);
+        courseRepository.save(course);
 
         // Create team that contains student "student1" (Team shortName needs to be empty since it is used as a prefix for the generated student logins)
         Team team = new Team().name(TEST_PREFIX + "Team").shortName(TEST_PREFIX + "team").exercise(exercise)

--- a/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/team/TeamIntegrationTest.java
@@ -29,7 +29,6 @@ import de.tum.in.www1.artemis.domain.enumeration.ExerciseMode;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.programming.ProgrammingExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
@@ -49,9 +48,6 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private TeamUtilService teamUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/AssessmentEventIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/AssessmentEventIntegrationTest.java
@@ -11,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.TextSubmission;
@@ -24,7 +23,6 @@ import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.TextAssessmentEventRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 
 class AssessmentEventIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -41,11 +39,6 @@ class AssessmentEventIntegrationTest extends AbstractSpringIntegrationIndependen
 
     @Autowired
     private TextAssessmentEventRepository textAssessmentEventRepository;
-
-
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/AssessmentEventIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/AssessmentEventIntegrationTest.java
@@ -42,8 +42,7 @@ class AssessmentEventIntegrationTest extends AbstractSpringIntegrationIndependen
     @Autowired
     private TextAssessmentEventRepository textAssessmentEventRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/AssessmentEventIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/AssessmentEventIntegrationTest.java
@@ -22,14 +22,10 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.TextAssessmentEventRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 
 class AssessmentEventIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "assessmentevent";
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private TextSubmissionRepository textSubmissionRepository;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
@@ -60,7 +60,6 @@ import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.fileupload.FileUploadExerciseFactory;
 import de.tum.in.www1.artemis.exercise.fileupload.FileUploadExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
@@ -118,9 +117,6 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private TextAssessmentService textAssessmentService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
@@ -131,8 +131,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
     @Autowired
     private TextAssessmentService textAssessmentService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
@@ -71,7 +71,6 @@ import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
 import de.tum.in.www1.artemis.repository.ExerciseGroupRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.TextBlockRepository;
@@ -107,9 +106,6 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private ExampleSubmissionRepository exampleSubmissionRepository;
-
-    @Autowired
-    private ResultRepository resultRepo;
 
     @Autowired
     private StudentParticipationRepository studentParticipationRepository;
@@ -168,7 +164,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         TextSubmission textSubmission = ParticipationFactory.generateTextSubmission("Some text", Language.ENGLISH, false);
         textSubmission = textExerciseUtilService.saveTextSubmission(textExercise, textSubmission, TEST_PREFIX + "student1");
         textAssessmentService.prepareSubmissionForAssessment(textSubmission, null);
-        var result = resultRepo.findDistinctBySubmissionId(textSubmission.getId());
+        var result = resultRepository.findDistinctBySubmissionId(textSubmission.getId());
         assertThat(result).isPresent();
     }
 
@@ -194,7 +190,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         textSubmission = textExerciseUtilService.saveTextSubmissionWithResultAndAssessor(textExercise, textSubmission, TEST_PREFIX + "student1", TEST_PREFIX + "tutor2");
         Result result = textSubmission.getLatestResult();
         result.setCompletionDate(null); // assessment is still in progress for this test
-        resultRepo.save(result);
+        resultRepository.save(result);
         StudentParticipation participation = request.get("/api/text-submissions/" + textSubmission.getId() + "/for-assessment", HttpStatus.LOCKED, StudentParticipation.class);
         assertThat(participation).as("participation is locked and should not be returned").isNull();
     }
@@ -947,7 +943,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         TextSubmission textSubmission = ParticipationFactory.generateTextSubmission("Test123", Language.ENGLISH, true);
         textSubmission = textExerciseUtilService.saveTextSubmissionWithResultAndAssessor(textExercise, textSubmission, student, originalAssessor);
         textSubmission.getLatestResult().setCompletionDate(originalAssessmentSubmitted ? now() : null);
-        resultRepo.save(textSubmission.getLatestResult());
+        resultRepository.save(textSubmission.getLatestResult());
         var params = new LinkedMultiValueMap<String, String>();
         params.add("submit", submit);
         List<Feedback> feedbacks = ParticipationFactory.generateFeedback();

--- a/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
@@ -79,7 +79,6 @@ import de.tum.in.www1.artemis.repository.TextBlockRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
 import de.tum.in.www1.artemis.service.TextAssessmentService;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.AssessmentUpdateDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ResultDTO;
 import de.tum.in.www1.artemis.web.rest.dto.TextAssessmentDTO;
@@ -130,8 +129,6 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private TextAssessmentService textAssessmentService;
-
-
 
     @Autowired
     private ExerciseUtilService exerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextAssessmentIntegrationTest.java
@@ -71,7 +71,6 @@ import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
 import de.tum.in.www1.artemis.repository.ExerciseGroupRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
@@ -89,9 +88,6 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
     private static final String TEST_PREFIX = "textassessment";
 
     @Autowired
-    private ExerciseRepository exerciseRepo;
-
-    @Autowired
     private ComplaintRepository complaintRepo;
 
     @Autowired
@@ -105,9 +101,6 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private TextSubmissionRepository textSubmissionRepository;
-
-    @Autowired
-    private ExerciseRepository exerciseRepository;
 
     @Autowired
     private SubmissionRepository submissionRepository;
@@ -158,7 +151,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         course = textExerciseUtilService.addCourseWithOneReleasedTextExercise();
         textExercise = exerciseUtilService.findTextExerciseWithTitle(course.getExercises(), "Text");
         textExercise.setAssessmentType(AssessmentType.SEMI_AUTOMATIC);
-        exerciseRepo.save(textExercise);
+        exerciseRepository.save(textExercise);
         // every test indirectly uses the submission selection in Athena, so we mock it here
         athenaRequestMockProvider.enableMockingOfRequests();
         athenaRequestMockProvider.mockSelectSubmissionsAndExpect("text", 0); // always select the first submission
@@ -397,7 +390,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
     void getParticipationForNonTextExercise() throws Exception {
         FileUploadExercise fileUploadExercise = FileUploadExerciseFactory.generateFileUploadExercise(now().minusDays(1), now().plusDays(1), now().plusDays(2), "png,pdf",
                 textExercise.getCourseViaExerciseGroupOrCourseMember());
-        exerciseRepo.save(fileUploadExercise);
+        exerciseRepository.save(fileUploadExercise);
 
         FileUploadSubmission fileUploadSubmission = ParticipationFactory.generateFileUploadSubmission(true);
         fileUploadExerciseUtilService.saveFileUploadSubmissionWithResultAndAssessorFeedback(fileUploadExercise, fileUploadSubmission, TEST_PREFIX + "student1",
@@ -428,7 +421,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
     void getDataForTextEditorForNonTextExercise_badRequest() throws Exception {
         FileUploadExercise fileUploadExercise = FileUploadExerciseFactory.generateFileUploadExercise(now().minusDays(1), now().plusDays(1), now().plusDays(2), "png,pdf",
                 textExercise.getCourseViaExerciseGroupOrCourseMember());
-        exerciseRepo.save(fileUploadExercise);
+        exerciseRepository.save(fileUploadExercise);
 
         FileUploadSubmission fileUploadSubmission = ParticipationFactory.generateFileUploadSubmission(true);
         fileUploadExerciseUtilService.saveFileUploadSubmissionWithResultAndAssessorFeedback(fileUploadExercise, fileUploadSubmission, TEST_PREFIX + "student1",
@@ -477,7 +470,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         TextExercise textExercise = TextExerciseFactory.generateTextExerciseForExam(exerciseGroup);
         exerciseGroup.addExercise(textExercise);
         exerciseGroupRepository.save(exerciseGroup);
-        textExercise = exerciseRepo.save(textExercise);
+        textExercise = exerciseRepository.save(textExercise);
 
         examRepository.save(exam);
 
@@ -500,7 +493,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         TextExercise textExercise = TextExerciseFactory.generateTextExerciseForExam(exerciseGroup);
         exerciseGroup.addExercise(textExercise);
         exerciseGroupRepository.save(exerciseGroup);
-        textExercise = exerciseRepo.save(textExercise);
+        textExercise = exerciseRepository.save(textExercise);
 
         examRepository.save(exam);
 
@@ -532,7 +525,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         TextExercise textExercise = TextExerciseFactory.generateTextExerciseForExam(exerciseGroup);
         exerciseGroup.addExercise(textExercise);
         exerciseGroupRepository.save(exerciseGroup);
-        textExercise = exerciseRepo.save(textExercise);
+        textExercise = exerciseRepository.save(textExercise);
 
         examRepository.save(exam);
 
@@ -779,7 +772,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         textExercise.setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_COMPLETELY);
         textExercise.setMaxPoints(10.0);
         textExercise.setBonusPoints(10.0);
-        exerciseRepo.save(textExercise);
+        exerciseRepository.save(textExercise);
 
         // setting up student submission
         TextSubmission textSubmission = ParticipationFactory.generateTextSubmission("Some text", Language.ENGLISH, true);
@@ -817,7 +810,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         textExercise.setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_COMPLETELY);
         textExercise.setMaxPoints(10.0);
         textExercise.setBonusPoints(0.0);
-        exerciseRepo.save(textExercise);
+        exerciseRepository.save(textExercise);
 
         // setting up student submission
         TextSubmission textSubmission = ParticipationFactory.generateTextSubmission("Some text", Language.ENGLISH, true);
@@ -848,7 +841,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         textExercise.setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_AS_BONUS);
         textExercise.setMaxPoints(10.0);
         textExercise.setBonusPoints(0.0);
-        exerciseRepo.save(textExercise);
+        exerciseRepository.save(textExercise);
 
         // setting up student submission
         TextSubmission textSubmission = ParticipationFactory.generateTextSubmission("Some text", Language.ENGLISH, true);
@@ -879,7 +872,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         textExercise.setIncludedInOverallScore(IncludedInOverallScore.NOT_INCLUDED);
         textExercise.setMaxPoints(10.0);
         textExercise.setBonusPoints(0.0);
-        exerciseRepo.save(textExercise);
+        exerciseRepository.save(textExercise);
 
         // setting up student submission
         TextSubmission textSubmission = ParticipationFactory.generateTextSubmission("Some text", Language.ENGLISH, true);
@@ -1052,7 +1045,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         exerciseGroup1 = examWithExerciseGroups.getExerciseGroups().getFirst();
         TextExercise exercise = TextExerciseFactory.generateTextExerciseForExam(exerciseGroup1);
         exercise.setAssessmentType(assessmentType);
-        exercise = exerciseRepo.save(exercise);
+        exercise = exerciseRepository.save(exercise);
         exerciseGroup1.addExercise(exercise);
 
         // add student submission
@@ -1067,7 +1060,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         // verify setup
         assertThat(exam.getNumberOfCorrectionRoundsInExam()).isEqualTo(2);
         assertThat(exam.getEndDate()).isBefore(now());
-        var optionalFetchedExercise = exerciseRepo.findWithEagerStudentParticipationsStudentAndSubmissionsById(exercise.getId());
+        var optionalFetchedExercise = exerciseRepository.findWithEagerStudentParticipationsStudentAndSubmissionsById(exercise.getId());
         assertThat(optionalFetchedExercise).isPresent();
         final var exerciseWithParticipation = optionalFetchedExercise.get();
         studentParticipation = exerciseWithParticipation.getStudentParticipations().stream().iterator().next();

--- a/src/test/java/de/tum/in/www1/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextExerciseIntegrationTest.java
@@ -120,8 +120,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @Autowired
     private ChannelRepository channelRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private ExamUtilService examUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextExerciseIntegrationTest.java
@@ -57,7 +57,6 @@ import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismStatus;
 import de.tum.in.www1.artemis.domain.plagiarism.text.TextPlagiarismResult;
 import de.tum.in.www1.artemis.domain.plagiarism.text.TextSubmissionElement;
 import de.tum.in.www1.artemis.exam.ExamUtilService;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.GradingCriterionUtil;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
@@ -123,9 +122,6 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private ParticipationUtilService participationUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private PageableSearchUtilService pageableSearchUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextExerciseIntegrationTest.java
@@ -65,7 +65,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
 import de.tum.in.www1.artemis.plagiarism.PlagiarismUtilService;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
 import de.tum.in.www1.artemis.repository.FeedbackRepository;
 import de.tum.in.www1.artemis.repository.GradingCriterionRepository;
@@ -105,9 +104,6 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private PlagiarismComparisonRepository plagiarismComparisonRepository;
-
-    @Autowired
-    private CourseRepository courseRepository;
 
     @Autowired
     private FeedbackRepository feedbackRepository;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextExerciseIntegrationTest.java
@@ -33,7 +33,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
-import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ExampleSubmission;
 import de.tum.in.www1.artemis.domain.Feedback;
@@ -74,7 +73,6 @@ import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
 import de.tum.in.www1.artemis.repository.metis.conversation.ChannelRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismComparisonRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.util.ExerciseIntegrationTestService;
 import de.tum.in.www1.artemis.util.InvalidExamExerciseDatesArgumentProvider;
 import de.tum.in.www1.artemis.util.InvalidExamExerciseDatesArgumentProvider.InvalidExamExerciseDateConfiguration;
@@ -120,13 +118,8 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @Autowired
     private ChannelRepository channelRepository;
 
-
-
     @Autowired
     private ExamUtilService examUtilService;
-
-    @Autowired
-    private CourseUtilService courseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
@@ -87,8 +87,7 @@ class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
     @Autowired
     private PostRepository postRepository;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
@@ -42,7 +42,6 @@ import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
 import de.tum.in.www1.artemis.participation.ParticipationUtilService;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionVersionRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
@@ -58,9 +57,6 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private static final String TEST_PREFIX = "textsubmissionintegration";
-
-    @Autowired
-    private ExerciseRepository exerciseRepo;
 
     @Autowired
     private TextSubmissionRepository submissionRepository;
@@ -367,7 +363,7 @@ class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void submitExercise_beforeDueDate_isTeamMode() throws Exception {
         releasedTextExercise.setMode(ExerciseMode.TEAM);
-        exerciseRepo.save(releasedTextExercise);
+        exerciseRepository.save(releasedTextExercise);
         Team team = new Team();
         team.setName("Team");
         team.setShortName("team");
@@ -407,7 +403,7 @@ class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
         Optional<SubmissionVersion> newVersion = submissionVersionRepository.findLatestVersion(submission.getId());
         assertThat(newVersion.orElseThrow().getId()).as("submission version was not created").isEqualTo(version.get().getId());
 
-        exerciseRepo.save(releasedTextExercise.participations(Set.of()));
+        exerciseRepository.save(releasedTextExercise.participations(Set.of()));
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
@@ -37,7 +37,6 @@ import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismComparison;
 import de.tum.in.www1.artemis.domain.plagiarism.PlagiarismSubmission;
 import de.tum.in.www1.artemis.domain.plagiarism.modeling.ModelingSubmissionElement;
 import de.tum.in.www1.artemis.domain.plagiarism.text.TextSubmissionElement;
-import de.tum.in.www1.artemis.exercise.ExerciseUtilService;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseFactory;
 import de.tum.in.www1.artemis.exercise.text.TextExerciseUtilService;
 import de.tum.in.www1.artemis.participation.ParticipationFactory;
@@ -80,9 +79,6 @@ class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
-
-    @Autowired
-    private ExerciseUtilService exerciseUtilService;
 
     @Autowired
     private ParticipationUtilService participationUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
@@ -46,7 +46,6 @@ import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionVersionRepository;
 import de.tum.in.www1.artemis.repository.TeamRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismComparisonRepository;
@@ -69,9 +68,6 @@ class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private PlagiarismComparisonRepository plagiarismComparisonRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private TeamRepository teamRepository;

--- a/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/text/TextSubmissionIntegrationTest.java
@@ -51,7 +51,6 @@ import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismCaseRepository;
 import de.tum.in.www1.artemis.repository.plagiarism.PlagiarismComparisonRepository;
-import de.tum.in.www1.artemis.user.UserUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.ExerciseDetailsDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
@@ -86,8 +85,6 @@ class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private PostRepository postRepository;
-
-
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupUtilService.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -51,6 +52,9 @@ public class TutorialGroupUtilService {
 
     @Value("${info.guided-tour.course-group-instructors:#{null}}")
     private Optional<String> tutorialGroupInstructors;
+
+    @Autowired
+    private CourseRepository courseRepo;
 
     @Autowired
     private TutorialGroupRepository tutorialGroupRepository;

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupUtilService.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -25,6 +24,7 @@ import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupFreePeriod;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupRegistration;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupSession;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupsConfiguration;
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupFreePeriodRepository;
 import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupRegistrationRepository;
 import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupRepository;

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupUtilService.java
@@ -24,7 +24,6 @@ import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupFreePeriod;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupRegistration;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupSession;
 import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroupsConfiguration;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupFreePeriodRepository;
 import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupRegistrationRepository;
 import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupRepository;
@@ -52,9 +51,6 @@ public class TutorialGroupUtilService {
 
     @Value("${info.guided-tour.course-group-instructors:#{null}}")
     private Optional<String> tutorialGroupInstructors;
-
-    @Autowired
-    private CourseRepository courseRepo;
 
     @Autowired
     private TutorialGroupRepository tutorialGroupRepository;

--- a/src/test/java/de/tum/in/www1/artemis/user/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/user/AccountResourceIntegrationTest.java
@@ -16,7 +16,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import de.tum.in.www1.artemis.AbstractSpringIntegrationIndependentTest;
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.AccountService;
 import de.tum.in.www1.artemis.service.dto.PasswordChangeDTO;
 import de.tum.in.www1.artemis.service.dto.UserDTO;
@@ -40,9 +39,6 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
 
     @Autowired
     private AccountService accountService;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private PasswordService passwordService;

--- a/src/test/java/de/tum/in/www1/artemis/user/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/user/AccountResourceIntegrationTest.java
@@ -47,8 +47,6 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
     @Autowired
     private PasswordService passwordService;
 
-
-
     private void testWithRegistrationDisabled(Executable test) throws Throwable {
         ConfigUtil.testWithChangedConfig(accountService, "registrationEnabled", Optional.of(Boolean.FALSE), test);
     }

--- a/src/test/java/de/tum/in/www1/artemis/user/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/user/AccountResourceIntegrationTest.java
@@ -47,8 +47,7 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
     @Autowired
     private PasswordService passwordService;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     private void testWithRegistrationDisabled(Executable test) throws Throwable {
         ConfigUtil.testWithChangedConfig(accountService, "registrationEnabled", Optional.of(Boolean.FALSE), test);

--- a/src/test/java/de/tum/in/www1/artemis/user/AccountResourceWithGitLabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/user/AccountResourceWithGitLabIntegrationTest.java
@@ -36,8 +36,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
     @Autowired
     private GitlabRequestMockProvider gitlabRequestMockProvider;
 
-    @Autowired
-    private UserUtilService userUtilService;
+
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/de/tum/in/www1/artemis/user/AccountResourceWithGitLabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/user/AccountResourceWithGitLabIntegrationTest.java
@@ -21,17 +21,9 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
 import de.tum.in.www1.artemis.connector.GitlabRequestMockProvider;
 import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.util.RequestUtilService;
 import de.tum.in.www1.artemis.web.rest.vm.ManagedUserVM;
 
 class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
-
-    @Autowired
-    private RequestUtilService request;
-
-    @Autowired
-    private UserRepository userRepo;
 
     @Autowired
     private GitlabRequestMockProvider gitlabRequestMockProvider;
@@ -78,7 +70,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         user.setActivated(false);
         user.setFirstName("Old Firstname");
         user.setActivationKey(testActivationKey);
-        user = userRepo.save(user);
+        user = userRepository.save(user);
 
         // setup user to register
         user.setFirstName("New Firstname");
@@ -96,7 +88,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         request.postWithoutLocation("/api/public/register", userVM, HttpStatus.CREATED, null);
 
         // Assert that old user data was deleted and user was written to db
-        Optional<User> updatedUser = userRepo.findOneByLogin(user.getLogin());
+        Optional<User> updatedUser = userRepository.findOneByLogin(user.getLogin());
         assertThat(updatedUser).isPresent();
         assertThat(updatedUser.get().getFirstName()).isEqualTo("New Firstname");
         assertThat(updatedUser.get().getActivated()).isFalse();
@@ -112,7 +104,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         // create activated user in repo
         User user = UserFactory.generateActivatedUser("ab123cde");
         user.setFirstName("Old Firstname");
-        user = userRepo.save(user);
+        user = userRepository.save(user);
 
         // setup user to register
         user.setFirstName("New Firstname");
@@ -128,7 +120,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         request.postWithoutLocation("/api/public/register", userVM, HttpStatus.BAD_REQUEST, null);
 
         // Assert that old user data is still there
-        Optional<User> updatedUser = userRepo.findOneByLogin(user.getLogin());
+        Optional<User> updatedUser = userRepository.findOneByLogin(user.getLogin());
         assertThat(updatedUser).isPresent();
         assertThat(updatedUser.get().getFirstName()).isEqualTo("Old Firstname");
         assertThat(updatedUser.get().getActivated()).isTrue();
@@ -151,7 +143,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         request.postWithoutLocation("/api/public/register", userVM, HttpStatus.INTERNAL_SERVER_ERROR, null);
 
         // The account shouldn't be saved
-        assertThat(userRepo.findOneByLogin(user.getLogin())).isEmpty();
+        assertThat(userRepository.findOneByLogin(user.getLogin())).isEmpty();
 
         // make another request
         doReturn(new org.gitlab4j.api.models.User().withId(1L)).when(mock(UserApi.class)).getUser(user.getLogin());
@@ -159,7 +151,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         request.postWithoutLocation("/api/public/register", userVM, HttpStatus.INTERNAL_SERVER_ERROR, null);
 
         // The account shouldn't be saved
-        assertThat(userRepo.findOneByLogin(user.getLogin())).isEmpty();
+        assertThat(userRepository.findOneByLogin(user.getLogin())).isEmpty();
     }
 
     @Test
@@ -178,7 +170,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         gitlabRequestMockProvider.mockDeactivateUser(user.getLogin(), false);
         request.postWithoutLocation("/api/public/register", userVM, HttpStatus.CREATED, null);
 
-        assertThat(userRepo.findOneByLogin(user.getLogin())).isPresent();
+        assertThat(userRepository.findOneByLogin(user.getLogin())).isPresent();
     }
 
     @Test
@@ -197,7 +189,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         gitlabRequestMockProvider.mockDeactivateUser(user.getLogin(), true);
         request.postWithoutLocation("/api/public/register", userVM, HttpStatus.INTERNAL_SERVER_ERROR, null);
 
-        assertThat(userRepo.findOneByLogin(user.getLogin())).isEmpty();
+        assertThat(userRepository.findOneByLogin(user.getLogin())).isEmpty();
     }
 
     @Test
@@ -216,7 +208,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         gitlabRequestMockProvider.mockDeactivateUser(user.getLogin(), false);
         request.postWithoutLocation("/api/public/register", userVM, HttpStatus.CREATED, null);
 
-        Optional<User> registeredUser = userRepo.findOneByLogin(user.getLogin());
+        Optional<User> registeredUser = userRepository.findOneByLogin(user.getLogin());
         assertThat(registeredUser).isPresent();
 
         // Activate the user
@@ -241,7 +233,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
         gitlabRequestMockProvider.mockDeactivateUser(user.getLogin(), false);
         request.postWithoutLocation("/api/public/register", userVM, HttpStatus.CREATED, null);
 
-        Optional<User> registeredUser = userRepo.findOneByLogin(user.getLogin());
+        Optional<User> registeredUser = userRepository.findOneByLogin(user.getLogin());
         assertThat(registeredUser).isPresent();
 
         // Activate the user
@@ -296,7 +288,7 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
             User user = UserFactory.generateActivatedUser(login);
             user.setEmail(email);
             user.setActivated(false);
-            userRepo.save(user);
+            userRepository.save(user);
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/user/AccountResourceWithGitLabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/user/AccountResourceWithGitLabIntegrationTest.java
@@ -36,8 +36,6 @@ class AccountResourceWithGitLabIntegrationTest extends AbstractSpringIntegration
     @Autowired
     private GitlabRequestMockProvider gitlabRequestMockProvider;
 
-
-
     @BeforeEach
     void setUp() {
         gitlabRequestMockProvider.enableMockingOfRequests();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
For testing we already use base classes that autowire some commonly used services. However, we often autowire the required service again in the integration test.

### Description
<!-- Describe your changes in detail -->
This PR removes a lot of duplicated / unnecessary autowires.


### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
