### PR TITLE
`Learning paths`: Add learning path completion button

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathNavigationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/learningpath/LearningPathNavigationService.java
@@ -53,12 +53,14 @@ public class LearningPathNavigationService {
         if (currentLearningObject == null) {
             currentLearningObject = learningPathRecommendationService.getLastLearningObject(learningPath.getUser(), recommendationStateWithAllCompetencies);
 
-            // If we still didn't find any learning object, there exists no learning object in the learning path and we can return an empty navigation
             if (currentLearningObject == null) {
+                // If we still didn't find any learning object, there exists no learning object in the learning path and we can return an empty navigation
                 return new LearningPathNavigationDTO(null, null, null, learningPath.getProgress());
             }
             else {
                 competencyOfCurrentLearningObject = findCorrespondingCompetencyForLearningObject(recommendationStateWithAllCompetencies, currentLearningObject, false);
+                return new LearningPathNavigationDTO(LearningPathNavigationObjectDTO.of(currentLearningObject, true, competencyOfCurrentLearningObject.getId()), null, null,
+                        learningPath.getProgress());
             }
         }
         else {

--- a/src/main/webapp/app/course/learning-paths/components/learning-path-nav-overview-learning-objects/learning-path-nav-overview-learning-objects.component.html
+++ b/src/main/webapp/app/course/learning-paths/components/learning-path-nav-overview-learning-objects/learning-path-nav-overview-learning-objects.component.html
@@ -1,6 +1,6 @@
 <div class="bg-light">
     @if (learningObjects()) {
-        @for (learningObject of learningObjects(); track learningObject) {
+        @for (learningObject of learningObjects(); let last = $last; track learningObject) {
             <div
                 (click)="selectLearningObject(learningObject)"
                 class="row p-3 m-0 clickable align-items-center"
@@ -17,7 +17,7 @@
                     </div>
                 }
             </div>
-            @if (!$last) {
+            @if (!last) {
                 <hr class="m-0 p-0" />
             }
         } @empty {

--- a/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.html
+++ b/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.html
@@ -15,9 +15,13 @@
         <div ngbDropdown class="col-4 dropdown" (openChange)="setIsDropdownOpen($event)" #navOverview="ngbDropdown">
             @if (!isLoading()) {
                 <div type="button" class="row justify-content-center align-items-center h-100" id="navigation-overview" ngbDropdownToggle>
+                   @if(currentLearningObject()) {
                     <span class="col-md-auto fw-bold">
-                        {{ currentLearningObject()?.name }}
+                            {{ currentLearningObject()?.name }}
                     </span>
+                   } @else {
+                       <span class="col-md-auto fw-bold" jhiTranslate="artemisApp.learningPath.navigation.recapLabel"></span>
+                   }
                     <fa-icon [icon]="faChevronDown" class="col-md-auto ps-0" />
                 </div>
             }

--- a/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.html
+++ b/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.html
@@ -15,13 +15,13 @@
         <div ngbDropdown class="col-4 dropdown" (openChange)="setIsDropdownOpen($event)" #navOverview="ngbDropdown">
             @if (!isLoading()) {
                 <div type="button" class="row justify-content-center align-items-center h-100" id="navigation-overview" ngbDropdownToggle>
-                   @if(currentLearningObject()) {
-                    <span class="col-md-auto fw-bold">
+                    @if (currentLearningObject()) {
+                        <span class="col-md-auto fw-bold">
                             {{ currentLearningObject()?.name }}
-                    </span>
-                   } @else {
-                       <span class="col-md-auto fw-bold" jhiTranslate="artemisApp.learningPath.navigation.recapLabel"></span>
-                   }
+                        </span>
+                    } @else {
+                        <span class="col-md-auto fw-bold" jhiTranslate="artemisApp.learningPath.navigation.recapLabel"></span>
+                    }
                     <fa-icon [icon]="faChevronDown" class="col-md-auto ps-0" />
                 </div>
             }
@@ -40,7 +40,7 @@
                             <span jhiTranslate="artemisApp.learningPath.navigation.nextButton"></span>
                         </button>
                     </div>
-                } @else if(currentLearningObject() && !successorLearningObject()) {
+                } @else if (currentLearningObject() && !successorLearningObject()) {
                     <div class="col-md-auto">
                         <button id="complete-button" (click)="completeLearningPath()" type="button" class="btn btn-primary">
                             <fa-icon [icon]="faFlag" />

--- a/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.html
+++ b/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.html
@@ -40,6 +40,13 @@
                             <span jhiTranslate="artemisApp.learningPath.navigation.nextButton"></span>
                         </button>
                     </div>
+                } @else if(currentLearningObject() && !successorLearningObject()) {
+                    <div class="col-md-auto">
+                        <button id="complete-button" (click)="completeLearningPath()" type="button" class="btn btn-primary">
+                            <fa-icon [icon]="faFlag" />
+                            <span jhiTranslate="artemisApp.learningPath.navigation.completeButton"></span>
+                        </button>
+                    </div>
                 }
             </div>
         </div>

--- a/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.ts
+++ b/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.ts
@@ -46,7 +46,7 @@ export class LearningPathNavComponent implements OnInit {
     }
 
     completeLearningPath(): void {
-        this.learningPathNavigationService.completeLearningPath(this.learningPathId());
+        this.learningPathNavigationService.completeLearningPath();
     }
 
     setIsDropdownOpen(isOpen: boolean): void {

--- a/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.ts
+++ b/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.ts
@@ -46,7 +46,7 @@ export class LearningPathNavComponent implements OnInit {
     }
 
     completeLearningPath(): void {
-        this.learningPathNavigationService.completeLearningPath();
+        this.learningPathNavigationService.completeLearningPath(this.learningPathId());
     }
 
     setIsDropdownOpen(isOpen: boolean): void {

--- a/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.ts
+++ b/src/main/webapp/app/course/learning-paths/components/learning-path-student-nav/learning-path-student-nav.component.ts
@@ -3,7 +3,7 @@ import { LearningPathNavigationObjectDTO } from 'app/entities/competency/learnin
 import { CommonModule } from '@angular/common';
 import { NgbAccordionModule, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { IconDefinition, faCheckCircle, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { IconDefinition, faCheckCircle, faChevronDown, faFlag } from '@fortawesome/free-solid-svg-icons';
 import { LearningPathNavOverviewComponent } from 'app/course/learning-paths/components/learning-path-nav-overview/learning-path-nav-overview.component';
 import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { LearningPathNavigationService } from 'app/course/learning-paths/services/learning-path-navigation.service';
@@ -18,6 +18,7 @@ import { LearningPathNavigationService } from 'app/course/learning-paths/service
 export class LearningPathNavComponent implements OnInit {
     protected readonly faChevronDown: IconDefinition = faChevronDown;
     protected readonly faCheckCircle: IconDefinition = faCheckCircle;
+    protected readonly faFlag: IconDefinition = faFlag;
 
     private learningPathNavigationService: LearningPathNavigationService = inject(LearningPathNavigationService);
 
@@ -42,6 +43,10 @@ export class LearningPathNavComponent implements OnInit {
 
     selectLearningObject(selectedLearningObject: LearningPathNavigationObjectDTO): void {
         this.learningPathNavigationService.loadRelativeLearningPathNavigation(this.learningPathId(), selectedLearningObject);
+    }
+
+    completeLearningPath(): void {
+        this.learningPathNavigationService.completeLearningPath();
     }
 
     setIsDropdownOpen(isOpen: boolean): void {

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
@@ -12,7 +12,7 @@
                 <jhi-learning-path-lecture-unit [lectureUnitId]="currentLearningObject()!.id" />
             } @else if (currentLearningObject()?.type === LearningObjectType.EXERCISE) {
                 <jhi-learning-path-exercise [courseId]="courseId()" [exerciseId]="currentLearningObject()!.id" />
-            } @else if(!isLearningPathNavigationLoading()) {
+            } @else if (!isLearningPathNavigationLoading()) {
                 <div class="row align-items-center justify-content-center h-100">
                     <div class="learning-path-no-content-container">
                         <h3 class="mb-3" jhiTranslate="artemisApp.learningPath.completion.title"></h3>

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
@@ -1,5 +1,5 @@
 <div class="col learning-path-student-page">
-    @if (isLoading()) {
+    @if (isLearningPathIdLoading()) {
         <div class="row justify-content-center align-items-center h-100">
             <div class="spinner-border text-primary" role="status">
                 <span class="sr-only" jhiTranslate="loading"></span>
@@ -12,11 +12,18 @@
                 <jhi-learning-path-lecture-unit [lectureUnitId]="currentLearningObject()!.id" />
             } @else if (currentLearningObject()?.type === LearningObjectType.EXERCISE) {
                 <jhi-learning-path-exercise [courseId]="courseId()" [exerciseId]="currentLearningObject()!.id" />
+            } @else if(!isLearningPathNavigationLoading()) {
+                <div class="row align-items-center justify-content-center h-100">
+                    <div class="learning-path-no-content-container">
+                        <h3 class="mb-3" jhiTranslate="artemisApp.learningPath.completion.title"></h3>
+                        <div jhiTranslate="artemisApp.learningPath.completion.description"></div>
+                    </div>
+                </div>
             }
         </div>
     } @else {
         <div class="row align-items-center justify-content-center h-100">
-            <div class="learning-path-generation-container">
+            <div class="learning-path-no-content-container">
                 <h3 class="mb-3" jhiTranslate="artemisApp.learningPath.generation.title"></h3>
                 <div jhiTranslate="artemisApp.learningPath.generation.description"></div>
                 <button

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
@@ -13,7 +13,7 @@
             } @else if (currentLearningObject()?.type === LearningObjectType.EXERCISE) {
                 <jhi-learning-path-exercise [courseId]="courseId()" [exerciseId]="currentLearningObject()!.id" />
             } @else if (!isLearningPathNavigationLoading()) {
-                <div class="row align-items-center justify-content-center h-100">
+                <div class="row align-items-center justify-content-center h-100 w-100">
                     <div class="learning-path-no-content-container">
                         <h3 class="mb-3" jhiTranslate="artemisApp.learningPath.completion.title"></h3>
                         <div jhiTranslate="artemisApp.learningPath.completion.description"></div>
@@ -22,7 +22,7 @@
             }
         </div>
     } @else {
-        <div class="row align-items-center justify-content-center h-100">
+        <div class="row align-items-center justify-content-center h-100 w-100">
             <div class="learning-path-no-content-container">
                 <h3 class="mb-3" jhiTranslate="artemisApp.learningPath.generation.title"></h3>
                 <div jhiTranslate="artemisApp.learningPath.generation.description"></div>

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.scss
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.scss
@@ -6,7 +6,7 @@
         overflow: auto;
     }
 
-    .learning-path-generation-container {
+    .learning-path-no-content-container {
         max-width: 500px;
         text-align: center;
     }

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.ts
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.ts
@@ -37,10 +37,11 @@ export class LearningPathStudentPageComponent implements OnInit {
     private readonly alertService: AlertService = inject(AlertService);
     private readonly activatedRoute: ActivatedRoute = inject(ActivatedRoute);
 
-    readonly isLoading = signal(false);
+    readonly isLearningPathIdLoading = signal(false);
     readonly learningPathId = signal<number | undefined>(undefined);
     readonly courseId: Signal<number> = toSignal(this.activatedRoute.parent!.parent!.params.pipe(map((params) => params.courseId)));
     readonly currentLearningObject = this.learningPathNavigationService.currentLearningObject;
+    readonly isLearningPathNavigationLoading = this.learningPathNavigationService.isLoading;
 
     ngOnInit(): void {
         this.loadLearningPathId(this.courseId());
@@ -48,7 +49,7 @@ export class LearningPathStudentPageComponent implements OnInit {
 
     private async loadLearningPathId(courseId: number): Promise<void> {
         try {
-            this.isLoading.set(true);
+            this.isLearningPathIdLoading.set(true);
             const learningPathId = await this.learningApiService.getLearningPathId(courseId);
             this.learningPathId.set(learningPathId);
         } catch (error) {
@@ -57,19 +58,19 @@ export class LearningPathStudentPageComponent implements OnInit {
                 this.alertService.error(error);
             }
         } finally {
-            this.isLoading.set(false);
+            this.isLearningPathIdLoading.set(false);
         }
     }
 
     async generateLearningPath(courseId: number): Promise<void> {
         try {
-            this.isLoading.set(true);
+            this.isLearningPathIdLoading.set(true);
             const learningPathId = await this.learningApiService.generateLearningPath(courseId);
             this.learningPathId.set(learningPathId);
         } catch (error) {
             this.alertService.error(error);
         } finally {
-            this.isLoading.set(false);
+            this.isLearningPathIdLoading.set(false);
         }
     }
 }

--- a/src/main/webapp/app/course/learning-paths/services/learning-path-navigation.service.ts
+++ b/src/main/webapp/app/course/learning-paths/services/learning-path-navigation.service.ts
@@ -41,8 +41,8 @@ export class LearningPathNavigationService {
         }
     }
 
-    completeLearningPath(learningPathId: number): void {
-        this.loadLearningPathNavigation(learningPathId);
+    completeLearningPath(): void {
+        this.learningPathNavigation.set({ predecessorLearningObject: this.currentLearningObject(), progress: 100 });
     }
 
     setCurrentLearningObjectCompletion(completed: boolean): void {

--- a/src/main/webapp/app/course/learning-paths/services/learning-path-navigation.service.ts
+++ b/src/main/webapp/app/course/learning-paths/services/learning-path-navigation.service.ts
@@ -41,13 +41,8 @@ export class LearningPathNavigationService {
         }
     }
 
-    completeLearningPath(): void {
-        this.learningPathNavigation.set({
-            predecessorLearningObject: this.currentLearningObject(),
-            currentLearningObject: undefined,
-            successorLearningObject: undefined,
-            progress: 100,
-        });
+    completeLearningPath(learningPathId: number): void {
+        this.loadLearningPathNavigation(learningPathId);
     }
 
     setCurrentLearningObjectCompletion(completed: boolean): void {

--- a/src/main/webapp/app/course/learning-paths/services/learning-path-navigation.service.ts
+++ b/src/main/webapp/app/course/learning-paths/services/learning-path-navigation.service.ts
@@ -41,6 +41,15 @@ export class LearningPathNavigationService {
         }
     }
 
+    completeLearningPath(): void {
+        this.learningPathNavigation.set({
+            predecessorLearningObject: this.currentLearningObject(),
+            currentLearningObject: undefined,
+            successorLearningObject: undefined,
+            progress: 100,
+        });
+    }
+
     setCurrentLearningObjectCompletion(completed: boolean): void {
         this.isCurrentLearningObjectCompleted.set(completed);
     }

--- a/src/main/webapp/app/entities/competency/learning-path.model.ts
+++ b/src/main/webapp/app/entities/competency/learning-path.model.ts
@@ -42,7 +42,7 @@ export interface LearningPathNavigationObjectDTO {
 
 export interface LearningPathNavigationDTO {
     predecessorLearningObject?: LearningPathNavigationObjectDTO;
-    currentLearningObject: LearningPathNavigationObjectDTO;
+    currentLearningObject?: LearningPathNavigationObjectDTO;
     successorLearningObject?: LearningPathNavigationObjectDTO;
     progress: number;
 }

--- a/src/main/webapp/i18n/de/learningPath.json
+++ b/src/main/webapp/i18n/de/learningPath.json
@@ -9,7 +9,8 @@
                     "showCompetenciesGraphButton": "Kompetenzgraph",
                     "emptyLearningObjectsLabel": "Diese Kompetenz enthält bisher noch keine Lernobjekte!",
                     "nextLearningObjectOnPathLabel": "Nächste"
-                }
+                },
+                "recapLabel": "Lernpfadobjekte wiederholen"
             },
             "competencyGraphModal": {
                 "title": "Abhängigkeiten der Lernpfadkompetenzen"
@@ -18,6 +19,10 @@
                 "title": "Willkommen bei deinem Lernpfad!",
                 "description": "Der Lernpfad ermöglicht es dir, in deinem eigenen Tempo zu lernen, mit einer personalisierten Lernreise, die auf deine Leistung zugeschnitten ist. Sie passt sich dynamisch an und stellt sicher, dass du immer die relevantesten Inhalte und Herausforderungen erhältst. Starte jetzt und erlebe deinen individuellen Weg zum Erfolg!",
                 "generateButton": "Meinen Lernfpad starten"
+            },
+            "completion": {
+                "title": "Herzlichen Glückwunsch!",
+                "description": "Herzlichen Glückwunsch zum Abschluss deines aktuellen Lernpfads! \uD83C\uDF89 Deine Mühe hat sich gelohnt. Neue Inhalte werden möglicherweise bald hinzugefügt, aber genieße diesen Moment des Erfolgs. Bleib dran für weitere Einheiten und mach weiter so!"
             }
         }
     }

--- a/src/main/webapp/i18n/de/learningPath.json
+++ b/src/main/webapp/i18n/de/learningPath.json
@@ -8,7 +8,7 @@
                 "overview": {
                     "title": "Lernpfad Kompetenzen",
                     "showCompetenciesGraphButton": "Kompetenzgraph",
-                    "emptyLearningObjectsLabel": "Diese Kompetenz enthält bisher noch keine Lernheiten!",
+                    "emptyLearningObjectsLabel": "Diese Kompetenz enthält bisher noch keine Lerneinheiten!",
                     "nextLearningObjectOnPathLabel": "Nächste"
                 },
                 "recapLabel": "Lerneinheiten wiederholen"

--- a/src/main/webapp/i18n/de/learningPath.json
+++ b/src/main/webapp/i18n/de/learningPath.json
@@ -4,6 +4,7 @@
             "navigation": {
                 "nextButton": "Weiter",
                 "previousButton": "Zurück",
+                "completeButton": "Abschließen",
                 "overview": {
                     "title": "Lernpfad Kompetenzen",
                     "showCompetenciesGraphButton": "Kompetenzgraph",

--- a/src/main/webapp/i18n/de/learningPath.json
+++ b/src/main/webapp/i18n/de/learningPath.json
@@ -4,7 +4,7 @@
             "navigation": {
                 "nextButton": "Weiter",
                 "previousButton": "Zurück",
-                "completeButton": "Abschließen",
+                "completeButton": "Ende des Lernfpads",
                 "overview": {
                     "title": "Lernpfad Kompetenzen",
                     "showCompetenciesGraphButton": "Kompetenzgraph",

--- a/src/main/webapp/i18n/de/learningPath.json
+++ b/src/main/webapp/i18n/de/learningPath.json
@@ -8,10 +8,10 @@
                 "overview": {
                     "title": "Lernpfad Kompetenzen",
                     "showCompetenciesGraphButton": "Kompetenzgraph",
-                    "emptyLearningObjectsLabel": "Diese Kompetenz enthält bisher noch keine Lernobjekte!",
+                    "emptyLearningObjectsLabel": "Diese Kompetenz enthält bisher noch keine Lernheiten!",
                     "nextLearningObjectOnPathLabel": "Nächste"
                 },
-                "recapLabel": "Lernpfadobjekte wiederholen"
+                "recapLabel": "Lerneinheiten wiederholen"
             },
             "competencyGraphModal": {
                 "title": "Abhängigkeiten der Lernpfadkompetenzen"

--- a/src/main/webapp/i18n/en/learningPath.json
+++ b/src/main/webapp/i18n/en/learningPath.json
@@ -9,7 +9,8 @@
                     "showCompetenciesGraphButton": "Competency graph",
                     "emptyLearningObjectsLabel": "This competency doesn't contain any learning objects yet!",
                     "nextLearningObjectOnPathLabel": "Next"
-                }
+                },
+                "recapLabel": "Recap learning path objects"
             },
             "competencyGraphModal": {
                 "title": "Learning path competency relations"
@@ -18,6 +19,10 @@
                 "title": "Welcome to your learning path!",
                 "description": "This feature lets you learn at your own pace with a personalized journey tailored to your performance. It adapts dynamically, ensuring you always have the most relevant content and challenges. Start now and experience a customized path to success!",
                 "generateButton": "Start my learning path"
+            },
+            "completion": {
+                "title": "Congratulations!",
+                "description" : "Congratulations on finishing your current learning path! \uD83C\uDF89 Your hard work has paid off. While new content may be added soon, enjoy this moment of achievement. Stay tuned for more units and keep up the great work!"
             }
         }
     }

--- a/src/main/webapp/i18n/en/learningPath.json
+++ b/src/main/webapp/i18n/en/learningPath.json
@@ -4,6 +4,7 @@
             "navigation": {
                 "nextButton": "Next",
                 "previousButton": "Previous",
+                "completeButton": "Complete",
                 "overview": {
                     "title": "Learning path competencies",
                     "showCompetenciesGraphButton": "Competency graph",

--- a/src/main/webapp/i18n/en/learningPath.json
+++ b/src/main/webapp/i18n/en/learningPath.json
@@ -8,10 +8,10 @@
                 "overview": {
                     "title": "Learning path competencies",
                     "showCompetenciesGraphButton": "Competency graph",
-                    "emptyLearningObjectsLabel": "This competency doesn't contain any learning objects yet!",
+                    "emptyLearningObjectsLabel": "This competency doesn't contain any learning units yet!",
                     "nextLearningObjectOnPathLabel": "Next"
                 },
-                "recapLabel": "Recap learning path objects"
+                "recapLabel": "Recap learning units"
             },
             "competencyGraphModal": {
                 "title": "Learning path competency relations"

--- a/src/main/webapp/i18n/en/learningPath.json
+++ b/src/main/webapp/i18n/en/learningPath.json
@@ -4,7 +4,7 @@
             "navigation": {
                 "nextButton": "Next",
                 "previousButton": "Previous",
-                "completeButton": "Complete",
+                "completeButton": "End of learning path",
                 "overview": {
                     "title": "Learning path competencies",
                     "showCompetenciesGraphButton": "Competency graph",

--- a/src/main/webapp/i18n/en/learningPath.json
+++ b/src/main/webapp/i18n/en/learningPath.json
@@ -23,7 +23,7 @@
             },
             "completion": {
                 "title": "Congratulations!",
-                "description" : "Congratulations on finishing your current learning path! \uD83C\uDF89 Your hard work has paid off. While new content may be added soon, enjoy this moment of achievement. Stay tuned for more units and keep up the great work!"
+                "description": "Congratulations on finishing your current learning path! \uD83C\uDF89 Your hard work has paid off. While new content may be added soon, enjoy this moment of achievement. Stay tuned for more units and keep up the great work!"
             }
         }
     }

--- a/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/competency/LearningPathIntegrationTest.java
@@ -678,7 +678,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
         lectureUnitService.setLectureUnitCompletion(thirdTextUnit, student, true);
         result = request.get("/api/learning-path/" + learningPath.getId() + "/navigation", HttpStatus.OK, LearningPathNavigationDTO.class);
-        verifyNavigationResult(result, secondTextUnit, thirdTextUnit, null);
+        verifyNavigationResult(result, thirdTextUnit, null, null);
     }
 
     private LearningPathNavigationObjectDTO.LearningObjectType getLearningObjectType(LearningObject learningObject) {

--- a/src/test/javascript/spec/component/learning-paths/components/learning-path-nav.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-paths/components/learning-path-nav.component.spec.ts
@@ -104,7 +104,7 @@ describe('LearningPathStudentNavComponent', () => {
     });
 
     it('should set current to previous unit on complete button', async () => {
-        const navigationDto = {
+        const previousNavigationDto = {
             predecessorLearningObject: {
                 id: 1,
                 name: 'Exercise',
@@ -119,20 +119,33 @@ describe('LearningPathStudentNavComponent', () => {
             },
             progress: 95,
         };
-        getLearningPathNavigationSpy.mockResolvedValue(navigationDto);
+        const currentNavigationDto = {
+            predecessorLearningObject: {
+                id: 2,
+                name: 'Lecture',
+                type: LearningObjectType.LECTURE,
+                completed: false,
+            },
+            progress: 95,
+        };
+        getLearningPathNavigationSpy.mockResolvedValue(previousNavigationDto);
 
         fixture.detectChanges();
         await fixture.whenStable();
         fixture.detectChanges();
 
+        getLearningPathNavigationSpy.mockResolvedValue(currentNavigationDto);
+
         const completeButton = fixture.debugElement.query(By.css('#complete-button'));
         completeButton.nativeElement.click();
 
         fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
 
-        expect(component.predecessorLearningObject()).toBe(navigationDto.currentLearningObject);
+        expect(component.predecessorLearningObject()).toBe(currentNavigationDto.predecessorLearningObject);
         expect(component.currentLearningObject()).toBeUndefined();
-        expect(component.learningPathProgress()).toBe(100);
+        expect(component.learningPathProgress()).toEqual(currentNavigationDto.progress);
     });
 
     it('should show navigation with previous and complete button', async () => {

--- a/src/test/javascript/spec/component/learning-paths/components/learning-path-nav.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-paths/components/learning-path-nav.component.spec.ts
@@ -89,7 +89,7 @@ describe('LearningPathStudentNavComponent', () => {
         expect(progressBar.nativeElement.style.width).toBe('50%');
     });
 
-    it('should navigation with back and previous button', async () => {
+    it('should navigate with next and previous button', async () => {
         fixture.detectChanges();
         await fixture.whenStable();
         fixture.detectChanges();
@@ -103,7 +103,39 @@ describe('LearningPathStudentNavComponent', () => {
         expect(nextButton).toBeTruthy();
     });
 
-    it('should show navigation with only previous button', async () => {
+    it('should set current to previous unit on complete button', async () => {
+        const navigationDto = {
+            predecessorLearningObject: {
+                id: 1,
+                name: 'Exercise',
+                type: LearningObjectType.EXERCISE,
+                completed: true,
+            },
+            currentLearningObject: {
+                id: 2,
+                name: 'Lecture',
+                type: LearningObjectType.LECTURE,
+                completed: false,
+            },
+            progress: 95,
+        };
+        getLearningPathNavigationSpy.mockResolvedValue(navigationDto);
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const completeButton = fixture.debugElement.query(By.css('#complete-button'));
+        completeButton.nativeElement.click();
+
+        fixture.detectChanges();
+
+        expect(component.predecessorLearningObject()).toBe(navigationDto.currentLearningObject);
+        expect(component.currentLearningObject()).toBeUndefined();
+        expect(component.learningPathProgress()).toBe(100);
+    });
+
+    it('should show navigation with previous and complete button', async () => {
         const navigationDto = {
             predecessorLearningObject: {
                 id: 1,
@@ -134,6 +166,9 @@ describe('LearningPathStudentNavComponent', () => {
 
         const nextButton = fixture.debugElement.query(By.css('#next-button'));
         expect(nextButton).toBeFalsy();
+
+        const completeButton = fixture.debugElement.query(By.css('#complete-button'));
+        expect(completeButton).toBeTruthy();
     });
 
     it('should show navigation with only next button', async () => {

--- a/src/test/javascript/spec/component/learning-paths/components/learning-path-nav.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-paths/components/learning-path-nav.component.spec.ts
@@ -104,7 +104,7 @@ describe('LearningPathStudentNavComponent', () => {
     });
 
     it('should set current to previous unit on complete button', async () => {
-        const previousNavigationDto = {
+        const navigationDto = {
             predecessorLearningObject: {
                 id: 1,
                 name: 'Exercise',
@@ -119,33 +119,18 @@ describe('LearningPathStudentNavComponent', () => {
             },
             progress: 95,
         };
-        const currentNavigationDto = {
-            predecessorLearningObject: {
-                id: 2,
-                name: 'Lecture',
-                type: LearningObjectType.LECTURE,
-                completed: false,
-            },
-            progress: 95,
-        };
-        getLearningPathNavigationSpy.mockResolvedValue(previousNavigationDto);
+        getLearningPathNavigationSpy.mockResolvedValue(navigationDto);
 
         fixture.detectChanges();
         await fixture.whenStable();
         fixture.detectChanges();
-
-        getLearningPathNavigationSpy.mockResolvedValue(currentNavigationDto);
 
         const completeButton = fixture.debugElement.query(By.css('#complete-button'));
         completeButton.nativeElement.click();
 
-        fixture.detectChanges();
-        await fixture.whenStable();
-        fixture.detectChanges();
-
-        expect(component.predecessorLearningObject()).toBe(currentNavigationDto.predecessorLearningObject);
+        expect(component.predecessorLearningObject()).toBe(navigationDto.currentLearningObject);
         expect(component.currentLearningObject()).toBeUndefined();
-        expect(component.learningPathProgress()).toEqual(currentNavigationDto.progress);
+        expect(component.learningPathProgress()).toBe(100);
     });
 
     it('should show navigation with previous and complete button', async () => {

--- a/src/test/javascript/spec/component/learning-paths/pages/learning-path-student-page.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-paths/pages/learning-path-student-page.component.spec.ts
@@ -104,7 +104,7 @@ describe('LearningPathStudentPageComponent', () => {
 
     it('should set isLoading correctly during learning path load', async () => {
         jest.spyOn(learningPathApiService, 'getLearningPathId').mockResolvedValue(learningPathId);
-        const loadingSpy = jest.spyOn(component.isLoading, 'set');
+        const loadingSpy = jest.spyOn(component.isLearningPathIdLoading, 'set');
 
         fixture.detectChanges();
         await fixture.whenStable();
@@ -134,7 +134,7 @@ describe('LearningPathStudentPageComponent', () => {
     it('should set isLoading correctly during learning path generation', async () => {
         jest.spyOn(learningPathApiService, 'getLearningPathId').mockRejectedValue(new EntityNotFoundError());
         jest.spyOn(learningPathApiService, 'generateLearningPath').mockResolvedValue(learningPathId);
-        const loadingSpy = jest.spyOn(component.isLoading, 'set');
+        const loadingSpy = jest.spyOn(component.isLearningPathIdLoading, 'set');
 
         fixture.detectChanges();
         await fixture.whenStable();

--- a/src/test/javascript/spec/service/learning-path/learning-path-navigation.service.spec.ts
+++ b/src/test/javascript/spec/service/learning-path/learning-path-navigation.service.spec.ts
@@ -85,22 +85,7 @@ describe('LearningPathNavigationService', () => {
     });
 
     it('should complete learning path', async () => {
-        const previousNavigationDto = {
-            predecessorLearningObject: {
-                id: 1,
-                name: 'Lecture 1',
-                completed: true,
-                type: LearningObjectType.LECTURE,
-            },
-            currentLearningObject: {
-                id: 2,
-                name: 'Exercise 1',
-                completed: false,
-                type: LearningObjectType.EXERCISE,
-            },
-            progress: 80,
-        } as LearningPathNavigationDTO;
-        const currentNavigationDto = {
+        const navigationDto = {
             predecessorLearningObject: {
                 id: 2,
                 name: 'Exercise 1',
@@ -110,20 +95,18 @@ describe('LearningPathNavigationService', () => {
             progress: 90,
         } as LearningPathNavigationDTO;
 
-        jest.spyOn(learningPathApiService, 'getLearningPathNavigation').mockResolvedValue(currentNavigationDto);
+        jest.spyOn(learningPathApiService, 'getLearningPathNavigation').mockResolvedValue(navigationDto);
         const completeLearningPathSpy = jest.spyOn(learningPathNavigationService, 'completeLearningPath');
 
         await learningPathNavigationService.loadLearningPathNavigation(learningPathId);
 
-        jest.spyOn(learningPathApiService, 'getLearningPathNavigation').mockResolvedValue(previousNavigationDto);
-
-        await learningPathNavigationService.completeLearningPath(learningPathId);
+        learningPathNavigationService.completeLearningPath();
 
         expect(learningPathNavigationService.learningPathNavigation()).toEqual({
-            predecessorLearningObject: currentNavigationDto.predecessorLearningObject,
+            predecessorLearningObject: navigationDto.currentLearningObject,
             currentLearningObject: undefined,
             successorLearningObject: undefined,
-            progress: currentNavigationDto.progress,
+            progress: 100,
         });
         expect(completeLearningPathSpy).toHaveBeenCalled();
     });

--- a/src/test/javascript/spec/service/learning-path/learning-path-navigation.service.spec.ts
+++ b/src/test/javascript/spec/service/learning-path/learning-path-navigation.service.spec.ts
@@ -85,7 +85,7 @@ describe('LearningPathNavigationService', () => {
     });
 
     it('should complete learning path', async () => {
-        const learningPathNavigationDto = {
+        const previousNavigationDto = {
             predecessorLearningObject: {
                 id: 1,
                 name: 'Lecture 1',
@@ -100,19 +100,30 @@ describe('LearningPathNavigationService', () => {
             },
             progress: 80,
         } as LearningPathNavigationDTO;
+        const currentNavigationDto = {
+            predecessorLearningObject: {
+                id: 2,
+                name: 'Exercise 1',
+                completed: false,
+                type: LearningObjectType.EXERCISE,
+            },
+            progress: 90,
+        } as LearningPathNavigationDTO;
 
-        jest.spyOn(learningPathApiService, 'getLearningPathNavigation').mockResolvedValue(learningPathNavigationDto);
+        jest.spyOn(learningPathApiService, 'getLearningPathNavigation').mockResolvedValue(currentNavigationDto);
         const completeLearningPathSpy = jest.spyOn(learningPathNavigationService, 'completeLearningPath');
 
         await learningPathNavigationService.loadLearningPathNavigation(learningPathId);
 
-        learningPathNavigationService.completeLearningPath();
+        jest.spyOn(learningPathApiService, 'getLearningPathNavigation').mockResolvedValue(previousNavigationDto);
+
+        await learningPathNavigationService.completeLearningPath(learningPathId);
 
         expect(learningPathNavigationService.learningPathNavigation()).toEqual({
-            predecessorLearningObject: learningPathNavigationDto.currentLearningObject,
+            predecessorLearningObject: currentNavigationDto.predecessorLearningObject,
             currentLearningObject: undefined,
             successorLearningObject: undefined,
-            progress: 100,
+            progress: currentNavigationDto.progress,
         });
         expect(completeLearningPathSpy).toHaveBeenCalled();
     });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently students don't really know when their learning path is (temporarily) completed.

### Description
<!-- Describe your changes in detail -->
This PR introduces a new button which indicates that the learning path has been (temporarily) completed. Additionally when clicking on the completion button the system now displays a short description that the learning path has been completed but in new units could be added in the near future. Meanwhile students still have the opportunity to recap the already completed learning objects.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student
- at least 1 lecture
- at least 1 competency with at least 1 video unit, text unit or similar

1. Log in to Artemis
2. Navigate to the learning paths UI
3. Finish the learning path
4. Verify that you see the completion button
5. Click the completion button
6. Verify that you see the Congratulations text
7. Verify that you still can open the navigation overview and navigate to completed learning objects

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged due to small additions

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/002803f0-8e73-4bf8-af43-5418bb7a3e10">
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/4049c9e7-a660-4051-8a15-bfea99c604fd">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a "Complete" button to mark learning paths as finished, enhancing user interaction.
	- Added conditional logic to improve the display of learning objects and navigation options based on their availability.
	- Implemented enhanced loading state handling for a clearer user experience during data retrieval.
	- Updated navigation structure to include congratulatory messages upon completing learning paths.
	- Enhanced German localization with a new "completeButton" and improved labels for clarity and user engagement.

- **Bug Fixes**
	- Improved navigation logic to handle cases when no current learning object is found, providing a more informative response.

- **Localization**
	- Updated English and German localization files to include new buttons and messages for improved user feedback and navigation.

- **Tests**
	- Enhanced test cases for the `LearningPathNavigationService` to validate the completion functionality and improve type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->