### PR TITLE
`Quiz exercises`: Allow file editing when importing from overview

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamImportService.java
@@ -337,7 +337,7 @@ public class ExamImportService {
                         yield Optional.empty();
                     }
                     // We don't allow a modification of the exercise at this point, so we can just pass an empty list of files.
-                    yield Optional.of(quizExerciseImportService.importQuizExercise(optionalOriginalQuizExercise.get(), (QuizExercise) exerciseToCopy));
+                    yield Optional.of(quizExerciseImportService.importQuizExercise(optionalOriginalQuizExercise.get(), (QuizExercise) exerciseToCopy, null));
                 }
             };
             // Attach the newly created Exercise to the new Exercise Group only if the importing was successful

--- a/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizExerciseImportService.java
@@ -75,6 +75,7 @@ public class QuizExerciseImportService extends ExerciseImportService {
      *
      * @param templateExercise The template exercise which should get imported
      * @param importedExercise The new exercise already containing values which should not get copied, i.e. overwritten
+     * @param files            The potential files to be added. Null if no change to files during import. ExamImportService sends null by default
      * @return The newly created exercise
      */
     @NotNull

--- a/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizExerciseImportService.java
@@ -2,19 +2,23 @@ package de.tum.in.www1.artemis.service.quiz;
 
 import static de.tum.in.www1.artemis.config.Constants.PROFILE_CORE;
 
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import de.tum.in.www1.artemis.domain.quiz.AnswerOption;
 import de.tum.in.www1.artemis.domain.quiz.DragAndDropMapping;
@@ -74,7 +78,7 @@ public class QuizExerciseImportService extends ExerciseImportService {
      * @return The newly created exercise
      */
     @NotNull
-    public QuizExercise importQuizExercise(final QuizExercise templateExercise, QuizExercise importedExercise) {
+    public QuizExercise importQuizExercise(final QuizExercise templateExercise, QuizExercise importedExercise, @Nullable List<MultipartFile> files) throws IOException {
         log.debug("Creating a new Exercise based on exercise {}", templateExercise);
         QuizExercise newExercise = copyQuizExerciseBasis(importedExercise);
         copyQuizQuestions(importedExercise, newExercise);
@@ -85,6 +89,9 @@ public class QuizExerciseImportService extends ExerciseImportService {
         channelService.createExerciseChannel(newQuizExercise, Optional.ofNullable(importedExercise.getChannelName()));
 
         competencyProgressService.updateProgressByLearningObjectAsync(newQuizExercise);
+        if (files != null) {
+            newQuizExercise = quizExerciseService.save(quizExerciseService.uploadNewFilesToNewImportedQuiz(newQuizExercise, files));
+        }
 
         return newQuizExercise;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizExerciseImportService.java
@@ -150,11 +150,14 @@ public class QuizExerciseImportService extends ExerciseImportService {
             URI backgroundFileIntendedPath = URI.create(FileService.BACKGROUND_FILE_SUBPATH);
             // Check whether pictureFilePublicPath is actually a picture file path
             // (which is the case when its path starts with the path backgroundFileIntendedPath)
-            FileService.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(backgroundFilePublicPath, backgroundFileIntendedPath);
-            // Need to copy the file and get a new path, otherwise two different questions would share the same image and would cause problems in case one was deleted
-            Path oldPath = FilePathService.actualPathForPublicPath(backgroundFilePublicPath);
-            Path newPath = fileService.copyExistingFileToTarget(oldPath, FilePathService.getDragAndDropBackgroundFilePath());
-            dndQuestion.setBackgroundFilePath(FilePathService.publicPathForActualPathOrThrow(newPath, null).toString());
+            // If it is null it is a new image which doesn't exist yet and will be added later.
+            if (FilePathService.actualPathForPublicPath(backgroundFilePublicPath) != null) {
+                FileService.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(backgroundFilePublicPath, backgroundFileIntendedPath);
+                // Need to copy the file and get a new path, otherwise two different questions would share the same image and would cause problems in case one was deleted
+                Path oldPath = FilePathService.actualPathForPublicPath(backgroundFilePublicPath);
+                Path newPath = fileService.copyExistingFileToTarget(oldPath, FilePathService.getDragAndDropBackgroundFilePath());
+                dndQuestion.setBackgroundFilePath(FilePathService.publicPathForActualPathOrThrow(newPath, null).toString());
+            }
         }
         else {
             log.warn("BackgroundFilePath of DragAndDropQuestion {} is null", dndQuestion.getId());
@@ -181,11 +184,14 @@ public class QuizExerciseImportService extends ExerciseImportService {
             URI pictureFileIntendedPath = URI.create(FileService.PICTURE_FILE_SUBPATH);
             // Check whether pictureFilePublicPath is actually a picture file path
             // (which is the case when its path starts with the path pictureFileIntendedPath)
-            FileService.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(pictureFilePublicPath, pictureFileIntendedPath);
-            // Need to copy the file and get a new path, same as above
-            Path oldDragItemPath = FilePathService.actualPathForPublicPath(pictureFilePublicPath);
-            Path newDragItemPath = fileService.copyExistingFileToTarget(oldDragItemPath, FilePathService.getDragItemFilePath());
-            dragItem.setPictureFilePath(FilePathService.publicPathForActualPathOrThrow(newDragItemPath, null).toString());
+            // If it is null it is a new image which doesn't exist yet and will be added later.
+            if (FilePathService.actualPathForPublicPath(pictureFilePublicPath) != null) {
+                FileService.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(pictureFilePublicPath, pictureFileIntendedPath);
+                // Need to copy the file and get a new path, same as above
+                Path oldDragItemPath = FilePathService.actualPathForPublicPath(pictureFilePublicPath);
+                Path newDragItemPath = fileService.copyExistingFileToTarget(oldDragItemPath, FilePathService.getDragItemFilePath());
+                dragItem.setPictureFilePath(FilePathService.publicPathForActualPathOrThrow(newDragItemPath, null).toString());
+            }
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/quiz/QuizExerciseService.java
@@ -380,6 +380,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
      *
      * @param dragItem the drag item
      * @param files    all provided files
+     * @param entityId The entity id connected to this file, can be question id for background, or the drag item id for drag item images
      */
     public void saveDndDragItemPicture(DragItem dragItem, Map<String, MultipartFile> files, @Nullable Long entityId) throws IOException {
         MultipartFile file = files.get(dragItem.getPictureFilePath());
@@ -465,7 +466,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
      * @param newQuizExercise the newly created quiz exercise, after importing basis of imported exercise
      * @param files           the new files to be added to the newQuizExercise which do not have a previous path and need to be saved in the server
      * @return the new exercise with the updated file paths which have been created and saved
-     * @throws IOException
+     * @throws IOException throws IO exception if corrupted files
      */
     public QuizExercise uploadNewFilesToNewImportedQuiz(QuizExercise newQuizExercise, List<MultipartFile> files) throws IOException {
         Map<String, MultipartFile> fileMap = files.stream().collect(Collectors.toMap(MultipartFile::getOriginalFilename, Function.identity()));

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -792,10 +792,8 @@ public class QuizExerciseResource {
         quizExerciseService.validateQuizExerciseFiles(importedExercise, nullsafeFiles, false);
 
         final var originalQuizExercise = quizExerciseRepository.findByIdElseThrow(sourceExerciseId);
-        QuizExercise newQuizExercise = quizExerciseImportService.importQuizExercise(originalQuizExercise, importedExercise);
-        if (files != null) {
-            newQuizExercise = quizExerciseService.save(quizExerciseService.uploadNewFilesToNewImportedQuiz(newQuizExercise, files));
-        }
+        QuizExercise newQuizExercise = quizExerciseImportService.importQuizExercise(originalQuizExercise, importedExercise, files);
+
         return ResponseEntity.created(new URI("/api/quiz-exercises/" + newQuizExercise.getId()))
                 .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, newQuizExercise.getId().toString())).body(newQuizExercise);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -766,7 +766,7 @@ public class QuizExerciseResource {
     @PostMapping(value = "quiz-exercises/import/{sourceExerciseId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @EnforceAtLeastEditor
     public ResponseEntity<QuizExercise> importExercise(@PathVariable long sourceExerciseId, @RequestPart("exercise") QuizExercise importedExercise,
-            @RequestPart(value = "files", required = false) List<MultipartFile> files) throws URISyntaxException {
+            @RequestPart(value = "files", required = false) List<MultipartFile> files) throws URISyntaxException, IOException {
         log.info("REST request to import from quiz exercise : {}", sourceExerciseId);
         if (sourceExerciseId <= 0 || (importedExercise.getCourseViaExerciseGroupOrCourseMember() == null && importedExercise.getExerciseGroup() == null)) {
             log.debug("Either the courseId or exerciseGroupId must be set for an import");
@@ -792,8 +792,10 @@ public class QuizExerciseResource {
         quizExerciseService.validateQuizExerciseFiles(importedExercise, nullsafeFiles, false);
 
         final var originalQuizExercise = quizExerciseRepository.findByIdElseThrow(sourceExerciseId);
-        final var newQuizExercise = quizExerciseImportService.importQuizExercise(originalQuizExercise, importedExercise);
-
+        QuizExercise newQuizExercise = quizExerciseImportService.importQuizExercise(originalQuizExercise, importedExercise);
+        if (files != null) {
+            newQuizExercise = quizExerciseService.save(quizExerciseService.uploadNewFilesToNewImportedQuiz(newQuizExercise, files));
+        }
         return ResponseEntity.created(new URI("/api/quiz-exercises/" + newQuizExercise.getId()))
                 .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, newQuizExercise.getId().toString())).body(newQuizExercise);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
~- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).~
~- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).~
- [x] I documented the Java code using JavaDoc style.


#### Client
No changes



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When making changes to a quiz that the user imports through "Import Quiz" from the exercise overview, adding new files throws an internal server error. This is because the new files are sent to the server, but nothing was done with them except to be  validated and throw an error ...

### Description
<!-- Describe your changes in detail -->
When the exercises were imported, the system checked if the file paths for the background and drag items were correct upload Paths. Since new images obviously do not have a correct path when they are new, I added a check for this. Then, I created a method that saves these images and links the path to the background/drag item path of the exercises.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Quiz

1. Navigate to Course Administration -> Exercises
2. From the overview press on "Import Quiz"
3. Make changes, specifically add/remove files
4. Save
5. No server error should be shown
6. Check that new quiz should have all changes saved
7. Check that quiz you imported from has not been changed

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Nothing should have changed from the exam exercise group import.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the import process for drag-and-drop questions to include checks for valid file paths, improving reliability.
	- Introduced a new method to facilitate the upload of new files associated with quiz exercises, specifically for drag-and-drop questions.

- **Bug Fixes**
	- Improved error handling by adding support for IOException in the import process, ensuring robustness during file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->