### PR TITLE
`Team exercises`: Fix exercise export

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -471,8 +471,8 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
             """)
     List<ProgrammingExercise> findAllProgrammingExercisesInCourseOrInExamsOfCourse(@Param("course") Course course);
 
-    @EntityGraph(type = LOAD, attributePaths = { "plagiarismDetectionConfig" })
-    Optional<ProgrammingExercise> findWithPlagiarismDetectionConfigById(long exerciseId);
+    @EntityGraph(type = LOAD, attributePaths = { "plagiarismDetectionConfig", "teamAssignmentConfig" })
+    Optional<ProgrammingExercise> findWithPlagiarismDetectionConfigAndTeamConfigById(long exerciseId);
 
     long countByShortNameAndCourse(String shortName, Course course);
 
@@ -501,15 +501,16 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
     }
 
     /**
-     * Find a programming exercise by its id and fetch related plagiarism detection config.
+     * Find a programming exercise by its id and fetch related plagiarism detection config and team config.
      * Throws an EntityNotFoundException if the exercise cannot be found.
      *
      * @param programmingExerciseId of the programming exercise.
      * @return The programming exercise related to the given id
      */
     @NotNull
-    default ProgrammingExercise findByIdWithPlagiarismDetectionConfigElseThrow(long programmingExerciseId) throws EntityNotFoundException {
-        return findWithPlagiarismDetectionConfigById(programmingExerciseId).orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
+    default ProgrammingExercise findByIdWithPlagiarismDetectionConfigAndTeamConfigElseThrow(long programmingExerciseId) throws EntityNotFoundException {
+        return findWithPlagiarismDetectionConfigAndTeamConfigById(programmingExerciseId)
+                .orElseThrow(() -> new EntityNotFoundException("Programming Exercise", programmingExerciseId));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/programming/ProgrammingExerciseExportImportResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/programming/ProgrammingExerciseExportImportResource.java
@@ -319,7 +319,7 @@ public class ProgrammingExerciseExportImportResource {
     @EnforceAtLeastInstructor
     @FeatureToggle({ Feature.ProgrammingExercises, Feature.Exports })
     public ResponseEntity<Resource> exportInstructorExercise(@PathVariable long exerciseId) throws IOException {
-        var programmingExercise = programmingExerciseRepository.findByIdWithPlagiarismDetectionConfigElseThrow(exerciseId);
+        var programmingExercise = programmingExerciseRepository.findByIdWithPlagiarismDetectionConfigAndTeamConfigElseThrow(exerciseId);
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, programmingExercise, null);
 
         long start = System.nanoTime();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseGitlabJenkinsIntegrationTest.java
@@ -487,6 +487,12 @@ class ProgrammingExerciseGitlabJenkinsIntegrationTest extends AbstractSpringInte
     }
 
     @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testExportProgrammingExerciseInstructorMaterial_withTeamConfig() throws Exception {
+        programmingExerciseTestService.exportProgrammingExerciseInstructorMaterial_withTeamConfig();
+    }
+
+    @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void exportProgrammingExerciseInstructorMaterialAsTutor_forbidden() throws Exception {
         programmingExerciseTestService.exportProgrammingExerciseInstructorMaterial_forbidden();

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseTestService.java
@@ -68,6 +68,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import de.tum.in.www1.artemis.config.StaticCodeAnalysisConfigurer;
 import de.tum.in.www1.artemis.course.CourseUtilService;
 import de.tum.in.www1.artemis.domain.Authority;
@@ -264,6 +266,9 @@ public class ProgrammingExerciseTestService {
 
     @Autowired
     private BuildPlanRepository buildPlanRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     public Course course;
 
@@ -1624,6 +1629,38 @@ public class ProgrammingExerciseTestService {
             else {
                 assertThat(listOfIncludedFiles).noneMatch((filename) -> BUILD_PLAN_FILE_NAME.equals(filename.toString()));
             }
+        }
+
+        FileUtils.deleteDirectory(extractedZipDir.toFile());
+        FileUtils.delete(zipFile);
+    }
+
+    void exportProgrammingExerciseInstructorMaterial_withTeamConfig() throws Exception {
+        TeamAssignmentConfig teamAssignmentConfig = new TeamAssignmentConfig();
+        teamAssignmentConfig.setExercise(exercise);
+        teamAssignmentConfig.setMinTeamSize(1);
+        teamAssignmentConfig.setMaxTeamSize(10);
+        exercise.setTeamAssignmentConfig(teamAssignmentConfig);
+        exercise = programmingExerciseRepository.save(exercise);
+
+        var zipFile = exportProgrammingExerciseInstructorMaterial(HttpStatus.OK, true);
+        // Assure, that the zip folder is already created and not 'in creation' which would lead to a failure when extracting it in the next step
+        await().until(zipFile::exists);
+        assertThat(zipFile).isNotNull();
+
+        // Recursively unzip the exported file, to make sure there is no erroneous content
+        Path extractedZipDir = zipFileTestUtilService.extractZipFileRecursively(zipFile.getAbsolutePath());
+
+        try (var files = Files.walk(extractedZipDir)) {
+            // Only test the correctly exported team assignment, other properties are tested above
+            var json = files.filter(Files::isRegularFile).filter(file -> file.getFileName().toString().matches(EXPORTED_EXERCISE_DETAILS_FILE_PREFIX + ".*.json")).findFirst();
+            assertThat(json).isPresent();
+
+            var exportedExercise = objectMapper.readValue(json.get().toFile(), ProgrammingExercise.class);
+            assertThat(exportedExercise.getTeamAssignmentConfig()).isNotNull();
+            assertThat(exportedExercise.getTeamAssignmentConfig().getId()).isNull();
+            assertThat(exportedExercise.getTeamAssignmentConfig().getMinTeamSize()).isEqualTo(1);
+            assertThat(exportedExercise.getTeamAssignmentConfig().getMaxTeamSize()).isEqualTo(10);
         }
 
         FileUtils.deleteDirectory(extractedZipDir.toFile());


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
Exporting a team programming exercise currently leads to an error. Fixes #9113


### Description
The team configuration should also get exported, but it was not fetched from the database.


### Steps for Testing
Create a programming exercise for teams and press the export exercise button. Check that the export works correctly.

#### Exam Mode Testing
not necessary since there are no team exercises in exams afaik.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
test added, coverage unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded functionality for fetching programming exercises to include team assignment configurations.
	- Enhanced export functionality for programming exercises to incorporate team configurations.

- **Bug Fixes**
	- Improved reliability in retrieving programming exercises by updating method calls and signatures.

- **Tests**
	- Added new tests to validate the export process of programming exercises involving team configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->