### PR TITLE
`Exam mode`: Hide unreleased programming exercise results

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -630,6 +630,19 @@ public class ExamService {
     }
 
     /**
+     * Determines whether the student should see the result of the exam.
+     * This is the case if the exam is started and not ended yet or if the results are already published.
+     *
+     * @param studentExam   The student exam
+     * @param participation The participation of the student
+     * @return true if the student should see the result, false otherwise
+     */
+    public static boolean shouldStudentSeeResult(StudentExam studentExam, StudentParticipation participation) {
+        return (studentExam.getExam().isStarted() && !studentExam.isEnded() && participation instanceof ProgrammingExerciseStudentParticipation)
+                || studentExam.areResultsPublishedYet();
+    }
+
+    /**
      * Helper method which attaches the result to its participation.
      * For direct automatic feedback during the exam conduction for {@link ProgrammingExercise}, we need to attach the results.
      * We also attach the result if the results are already published for the exam.
@@ -642,8 +655,7 @@ public class ExamService {
      */
     private static void setResultIfNecessary(StudentExam studentExam, StudentParticipation participation, boolean isAtLeastInstructor) {
         // Only set the result during the exam for programming exercises (for direct automatic feedback) or after publishing the results
-        boolean isStudentAllowedToSeeResult = (studentExam.getExam().isStarted() && !studentExam.isEnded() && participation instanceof ProgrammingExerciseStudentParticipation)
-                || studentExam.areResultsPublishedYet();
+        boolean isStudentAllowedToSeeResult = shouldStudentSeeResult(studentExam, participation);
         Optional<Submission> latestSubmission = participation.findLatestSubmission();
 
         // To prevent LazyInitializationException.

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/programming/ProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/programming/ProgrammingExerciseParticipationResource.java
@@ -7,6 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
 import de.tum.in.www1.artemis.domain.Result;
+import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUri;
 import de.tum.in.www1.artemis.domain.enumeration.RepositoryType;
 import de.tum.in.www1.artemis.domain.participation.Participation;
@@ -31,6 +33,7 @@ import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
+import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastInstructor;
 import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastStudent;
@@ -38,6 +41,7 @@ import de.tum.in.www1.artemis.security.annotations.EnforceAtLeastTutor;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.ParticipationAuthorizationCheckService;
 import de.tum.in.www1.artemis.service.ResultService;
+import de.tum.in.www1.artemis.service.exam.ExamService;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseParticipationService;
 import de.tum.in.www1.artemis.service.programming.ProgrammingSubmissionService;
 import de.tum.in.www1.artemis.service.programming.RepositoryService;
@@ -73,10 +77,13 @@ public class ProgrammingExerciseParticipationResource {
 
     private final RepositoryService repositoryService;
 
+    private final StudentExamRepository studentExamRepository;
+
     public ProgrammingExerciseParticipationResource(ProgrammingExerciseParticipationService programmingExerciseParticipationService, ResultRepository resultRepository,
             ParticipationRepository participationRepository, ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository,
             ProgrammingSubmissionService submissionService, ProgrammingExerciseRepository programmingExerciseRepository, AuthorizationCheckService authCheckService,
-            ResultService resultService, ParticipationAuthorizationCheckService participationAuthCheckService, RepositoryService repositoryService) {
+            ResultService resultService, ParticipationAuthorizationCheckService participationAuthCheckService, RepositoryService repositoryService,
+            StudentExamRepository studentExamRepository) {
         this.programmingExerciseParticipationService = programmingExerciseParticipationService;
         this.participationRepository = participationRepository;
         this.programmingExerciseStudentParticipationRepository = programmingExerciseStudentParticipationRepository;
@@ -87,6 +94,7 @@ public class ProgrammingExerciseParticipationResource {
         this.resultService = resultService;
         this.participationAuthCheckService = participationAuthCheckService;
         this.repositoryService = repositoryService;
+        this.studentExamRepository = studentExamRepository;
     }
 
     /**
@@ -103,6 +111,9 @@ public class ProgrammingExerciseParticipationResource {
                 .orElseThrow(() -> new EntityNotFoundException("Participation", participationId));
 
         hasAccessToParticipationElseThrow(participation);
+        if (shouldHideExamExerciseResults(participation)) {
+            participation.setResults(Set.of());
+        }
 
         // hide details that should not be shown to the students
         resultService.filterSensitiveInformationIfNecessary(participation, participation.getResults(), Optional.empty());
@@ -123,6 +134,9 @@ public class ProgrammingExerciseParticipationResource {
 
         // TODO: improve access checks to avoid fetching the user multiple times
         hasAccessToParticipationElseThrow(participation);
+        if (shouldHideExamExerciseResults(participation)) {
+            participation.setResults(Set.of());
+        }
 
         // hide details that should not be shown to the students
         resultService.filterSensitiveInformationIfNecessary(participation, participation.getResults(), Optional.empty());
@@ -143,6 +157,12 @@ public class ProgrammingExerciseParticipationResource {
             @RequestParam(defaultValue = "false") boolean withSubmission) {
         var participation = participationRepository.findByIdElseThrow(participationId);
         participationAuthCheckService.checkCanAccessParticipationElseThrow(participation);
+
+        if (participation instanceof ProgrammingExerciseStudentParticipation programmingExerciseStudentParticipation
+                && shouldHideExamExerciseResults(programmingExerciseStudentParticipation)) {
+            return ResponseEntity.ok(null);
+        }
+
         Optional<Result> result = resultRepository.findLatestResultWithFeedbacksForParticipation(participation.getId(), withSubmission);
         result.ifPresent(value -> resultService.filterSensitiveInformationIfNecessary(participation, value));
 
@@ -388,6 +408,23 @@ public class ProgrammingExerciseParticipationResource {
                 throw new AccessForbiddenException("Participation not yet started");
             }
         }
+    }
+
+    /**
+     * Checks if the results should be hidden for the given participation.
+     *
+     * @param participation the participation to check
+     * @return true if the results should be hidden, false otherwise
+     */
+    private boolean shouldHideExamExerciseResults(ProgrammingExerciseStudentParticipation participation) {
+        if (participation.getProgrammingExercise().isExamExercise()) {
+            User student = participation.getStudent()
+                    .orElseThrow(() -> new EntityNotFoundException("Participation with id " + participation.getId() + " does not have a student!"));
+            var studentExam = studentExamRepository.findByExerciseIdAndUserId(participation.getExercise().getId(), student.getId())
+                    .orElseThrow(() -> new EntityNotFoundException("Participation " + participation.getId() + " does not have a student exam!"));
+            return !ExamService.shouldStudentSeeResult(studentExam, participation);
+        }
+        return false;
     }
 
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/ResultWebsocketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/ResultWebsocketService.java
@@ -76,7 +76,7 @@ public class ResultWebsocketService {
         final Exercise exercise = studentParticipation.getExercise();
         boolean isWorkingPeriodOver;
         if (exercise.isExamExercise()) {
-            isWorkingPeriodOver = examDateService.isExerciseWorkingPeriodOver(exercise, studentParticipation);
+            isWorkingPeriodOver = examDateService.isIndividualExerciseWorkingPeriodOver(exercise.getExam(), studentParticipation);
         }
         else {
             isWorkingPeriodOver = exerciseDateService.isAfterLatestDueDate(exercise);


### PR DESCRIPTION
### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, students can see the current result of their programming exercise submissions before the result release date. We do not want to leak this information.

### Description
<!-- Describe your changes in detail -->

The repository view, the commit history, and the exam summary no longer receive information about the results of exam programming exercises when the results haven't been published yet. Students can still see the results if:

- The exam is ongoing.
- The results have been published.

Note that this is meant as a quick fix for the bug described above. In the future, we want to show the results that were created during the exam in the repo view / commit history.

#### Exam Mode Testing

Prerequisites:
- 1 Exam with a programming exercise (enable manual assessment). Enable both the online editor and the offline IDE.
- 1 Student
- 1 Instructor
- Two browsers / incognito mode (one for the student, one for the instructor)

1. Participate in the exam as the student. Submit a few solutions to the programming exercise (e.g. some with build errors, some without)
2. Open the repository view via the Code button popup ![image](https://github.com/user-attachments/assets/62db3beb-33b8-47b0-86aa-66da2cae94b5).
3. Verify that the displayed result is the most recent one.
4. Open the commit history view.
5. Verify that the commit history shows every result.
6. Wait for the exam to end and hand in normally.
7. Check that the summary you see works as expected.
8. Open the repository view via the code button. Check that no result is displayed.
9. Open the commit history view. Check that no results are displayed.

----

10. On the other browser, log in as the instructor.
11. Assess the programming exercise.
12. As the student: Check that you still cannot see the result of the programming exercise on the summary, the repository view, or the commit history.
13. As the instructor: Edit the exam; set the release date of the results to now.
14. As the student: Check that you can see every result again on the summary, repository view, and commit history.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Exam Mode Test
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots

No ui changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced logic to determine if students can see their exam results based on specific conditions.
	- Enhanced access control for programming exercise participations in exam contexts.

- **Improvements**
	- Streamlined result visibility checks, improving clarity and maintainability.
	- Improved accuracy of determining working period status for individual exams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->