### PR TITLE
`Exam mode`: Disable start button when waiting for response

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -103,7 +103,7 @@
                 </div>
             </div>
             <ng-container #startButton>
-                <button id="start-exam" [disabled]="!startButtonEnabled || waitingForExamStart" type="submit" (click)="startExam()" class="btn btn-primary">
+                <button id="start-exam" [disabled]="!startButtonEnabled || waitingForExamStart || waitingForExamFetching" type="submit" (click)="startExam()" class="btn btn-primary">
                     <span jhiTranslate="artemisApp.exam.startExam"></span>
                 </button>
                 @if (!startButtonEnabled) {

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -103,7 +103,7 @@
                 </div>
             </div>
             <ng-container #startButton>
-                <button id="start-exam" [disabled]="!startButtonEnabled || waitingForExamStart || waitingForExamFetching" type="submit" (click)="startExam()" class="btn btn-primary">
+                <button id="start-exam" [disabled]="!startButtonEnabled || waitingForExamStart || isFetching" type="submit" (click)="startExam()" class="btn btn-primary">
                     <span jhiTranslate="artemisApp.exam.startExam"></span>
                 </button>
                 @if (!startButtonEnabled) {

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
@@ -51,6 +51,7 @@ export class ExamParticipationCoverComponent implements OnChanges, OnDestroy, On
 
     interval: number;
     waitingForExamStart = false;
+    waitingForExamFetching = false;
     timeUntilStart = '0';
 
     accountName = '';
@@ -149,9 +150,11 @@ export class ExamParticipationCoverComponent implements OnChanges, OnDestroy, On
             this.examParticipationService.saveStudentExamToLocalStorage(this.exam.course!.id!, this.exam.id!, this.studentExam);
             this.onExamStarted.emit(this.studentExam);
         } else {
+            this.waitingForExamFetching = true;
             this.examParticipationService
                 .loadStudentExamWithExercisesForConduction(this.exam.course!.id!, this.exam.id!, this.studentExam.id!)
                 .subscribe((studentExam: StudentExam) => {
+                    this.waitingForExamFetching = false;
                     this.studentExam = studentExam;
                     this.examParticipationService.saveStudentExamToLocalStorage(this.exam.course!.id!, this.exam.id!, studentExam);
                     if (this.hasStarted()) {

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
@@ -13,6 +13,7 @@ import dayjs from 'dayjs/esm';
 import { EXAM_START_WAIT_TIME_MINUTES } from 'app/app.constants';
 import { UI_RELOAD_TIME } from 'app/shared/constants/exercise-exam-constants';
 import { faArrowLeft, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { Subscription } from 'rxjs';
 
 @Component({
     selector: 'jhi-exam-participation-cover',
@@ -51,7 +52,8 @@ export class ExamParticipationCoverComponent implements OnChanges, OnDestroy, On
 
     interval: number;
     waitingForExamStart = false;
-    waitingForExamFetching = false;
+    isFetching = false;
+    loadExamSubscription?: Subscription;
     timeUntilStart = '0';
 
     accountName = '';
@@ -117,6 +119,7 @@ export class ExamParticipationCoverComponent implements OnChanges, OnDestroy, On
         if (this.interval) {
             clearInterval(this.interval);
         }
+        this.loadExamSubscription?.unsubscribe();
     }
 
     /**
@@ -150,11 +153,11 @@ export class ExamParticipationCoverComponent implements OnChanges, OnDestroy, On
             this.examParticipationService.saveStudentExamToLocalStorage(this.exam.course!.id!, this.exam.id!, this.studentExam);
             this.onExamStarted.emit(this.studentExam);
         } else {
-            this.waitingForExamFetching = true;
-            this.examParticipationService
+            this.isFetching = true;
+            this.loadExamSubscription = this.examParticipationService
                 .loadStudentExamWithExercisesForConduction(this.exam.course!.id!, this.exam.id!, this.studentExam.id!)
                 .subscribe((studentExam: StudentExam) => {
-                    this.waitingForExamFetching = false;
+                    this.isFetching = false;
                     this.studentExam = studentExam;
                     this.examParticipationService.saveStudentExamToLocalStorage(this.exam.course!.id!, this.exam.id!, studentExam);
                     if (this.hasStarted()) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When Artemis slows down during exam start, students can repeatedly fetch the exam from the server via the start exam button. This adds additional load that can be reduced by disableing the button while waiting for the server response.

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Students
- 1 Exam that will start in the future (>5 min)

1. Navigate to the exam
2. Enter the name and tick the checkbox
3. The button should be disabled (read text below)
4. Wait until it's less than 5 min to start the exam
5. The button should now be enabled
6. Klick the button
7. While the client is waiting for the response the button should be disabled (can be very short on a system that's currently not failing)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Exam Mode Test
- [x] Test 1
- [ ] Test 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved logic for enabling and disabling the "Start Exam" button to enhance user experience, preventing premature exam starts.
	- Added a new state to track when exam data is being fetched, allowing for better state management during exam participation.

- **Bug Fixes**
	- Adjusted component logic to differentiate between waiting for exam data and waiting for the exam to start, improving clarity in user interface feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->