### PR TITLE
`Communication`: Fix incorrect display of edit and delete icons when switching between threads

### DIFF
--- a/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.ts
@@ -32,17 +32,12 @@ export class AnswerPostHeaderComponent extends PostingHeaderDirective<AnswerPost
 
     ngOnInit() {
         super.ngOnInit();
-        // determines if the current user is the author of the original post, that the answer belongs to
-        this.isAuthorOfOriginalPost = this.metisService.metisUserIsAuthorOfPosting(this.posting.post!);
-        this.isAnswerOfAnnouncement = getAsChannelDTO(this.posting.post?.conversation)?.isAnnouncementChannel ?? false;
-        const isCourseWideChannel = getAsChannelDTO(this.posting.post?.conversation)?.isCourseWide ?? false;
-        const isAtLeastInstructorInCourse = this.metisService.metisUserIsAtLeastInstructorInCourse();
-        const mayEditOrDeleteOtherUsersAnswer =
-            (isCourseWideChannel && isAtLeastInstructorInCourse) || (getAsChannelDTO(this.metisService.getCurrentConversation())?.hasChannelModerationRights ?? false);
-        this.mayEditOrDelete = !this.isReadOnlyMode && (this.isAuthorOfPosting || mayEditOrDeleteOtherUsersAnswer);
+        this.setMayEditOrDelete();
     }
 
     ngOnChanges() {
+        this.setUserProperties();
+        this.setMayEditOrDelete();
         this.setUserAuthorityIconAndTooltip();
     }
 
@@ -62,5 +57,16 @@ export class AnswerPostHeaderComponent extends PostingHeaderDirective<AnswerPost
             this.posting.resolvesPost = !this.posting.resolvesPost;
             this.metisService.updateAnswerPost(this.posting).subscribe();
         }
+    }
+
+    setMayEditOrDelete(): void {
+        // determines if the current user is the author of the original post, that the answer belongs to
+        this.isAuthorOfOriginalPost = this.metisService.metisUserIsAuthorOfPosting(this.posting.post!);
+        this.isAnswerOfAnnouncement = getAsChannelDTO(this.posting.post?.conversation)?.isAnnouncementChannel ?? false;
+        const isCourseWideChannel = getAsChannelDTO(this.posting.post?.conversation)?.isCourseWide ?? false;
+        const isAtLeastInstructorInCourse = this.metisService.metisUserIsAtLeastInstructorInCourse();
+        const mayEditOrDeleteOtherUsersAnswer =
+            (isCourseWideChannel && isAtLeastInstructorInCourse) || (getAsChannelDTO(this.metisService.getCurrentConversation())?.hasChannelModerationRights ?? false);
+        this.mayEditOrDelete = !this.isReadOnlyMode && (this.isAuthorOfPosting || mayEditOrDeleteOtherUsersAnswer);
     }
 }

--- a/src/main/webapp/app/shared/metis/posting-header/post-header/post-header.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-header/post-header/post-header.component.ts
@@ -17,6 +17,7 @@ export class PostHeaderComponent extends PostingHeaderDirective<Post> implements
     readOnlyMode = false;
     @Input() lastReadDate?: dayjs.Dayjs;
     @Input() previewMode: boolean;
+    @Input() isThreadSidebar: boolean;
     @ViewChild(PostCreateEditModalComponent) postCreateEditModal?: PostCreateEditModalComponent;
     isAtLeastInstructorInCourse: boolean;
     mayEditOrDelete = false;
@@ -31,18 +32,15 @@ export class PostHeaderComponent extends PostingHeaderDirective<Post> implements
 
     ngOnInit() {
         super.ngOnInit();
-        this.isAtLeastInstructorInCourse = this.metisService.metisUserIsAtLeastInstructorInCourse();
-        const isCourseWideChannel = getAsChannelDTO(this.posting.conversation)?.isCourseWide ?? false;
-        const isAtLeastInstructorInCourse = this.metisService.metisUserIsAtLeastInstructorInCourse();
-        const mayEditOrDeleteOtherUsersAnswer =
-            (isCourseWideChannel && isAtLeastInstructorInCourse) || (getAsChannelDTO(this.metisService.getCurrentConversation())?.hasChannelModerationRights ?? false);
-        this.mayEditOrDelete = !this.readOnlyMode && !this.previewMode && (this.isAuthorOfPosting || mayEditOrDeleteOtherUsersAnswer);
+        this.setMayEditOrDelete();
     }
 
     /**
      * on changes: re-evaluates authority roles
      */
     ngOnChanges() {
+        this.setUserProperties();
+        this.setMayEditOrDelete();
         this.setUserAuthorityIconAndTooltip();
     }
 
@@ -58,5 +56,13 @@ export class PostHeaderComponent extends PostingHeaderDirective<Post> implements
      */
     deletePosting(): void {
         this.metisService.deletePost(this.posting);
+    }
+
+    setMayEditOrDelete(): void {
+        this.isAtLeastInstructorInCourse = this.metisService.metisUserIsAtLeastInstructorInCourse();
+        const isCourseWideChannel = getAsChannelDTO(this.posting.conversation)?.isCourseWide ?? false;
+        const mayEditOrDeleteOtherUsersAnswer =
+            (isCourseWideChannel && this.isAtLeastInstructorInCourse) || (getAsChannelDTO(this.metisService.getCurrentConversation())?.hasChannelModerationRights ?? false);
+        this.mayEditOrDelete = !this.readOnlyMode && !this.previewMode && (this.isAuthorOfPosting || mayEditOrDeleteOtherUsersAnswer);
     }
 }

--- a/src/main/webapp/app/shared/metis/posting-header/post-header/post-header.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-header/post-header/post-header.component.ts
@@ -17,7 +17,6 @@ export class PostHeaderComponent extends PostingHeaderDirective<Post> implements
     readOnlyMode = false;
     @Input() lastReadDate?: dayjs.Dayjs;
     @Input() previewMode: boolean;
-    @Input() isThreadSidebar: boolean;
     @ViewChild(PostCreateEditModalComponent) postCreateEditModal?: PostCreateEditModalComponent;
     isAtLeastInstructorInCourse: boolean;
     mayEditOrDelete = false;

--- a/src/main/webapp/app/shared/metis/posting-header/posting-header.directive.ts
+++ b/src/main/webapp/app/shared/metis/posting-header/posting-header.directive.ts
@@ -75,7 +75,7 @@ export abstract class PostingHeaderDirective<T extends Posting> implements OnIni
         } else if (this.posting.authorRole === UserRole.TUTOR) {
             this.userAuthority = 'tutor';
             this.userRoleBadge = roleBadgeTranslationPath + this.userAuthority;
-            this.userAuthorityTooltip += toolTipTranslationPath + this.userAuthority;
+            this.userAuthorityTooltip = toolTipTranslationPath + this.userAuthority;
         }
     }
 

--- a/src/main/webapp/app/shared/metis/posting-header/posting-header.directive.ts
+++ b/src/main/webapp/app/shared/metis/posting-header/posting-header.directive.ts
@@ -27,11 +27,9 @@ export abstract class PostingHeaderDirective<T extends Posting> implements OnIni
      * determines icon and tooltip for authority type of the author
      */
     ngOnInit(): void {
-        this.isAtLeastTutorInCourse = this.metisService.metisUserIsAtLeastTutorInCourse();
-        this.isAuthorOfPosting = this.metisService.metisUserIsAuthorOfPosting(this.posting);
         this.postingIsOfToday = dayjs().isSame(this.posting.creationDate, 'day');
         this.todayFlag = this.getTodayFlag();
-        this.setUserAuthorityIconAndTooltip();
+        this.setUserProperties();
     }
 
     /**
@@ -43,6 +41,20 @@ export abstract class PostingHeaderDirective<T extends Posting> implements OnIni
         } else {
             return undefined;
         }
+    }
+
+    /**
+     * Sets various user properties related to the posting and course.
+     * Checks if the current user is the author of the posting and sets the `isAuthorOfPosting` flag accordingly.
+     * Checks if the current user has at least a tutor role in the course and sets the `isAtLeastTutorInCourse` flag accordingly.
+     * Calls `setUserAuthorityIconAndTooltip()` to set the user's authority icon and tooltip based on their role.
+     *
+     * @returns {void}
+     */
+    setUserProperties(): void {
+        this.isAuthorOfPosting = this.metisService.metisUserIsAuthorOfPosting(this.posting);
+        this.isAtLeastTutorInCourse = this.metisService.metisUserIsAtLeastTutorInCourse();
+        this.setUserAuthorityIconAndTooltip();
     }
 
     /**

--- a/src/main/webapp/app/shared/metis/posting-header/posting-header.directive.ts
+++ b/src/main/webapp/app/shared/metis/posting-header/posting-header.directive.ts
@@ -58,7 +58,7 @@ export abstract class PostingHeaderDirective<T extends Posting> implements OnIni
     }
 
     /**
-     * assigns suitable icon and tooltip for the author's most privileged authority type
+     * assigns suitable icon and tooltip for the author's authority type
      */
     setUserAuthorityIconAndTooltip(): void {
         const toolTipTranslationPath = 'artemisApp.metis.userAuthorityTooltips.';


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.

### Description
<!-- Describe your changes in detail -->
This PR addresses the issue where the edit and delete icons do not update correctly when switching between threads. The problem was due to the user properties not being set correctly for each thread.

Solves #8981 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Students
- 1 Course with Communications enabled

1. Log in to Artemis
2. Navigate to a Course with Communication enabled
3. As User 1 (Instructor), send two messages in a channel.
4. On the first message, reply a few times.
5. As User 2 (Student), on the second message, reply a few times.
6. Switch to the thread of the first message.
7. Make sure that the edit and delete icons are shown correctly (expected behaviour is admin/instructor can edit/delete all messages, while student can only edit/delete their own messages)


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved code organization and encapsulation in post header components to better manage user permissions for editing and deleting posts.
  - Consolidated logic for setting user properties and edit/delete permissions into dedicated methods for cleaner and more maintainable code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->