### PR TITLE
`Development`: Fix pre-commit hook deprecation warning

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm exec --no lint-staged --shell
+lint-staged --shell


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
Running the pre-commit hooks currently prints a deprecation warning: 
![grafik](https://github.com/user-attachments/assets/816a8d93-c54e-4b0d-943c-24a5e055670e)


### Description
Removed the lines as mentioned by the warning. See also https://github.com/typicode/husky/releases/tag/v9.1.1


### Steps for Testing
code review, if you want try to locally commit something and see that the hooks still run, but no deprecation warning is shown.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the pre-commit hook execution process for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->