### PR TITLE
`Integrated code lifecycle`: Fix an issue when parsing special characters

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/BuildJobExecutionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/BuildJobExecutionService.java
@@ -354,9 +354,9 @@ public class BuildJobExecutionService {
                     }
                 }
             }
-            catch (IllegalStateException e) {
-                // Exceptions due to one invalid sca file should not lead to the whole build to fail.
-                String msg = "Invalid report format in file " + fileName + ", ignoring.";
+            catch (Exception e) {
+                // Exceptions due to one invalid file should not lead to the whole build to fail.
+                String msg = "Error while parsing report file" + fileName + ", ignoring.";
                 buildLogsMap.appendBuildLogEntry(buildJobId, msg);
                 log.warn(msg, e);
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/TestResultXmlParser.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/TestResultXmlParser.java
@@ -17,6 +17,9 @@ class TestResultXmlParser {
 
     private static final XmlMapper mapper = new XmlMapper();
 
+    // https://stackoverflow.com/a/4237934
+    private static final String INVALID_XML_CHARS = "[^\t\r\n -\uD7FF\uE000-�\uD800\uDC00-\uDBFF\uDFFF]";
+
     /**
      * Parses the test result file and extracts failed and successful tests.
      *
@@ -27,6 +30,7 @@ class TestResultXmlParser {
      */
     static void processTestResultFile(String testResultFileString, List<BuildResult.LocalCITestJobDTO> failedTests, List<BuildResult.LocalCITestJobDTO> successfulTests)
             throws IOException {
+        testResultFileString = testResultFileString.replaceAll(INVALID_XML_CHARS, "");
         TestSuite testSuite = mapper.readValue(testResultFileString, TestSuite.class);
 
         // If the xml file is only one test suite, parse it directly

--- a/src/main/resources/templates/c/gcc/test/testUtils/Utils.py
+++ b/src/main/resources/templates/c/gcc/test/testUtils/Utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import select
 import signal
 from datetime import datetime
@@ -154,6 +155,14 @@ def printProg(text: str, addToCache: bool = True):
     __printStdout(msg)
     if addToCache:
         testerOutputCache.append(msg)
+
+def sanitizeXml(text: str):
+    """
+    Removes all characters that are not allowed in XML
+    """
+    # remove ANSI escape sequences first to avoid spurious characters
+    # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+    return re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', "", text)
 
 
 def shortenText(text: str, maxNumChars: int):

--- a/src/main/resources/templates/c/gcc/test/testUtils/Utils.py
+++ b/src/main/resources/templates/c/gcc/test/testUtils/Utils.py
@@ -163,7 +163,7 @@ def sanitizeXml(text: str) -> str:
     # remove ANSI escape sequences first to avoid spurious characters
     # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
     text = re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', "", text)
-    return re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', "", text)
+    return re.sub("[\\x01-\\x08\\x0B-\\x0C\\x0E-\\x1F\\x7F-\\x84\\x86-\\x9F]", "", text)
 
 def shortenText(text: str, maxNumChars: int):
     """

--- a/src/main/resources/templates/c/gcc/test/testUtils/Utils.py
+++ b/src/main/resources/templates/c/gcc/test/testUtils/Utils.py
@@ -156,14 +156,13 @@ def printProg(text: str, addToCache: bool = True):
     if addToCache:
         testerOutputCache.append(msg)
 
-def sanitizeXml(text: str):
+def sanitizeXml(text: str) -> str:
     """
     Removes all characters that are not allowed in XML
     """
     # remove ANSI escape sequences first to avoid spurious characters
     # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
     return re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', "", text)
-
 
 def shortenText(text: str, maxNumChars: int):
     """

--- a/src/main/resources/templates/c/gcc/test/testUtils/Utils.py
+++ b/src/main/resources/templates/c/gcc/test/testUtils/Utils.py
@@ -162,6 +162,7 @@ def sanitizeXml(text: str) -> str:
     """
     # remove ANSI escape sequences first to avoid spurious characters
     # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+    text = re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', "", text)
     return re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', "", text)
 
 def shortenText(text: str, maxNumChars: int):

--- a/src/main/resources/templates/c/gcc/test/testUtils/junit/TestCase.py
+++ b/src/main/resources/templates/c/gcc/test/testUtils/junit/TestCase.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from enum import Enum
 from xml.etree import ElementTree as Et
 
-from testUtils.Utils import shortenText
+from testUtils.Utils import shortenText, sanitizeXml
 
 
 class Result(Enum):
@@ -40,14 +40,14 @@ class TestCase:
         if self.result != Result.SUCCESS:
             result: Et.Element = Et.SubElement(case, self.result.value)
             result.set("message", self.message)
-            result.text = self.genErrFailureMessage()
+            result.text = sanitizeXml(self.genErrFailureMessage())
 
         if self.stdout:
             stdout: Et.Element = Et.SubElement(case, "system-out")
-            stdout.text = shortenText(self.stdout, maxCharsPerOutput) + "\n"
+            stdout.text = sanitizeXml(shortenText(self.stdout, maxCharsPerOutput) + "\n")
         if self.stderr:
             stderr: Et.Element = Et.SubElement(case, "system-err")
-            stderr.text = shortenText(self.stderr, maxCharsPerOutput) + "\n"
+            stderr.text = sanitizeXml(shortenText(self.stderr, maxCharsPerOutput) + "\n")
 
     def genErrFailureMessage(self, maxChars=5000):
         oneThird: int = int(maxChars / 3)
@@ -72,4 +72,4 @@ class TestCase:
             testerMsg += shortenText(self.testerOutput, maxChars - len(testerMsg) - len(stderrMsg) - len(stdoutMsg)) + "\n"
         else:
             testerMsg += "No tester output found!\n"
-        return self.message + stdoutMsg + stderrMsg + testerMsg
+        return sanitizeXml(self.message + stdoutMsg + stderrMsg + testerMsg)

--- a/src/test/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/TestResultXmlParserTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/connectors/localci/buildagent/TestResultXmlParserTest.java
@@ -158,4 +158,33 @@ class TestResultXmlParserTest {
         assertThat(failedTests).isEmpty();
         assertThat(successfulTests).isEmpty();
     }
+
+    @Test
+    void testOutputInvalidXMLCharacters() throws IOException {
+        String input = """
+                <?xml version='1.0' encoding='us-ascii'?>
+                <testsuites>
+                <testsuite name="GBS-Tester-1.36">
+                <testcase name="CompileLinkedList" time="1.90495">
+                <failure message="Build for directory ../assignment/build failed. Returncode is 2.">Build for directory ../assignment/build failed. Returncode is 2.
+                ======================stdout======================
+                [ 50%] [32mBuilding CXX object CMakeFiles/linked-list-iterator-test.dir/linked-list-iterator-test.cpp.o[0m
+
+
+                ======================stderr======================
+                /var/tmp/testing-dir/tests/linked-list-iterator-test.cpp:52:5: error: &#8216;linked_list&#8217; was not declared in this scope
+                   52 |     linked_list&lt;TestType&gt; list;
+                      |     ^~~~~~~~~~~
+                /var/tmp/testing-dir/tests/linked-list-iterator-test.cpp:52:25: error: expected primary-expression before &#8216;&gt;&#8217; token
+                   52 |     linked_list&lt;TestType&gt; list;
+                      |                         ^
+                </failure></testcase></testsuite></testsuites>
+                """;
+        TestResultXmlParser.processTestResultFile(input, failedTests, successfulTests);
+        assertThat(successfulTests).isEmpty();
+        assertThat(failedTests).hasSize(1);
+        var test = failedTests.getFirst();
+        assertThat(test.getName()).isEqualTo("CompileLinkedList");
+        assertThat(test.getTestMessages().getFirst()).isEqualTo("Build for directory ../assignment/build failed. Returncode is 2.");
+    }
 }


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
When the result.xml file contains invalid characters (e.g. when they are used in stdout which is provided as part of the result file) the parsing fails.

Test that the newly changed C/GCC template works correctly.

### Description
We now remove such invalid characters before parsing.


### Steps for Testing
code review, quite hard to replicate since you need an exercise where such invalid chars get printed. Reviewing the new test case should be enough. You can also locally outcomment the replaceAll line and see that the test now fails.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a function to sanitize XML inputs, ensuring invalid characters are removed.

- **Bug Fixes**
  - Broadened exception handling for parsing test results to handle any error, improving robustness.

- **Tests**
  - Added tests to verify the handling of invalid XML characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->