### PR TITLE
`Modeling exercises`: Fix missing markers in solution diagram

### DIFF
--- a/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.html
+++ b/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.html
@@ -108,7 +108,7 @@
         }
     </div>
     @if (readOnly) {
-        <div class="d-flex align-items-center justify-content-center readonly-diagram" [innerHtml]="readOnlySVG"></div>
+        <div class="d-flex align-items-center justify-content-center readonly-diagram" [innerHtml]="readOnlySVG" [ngStyle]="{ marginTop: isFullScreen ? '30px' : '' }"></div>
     }
 
     @if (withExplanation) {

--- a/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.html
+++ b/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.html
@@ -108,7 +108,7 @@
         }
     </div>
     @if (readOnly) {
-        <div class="d-flex align-items-center justify-content-center readonly-diagram" [innerHtml]="readOnlySVG" [ngStyle]="{ marginTop: isFullScreen ? '30px' : '' }"></div>
+        <div class="d-flex align-items-center justify-content-center readonly-diagram" [innerHtml]="readOnlySVG" [style.margin-top]="isFullScreen ? '30px' : ''"></div>
     }
 
     @if (withExplanation) {

--- a/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.scss
+++ b/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.scss
@@ -47,6 +47,11 @@ $draggable-width: 15px;
     overflow: hidden;
 }
 
+.readonly-diagram {
+    height: 100%;
+    overflow: hidden;
+}
+
 @keyframes spin {
     0% {
         transform: rotate(0);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] ~~I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).~~
- [ ] ~~I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).~~
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [ ] ~~I translated all newly inserted strings into English and German.~~


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #8823 

Currently the markers in the solution diagram of modeling exercises are not rendered correctly.

### Description
<!-- Describe your changes in detail -->

Fix the issue by destroying the hidden Apollon Editor SVG that causes id collisions for the `<marker>` elements with the solution diagram.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Modeling Exercise using a Component Diagram

1. Log in to Artemis
2. Navigate to a course
3. Create a modeling exercise using a Component Diagram
4. Setup a solution containing two components connected via an interface (lollipops), i.e. -o)-
5. Create exercise
6. On the exercise detail view the )-connector to the interface should now be visible. 

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
not changes

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

The marker is not showing: (before fix)
<img width="547" alt="image" src="https://github.com/user-attachments/assets/6956b1a3-c217-48f9-aa63-9dbd6a4aee73">

Marker is showing: (after fix)
<img width="561" alt="image" src="https://github.com/user-attachments/assets/5ca2b088-9948-4e3c-a8ec-fdcacc5e2e2e">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic styling to adjust the top margin of read-only diagrams in the modeling editor based on full-screen mode.
  
- **Style**
  - Added a new CSS class `.readonly-diagram` to enhance the visual representation of read-only diagrams.
  
- **Refactor**
  - Implemented a new method for resource cleanup to prevent SVG `<marker>` id collisions in the modeling editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->