### PR TITLE
`Development`: Disable declaration of globally scoped variables

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,6 +85,7 @@ module.exports = [
             'no-case-declarations': 'off',
             'prefer-const': 'warn',
             'prefer-spread': 'warn',
+            'no-var': 'error',
             'sort-imports': [
                 'error',
                 {


### PR DESCRIPTION
### Motivation and Context
Declaring variables in typescipt with `var` should be avoided, we should use `let` or `const` instead.


### Description
Activate the corresponding eslint check.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced code quality by introducing a new linting rule that prohibits the use of `var`, promoting the adoption of `let` and `const` for variable declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->