### PR TITLE
`Communication`: Fix resolved icon update

### DIFF
--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -548,7 +548,6 @@ export class MetisService implements OnDestroy {
     }
 
     private handleNewOrUpdatedMessage = (postDTO: MetisPostDTO): void => {
-        postDTO.post = this.cachedPosts.find((post) => post.id === postDTO.post.id) ?? postDTO.post;
         const postConvId = postDTO.post.conversation?.id;
         const postIsNotFromCurrentConversation = this.currentPostContextFilter.conversationId && postConvId !== this.currentPostContextFilter.conversationId;
         const postIsNotFromCurrentPlagiarismCase =
@@ -562,6 +561,7 @@ export class MetisService implements OnDestroy {
             return;
         }
 
+        postDTO.post.answers = this.cachedPosts.find((post) => post.id === postDTO.post.id)?.answers ?? postDTO.post.answers;
         postDTO.post.creationDate = dayjs(postDTO.post.creationDate);
         postDTO.post.answers?.forEach((answer: AnswerPost) => {
             answer.creationDate = dayjs(answer.creationDate);
@@ -661,14 +661,5 @@ export class MetisService implements OnDestroy {
         other.courseWideChannelIds?.sort((a, b) => a - b);
 
         return this.currentPostContextFilter.courseWideChannelIds?.toString() !== other.courseWideChannelIds?.toString();
-    }
-
-    changeResolvedStatus(postId: number | undefined, status: boolean | undefined) {
-        const indexOfCachedPost = this.cachedPosts.findIndex((cachedPost) => cachedPost.id === postId);
-        if (indexOfCachedPost > -1) {
-            if (this.cachedPosts[indexOfCachedPost]) {
-                this.cachedPosts[indexOfCachedPost].resolved = status;
-            }
-        }
     }
 }

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -663,7 +663,7 @@ export class MetisService implements OnDestroy {
         return this.currentPostContextFilter.courseWideChannelIds?.toString() !== other.courseWideChannelIds?.toString();
     }
 
-    changeResolvedStatus(postId: number, status: boolean | undefined) {
+    changeResolvedStatus(postId: number | undefined, status: boolean | undefined) {
         const indexOfCachedPost = this.cachedPosts.findIndex((cachedPost) => cachedPost.id === postId);
         if (indexOfCachedPost > -1) {
             if (this.cachedPosts[indexOfCachedPost]) {

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -236,7 +236,6 @@ export class MetisService implements OnDestroy {
                         this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
                     }
                 }
-                this.getFilteredPosts(this.currentPostContextFilter, true);
             }),
         );
     }

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -236,6 +236,7 @@ export class MetisService implements OnDestroy {
                         this.totalNumberOfPosts$.next(this.cachedTotalNumberOfPots);
                     }
                 }
+                this.getFilteredPosts(this.currentPostContextFilter, true);
             }),
         );
     }
@@ -660,5 +661,12 @@ export class MetisService implements OnDestroy {
         other.courseWideChannelIds?.sort((a, b) => a - b);
 
         return this.currentPostContextFilter.courseWideChannelIds?.toString() !== other.courseWideChannelIds?.toString();
+    }
+
+    changeResolvedStatus(postId: number, status: boolean | undefined) {
+        const indexOfCachedPost = this.cachedPosts.findIndex((cachedPost) => cachedPost.id === postId);
+        if (indexOfCachedPost > -1) {
+            this.cachedPosts[indexOfCachedPost].resolved = status;
+        }
     }
 }

--- a/src/main/webapp/app/shared/metis/metis.service.ts
+++ b/src/main/webapp/app/shared/metis/metis.service.ts
@@ -666,7 +666,9 @@ export class MetisService implements OnDestroy {
     changeResolvedStatus(postId: number, status: boolean | undefined) {
         const indexOfCachedPost = this.cachedPosts.findIndex((cachedPost) => cachedPost.id === postId);
         if (indexOfCachedPost > -1) {
-            this.cachedPosts[indexOfCachedPost].resolved = status;
+            if (this.cachedPosts[indexOfCachedPost]) {
+                this.cachedPosts[indexOfCachedPost].resolved = status;
+            }
         }
     }
 }

--- a/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.ts
@@ -62,7 +62,7 @@ export class AnswerPostHeaderComponent extends PostingHeaderDirective<AnswerPost
         if (this.isAtLeastTutorInCourse || this.isAuthorOfOriginalPost) {
             this.posting.resolvesPost = !this.posting.resolvesPost;
             this.metisService.updateAnswerPost(this.posting).subscribe();
-            this.metisService.changeResolvedStatus(this.posting.post!.id!, this.posting.resolvesPost);
+            this.metisService.changeResolvedStatus(this.posting.post?.id, this.posting.resolvesPost);
         }
     }
 }

--- a/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.ts
@@ -17,7 +17,6 @@ export class AnswerPostHeaderComponent extends PostingHeaderDirective<AnswerPost
 
     @Input() lastReadDate?: dayjs.Dayjs;
     @Output() openPostingCreateEditModal = new EventEmitter<void>();
-    @Output() resolvedStatusChanged = new EventEmitter<boolean>();
 
     isAuthorOfOriginalPost: boolean;
     isAnswerOfAnnouncement: boolean;
@@ -62,7 +61,6 @@ export class AnswerPostHeaderComponent extends PostingHeaderDirective<AnswerPost
         if (this.isAtLeastTutorInCourse || this.isAuthorOfOriginalPost) {
             this.posting.resolvesPost = !this.posting.resolvesPost;
             this.metisService.updateAnswerPost(this.posting).subscribe();
-            this.metisService.changeResolvedStatus(this.posting.post?.id, this.posting.resolvesPost);
         }
     }
 }

--- a/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.ts
@@ -17,6 +17,7 @@ export class AnswerPostHeaderComponent extends PostingHeaderDirective<AnswerPost
 
     @Input() lastReadDate?: dayjs.Dayjs;
     @Output() openPostingCreateEditModal = new EventEmitter<void>();
+    @Output() resolvedStatusChanged = new EventEmitter<boolean>();
 
     isAuthorOfOriginalPost: boolean;
     isAnswerOfAnnouncement: boolean;
@@ -61,6 +62,7 @@ export class AnswerPostHeaderComponent extends PostingHeaderDirective<AnswerPost
         if (this.isAtLeastTutorInCourse || this.isAuthorOfOriginalPost) {
             this.posting.resolvesPost = !this.posting.resolvesPost;
             this.metisService.updateAnswerPost(this.posting).subscribe();
+            this.metisService.changeResolvedStatus(this.posting.post!.id!, this.posting.resolvesPost);
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] This is a small issue that I tested locally.
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [X] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When the user tries to mark a message as resolved, the resolved icon does not appear until s/he refreshes the page.
Closes #9005


### Description
<!-- Describe your changes in detail -->
Resolved icon updates immediately when a user marks a message as resolved, without needing a page refresh. Now, users can see the resolved state of a message instantly after performing the action.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Click 'Communication' button of a course
4. Write a new message to a random channel
5. Click 'reply in thread' to write an answer to that message
6. Click arrow icon on the answer post to mark the post as resolved
7. See that resolved icon appears on the post header without refreshing the page



### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of message handling by better synchronizing post answers and updating creation dates correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->