### PR TITLE
`Quiz exercises`: Fix an issue where the icons for the questions overlap the page

### DIFF
--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
@@ -140,60 +140,72 @@
                         <span jhiTranslate="artemisApp.quizExercise.quizInstructions.autoSave"></span>
                     </div>
                     @if (!showingResult) {
-                        <div id="remaining-time">
-                            @if (!waitingForQuizStart) {
-                                <div>
-                                    <span jhiTranslate="artemisApp.quizExercise.remainingTime" class="colon-suffix"></span>
-                                    <span
-                                        id="remaining-time-value"
-                                        [ngClass]="{
-                                            'time-critical': remainingTimeSeconds < 60 || remainingTimeSeconds < quizExercise.duration! / 4,
-                                            'time-warning': remainingTimeSeconds < 120 || remainingTimeSeconds < quizExercise.duration! / 2,
-                                        }"
-                                    >
-                                        {{ remainingTimeText }}
-                                    </span>
-                                </div>
-                            }
-                            @if (mode === 'live' && waitingForQuizStart && quizExercise.remainingNumberOfAttempts !== 0) {
-                                <div>
-                                    <span jhiTranslate="artemisApp.quizExercise.waitingForStart"></span>
-                                </div>
-                            }
-                            @if (mode === 'live' && !waitingForQuizStart) {
-                                <div>
-                                    @if (!isMobile) {
-                                        <span ngbTooltip="{{ submission.submissionDate | artemisDate: 'long' : true }}" placement="right auto">
-                                            @if (!submission.submitted) {
-                                                <span jhiTranslate="artemisApp.quizExercise.lastSaved" class="colon-suffix"></span>
-                                            }
-                                            @if (submission.submitted) {
-                                                <span jhiTranslate="artemisApp.quizExercise.submitted" class="colon-suffix"></span>
-                                            }
-                                            @if (justSaved) {
-                                                <span jhiTranslate="justNow"></span>
-                                            }
-                                            @if (!justSaved && lastSavedTimeText !== '') {
-                                                <span>{{ lastSavedTimeText }}</span>
-                                            }
-                                            @if (!justSaved && lastSavedTimeText === '') {
-                                                <span jhiTranslate="artemisApp.quizExercise.lastSavedTimeNever"></span>
-                                            }
+                        <div id="remaining-time" class="d-flex justfiy-content-between gap-5">
+                            <div>
+                                @if (!waitingForQuizStart) {
+                                    <div>
+                                        <span jhiTranslate="artemisApp.quizExercise.remainingTime" class="colon-suffix"></span>
+                                        <span
+                                            id="remaining-time-value"
+                                            [ngClass]="{
+                                                'time-critical': remainingTimeSeconds < 60 || remainingTimeSeconds < quizExercise.duration! / 4,
+                                                'time-warning': remainingTimeSeconds < 120 || remainingTimeSeconds < quizExercise.duration! / 2,
+                                            }"
+                                        >
+                                            {{ remainingTimeText }}
                                         </span>
-                                    }
-                                    <!-- Only display save and submission hint without time stamps for mobile -->
-                                    @if (isMobile) {
-                                        <span ngbTooltip="{{ submission.submissionDate | artemisDate: 'long' : true }}" placement="right auto">
-                                            @if (!submission.submitted) {
-                                                <span jhiTranslate="artemisApp.quizExercise.lastSaved"></span>
-                                            }
-                                            @if (submission.submitted) {
-                                                <span jhiTranslate="artemisApp.quizExercise.submitted"></span>
-                                            }
-                                        </span>
-                                    }
-                                </div>
-                            }
+                                    </div>
+                                }
+                                @if (mode === 'live' && waitingForQuizStart && quizExercise.remainingNumberOfAttempts !== 0) {
+                                    <div>
+                                        <span jhiTranslate="artemisApp.quizExercise.waitingForStart"></span>
+                                    </div>
+                                }
+                                @if (mode === 'live' && !waitingForQuizStart) {
+                                    <div>
+                                        @if (!isMobile) {
+                                            <span ngbTooltip="{{ submission.submissionDate | artemisDate: 'long' : true }}" placement="right auto">
+                                                @if (!submission.submitted) {
+                                                    <span jhiTranslate="artemisApp.quizExercise.lastSaved" class="colon-suffix"></span>
+                                                }
+                                                @if (submission.submitted) {
+                                                    <span jhiTranslate="artemisApp.quizExercise.submitted" class="colon-suffix"></span>
+                                                }
+                                                @if (justSaved) {
+                                                    <span jhiTranslate="justNow"></span>
+                                                }
+                                                @if (!justSaved && lastSavedTimeText !== '') {
+                                                    <span>{{ lastSavedTimeText }}</span>
+                                                }
+                                                @if (!justSaved && lastSavedTimeText === '') {
+                                                    <span jhiTranslate="artemisApp.quizExercise.lastSavedTimeNever"></span>
+                                                }
+                                            </span>
+                                        }
+                                        <!-- Only display save and submission hint without time stamps for mobile -->
+                                        @if (isMobile) {
+                                            <span ngbTooltip="{{ submission.submissionDate | artemisDate: 'long' : true }}" placement="right auto">
+                                                @if (!submission.submitted) {
+                                                    <span jhiTranslate="artemisApp.quizExercise.lastSaved"></span>
+                                                }
+                                                @if (submission.submitted) {
+                                                    <span jhiTranslate="artemisApp.quizExercise.submitted"></span>
+                                                }
+                                            </span>
+                                        }
+                                    </div>
+                                }
+                                @if (mode === 'practice') {
+                                    <div>
+                                        <span jhiTranslate="artemisApp.quizExercise.practiceMode"></span>
+                                    </div>
+                                }
+                                @if (mode === 'preview') {
+                                    <div>
+                                        <span jhiTranslate="artemisApp.quizExercise.previewMode"></span>
+                                    </div>
+                                }
+                            </div>
                             @if (mode === 'live') {
                                 <jhi-connection-status class="connection-status-quiz">
                                     <ng-container innerContent>
@@ -202,16 +214,6 @@
                                         }
                                     </ng-container>
                                 </jhi-connection-status>
-                            }
-                            @if (mode === 'practice') {
-                                <div>
-                                    <span jhiTranslate="artemisApp.quizExercise.practiceMode"></span>
-                                </div>
-                            }
-                            @if (mode === 'preview') {
-                                <div>
-                                    <span jhiTranslate="artemisApp.quizExercise.previewMode"></span>
-                                </div>
                             }
                         </div>
                     }

--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
@@ -38,7 +38,7 @@
     <div class="row m-0 pb-5">
         @if (quizExercise) {
             <div class="col-md-auto">
-                <div class="p-0 col-md-auto quiz-navigation stepwizardquiz sticky-top">
+                <div class="p-0 col-md-auto quiz-navigation stepwizardquiz sticky-top-quiz">
                     @for (question of quizExercise.quizQuestions; track question; let i = $index) {
                         <div class="stepwizardquiz__step mb-3" [class.mb-3]="!$last">
                             @if (question.type === DRAG_AND_DROP) {

--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
@@ -38,7 +38,7 @@
     <div class="row m-0 pb-5">
         @if (quizExercise) {
             <div class="col-md-auto">
-                <div class="p-0 col-md-auto quiz-navigation stepwizardquiz sticky-top-quiz">
+                <div class="p-0 col-md-auto quiz-navigation stepwizardquiz sticky-top" [ngClass]="{ 'sticky-top-quiz': mode === 'preview' }">
                     @for (question of quizExercise.quizQuestions; track question; let i = $index) {
                         <div class="stepwizardquiz__step mb-3" [class.mb-3]="!$last">
                             @if (question.type === DRAG_AND_DROP) {

--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.scss
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.scss
@@ -7,10 +7,10 @@
     height: 70px;
     position: sticky;
     padding: 0 10px;
-    bottom: 0;
+    bottom: 2px;
     left: 0;
     right: 0;
-    z-index: 30;
+    z-index: 15;
     box-shadow: 0 0 3px var(--quiz-participation-footer-box-shadow);
     background: var(--quiz-participation-footer-background);
 
@@ -269,5 +269,5 @@
 .sticky-top-quiz {
     position: sticky;
     top: 85px;
-    z-index: 1020;
+    z-index: 18;
 }

--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.scss
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.scss
@@ -265,3 +265,9 @@
         }
     }
 }
+
+.sticky-top-quiz {
+    position: sticky;
+    top: 85px;
+    z-index: 1020;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It fixes #9023 as well as the unfitted content of quiz footer in live participation mode. (See screenshots)

### Description
<!-- Describe your changes in detail -->
I added a custom sticky top css class to be able to modify top property, so we can specify the threshold, where it is treated as fixed positioned after certain point. This will be the case only for preview mode. 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor 
- 1 Student
- 1 Quiz exercise with multiple mc questions (at least 5 questions)

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to Exercises
4. Click on "Preview Quiz" 
5. Scroll down 
6. Verify that the icons for mc questions on the left do not overlap the page header anymore
7. Go back and start the quiz 
8. Log in with a student account
9. Navigate to course 
10. Go to exercises and participate the quiz
11. Verify that the content of footer is not exceeding anymore

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before
<img width="167" alt="Screenshot 2024-07-13 at 01 15 09" src="https://github.com/user-attachments/assets/48e46b9e-ff9f-4809-8b52-a4694418962d">

<img width="1170" alt="Screenshot 2024-07-13 at 18 54 18" src="https://github.com/user-attachments/assets/5ec2d9be-5395-45f3-9583-505519baff10">

After 
<img width="656" alt="Screenshot 2024-07-13 at 01 15 27" src="https://github.com/user-attachments/assets/2f07512b-f07f-4081-adc3-498a41260609">

<img width="933" alt="Screenshot 2024-07-13 at 18 54 30" src="https://github.com/user-attachments/assets/b4f26f85-b26c-410c-a341-f77a3de24f9e">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the CSS class name for quiz navigation to `quiz-navigation stepwizardquiz sticky-top-quiz` for better styling and layout.

- **New Features**
  - Added conditional blocks in the remaining-time section for different modes: 'live', 'practice', and 'preview'. 

- **Bug Fixes**
  - Introduced a new CSS class `.sticky-top-quiz` to ensure sticky behavior for the quiz component, enhancing user experience during quiz navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->