### PR TITLE
`Development`: Replace invalid commands

### DIFF
--- a/docs/dev/setup/client.rst
+++ b/docs/dev/setup/client.rst
@@ -31,7 +31,7 @@ command:
 
 .. code:: bash
 
-   npm run serve
+   npm run start --
 
 This compiles TypeScript code to JavaScript code, starts the live reloading feature
 (i.e. whenever you change a TypeScript file and save, the client is automatically reloaded with the new code)
@@ -41,7 +41,7 @@ and will start the client application in your browser on
 with your TUM Online account.
 
 .. HINT::
-   In case you encounter any problems regarding JavaScript heap memory leaks when executing ``npm run serve`` or
+   In case you encounter any problems regarding JavaScript heap memory leaks when executing ``npm run start --`` or
    any other scripts from ``package.json``, you can adjust a
    `memory limit parameter <https://nodejs.org/docs/latest-v16.x/api/cli.html#--max-old-space-sizesize-in-megabytes>`__
    (``node-options=--max-old-space-size=6144``) which is set by default in the project-wide `.npmrc` file.

--- a/docs/dev/setup/client.rst
+++ b/docs/dev/setup/client.rst
@@ -31,7 +31,7 @@ command:
 
 .. code:: bash
 
-   npm run start --
+   npm run start
 
 This compiles TypeScript code to JavaScript code, starts the live reloading feature
 (i.e. whenever you change a TypeScript file and save, the client is automatically reloaded with the new code)
@@ -41,7 +41,7 @@ and will start the client application in your browser on
 with your TUM Online account.
 
 .. HINT::
-   In case you encounter any problems regarding JavaScript heap memory leaks when executing ``npm run start --`` or
+   In case you encounter any problems regarding JavaScript heap memory leaks when executing ``npm run start`` or
    any other scripts from ``package.json``, you can adjust a
    `memory limit parameter <https://nodejs.org/docs/latest-v16.x/api/cli.html#--max-old-space-sizesize-in-megabytes>`__
    (``node-options=--max-old-space-size=6144``) which is set by default in the project-wide `.npmrc` file.

--- a/docs/dev/setup/server.rst
+++ b/docs/dev/setup/server.rst
@@ -195,7 +195,7 @@ The recommended way is to run the server and the client separately. This provide
 module replacement in the client.
 
 * **Artemis (Server):** The server will be started separated from the client. The startup time decreases significantly.
-* **Artemis (Client):** Will execute ``npm install`` and ``npm run start --``. The client will be available at
+* **Artemis (Client):** Will execute ``npm install`` and ``npm run start``. The client will be available at
   `http://localhost:9000/ <http://localhost:9000/>`__ with hot module replacement enabled (also see
   `Client Setup <#client-setup>`__).
 

--- a/docs/dev/setup/server.rst
+++ b/docs/dev/setup/server.rst
@@ -195,7 +195,7 @@ The recommended way is to run the server and the client separately. This provide
 module replacement in the client.
 
 * **Artemis (Server):** The server will be started separated from the client. The startup time decreases significantly.
-* **Artemis (Client):** Will execute ``npm install`` and ``npm run serve``. The client will be available at
+* **Artemis (Client):** Will execute ``npm install`` and ``npm run start --``. The client will be available at
   `http://localhost:9000/ <http://localhost:9000/>`__ with hot module replacement enabled (also see
   `Client Setup <#client-setup>`__).
 


### PR DESCRIPTION

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context

PR #9043 removed the serve script from package.json. Replaces occurences in documentation with the command formerly executed by `npm run serve`.



### Description

Replaces all occurences of `npm run serve` wit `npm run start --` as the `serve` script was set as `npm run start --`.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions to replace `npm run serve` with `npm run start` for both client and server configurations.
  - Included guidance on adjusting memory limit parameters in the `.npmrc` file to prevent potential JavaScript heap memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->