### PR TITLE
`Development`: Use directive for programming repository button details in exercise detail overview

### DIFF
--- a/src/main/webapp/app/detail-overview-list/components/programming-repository-buttons-detail.component.html
+++ b/src/main/webapp/app/detail-overview-list/components/programming-repository-buttons-detail.component.html
@@ -1,0 +1,8 @@
+@if (detail.data.participation?.repositoryUri && detail.data.exerciseId) {
+    <div class="clone-buttons">
+        <jhi-code-button [smallButtons]="true" [routerLinkForRepositoryView]="['.', 'repository', detail.data.type]" [repositoryUri]="detail.data.participation?.repositoryUri!" />
+        <jhi-programming-exercise-instructor-repo-download class="ms-2" [exerciseId]="detail.data.exerciseId" [repositoryType]="detail.data.type" />
+    </div>
+} @else {
+    <jhi-no-data />
+}

--- a/src/main/webapp/app/detail-overview-list/components/programming-repository-buttons-detail.component.ts
+++ b/src/main/webapp/app/detail-overview-list/components/programming-repository-buttons-detail.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+import type { ProgrammingRepositoryButtonsDetail } from 'app/detail-overview-list/detail.model';
+import { NoDataComponent } from 'app/shared/no-data-component';
+import { RouterModule } from '@angular/router';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
+import { ArtemisProgrammingExerciseActionsModule } from 'app/exercises/programming/shared/actions/programming-exercise-actions.module';
+
+@Component({
+    selector: 'jhi-programming-repository-buttons-detail',
+    templateUrl: 'programming-repository-buttons-detail.component.html',
+    standalone: true,
+    imports: [NoDataComponent, RouterModule, ArtemisSharedComponentModule, ArtemisProgrammingExerciseActionsModule],
+})
+export class ProgrammingRepositoryButtonsDetailComponent {
+    @Input() detail: ProgrammingRepositoryButtonsDetail;
+}

--- a/src/main/webapp/app/detail-overview-list/detail-overview-list.component.html
+++ b/src/main/webapp/app/detail-overview-list/detail-overview-list.component.html
@@ -15,22 +15,6 @@
                     </dt>
                 }
                 @switch (detail.type) {
-                    @case (DetailType.ProgrammingRepositoryButtons) {
-                        <dd id="detail-value-{{ detail.title }}">
-                            @if (detail.data.participation?.repositoryUri && detail.data.exerciseId) {
-                                <div class="clone-buttons">
-                                    <jhi-code-button
-                                        [smallButtons]="true"
-                                        [routerLinkForRepositoryView]="['.', 'repository', detail.data.type]"
-                                        [repositoryUri]="detail.data.participation?.repositoryUri!"
-                                    />
-                                    <jhi-programming-exercise-instructor-repo-download class="ms-2" [exerciseId]="detail.data.exerciseId" [repositoryType]="detail.data.type" />
-                                </div>
-                            } @else {
-                                <ng-container *ngTemplateOutlet="noData" />
-                            }
-                        </dd>
-                    }
                     @case (DetailType.ProgrammingAuxiliaryRepositoryButtons) {
                         <dd id="detail-value-{{ detail.title }}">
                             <ul>

--- a/src/main/webapp/app/detail-overview-list/detail.model.ts
+++ b/src/main/webapp/app/detail-overview-list/detail.model.ts
@@ -83,7 +83,7 @@ interface ProgrammingIrisEnabledDetail extends DetailBase {
     data: { exercise?: ProgrammingExercise; course?: Course; disabled: boolean; subSettingsType: IrisSubSettingsType };
 }
 
-interface ProgrammingRepositoryButtonsDetail extends DetailBase {
+export interface ProgrammingRepositoryButtonsDetail extends DetailBase {
     type: DetailType.ProgrammingRepositoryButtons;
     data: {
         exerciseId?: number;

--- a/src/main/webapp/app/detail-overview-list/exercise-detail.directive.ts
+++ b/src/main/webapp/app/detail-overview-list/exercise-detail.directive.ts
@@ -5,6 +5,7 @@ import { TextDetailComponent } from 'app/detail-overview-list/components/text-de
 import { DateDetailComponent } from 'app/detail-overview-list/components/date-detail.component';
 import { LinkDetailComponent } from 'app/detail-overview-list/components/link-detail.component';
 import { BooleanDetailComponent } from 'app/detail-overview-list/components/boolean-detail.component';
+import { ProgrammingRepositoryButtonsDetailComponent } from 'app/detail-overview-list/components/programming-repository-buttons-detail.component';
 
 @Directive({
     selector: '[jhiExerciseDetail]',
@@ -28,6 +29,7 @@ export class ExerciseDetailDirective implements OnInit, OnDestroy {
             [DetailType.Date]: DateDetailComponent,
             [DetailType.Link]: LinkDetailComponent,
             [DetailType.Boolean]: BooleanDetailComponent,
+            [DetailType.ProgrammingRepositoryButtons]: ProgrammingRepositoryButtonsDetailComponent,
         };
 
         const detailComponent = detailTypeToComponent[this.detail.type];

--- a/src/test/javascript/spec/component/exercise-detail.directive.spec.ts
+++ b/src/test/javascript/spec/component/exercise-detail.directive.spec.ts
@@ -1,13 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ExerciseDetailDirective } from 'app/detail-overview-list/exercise-detail.directive';
 import { Component, ViewChild } from '@angular/core';
-import type { BooleanDetail, DateDetail, Detail, LinkDetail, NotShownDetail, ShownDetail, TextDetail } from 'app/detail-overview-list/detail.model';
+import type {
+    BooleanDetail,
+    DateDetail,
+    Detail,
+    LinkDetail,
+    NotShownDetail,
+    ProgrammingRepositoryButtonsDetail,
+    ShownDetail,
+    TextDetail,
+} from 'app/detail-overview-list/detail.model';
 import { TextDetailComponent } from 'app/detail-overview-list/components/text-detail.component';
 import { MockComponent } from 'ng-mocks';
 import { DetailType } from 'app/detail-overview-list/detail-overview-list.component';
 import { DateDetailComponent } from 'app/detail-overview-list/components/date-detail.component';
 import { LinkDetailComponent } from 'app/detail-overview-list/components/link-detail.component';
 import { BooleanDetailComponent } from 'app/detail-overview-list/components/boolean-detail.component';
+import { ProgrammingRepositoryButtonsDetailComponent } from 'app/detail-overview-list/components/programming-repository-buttons-detail.component';
 
 @Component({
     template: `<div jhiExerciseDetail [detail]="detail"></div>`,
@@ -62,6 +72,10 @@ describe('ExerciseDetailDirective', () => {
 
         it('should create BooleanDetail component', () => {
             checkComponentForDetailWasCreated({ type: DetailType.Boolean } as BooleanDetail, BooleanDetailComponent);
+        });
+
+        it('should create ProgrammingRepositoryButtonsDetailComponent component', () => {
+            checkComponentForDetailWasCreated({ type: DetailType.ProgrammingRepositoryButtons } as ProgrammingRepositoryButtonsDetail, ProgrammingRepositoryButtonsDetailComponent);
         });
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
Follow up on https://github.com/ls1intum/Artemis/pull/8644


### Description
* Added a component for LinkDetail
* Using ExerciseDetails directive for LinkDetail
* Added unit test
* Moved detail component HTML from inline to own files
* Improved reusability of details components and reduced code duplication by moving `<dd>` tag to the `detail-overview-list.component`


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Navigate to the details page of a programming exercise 
2. Verify that you a forwarded to the course overview when clicking the link
3. Verify that checkmarks and crosses are displayed for the boolean values (e.g. `Included in Score`)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage


### Screenshots
<img width="1256" alt="directive-boolean" src="https://github.com/user-attachments/assets/a9d77cce-b230-4235-b350-bc710cd15fe5">

<img width="1211" alt="directive-link" src="https://github.com/user-attachments/assets/0e8807e5-b0a1-418f-9e83-7d049dc45058">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `BooleanDetailComponent`, `DateDetailComponent`, `LinkDetailComponent`, and `TextDetailComponent` to the app, enhancing the detail overview list with dedicated components for each detail type.

- **Refactor**
  - Separated inline templates into external HTML files for `DateDetailComponent` and `TextDetailComponent` to improve readability and maintainability.

- **Chores**
  - Updated `ExerciseDetailDirective` to include support for rendering new detail components.
  - Simplified rendering logic in `detail-overview-list.component.html` to use a generic component for all detail types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->