### PR TITLE
`Exam mode`: Fix an error when accessing a test exam with unassigned exercise number by instructor

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -374,7 +374,13 @@ public interface StudentExamRepository extends ArtemisJpaRepository<StudentExam,
     default List<StudentExam> createRandomStudentExams(Exam exam, Set<User> users, ExamQuizQuestionsGenerator examQuizQuestionsGenerator) {
         List<StudentExam> studentExams = new ArrayList<>();
         SecureRandom random = new SecureRandom();
-        long numberOfOptionalExercises = exam.getNumberOfExercisesInExam() - exam.getExerciseGroups().stream().filter(ExerciseGroup::getIsMandatory).count();
+        long numberOfOptionalExercises = 0;
+        try {
+            numberOfOptionalExercises = exam.getNumberOfExercisesInExam() - exam.getExerciseGroups().stream().filter(ExerciseGroup::getIsMandatory).count();
+        }
+        catch (NullPointerException e) {
+            throw new EntityNotFoundException("The number of exercises in the exam " + exam.getId() + " does not exist");
+        }
 
         // Determine the default working time by computing the duration between start and end date of the exam
         int defaultWorkingTime = exam.getWorkingTime();

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -374,13 +374,13 @@ public interface StudentExamRepository extends ArtemisJpaRepository<StudentExam,
     default List<StudentExam> createRandomStudentExams(Exam exam, Set<User> users, ExamQuizQuestionsGenerator examQuizQuestionsGenerator) {
         List<StudentExam> studentExams = new ArrayList<>();
         SecureRandom random = new SecureRandom();
-        long numberOfOptionalExercises = 0;
+        long numberOfOptionalExercises;
 
         // In case the total number of exercises in the exam is not set by the instructor
-        try {
+        if (exam.getNumberOfExercisesInExam() != null) {
             numberOfOptionalExercises = exam.getNumberOfExercisesInExam() - exam.getExerciseGroups().stream().filter(ExerciseGroup::getIsMandatory).count();
         }
-        catch (NullPointerException e) {
+        else {
             throw new EntityNotFoundException("The number of exercises in the exam " + exam.getId() + " does not exist");
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -374,15 +374,12 @@ public interface StudentExamRepository extends ArtemisJpaRepository<StudentExam,
     default List<StudentExam> createRandomStudentExams(Exam exam, Set<User> users, ExamQuizQuestionsGenerator examQuizQuestionsGenerator) {
         List<StudentExam> studentExams = new ArrayList<>();
         SecureRandom random = new SecureRandom();
-        long numberOfOptionalExercises;
 
         // In case the total number of exercises in the exam is not set by the instructor
-        if (exam.getNumberOfExercisesInExam() != null) {
-            numberOfOptionalExercises = exam.getNumberOfExercisesInExam() - exam.getExerciseGroups().stream().filter(ExerciseGroup::getIsMandatory).count();
-        }
-        else {
+        if (exam.getNumberOfExercisesInExam() == null) {
             throw new EntityNotFoundException("The number of exercises in the exam " + exam.getId() + " does not exist");
         }
+        long numberOfOptionalExercises = exam.getNumberOfExercisesInExam() - exam.getExerciseGroups().stream().filter(ExerciseGroup::getIsMandatory).count();
 
         // Determine the default working time by computing the duration between start and end date of the exam
         int defaultWorkingTime = exam.getWorkingTime();

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -375,6 +375,8 @@ public interface StudentExamRepository extends ArtemisJpaRepository<StudentExam,
         List<StudentExam> studentExams = new ArrayList<>();
         SecureRandom random = new SecureRandom();
         long numberOfOptionalExercises = 0;
+
+        // In case the total number of exercises in the exam is not set by the instructor
         try {
             numberOfOptionalExercises = exam.getNumberOfExercisesInExam() - exam.getExerciseGroups().stream().filter(ExerciseGroup::getIsMandatory).count();
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When the user wants to access a test exam with an exercise number that has not been assigned by the instructor, then the user sees an internal server error. Users should not see an internal server error. The reason is that exam.getNumberOfExercisesInExam() throws NullPointerException.

### Description
<!-- Describe your changes in detail -->
Add null check for exam.getNumberOfExercisesInExam().

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor or Admin
- 1 Test Exam with unassigned number of exercises

1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to Exams
4. Create a Test Exam
5. Do not assign number of exercises 
6. Go to Exams in Student View 
7. Verify that you don't get any internal server error

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Real and 1 Test Exam
- 1 Student

1. Log in to Artemis
2. Navigate to Exams
3. Verify that nothing changed when accessing a real and test exam

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before 
![image](https://github.com/ls1intum/Artemis/assets/117287716/c5d541d1-5749-46a0-b656-39c61e62a255)

After
<img width="1029" alt="Screenshot 2024-07-11 at 02 30 11" src="https://github.com/ls1intum/Artemis/assets/117287716/43393137-20af-40b0-9809-46a1597c5c41">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added error handling to ensure exams have a defined number of exercises, throwing an error if not set by the instructor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->