### PR TITLE
`Quiz exercises`: Render images immediately upon import

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
@@ -265,11 +265,6 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
     makeFileMapPreview() {
         this.filePool.forEach((value, key) => {
             this.filePreviewPaths.set(key, URL.createObjectURL(value.file));
-            this.addNewFile.emit({
-                fileName: key,
-                file: value.file,
-                path: value.path,
-            });
             this.changeDetector.detectChanges();
         });
     }

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
@@ -62,7 +62,7 @@ import { FileService } from 'app/shared/http/file.service';
 })
 export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, AfterViewInit, QuizQuestionEdit {
     @ViewChild('clickLayer', { static: false }) private clickLayer: ElementRef;
-    @ViewChild('backgroundImage', { static: false }) private backgroundImage: SecuredImageComponent;
+    @ViewChild('backgroundImage ', { static: false }) private backgroundImage: SecuredImageComponent;
     @ViewChild('markdownEditor', { static: false }) private markdownEditor: MarkdownEditorComponent;
 
     @Input() question: DragAndDropQuestion;
@@ -163,8 +163,6 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
                 }
             }
         }
-        // render import images on UI immediatly
-        this.makeFileMapPreview();
     }
 
     /**
@@ -218,7 +216,8 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
                 debounceTime(300),
             )
             .subscribe(() => this.adjustClickLayerWidth());
-
+        // render import images on UI immediatly
+        this.makeFileMapPreview();
         // Trigger click layer width adjustment upon window resize.
         window.onresize = () => this.adjustClickLayerWidth();
     }
@@ -268,7 +267,6 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
                 this.filePreviewPaths.set(key, URL.createObjectURL(value.file));
             });
             this.changeDetector.detectChanges();
-            this.adjustClickLayerWidth();
         }
     }
 

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
@@ -163,6 +163,8 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
                 }
             }
         }
+        // render import images on UI immediatly
+        this.makeFileMapPreview();
     }
 
     /**
@@ -254,6 +256,22 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
      */
     drop(): void {
         this.dropAllowed = false;
+    }
+
+    /**
+     * This method takes the files and creates preview objects so that images
+     * are rendered immediately on the UI after importing
+     */
+    makeFileMapPreview() {
+        this.filePool.forEach((value, key) => {
+            this.filePreviewPaths.set(key, URL.createObjectURL(value.file));
+            this.addNewFile.emit({
+                fileName: key,
+                file: value.file,
+                path: value.path,
+            });
+            this.changeDetector.detectChanges();
+        });
     }
 
     /**

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
@@ -263,10 +263,13 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
      * are rendered immediately on the UI after importing
      */
     makeFileMapPreview() {
-        this.filePool.forEach((value, key) => {
-            this.filePreviewPaths.set(key, URL.createObjectURL(value.file));
+        if (this.filePool) {
+            this.filePool.forEach((value, key) => {
+                this.filePreviewPaths.set(key, URL.createObjectURL(value.file));
+            });
+            this.adjustClickLayerWidth();
             this.changeDetector.detectChanges();
-        });
+        }
     }
 
     /**

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
@@ -267,8 +267,8 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
             this.filePool.forEach((value, key) => {
                 this.filePreviewPaths.set(key, URL.createObjectURL(value.file));
             });
-            this.adjustClickLayerWidth();
             this.changeDetector.detectChanges();
+            this.adjustClickLayerWidth();
         }
     }
 

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-question-list-edit-existing.component.ts
@@ -181,7 +181,6 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
             this.handleJsonFile();
         }
     }
-
     handleJsonFile() {
         const fileReader = this.generateFileReader();
         fileReader.onload = () => this.onFileLoadImport(fileReader);
@@ -326,7 +325,7 @@ export class QuizQuestionListEditExistingComponent implements OnChanges {
         const files: Map<string, { path: string; file: File }> = new Map<string, { path: string; file: File }>();
         // To make sure all questions are duplicated (new resources are created), we need to remove some fields from the input questions,
         // This contains removing all ids, duplicating images in case of dnd questions, the question statistic and the exercise
-        var questionIndex = 0;
+        let questionIndex = 0;
         for (const question of existingQuizQuestions) {
             // do not set question.exercise = this.quizExercise, because it will cause a cycle when converting to json
             question.exercise = undefined;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
~- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).~
~- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).~
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
~- [ ] I translated all newly inserted strings into English and German.~


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When importing quiz Exercises at the moment (json,zip or any other import from within the quiz editor). The images (most of the time ) do not show unless the quiz is saved. This PR fixes that by creating Preview paths for the imported images.

### Description
<!-- Describe your changes in detail -->
This happened because the import functions make duplicates of the imported image/exercise but did not update the file preview paths and they do not show until they are uploaded in the server and retrieved. This PR creates the file preview Paths directly on import so the user does not have to save them to see them. 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Quiz

1. Log in to Artemis
2. Navigate to Course Administration
3. Import any other quiz with Drag and Drop question. 
4. Confirm the images immediatly and correctly displayed.

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
![beforeTheFix](https://github.com/user-attachments/assets/6cfce6d6-0fdc-4403-8434-a27663b51335)
After:
![afterTheFix](https://github.com/user-attachments/assets/76bce828-f2b7-4b23-bbd7-0b2bd836f096)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced drag-and-drop question editing interface with immediate visual feedback for imported images.
	- Introduced a method for generating previews of uploaded files, improving user interaction.

- **Bug Fixes**
	- Improved variable scoping for question index, ensuring better reliability within the quiz question editing component.

- **Style**
	- Minor formatting adjustments made for improved code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->