### PR TITLE
`Quiz exercises`: Add warning when saving questions with too many items

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizSubmission.java
@@ -35,4 +35,12 @@ public class QuizSubmission extends AbstractQuizSubmission {
     public String toString() {
         return "QuizSubmission{" + "id=" + getId() + ", scoreInPoints='" + getScoreInPoints() + "'" + "}";
     }
+
+    public void filterForStudentsDuringQuiz() {
+        for (SubmittedAnswer submittedAnswer : getSubmittedAnswers()) {
+            if (submittedAnswer.getQuizQuestion() != null) {
+                submittedAnswer.getQuizQuestion().filterForStudentsDuringQuiz();
+            }
+        }
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizSubmissionService.java
@@ -277,6 +277,7 @@ public class QuizSubmissionService extends AbstractQuizSubmissionService<QuizSub
         var participation = participationService.findOneByExerciseAndStudentLoginAnyState(quizExercise, userLogin).orElseThrow();
         quizSubmission.setParticipation(participation);
         quizSubmission = quizSubmissionRepository.save(quizSubmission);
+        quizSubmission.filterForStudentsDuringQuiz();
         log.info("{} Saved quiz submission for user {} in quiz {} after {} ", logText, userLogin, exerciseId, TimeLogUtil.formatDurationFrom(start));
 
         return quizSubmission;
@@ -386,6 +387,8 @@ public class QuizSubmissionService extends AbstractQuizSubmissionService<QuizSub
     @Override
     protected QuizSubmission save(QuizExercise quizExercise, QuizSubmission quizSubmission, User user) {
         quizSubmission.setParticipation(this.getParticipation(quizExercise, quizSubmission, user));
-        return quizSubmissionRepository.save(quizSubmission);
+        var savedQuizSubmission = quizSubmissionRepository.save(quizSubmission);
+        savedQuizSubmission.filterForStudentsDuringQuiz();
+        return savedQuizSubmission;
     }
 }

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-update.component.html
@@ -320,7 +320,7 @@
                         <button
                             id="quiz-save"
                             class="btn btn-success"
-                            (click)="save()"
+                            (click)="validateItemLimit()"
                             [disabled]="isSaveDisabled()"
                             jhiTranslate="entity.action.save"
                             [ngbTooltip]="quizIsValid ? '' : tooltipTranslate"

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-update.component.ts
@@ -401,8 +401,8 @@ export class QuizExerciseUpdateComponent extends QuizExerciseValidationDirective
             const numberOfDropLocations = dragAndDropQuestion.dropLocations?.length ?? 1;
             const numberOfDragItems = dragAndDropQuestion.dragItems?.length ?? 1;
             const numberOfCorrectMappings = dragAndDropQuestion.correctMappings?.length ?? 1;
-            // Magic number is 15 * 15 * 15
-            return numberOfCorrectMappings * numberOfDragItems * numberOfDropLocations > 3375;
+            // Magic number is 13 * 13 * 13
+            return numberOfCorrectMappings * numberOfDragItems * numberOfDropLocations > 2197;
         });
     }
     checkItemCountShortAnswer(shortAnswerQuestions: ShortAnswerQuestion[]): boolean {
@@ -411,8 +411,8 @@ export class QuizExerciseUpdateComponent extends QuizExerciseValidationDirective
             const numberOfCorrectMappings = shortAnswerQuestion.correctMappings?.length ?? 1;
             const numberOfSpots = shortAnswerQuestion.spots?.length ?? 1;
             const numberOfSolutions = shortAnswerQuestion.solutions?.length ?? 1;
-            // Magic number is 15 * 15 * 15
-            return numberOfCorrectMappings * numberOfSpots * numberOfSolutions > 3375;
+            // Magic number is 13 * 13 * 13
+            return numberOfCorrectMappings * numberOfSpots * numberOfSolutions > 2197;
         });
     }
 

--- a/src/main/webapp/i18n/de/quizExercise.json
+++ b/src/main/webapp/i18n/de/quizExercise.json
@@ -1,5 +1,11 @@
 {
     "artemisApp": {
+        "quizWarning": {
+            "title": "Achtung!",
+            "question": "Mögliche Leistungsprobleme",
+            "description": "Du verwendest in dieser Quizaufgabe eine sehr große Anzahl an Short-Answer Elementen und/oder Drag-and-Drop Elementen. Dies kann zu erheblichen Performancebeeinträchtigungen führen. Bist du sicher, dass du die Aufgabe so speichern möchtest?",
+            "confirmButton": "Trotzdem speichern"
+        },
         "quizExercise": {
             "home": {
                 "title": "Quiz",

--- a/src/main/webapp/i18n/en/quizExercise.json
+++ b/src/main/webapp/i18n/en/quizExercise.json
@@ -3,7 +3,7 @@
         "quizWarning": {
             "title": "Attention!",
             "question": "Potential Performance Issues",
-            "description": "You are using a very large number of Short-Answer items and/or Drag-and-Drop items in this quiz. This can lead to significant performance issues. Are you sure you want to save the task this way?",
+            "description": "You are using a very large number of Short-Answer items and/or Drag-and-Drop items in this quiz. This can lead to significant performance issues. Are you sure you want to save the exercise this way?",
             "confirmButton": "Save anyway"
         },
         "quizExercise": {

--- a/src/main/webapp/i18n/en/quizExercise.json
+++ b/src/main/webapp/i18n/en/quizExercise.json
@@ -1,5 +1,11 @@
 {
     "artemisApp": {
+        "quizWarning": {
+            "title": "Attention!",
+            "question": "Potential Performance Issues",
+            "description": "You are using a very large number of Short-Answer items and/or Drag-and-Drop items in this quiz. This can lead to significant performance issues. Are you sure you want to save the task this way?",
+            "confirmButton": "Save anyway"
+        },
         "quizExercise": {
             "home": {
                 "title": "Quiz Exercises",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Quiz exercises with a large amount of drag and drop and/or short answer items lead to performance issues. 


### Description
<!-- Describe your changes in detail -->
Add a modal dialog that warns the user of possible performance issues, when adding a large amount of drag and drop and/or short answer items. Since we want to allow instructors to edit existing exercises we don't prevent the save-option completely. 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Management
3. Go to Exercises
4. Create or Edit a Quiz Exercise
5. Add a Drag and Drop Question with at least 13 * 13 * 13 + 1 items (Drag Items, Drag Locations, CorrectMappings)
6. Verify that the modal dialog appears
7. On Cancel the modal dialog should close (nothing else happens), on Save Anyway the exercise should be saved
8. Add a Short Answer Question with at least 13 * 13 * 13 + 1 items (Spots, Solutions, CorrectMappings)
9. Verify that the modal dialog appears
10. On Cancel the modal dialog should close (nothing else happens), on Save Anyway the exercise should be saved



### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![Screenshot 2024-07-26 at 10 47 59](https://github.com/user-attachments/assets/27d32631-1569-4754-b5b1-ced6db9cd084)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced quiz management functionality with improved validation for item limits on Short-Answer and Drag-and-Drop questions.
	- Introduced modal dialogs for user confirmation when performance risks are detected from quiz configurations.
	- Added warnings to inform users of potential performance issues when saving quizzes with many interactive elements.

- **Bug Fixes**
	- Improved control flow for the save button to ensure validations are performed before saving.

- **Documentation**
	- Updated JSON files with new warning messages in both English and German to enhance user awareness regarding performance concerns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->