### PR TITLE
`Development`: Disable LTI exercise link button when no exercise is selected

### DIFF
--- a/src/main/webapp/app/lti/lti13-deep-linking.component.html
+++ b/src/main/webapp/app/lti/lti13-deep-linking.component.html
@@ -75,9 +75,15 @@
     </div>
     <div class="modal-footer">
         <div>
-            <button type="submit" (click)="sendDeepLinkRequest()" class="btn btn-success">
-                <span class="d-sm-inline" jhiTranslate="artemisApp.lti13.deepLinking.link"></span>
-            </button>
+            @if (selectedExercises != undefined && selectedExercises.size > 0) {
+                <button type="submit" (click)="sendDeepLinkRequest()" class="btn btn-success">
+                    <span class="d-sm-inline" jhiTranslate="artemisApp.lti13.deepLinking.link"></span>
+                </button>
+            } @else {
+                <button type="submit" class="btn btn-success disabled">
+                    <span class="d-sm-inline" jhiTranslate="artemisApp.lti13.deepLinking.selectToLink"></span>
+                </button>
+            }
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/lti/lti13-deep-linking.component.html
+++ b/src/main/webapp/app/lti/lti13-deep-linking.component.html
@@ -75,7 +75,7 @@
     </div>
     <div class="modal-footer">
         <div>
-            @if (selectedExercises != undefined && selectedExercises.size > 0) {
+            @if (selectedExercises?.size) {
                 <button type="submit" (click)="sendDeepLinkRequest()" class="btn btn-success">
                     <span class="d-sm-inline" jhiTranslate="artemisApp.lti13.deepLinking.link"></span>
                 </button>

--- a/src/main/webapp/app/lti/lti13-deep-linking.component.ts
+++ b/src/main/webapp/app/lti/lti13-deep-linking.component.ts
@@ -130,7 +130,7 @@ export class Lti13DeepLinkingComponent implements OnInit {
      * If an exercise is selected, it sends a POST request to initiate deep linking.
      */
     sendDeepLinkRequest() {
-        if (this.selectedExercises && this.selectedExercises.size > 0) {
+        if (this.selectedExercises?.size) {
             const ltiIdToken = this.sessionStorageService.retrieve('ltiIdToken') ?? '';
             const clientRegistrationId = this.sessionStorageService.retrieve('clientRegistrationId') ?? '';
             const exerciseIds = Array.from(this.selectedExercises).join(',');

--- a/src/main/webapp/app/lti/lti13-deep-linking.component.ts
+++ b/src/main/webapp/app/lti/lti13-deep-linking.component.ts
@@ -130,7 +130,7 @@ export class Lti13DeepLinkingComponent implements OnInit {
      * If an exercise is selected, it sends a POST request to initiate deep linking.
      */
     sendDeepLinkRequest() {
-        if (this.selectedExercises) {
+        if (this.selectedExercises && this.selectedExercises.size > 0) {
             const ltiIdToken = this.sessionStorageService.retrieve('ltiIdToken') ?? '';
             const clientRegistrationId = this.sessionStorageService.retrieve('clientRegistrationId') ?? '';
             const exerciseIds = Array.from(this.selectedExercises).join(',');
@@ -154,6 +154,8 @@ export class Lti13DeepLinkingComponent implements OnInit {
                     onError(this.alertService, error);
                 },
             });
+        } else {
+            this.alertService.error('artemisApp.lti13.deepLinking.selectToLink');
         }
     }
 }

--- a/src/main/webapp/i18n/de/lti.json
+++ b/src/main/webapp/i18n/de/lti.json
@@ -87,6 +87,7 @@
                 "linkedSuccessfully": "Verknüpfung der Übungen erfolgreich",
                 "linkedFailed": "Fehler beim Deep-Linking",
                 "link": "Verlinken",
+                "selectToLink": "Übungen zum Verlinken auswählen",
                 "unknownError": "Aufgrund eines unbekannten Fehlers nicht erfolgreich. Bitte kontaktiere einen Admin!",
                 "noCoursesError": "Keiner deiner Artemis-Kurse hat LTI aktiviert. Bitte fahre mit der Konfiguration mindestens eines Kurses fort.",
                 "learnMore": "Erfahre mehr über die Einrichtung von LTI in einem Kurs.."

--- a/src/main/webapp/i18n/en/lti.json
+++ b/src/main/webapp/i18n/en/lti.json
@@ -87,6 +87,7 @@
                 "linkedSuccessfully": "Linked exercises successfully",
                 "linkedFailed": "Error during deep linking",
                 "link": "Link",
+                "selectToLink": "Select exercises to link",
                 "unknownError": "Unsuccessful due to an unknown error. Please contact an admin!",
                 "noCoursesError": "You do not have any LTI-enabled courses in Artemis yet. Please configure at least one course to use this feature.",
                 "learnMore": "Learn more about enabling LTI in your course.."

--- a/src/test/javascript/spec/component/lti/lti13-deep-linking.component.spec.ts
+++ b/src/test/javascript/spec/component/lti/lti13-deep-linking.component.spec.ts
@@ -84,7 +84,7 @@ describe('Lti13DeepLinkingComponent', () => {
 
         component.selectedExercises = new Set();
         component.sendDeepLinkRequest();
-        expect(alertServiceMock.error).toHaveBeenCalledTimes(2);
+        expect(alertServiceMock.error).toHaveBeenNthCalledWith(2, 'artemisApp.lti13.deepLinking.selectToLink');
     });
 
     it('should navigate on init when user is authenticated', fakeAsync(() => {

--- a/src/test/javascript/spec/component/lti/lti13-deep-linking.component.spec.ts
+++ b/src/test/javascript/spec/component/lti/lti13-deep-linking.component.spec.ts
@@ -7,7 +7,7 @@ import { AccountService } from 'app/core/auth/account.service';
 import { SortService } from 'app/shared/service/sort.service';
 import { of, throwError } from 'rxjs';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
-import { MockPipe, MockProvider } from 'ng-mocks';
+import { MockPipe } from 'ng-mocks';
 import { User } from 'app/core/user/user.model';
 import { Course } from 'app/entities/course.model';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
@@ -27,6 +27,7 @@ describe('Lti13DeepLinkingComponent', () => {
     const courseManagementServiceMock = { findWithExercises: jest.fn() };
     const accountServiceMock = { identity: jest.fn(), getAuthenticationState: jest.fn() };
     const sortServiceMock = { sortByProperty: jest.fn() };
+    const alertServiceMock = { error: jest.fn(), addAlert: jest.fn() };
 
     const exercise1 = { id: 1, shortName: 'git', type: ExerciseType.PROGRAMMING } as Exercise;
     const exercise2 = { id: 2, shortName: 'test', type: ExerciseType.PROGRAMMING } as Exercise;
@@ -46,7 +47,7 @@ describe('Lti13DeepLinkingComponent', () => {
                 { provide: AccountService, useValue: accountServiceMock },
                 { provide: SortService, useValue: sortServiceMock },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
-                MockProvider(AlertService),
+                { provide: AlertService, useValue: alertServiceMock },
             ],
         }).compileComponents();
         jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -75,6 +76,16 @@ describe('Lti13DeepLinkingComponent', () => {
         expect(component.course).toEqual(course);
         expect(component.exercises).toContainAllValues(course.exercises!);
     }));
+
+    it('should alert user when no exercise is selected', () => {
+        component.selectedExercises = undefined;
+        component.sendDeepLinkRequest();
+        expect(alertServiceMock.error).toHaveBeenCalledWith('artemisApp.lti13.deepLinking.selectToLink');
+
+        component.selectedExercises = new Set();
+        component.sendDeepLinkRequest();
+        expect(alertServiceMock.error).toHaveBeenCalledTimes(2);
+    });
 
     it('should navigate on init when user is authenticated', fakeAsync(() => {
         const redirectSpy = jest.spyOn(component, 'redirectUserToLoginThenTargetLink');


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When linking an Artemis exercise to Moodle, the instructor selects all those exercises from a list. The Link button is available without any selection though and the checkmarks are hardly visible.

### Description
<!-- Describe your changes in detail -->
I disabled the button when no exercises are selected and changed the button text to highlight the necessary user action.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
#### Full System Test
Prerequisites:
- 1 Instructor
- 1 Moodle Admin Account
- 1 LTI-enabled course with at least 1 exercise

1. Go to Moodle and Select content from Artemis
2. Select your LTI-enabled course
3. Verify that you cannot click the button with no exercises selected
4. Verify that you can click the button with exercises selected

#### Artemis-Only Test
*This test will throw internal server errors as Moodle context is missing. However, all changed aspects are visible here and no Moodle Account is required.*
Prerequisites:
- 1 Instructor
- 1 LTI-enabled course with at least 1 exercise

1. Get the Moodle course's ID
2. Navigate to <url>/lti/exercises/<course:id> (e.g. https://artemis-test3.artemis.cit.tum.de/lti/exercises/65)
3. Verify that you cannot click the button with no exercises selected
4. Verify that you can click the button with exercises selected

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://github.com/user-attachments/assets/21ec2597-88c1-4552-8174-ccf0e1c12849)
![image](https://github.com/user-attachments/assets/16426003-0997-450c-b95d-1e3bfb7e9759)
![image](https://github.com/user-attachments/assets/149461cf-37bd-46eb-9e25-e83571f59185)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Conditional button rendering based on exercise selection for deep linking.
  - Error messages for unselected exercises during deep linking.
  
- **Localization**
  - Added German localization for the prompt to select exercises.
  - Added English localization for the prompt to select exercises.

- **Tests**
  - Enhanced test cases for alert notifications and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->