### PR TITLE
`Quiz exercises`: Remove evaluate button from overview

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-manage-buttons.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-manage-buttons.component.html
@@ -30,40 +30,34 @@
         </div>
     }
     <div class="{{ isDetailPage ? 'd-flex' : 'btn-group-vertical me-1 mb-1' }} ">
-        @if (quizExercise.isAtLeastInstructor) {
+        @if (quizExercise.isAtLeastEditor) {
             <button type="submit" (click)="exportQuizExercise(true)" class="btn btn-warning btn-sm me-1 mb-1">
                 <fa-icon [icon]="faFileExport" />
                 <span class="d-none d-md-inline" jhiTranslate="entity.action.export"></span>
             </button>
         }
-        @if (quizExercise.isAtLeastEditor) {
-            <a
-                [hidden]="quizExercise.quizEnded"
-                [class.disabled]="!quizExercise.isEditable"
-                [routerLink]="[baseUrl, 'quiz-exercises', quizExercise.id, 'edit']"
-                class="btn btn-warning btn-sm me-1 mb-1"
-            >
-                <div>
-                    <fa-icon [icon]="faWrench" />
-                    <span class="d-none d-md-inline" jhiTranslate="entity.action.edit"></span>
-                </div>
+        @if (quizExercise.isAtLeastEditor && !quizExercise.quizEnded) {
+            <a [class.disabled]="!quizExercise.isEditable" [routerLink]="[baseUrl, 'quiz-exercises', quizExercise.id, 'edit']" class="btn btn-warning btn-sm me-1 mb-1">
+                <fa-icon [icon]="faWrench" />
+                <span class="d-none d-md-inline" jhiTranslate="entity.action.edit"></span>
             </a>
         }
-        @if (quizExercise.isAtLeastInstructor) {
-            <a [hidden]="!quizExercise.quizEnded" [routerLink]="[baseUrl, 'quiz-exercises', quizExercise.id, 're-evaluate']" class="btn btn-warning btn-sm me-1 mb-1">
+        @if (quizExercise.isAtLeastInstructor && quizExercise.quizEnded) {
+            <a [routerLink]="[baseUrl, 'quiz-exercises', quizExercise.id, 're-evaluate']" class="btn btn-warning btn-sm me-1 mb-1">
                 <fa-icon [icon]="faWrench" />
                 <span class="d-none d-md-inline" jhiTranslate="entity.action.re-evaluate"></span>
             </a>
-            <jhi-button
-                [btnType]="ButtonType.WARNING"
-                [btnSize]="ButtonSize.SMALL"
-                [title]="'artemisApp.quizExercise.evaluateQuizExercise'"
-                [icon]="faClipboardCheck"
-                [isLoading]="isEvaluatingQuizExercise"
-                (onClick)="evaluateQuizExercise()"
-                [hidden]="!quizExercise.quizEnded"
-                class="me-1 mb-1"
-            />
+            @if (isDetailPage) {
+                <jhi-button
+                    [btnType]="ButtonType.WARNING"
+                    [btnSize]="ButtonSize.SMALL"
+                    [title]="'artemisApp.quizExercise.evaluateQuizExercise'"
+                    [icon]="faClipboardCheck"
+                    [isLoading]="isEvaluatingQuizExercise"
+                    (onClick)="evaluateQuizExercise()"
+                    class="me-1 mb-1"
+                />
+            }
         }
     </div>
     @if (quizExercise.isAtLeastInstructor) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The exercise overview is built to display two buttons per column. If there are more than that, the alignment is off and the buttons get quite small and unusable.

### Description
<!-- Describe your changes in detail -->
Remove the evaluate button from the exercise overview, the button should be still visible in the exercise detail view.
Enable the quiz export button for editors in the exercise overview as well as in the details page.
Additionally moved some hidden attributes into the conditions of `@if`s

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Editor
- 3 Quiz exercises (1 unreleased, 1 running, 1 after the working time)

1. Log in to Artemis
2. Navigate to the exercise overview as instructor
3. Look that there are at most 2 buttons per column for quiz exercises
4. Check that the evaluate button is still present in the detail page of the ended quiz
5. Navigate to the exercise overview as editor
6. Look that there are at most 2 buttons per column for quiz exercises
7. Check that the export button is visible both in the overview and detail page

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
#### Editor view
Overview:
<img width="1699" alt="Bildschirmfoto 2024-07-26 um 11 35 46" src="https://github.com/user-attachments/assets/23bf9386-f2b8-4689-b06a-4045d9e9fdf9">
Detail view:
<img width="634" alt="Bildschirmfoto 2024-07-26 um 11 36 00" src="https://github.com/user-attachments/assets/1aa4ee38-af2d-4064-909b-8dcb0a77902f">


#### Instructor view
Overview:
<img width="1697" alt="Bildschirmfoto 2024-07-26 um 11 36 32" src="https://github.com/user-attachments/assets/5ec3f392-fb90-480f-bf4c-1d15acf0a330">
Detail view:
<img width="1005" alt="Bildschirmfoto 2024-07-26 um 11 36 20" src="https://github.com/user-attachments/assets/47e33f05-32f1-4e2f-a101-8c719ee1638e">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded access for users with the Editor role to export quiz exercises.
	- Enhanced conditional logic for displaying edit links based on quiz status.

- **Improvements**
	- Refined visibility of buttons and links based on user roles and quiz state, improving overall usability and contextual relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->