### PR TITLE
`Quiz exercises`: Import existing quiz exercises from zip files

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.service.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.service.ts
@@ -260,7 +260,7 @@ export class QuizExerciseService {
                 if ((question as DragAndDropQuestion).backgroundFilePath) {
                     const filePath = (question as DragAndDropQuestion).backgroundFilePath!;
                     const fileNameExtension = filePath.split('.').last();
-                    filePromises.push(this.fetchFilePromise(`q${questionIndex}_background.${fileNameExtension}`, zip, filePath ));
+                    filePromises.push(this.fetchFilePromise(`q${questionIndex}_background.${fileNameExtension}`, zip, filePath));
                 }
                 if ((question as DragAndDropQuestion).dragItems) {
                     (question as DragAndDropQuestion).dragItems?.forEach((dragItem, drag_index) => {

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.service.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.service.ts
@@ -258,12 +258,16 @@ export class QuizExerciseService {
         questions.forEach((question, questionIndex) => {
             if (question.type === QuizQuestionType.DRAG_AND_DROP) {
                 if ((question as DragAndDropQuestion).backgroundFilePath) {
-                    filePromises.push(this.fetchFilePromise(`q${questionIndex}_background.png`, zip, (question as DragAndDropQuestion).backgroundFilePath!));
+                    const filePath = (question as DragAndDropQuestion).backgroundFilePath!;
+                    const fileNameExtension = filePath.split('.').last();
+                    filePromises.push(this.fetchFilePromise(`q${questionIndex}_background.${fileNameExtension}`, zip, filePath ));
                 }
                 if ((question as DragAndDropQuestion).dragItems) {
                     (question as DragAndDropQuestion).dragItems?.forEach((dragItem, drag_index) => {
                         if (dragItem.pictureFilePath) {
-                            filePromises.push(this.fetchFilePromise(`q${questionIndex}_dragItem-${drag_index}.png`, zip, dragItem.pictureFilePath));
+                            const filePath = dragItem.pictureFilePath!;
+                            const fileNameExtension = filePath.split('.').last();
+                            filePromises.push(this.fetchFilePromise(`q${questionIndex}_dragItem-${drag_index}.${fileNameExtension}`, zip, filePath));
                         }
                     });
                 }

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.html
@@ -41,7 +41,7 @@
                         <span jhiTranslate="artemisApp.quizExercise.importJSON" class="font-weight-bold colon-suffix no-flex-shrink"></span>
                     </div>
                     <div class="input-group flex-grow-1 col">
-                        <input id="importFileInput" type="file" accept=".json" class="form-control" (change)="setImportFile($event)" placeholder="Upload file..." />
+                        <input id="importFileInput" type="file" accept=".json,.zip" class="form-control" (change)="setImportFile($event)" placeholder="Upload file..." />
                         <button class="btn btn-outline-primary" (click)="importQuiz()" jhiTranslate="entity.action.import" [ngClass]="{ disabled: !importFile }"></button>
                     </div>
                 </div>

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -341,7 +341,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
             } else if (question.type === QuizQuestionType.DRAG_AND_DROP) {
                 const dndQuestion = question as DragAndDropQuestion;
                 // Get image from the old question and duplicate it on the server and then save new image to the question,
-                const backgroundImageFile : File | undefined = images.get(`q${questionIndex}_background`);
+                const backgroundImageFile: File | undefined = images.get(`q${questionIndex}_background`);
                 if (backgroundImageFile) {
                     const backgroundFile = backgroundImageFile;
                     files.set(backgroundFile.name, { path: dndQuestion.backgroundFilePath!, file: backgroundFile });

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -167,7 +167,6 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
     /**
      * Imports a json quiz file and adds questions to current quiz exercise.
      */
-
     async importQuiz() {
         if (!this.importFile) {
             return;
@@ -197,9 +196,9 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
 
         try {
             const zipContent = await jszip.loadAsync(file);
-            const jsonFiles = Object.keys(zipContent.files).filter(fileName => fileName.endsWith('.json'));
+            const jsonFiles = Object.keys(zipContent.files).filter((fileName) => fileName.endsWith('.json'));
 
-            const images = await this.extractImagesFromZip(zipContent)
+            const images = await this.extractImagesFromZip(zipContent);
             const jsonFile = zipContent.files[jsonFiles[0]];
             const jsonContent = await jsonFile.async('string');
             await this.processJsonContent(jsonContent,true,images);
@@ -224,8 +223,8 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
 
         return images;
     }
-    async processJsonContent(jsonContent: string , isZip: boolean = false, images : Map<string, File> = new Map()) {
-        if(isZip){
+    async processJsonContent(jsonContent: string, isZip: boolean = false, images : Map<string, File> = new Map()) {
+        if( isZip ){
             const questions = JSON.parse(jsonContent) as QuizQuestion[];
             await this.handleConversionOfExistingQuestions(questions, images);
         } else {
@@ -243,7 +242,6 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
                 alert('Import Quiz Failed! Invalid quiz file.');
             }
         }
-
     }
 
     async onFileLoadImport(fileReader: FileReader) {
@@ -356,12 +354,12 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
                 const backgroundImageFile :File|undefined = images.get(`q${questionIndex}_background`);
                 if(backgroundImageFile) {
                     const backgroundFile = backgroundImageFile;
-                    files.set(backgroundFile.name, {path: dndQuestion.backgroundFilePath!, file: backgroundFile});
+                    files.set(backgroundFile.name, {path: dndQuestion.backgroundFilePath!, file: backgroundFile });
                     dndQuestion.backgroundFilePath = backgroundFile.name;
 
                 } else {
                     const backgroundFile = await this.fileService.getFile(dndQuestion.backgroundFilePath!, this.filePool);
-                    files.set(backgroundFile.name, {path: dndQuestion.backgroundFilePath!, file: backgroundFile});
+                    files.set(backgroundFile.name, { path: dndQuestion.backgroundFilePath!, file: backgroundFile });
                     dndQuestion.backgroundFilePath = backgroundFile.name;
                 }
 
@@ -373,21 +371,20 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
                     dropLocation.invalid = false;
                 });
                 for (const dragItem of dndQuestion.dragItems || []) {
-                    var dragItemCounter = 0
+                    var dragItemCounter = 0;
                     // Duplicating image on server. This is only valid for image drag items. For text drag items, pictureFilePath is undefined,
                     if (dragItem.pictureFilePath) {
                         const exportedDragItemFile :File|undefined = images.get(`q${questionIndex}_dragItem-${dragItemCounter}`);
-                        if(exportedDragItemFile){
+                        if (exportedDragItemFile) {
                             files.set(exportedDragItemFile.name, { path: dragItem.pictureFilePath, file: exportedDragItemFile });
                             dragItem.pictureFilePath = exportedDragItemFile.name;
-                        }
-                        else {
+                        } else {
                             const dragItemFile = await this.fileService.getFile(dragItem.pictureFilePath, this.filePool);
                             files.set(dragItemFile.name, { path: dragItem.pictureFilePath, file: dragItemFile });
                             dragItem.pictureFilePath = dragItemFile.name;
                         }
 
-                        dragItemCounter+=1
+                        dragItemCounter += 1
 
                     }
                     dragItem.tempID = dragItem.id;
@@ -440,7 +437,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
                 });
             }
             newQuizQuestions.push(question);
-            questionIndex +=1
+            questionIndex += 1
         }
         if (files.size > 0) {
             this.onFilesAdded.emit(files);

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -208,13 +208,11 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
         const images: Map<string, File> = new Map();
 
         for (const [fileName, zipEntry] of Object.entries(zipContent.files)) {
-            if (fileName.endsWith('.png') || fileName.endsWith('.jpg') || fileName.endsWith('.jpeg')) {
-                const lastDotIndex = fileName.lastIndexOf('.');
-                const fileNameNoExtension = fileName.substring(0, lastDotIndex);
-                const imageData = await zipEntry.async('blob');
-                const imageFile = new File([imageData], fileName);
-                images.set(fileNameNoExtension, imageFile);
-            }
+            const lastDotIndex = fileName.lastIndexOf('.');
+            const fileNameNoExtension = fileName.substring(0, lastDotIndex);
+            const imageData = await zipEntry.async('blob');
+            const imageFile = new File([imageData], fileName);
+            images.set(fileNameNoExtension, imageFile);
         }
         return images;
     }

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -373,9 +373,8 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
                             files.set(dragItemFile.name, { path: dragItem.pictureFilePath, file: dragItemFile });
                             dragItem.pictureFilePath = dragItemFile.name;
                         }
-
-                        dragItemCounter += 1;
                     }
+                    dragItemCounter += 1;
                     dragItem.tempID = dragItem.id;
                     dragItem.id = undefined;
                     dragItem.invalid = false;

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -206,13 +206,14 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
     }
     async extractImagesFromZip(zipContent: JSZip) {
         const images: Map<string, File> = new Map();
-
         for (const [fileName, zipEntry] of Object.entries(zipContent.files)) {
-            const lastDotIndex = fileName.lastIndexOf('.');
-            const fileNameNoExtension = fileName.substring(0, lastDotIndex);
-            const imageData = await zipEntry.async('blob');
-            const imageFile = new File([imageData], fileName);
-            images.set(fileNameNoExtension, imageFile);
+            if (!fileName.endsWith('.json')){
+                const lastDotIndex = fileName.lastIndexOf('.');
+                const fileNameNoExtension = fileName.substring(0, lastDotIndex);
+                const imageData = await zipEntry.async('blob');
+                const imageFile = new File([imageData], fileName);
+                images.set(fileNameNoExtension, imageFile);
+            }
         }
         return images;
     }

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -207,7 +207,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
     async extractImagesFromZip(zipContent: JSZip) {
         const images: Map<string, File> = new Map();
         for (const [fileName, zipEntry] of Object.entries(zipContent.files)) {
-            if (!fileName.endsWith('.json')){
+            if (!fileName.endsWith('.json')) {
                 const lastDotIndex = fileName.lastIndexOf('.');
                 const fileNameNoExtension = fileName.substring(0, lastDotIndex);
                 const imageData = await zipEntry.async('blob');

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -200,6 +200,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
             const jsonContent = await jsonFile.async('string');
             await this.processJsonContent(jsonContent, images);
         } catch (error) {
+            alert('Import Quiz Failed! Invalid zip file.');
             return;
         }
     }
@@ -231,6 +232,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
             }
         } catch (e) {
             alert('Import Quiz Failed! Invalid quiz file.');
+            return;
         }
     }
 

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -176,23 +176,23 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
         const fileExtension = fileName.split('.').last()?.toLowerCase();
 
         if (fileExtension === 'zip') {
-            await this.handleZipFile(this.importFile);
+            await this.handleZipFile();
         } else {
-            this.handleJsonFile(this.importFile);
+            this.handleJsonFile();
         }
     }
 
-    handleJsonFile(file: File) {
+    handleJsonFile() {
         const fileReader = this.generateFileReader();
         fileReader.onload = () => this.onFileLoadImport(fileReader);
-        fileReader.readAsText(file);
+        fileReader.readAsText(this.importFile!);
     }
 
-    async handleZipFile(file: File) {
+    async handleZipFile() {
         const jszip = new JSZip();
 
         try {
-            const zipContent = await jszip.loadAsync(file);
+            const zipContent = await jszip.loadAsync(this.importFile!);
             const jsonFiles = Object.keys(zipContent.files).filter((fileName) => fileName.endsWith('.json'));
 
             const images = await this.extractImagesFromZip(zipContent);

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -360,8 +360,8 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
                     dropLocation.id = undefined;
                     dropLocation.invalid = false;
                 });
+                let dragItemCounter = 0;
                 for (const dragItem of dndQuestion.dragItems || []) {
-                    var dragItemCounter = 0;
                     // Duplicating image on server. This is only valid for image drag items. For text drag items, pictureFilePath is undefined,
                     if (dragItem.pictureFilePath) {
                         const exportedDragItemFile: File | undefined = images.get(`q${questionIndex}_dragItem-${dragItemCounter}`);

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -182,6 +182,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
             await this.handleZipFile(this.importFile);
         } else {
             alert('Unsupported file type. Please upload a JSON or ZIP file.');
+            return;
         }
     }
 
@@ -198,17 +199,13 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
             const zipContent = await jszip.loadAsync(file);
             const jsonFiles = Object.keys(zipContent.files).filter(fileName => fileName.endsWith('.json'));
 
-            if (jsonFiles.length !== 1) {
-                alert('The ZIP file must contain exactly one JSON file.');
-                return;
-            }
-
             const images = await this.extractImagesFromZip(zipContent)
             const jsonFile = zipContent.files[jsonFiles[0]];
             const jsonContent = await jsonFile.async('string');
             await this.processJsonContent(jsonContent,true,images);
         } catch (error) {
             alert('Failed to read ZIP file.');
+            return;
         }
     }
     async extractImagesFromZip(zipContent: JSZip) {
@@ -332,6 +329,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
      * Convert the given list of existing QuizQuestions to a list of new QuizQuestions
      *
      * @param existingQuizQuestions the list of existing QuizQuestions to be converted
+     * @param images if a zip file was provided, the images exported will be used to create the Dnd
      * @return the list of new QuizQuestions
      */
     private async handleConversionOfExistingQuestions(existingQuizQuestions: Array<QuizQuestion>, images: Map<string, File> = new Map()) {

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -180,7 +180,6 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
         } else if (fileExtension === 'zip') {
             await this.handleZipFile(this.importFile);
         } else {
-            alert('Unsupported file type. Please upload a JSON or ZIP file.');
             return;
         }
     }
@@ -201,9 +200,8 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
             const images = await this.extractImagesFromZip(zipContent);
             const jsonFile = zipContent.files[jsonFiles[0]];
             const jsonContent = await jsonFile.async('string');
-            await this.processJsonContent(jsonContent,true,images);
+            await this.processJsonContent(jsonContent, true, images);
         } catch (error) {
-            alert('Failed to read ZIP file.');
             return;
         }
     }
@@ -214,17 +212,16 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
             if (fileName.endsWith('.png') || fileName.endsWith('.jpg') || fileName.endsWith('.jpeg')) {
                 const lastDotIndex = fileName.lastIndexOf('.');
                 const fileNameNoExtension =  fileName.substring(0, lastDotIndex);
-
                 const imageData = await zipEntry.async('blob');
                 const imageFile = new File([imageData], fileName);
                 images.set(fileNameNoExtension, imageFile);
             }
         }
-
         return images;
     }
-    async processJsonContent(jsonContent: string, isZip: boolean = false, images : Map<string, File> = new Map()) {
-        if( isZip ){
+
+    async processJsonContent(jsonContent: string, isZip: boolean = false, images: Map<string, File> = new Map()) {
+        if(isZip){
             const questions = JSON.parse(jsonContent) as QuizQuestion[];
             await this.handleConversionOfExistingQuestions(questions, images);
         } else {
@@ -352,11 +349,10 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
                 const dndQuestion = question as DragAndDropQuestion;
                 // Get image from the old question and duplicate it on the server and then save new image to the question,
                 const backgroundImageFile :File|undefined = images.get(`q${questionIndex}_background`);
-                if(backgroundImageFile) {
+                if (backgroundImageFile) {
                     const backgroundFile = backgroundImageFile;
-                    files.set(backgroundFile.name, {path: dndQuestion.backgroundFilePath!, file: backgroundFile });
+                    files.set(backgroundFile.name, { path: dndQuestion.backgroundFilePath!, file: backgroundFile });
                     dndQuestion.backgroundFilePath = backgroundFile.name;
-
                 } else {
                     const backgroundFile = await this.fileService.getFile(dndQuestion.backgroundFilePath!, this.filePool);
                     files.set(backgroundFile.name, { path: dndQuestion.backgroundFilePath!, file: backgroundFile });
@@ -374,7 +370,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
                     var dragItemCounter = 0;
                     // Duplicating image on server. This is only valid for image drag items. For text drag items, pictureFilePath is undefined,
                     if (dragItem.pictureFilePath) {
-                        const exportedDragItemFile :File|undefined = images.get(`q${questionIndex}_dragItem-${dragItemCounter}`);
+                        const exportedDragItemFile: File | undefined = images.get(`q${questionIndex}_dragItem-${dragItemCounter}`);
                         if (exportedDragItemFile) {
                             files.set(exportedDragItemFile.name, { path: dragItem.pictureFilePath, file: exportedDragItemFile });
                             dragItem.pictureFilePath = exportedDragItemFile.name;
@@ -384,8 +380,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
                             dragItem.pictureFilePath = dragItemFile.name;
                         }
 
-                        dragItemCounter += 1
-
+                        dragItemCounter += 1;
                     }
                     dragItem.tempID = dragItem.id;
                     dragItem.id = undefined;
@@ -437,7 +432,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
                 });
             }
             newQuizQuestions.push(question);
-            questionIndex += 1
+            questionIndex += 1;
         }
         if (files.size > 0) {
             this.onFilesAdded.emit(files);

--- a/src/main/webapp/i18n/de/quizExercise.json
+++ b/src/main/webapp/i18n/de/quizExercise.json
@@ -228,7 +228,7 @@
                 "proportional_with_penalty": "Jede richtige Antwort führt zu einem Bruchteil der Gesamtpunktzahl. Um Rätselraten zu vermeiden, wird für jeden Fehler der gleiche Anteil von den erreichten Punkten abgezogen. Beispiel: Wenn die Punktzahl der Frage 3 ist und es 5 Optionen gibt, ergibt jede richtige Antwortmöglichkeit 0,6 Punkte. Jede falsche Antwortmöglichkeit zieht 0,6 Punkte ab. Studierende mit 3 richtigen und 2 falschen Antworten erhalten dann 0,6 Punkte.",
                 "proportional_without_penalty": "Jede richtige Antwort führt zu einem Bruchteil der Gesamtpunktzahl. Bei falschen Antworten werden keine Punkte abgezogen. Beispiel: Wenn die Punktzahl der Frage 3 ist und es 5 Optionen gibt, ergibt jede richtige Antwortmöglichkeit 0,6 Punkte. Studierende mit 3 richtigen und 2 falschen Antworten erhalten dann 1,8 Punkte."
             },
-            "importJSON": "Fragen importieren (JSON)",
+            "importJSON": "Fragen importieren (JSON/Zip)",
             "importWarningShort": "Ungültige Fragen gefunden",
             "importWarningLong": "Bei den folgenden Fragen ist ein ungültiges Flag gesetzt. Bist du sicher, dass du fortfahren möchtest? <strong>In diesem Fall werden die ungültigen Flags zurückgesetzt</ strong>.",
             "confirmImport": "Weiter",

--- a/src/main/webapp/i18n/en/quizExercise.json
+++ b/src/main/webapp/i18n/en/quizExercise.json
@@ -228,7 +228,7 @@
                 "proportional_with_penalty": "Each correct answer is awarded with a fraction of the total score. To avoid guesswork, the same fraction is subtracted from the achieved points for each mistake. Example: if the question contains 3 points and 5 answer options, each correct answer option is awarded with 0.6 points. Each wrong answer option subtracts 0.6 points. A student with 3 correct and 2 wrong answers would then receive 0.6 points.",
                 "proportional_without_penalty": "Each correct answer is awarded with a fraction of the total score. No points are deducted for mistakes. Example: if the question contains 3 points and 5 answer options, each correct answer option is awarded with 0.6 points. A student with 3 correct and 2 wrong answers would then receive 1.8 points."
             },
-            "importJSON": "Import Question(s) in JSON Format",
+            "importJSON": "Import Question(s) in JSON/Zip Format",
             "importWarningShort": "Invalid questions found",
             "importWarningLong": "The following questions have an invalid flag set. Are you sure you want to continue? <strong>If so, the invalid flags will be reset</strong>.",
             "confirmImport": "Continue",

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
@@ -30,6 +30,7 @@ import { ChangeDetectorRef, EventEmitter } from '@angular/core';
 import { QuizQuestion } from 'app/entities/quiz/quiz-question.model';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FileService } from 'app/shared/http/file.service';
+import JSZip from 'jszip';
 
 const createValidMCQuestion = () => {
     const question = new MultipleChoiceQuestion();
@@ -445,6 +446,51 @@ describe('QuizQuestionListEditExistingComponent', () => {
             expect(onQuestionsAddedSpy).toHaveBeenCalledOnce();
             expect(onFilesAddedSpy).toHaveBeenCalledOnce();
             expect(getFileMock).toHaveBeenCalledTimes(3);
+        });
+        it('should correctly differentiate between JSON and ZIP files', async () => {
+            const handleJsonFileSpy = jest.spyOn(component, 'handleJsonFile');
+            const handleZipFileSpy = jest.spyOn(component, 'handleZipFile');
+
+            // Test JSON file
+            const jsonFile = new File(['{}'], 'quiz.json', { type: 'application/json' });
+            component.importFile = jsonFile;
+            await component.importQuiz();
+            expect(handleJsonFileSpy).toHaveBeenCalledWith(jsonFile);
+
+            // Test ZIP file
+            const zipFile = new File([], 'quiz.zip', { type: 'application/zip' });
+            component.importFile = zipFile;
+            await component.importQuiz();
+            expect(handleZipFileSpy).toHaveBeenCalledWith(zipFile);
+        });
+        it('should correctly extract images from a ZIP file', async () => {
+            const extractImagesFromZipSpy = jest.spyOn(component, 'extractImagesFromZip');
+
+            const zip = new JSZip();
+            zip.file('image1.png', 'fakeImageData1');
+            zip.file('image2.jpg', 'fakeImageData2');
+            zip.file('data.json', '{}');
+            const zipContent = await zip.generateAsync({ type: 'blob' });
+
+            // Use a blob to simulate the file
+            component.importFile = new File([zipContent], 'quiz.zip', { type: 'application/zip' });
+
+            const extractedImages = new Map();
+            extractedImages.set('image1', new File(['fakeImageData1'], 'image1.png'));
+            extractedImages.set('image2', new File(['fakeImageData2'], 'image2.jpg'));
+
+            // Mocking JSZip methods
+            jest.spyOn(JSZip.prototype, 'loadAsync').mockResolvedValue(zip);
+            jest.spyOn(zip.files['image1.png'], 'async').mockResolvedValue(new Blob(['fakeImageData1']));
+            jest.spyOn(zip.files['image2.jpg'], 'async').mockResolvedValue(new Blob(['fakeImageData2']));
+
+            const result = await component.extractImagesFromZip(zip);
+
+            // Verify images are correctly extracted
+            expect(extractImagesFromZipSpy).toHaveBeenCalledWith(zip);
+            expect(result.size).toBe(2);
+            expect(result.has('image1')).toBe(true);
+            expect(result.has('image2')).toBe(true);
         });
     });
 });

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
@@ -447,18 +447,18 @@ describe('QuizQuestionListEditExistingComponent', () => {
             expect(onFilesAddedSpy).toHaveBeenCalledOnce();
             expect(getFileMock).toHaveBeenCalledTimes(3);
         });
-        
+
         it('should correctly differentiate between JSON and ZIP files', async () => {
             const handleJsonFileSpy = jest.spyOn(component, 'handleJsonFile');
             const handleZipFileSpy = jest.spyOn(component, 'handleZipFile');
             const jsonFile = new File(['{}'], 'quiz.json', { type: 'application/json' });
             component.importFile = jsonFile;
             await component.importQuiz();
-            expect(handleJsonFileSpy).toHaveBeenCalledWith(jsonFile);
+            expect(handleJsonFileSpy).toHaveBeenCalledWith();
             const zipFile = new File([], 'quiz.zip', { type: 'application/zip' });
             component.importFile = zipFile;
             await component.importQuiz();
-            expect(handleZipFileSpy).toHaveBeenCalledWith(zipFile);
+            expect(handleZipFileSpy).toHaveBeenCalledWith();
         });
 
         it('should correctly extract images from a ZIP file', async () => {

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
@@ -447,6 +447,7 @@ describe('QuizQuestionListEditExistingComponent', () => {
             expect(onFilesAddedSpy).toHaveBeenCalledOnce();
             expect(getFileMock).toHaveBeenCalledTimes(3);
         });
+        
         it('should correctly differentiate between JSON and ZIP files', async () => {
             const handleJsonFileSpy = jest.spyOn(component, 'handleJsonFile');
             const handleZipFileSpy = jest.spyOn(component, 'handleZipFile');
@@ -459,6 +460,7 @@ describe('QuizQuestionListEditExistingComponent', () => {
             await component.importQuiz();
             expect(handleZipFileSpy).toHaveBeenCalledWith(zipFile);
         });
+
         it('should correctly extract images from a ZIP file', async () => {
             const extractImagesFromZipSpy = jest.spyOn(component, 'extractImagesFromZip');
             const zip = new JSZip();

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
@@ -341,7 +341,7 @@ describe('QuizQuestionListEditExistingComponent', () => {
             expect(generateFileReaderStub).toHaveBeenCalledOnce();
             const addQuestionSpy = jest.spyOn(component, 'addQuestions').mockImplementation();
             await component.onFileLoadImport(reader);
-            expect(addQuestionSpy).toHaveBeenCalledWith(questions);
+            expect(addQuestionSpy).toHaveBeenCalledWith(questions, new Map());
             expect(component.importFile).toBeUndefined();
             expect(component.importFileName).toBe('');
             expect(getElementStub).toHaveBeenCalledOnce();

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
@@ -477,8 +477,8 @@ describe('QuizQuestionListEditExistingComponent', () => {
             const result = await component.extractImagesFromZip(zip);
             expect(extractImagesFromZipSpy).toHaveBeenCalledWith(zip);
             expect(result.size).toBe(2);
-            expect(result.has('image1')).toBe(true);
-            expect(result.has('image2')).toBe(true);
+            expect(result.has('image1')).toBeTrue();
+            expect(result.has('image2')).toBeTrue();
         });
     });
 });

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
@@ -450,14 +450,10 @@ describe('QuizQuestionListEditExistingComponent', () => {
         it('should correctly differentiate between JSON and ZIP files', async () => {
             const handleJsonFileSpy = jest.spyOn(component, 'handleJsonFile');
             const handleZipFileSpy = jest.spyOn(component, 'handleZipFile');
-
-            // Test JSON file
             const jsonFile = new File(['{}'], 'quiz.json', { type: 'application/json' });
             component.importFile = jsonFile;
             await component.importQuiz();
             expect(handleJsonFileSpy).toHaveBeenCalledWith(jsonFile);
-
-            // Test ZIP file
             const zipFile = new File([], 'quiz.zip', { type: 'application/zip' });
             component.importFile = zipFile;
             await component.importQuiz();
@@ -465,28 +461,20 @@ describe('QuizQuestionListEditExistingComponent', () => {
         });
         it('should correctly extract images from a ZIP file', async () => {
             const extractImagesFromZipSpy = jest.spyOn(component, 'extractImagesFromZip');
-
             const zip = new JSZip();
             zip.file('image1.png', 'fakeImageData1');
             zip.file('image2.jpg', 'fakeImageData2');
             zip.file('data.json', '{}');
             const zipContent = await zip.generateAsync({ type: 'blob' });
 
-            // Use a blob to simulate the file
             component.importFile = new File([zipContent], 'quiz.zip', { type: 'application/zip' });
-
             const extractedImages = new Map();
             extractedImages.set('image1', new File(['fakeImageData1'], 'image1.png'));
             extractedImages.set('image2', new File(['fakeImageData2'], 'image2.jpg'));
-
-            // Mocking JSZip methods
             jest.spyOn(JSZip.prototype, 'loadAsync').mockResolvedValue(zip);
             jest.spyOn(zip.files['image1.png'], 'async').mockResolvedValue(new Blob(['fakeImageData1']));
             jest.spyOn(zip.files['image2.jpg'], 'async').mockResolvedValue(new Blob(['fakeImageData2']));
-
             const result = await component.extractImagesFromZip(zip);
-
-            // Verify images are correctly extracted
             expect(extractImagesFromZipSpy).toHaveBeenCalledWith(zip);
             expect(result.size).toBe(2);
             expect(result.has('image1')).toBe(true);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
~- [ ] I added multiple screenshots/screencasts of my UI changes.~
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I translated all newly inserted strings into English and German. todo


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A previous [Pull Request](https://github.com/ls1intum/Artemis/pull/8841) allowed for the images of quiz exercises to be exported along the json file in a zip folder. The primary goal was to save images even after a quiz is deleted. 
However, it is less intuitive for users that they have to find the json file inside the zip folder. This PR allows the users to import quiz exercises with the downloaded zip folder directly as well as with json alone. The benefit of importing with the zip folder is that while json fails to import dnd exercises of deleted quizes, the zip folder retains the data.

### Description
<!-- Describe your changes in detail -->
The Json import functionality would previously look for the image paths on DnD exercises to try to recreate the quiz. This could lead to failed imports because these paths are deleted with the quiz. Now, the import functionality checks if there is a corresponding image to the imported exercise, and prioritieses the images in the zip folder even if a path exists . The json import has remained unchanged. 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Quiz Exercises

1. Log in to Artemis
2. Navigate to Course Management
3. Create Quiz with at least 1 Drag And Drop(DnD) Exercise. (A quiz without any images is exported as a json)
4. Export the Exercise -> zip folder with a json and the images is downloaded
5. Create new Quiz, scroll down and click on "Add Existing Exercises"
6. Try to import the quiz using the Zip File 
7. Delete the original quiz and try to import it again through the zip. (json import would fail here)
8. Confirm Success (Have to press save to see the images, this is how it was before as well)

Json import should still work as they used to.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->
<!-- 
#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance  -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Expanded file upload support to include both JSON and ZIP formats for quiz imports.
  - Improved handling of images extracted from ZIP files during quiz question import.

- **Bug Fixes**
  - Enhanced file import process reliability by ensuring appropriate handlers are called based on file type.

- **Documentation**
  - Updated localization strings for German and English to reflect the new file types supported in the import feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->