### PR TITLE
feat: Add iris message pop up

### DIFF
--- a/src/main/webapp/app/iris/exercise-chatbot/exercise-chatbot-button.component.html
+++ b/src/main/webapp/app/iris/exercise-chatbot/exercise-chatbot-button.component.html
@@ -1,4 +1,21 @@
 @if (!chatOpen) {
+    <div
+        #chatBubble
+        class="message-bubble"
+        (click)="handleButtonClick()"
+        [ngClass]="{ 'content-overflow': this.isOverflowing }"
+        [@expandAnimation]="newIrisMessage ? 'visible' : 'hidden'"
+    >
+        @if (newIrisMessage) {
+            <span [innerHTML]="newIrisMessage | htmlForMarkdown"></span>
+            @if (this.isOverflowing) {
+                <div class="read-more">
+                    <span> See full message </span>
+                    <fa-icon [icon]="faAngleDoubleDown" class="read-more-icon" />
+                </div>
+            }
+        }
+    </div>
     <div class="chatbot-button">
         <jhi-iris-logo [size]="IrisLogoSize.MEDIUM" [look]="IrisLogoLookDirection.LEFT" (click)="handleButtonClick()" />
         @if (hasNewMessages) {

--- a/src/main/webapp/app/iris/exercise-chatbot/exercise-chatbot-button.component.scss
+++ b/src/main/webapp/app/iris/exercise-chatbot/exercise-chatbot-button.component.scss
@@ -11,6 +11,64 @@
     }
 }
 
+.message-bubble {
+    --r: 13px; /* the radius */
+
+    position: absolute;
+    z-index: 50;
+    bottom: 100px;
+    right: 80px;
+    width: 350px;
+    height: 450px;
+    background-color: var(--iris-client-chat-background);
+    cursor: pointer;
+    transition: all 0.1s ease-in-out;
+    overflow-y: hidden;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+    padding: 10px;
+    display: flex;
+    border-radius: var(--r);
+    border-bottom-right-radius: 0;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+
+    &:hover {
+        transform: scale(1.05);
+        .read-more > span {
+            text-decoration: underline;
+        }
+    }
+}
+.content-overflow {
+    &::before {
+        content: '';
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        background: linear-gradient(0, var(--iris-chat-bubble-fade) 2%, transparent);
+    }
+}
+
+.read-more {
+    position: absolute;
+    cursor: pointer;
+    bottom: 5px;
+    text-align: center;
+    padding: 0 10px;
+    width: 150px;
+    left: calc(50% - 75px);
+    font-size: 14px;
+    z-index: 100;
+    color: var(--link-color);
+}
+
+.hidden {
+    display: none;
+}
+
 .btn-circle {
     width: 40px;
     height: 40px;

--- a/src/main/webapp/app/iris/exercise-chatbot/exercise-chatbot-button.component.ts
+++ b/src/main/webapp/app/iris/exercise-chatbot/exercise-chatbot-button.component.ts
@@ -1,28 +1,61 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Overlay } from '@angular/cdk/overlay';
 import { ActivatedRoute } from '@angular/router';
 import { IrisChatbotWidgetComponent } from 'app/iris/exercise-chatbot/widget/chatbot-widget.component';
-import { Subscription } from 'rxjs';
-import { faChevronDown, faCircle } from '@fortawesome/free-solid-svg-icons';
+import { EMPTY, Subscription, filter, of, switchMap } from 'rxjs';
+import { faAngleDoubleDown, faChevronDown, faCircle } from '@fortawesome/free-solid-svg-icons';
 import { IrisLogoLookDirection, IrisLogoSize } from 'app/iris/iris-logo/iris-logo.component';
 import { ChatServiceMode, IrisChatService } from 'app/iris/iris-chat.service';
+import { animate, state, style, transition, trigger } from '@angular/animations';
+import { IrisTextMessageContent } from 'app/entities/iris/iris-content-type.model';
 
 @Component({
     selector: 'jhi-exercise-chatbot-button',
     templateUrl: './exercise-chatbot-button.component.html',
     styleUrls: ['./exercise-chatbot-button.component.scss'],
+    animations: [
+        trigger('expandAnimation', [
+            state(
+                'hidden',
+                style({
+                    opacity: 0,
+                    transform: 'scale(0)',
+                    transformOrigin: 'bottom right',
+                }),
+            ),
+            state(
+                'visible',
+                style({
+                    opacity: 1,
+                    transform: 'scale(1)',
+                    transformOrigin: 'bottom right',
+                }),
+            ),
+            transition('hidden => visible', animate('300ms ease-out')),
+            transition('visible => hidden', animate('300ms ease-in')),
+        ]),
+    ],
 })
 export class IrisExerciseChatbotButtonComponent implements OnInit, OnDestroy {
     dialogRef: MatDialogRef<IrisChatbotWidgetComponent> | null = null;
     chatOpen = false;
+    isOverflowing = false;
     hasNewMessages = false;
+    newIrisMessage: string | undefined;
+
+    private readonly CHAT_BUBBLE_TIMEOUT = 10000;
+
     private numNewMessagesSubscription: Subscription;
     private paramsSubscription: Subscription;
+    private latestIrisMessageSubscription: Subscription;
 
     // Icons
     faCircle = faCircle;
     faChevronDown = faChevronDown;
+    faAngleDoubleDown = faAngleDoubleDown;
+
+    @ViewChild('chatBubble') chatBubble: ElementRef;
 
     protected readonly IrisLogoLookDirection = IrisLogoLookDirection;
     protected readonly IrisLogoSize = IrisLogoSize;
@@ -35,7 +68,7 @@ export class IrisExerciseChatbotButtonComponent implements OnInit, OnDestroy {
     ) {}
 
     ngOnInit() {
-        // Subscribes to route params and gets the exerciseId from the route
+        // Subscribes to route params and gets the exerciseId from the router
         this.paramsSubscription = this.route.params.subscribe((params) => {
             const exerciseId = parseInt(params['exerciseId'], 10);
             this.chatService.switchTo(ChatServiceMode.EXERCISE, exerciseId);
@@ -45,6 +78,24 @@ export class IrisExerciseChatbotButtonComponent implements OnInit, OnDestroy {
         this.numNewMessagesSubscription = this.chatService.numNewMessages.subscribe((num) => {
             this.hasNewMessages = num > 0;
         });
+        this.latestIrisMessageSubscription = this.chatService.newIrisMessage
+            .pipe(
+                filter((msg) => !!msg),
+                switchMap((msg) => {
+                    if (msg!.content && msg!.content.length > 0) {
+                        return of((msg!.content[0] as IrisTextMessageContent).textContent);
+                    }
+                    return EMPTY;
+                }),
+            )
+            .subscribe((message) => {
+                this.newIrisMessage = message;
+                setTimeout(() => this.checkOverflow(), 0);
+                setTimeout(() => {
+                    this.newIrisMessage = undefined;
+                    this.isOverflowing = false;
+                }, this.CHAT_BUBBLE_TIMEOUT);
+            });
     }
 
     ngOnDestroy() {
@@ -54,6 +105,9 @@ export class IrisExerciseChatbotButtonComponent implements OnInit, OnDestroy {
         }
         this.numNewMessagesSubscription?.unsubscribe();
         this.paramsSubscription.unsubscribe();
+        this.latestIrisMessageSubscription.unsubscribe();
+        this.newIrisMessage = undefined;
+        this.isOverflowing = false;
     }
 
     /**
@@ -72,11 +126,21 @@ export class IrisExerciseChatbotButtonComponent implements OnInit, OnDestroy {
     }
 
     /**
+     * Checks if the chat bubble is overflowing and sets isOverflowing to true if it is.
+     */
+    public checkOverflow() {
+        const element = this.chatBubble.nativeElement;
+        this.isOverflowing = element.scrollHeight > element.clientHeight;
+    }
+
+    /**
      * Opens the chat dialog using MatDialog.
      * Sets the configuration options for the dialog, including position, size, and data.
      */
     openChat() {
         this.chatOpen = true;
+        this.newIrisMessage = undefined;
+        this.isOverflowing = false;
         this.dialogRef = this.dialog.open(IrisChatbotWidgetComponent, {
             hasBackdrop: false,
             scrollStrategy: this.overlay.scrollStrategies.noop(),
@@ -85,4 +149,6 @@ export class IrisExerciseChatbotButtonComponent implements OnInit, OnDestroy {
         });
         this.dialogRef.afterClosed().subscribe(() => (this.chatOpen = false));
     }
+
+    protected readonly IrisTextMessageContent = IrisTextMessageContent;
 }

--- a/src/main/webapp/app/iris/iris-chat.service.ts
+++ b/src/main/webapp/app/iris/iris-chat.service.ts
@@ -27,6 +27,7 @@ export enum ChatServiceMode {
 export class IrisChatService implements OnDestroy {
     sessionId?: number;
     messages: BehaviorSubject<IrisMessage[]> = new BehaviorSubject([]);
+    newIrisMessage: BehaviorSubject<IrisMessage | undefined> = new BehaviorSubject(undefined);
     numNewMessages: BehaviorSubject<number> = new BehaviorSubject(0);
     stages: BehaviorSubject<IrisStageDTO[]> = new BehaviorSubject([]);
     suggestions: BehaviorSubject<string[]> = new BehaviorSubject([]);
@@ -97,6 +98,9 @@ export class IrisChatService implements OnDestroy {
     private replaceOrAddMessage(message: IrisMessage) {
         const messageWasReplaced = this.replaceMessage(message);
         if (!messageWasReplaced) {
+            if (message.sender === IrisSender.LLM) {
+                this.newIrisMessage.next(message);
+            }
             this.messages.next([...this.messages.getValue(), message]);
         }
     }
@@ -238,6 +242,7 @@ export class IrisChatService implements OnDestroy {
             this.stages.next([]);
             this.suggestions.next([]);
             this.numNewMessages.next(0);
+            this.newIrisMessage.next(undefined);
         }
         this.error.next(undefined);
     }

--- a/src/main/webapp/content/scss/themes/_dark-variables.scss
+++ b/src/main/webapp/content/scss/themes/_dark-variables.scss
@@ -641,6 +641,7 @@ $competency-rings-blue-bg: transparentize($competency-rings-blue, 0.8);
 
 // Iris Chatbot
 $iris-chat-widget-background: var(--neutral-dark-l-5);
+$iris-chat-bubble-fade: $black;
 $iris-client-chat-background: var(--neutral-dark-l-10);
 $iris-client-chat-input: var(--neutral-dark-l-5);
 $iris-my-chat-background: #008462;

--- a/src/main/webapp/content/scss/themes/_default-variables.scss
+++ b/src/main/webapp/content/scss/themes/_default-variables.scss
@@ -569,6 +569,7 @@ $competency-rings-blue-bg: transparentize($competency-rings-blue, 0.8);
 // Iris Chatbot
 // TODO: Use standard colors
 $iris-chat-widget-background: $white;
+$iris-chat-bubble-fade: $white;
 $iris-client-chat-background: var(--gray-200);
 $iris-client-chat-input: $white;
 $iris-my-chat-background: #a9dcb5;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.


#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [ ] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


### Description
<!-- Describe your changes in detail -->


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://docs.artemis.cit.tum.de/user/exam_mode/) as reference.
4. ...

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
