### PR TITLE
`Development`: Add server tests for result hiding behavior for exam exercises

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamUtilService.java
@@ -629,6 +629,10 @@ public class ExamUtilService {
         return addStudentExamWithUser(exam, userRepo.findOneByLogin(userLogin).orElseThrow());
     }
 
+    public StudentExam addStudentExamWithUserAndWorkingTime(Exam exam, String userLogin, int workingTime) {
+        return addStudentExamWithUserAndWorkingTime(exam, userRepo.findOneByLogin(userLogin).orElseThrow(), workingTime);
+    }
+
     /**
      * Creates and saves a StudentExam for the given Exam and User.
      *
@@ -637,9 +641,21 @@ public class ExamUtilService {
      * @return The newly created StudentExam
      */
     public StudentExam addStudentExamWithUser(Exam exam, User user) {
+        return addStudentExamWithUserAndWorkingTime(exam, user, exam.getDuration());
+    }
+
+    /**
+     * Creates and saves a StudentExam for the given Exam and User with the given working time.
+     *
+     * @param exam        The Exam for which the StudentExam should be created
+     * @param user        The User for which the StudentExam should be created
+     * @param workingTime The working time for the StudentExam
+     * @return The newly created StudentExam
+     */
+    public StudentExam addStudentExamWithUserAndWorkingTime(Exam exam, User user, int workingTime) {
         StudentExam studentExam = ExamFactory.generateStudentExam(exam);
         studentExam.setUser(user);
-        studentExam.setWorkingTime(exam.getDuration());
+        studentExam.setWorkingTime(workingTime);
         studentExam = studentExamRepository.save(studentExam);
         return studentExam;
     }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
@@ -213,7 +213,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetParticipationWithLatestResult_duringExam() throws Exception {
+    void testGetParticipationWithLatestResult_showsResultsDuringExam() throws Exception {
         var now = ZonedDateTime.now();
         programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(2), now.minusHours(1), now.plusHours(1),
                 now.plusHours(10), TEST_PREFIX + "student1", 120 * 60);
@@ -226,7 +226,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetParticipationWithLatestResult_afterExam_beforeExamResultsPublished() throws Exception {
+    void testGetParticipationWithLatestResult_afterExam_hidesResultsBeforeExamResultsPublished() throws Exception {
         var now = ZonedDateTime.now();
         programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(4), now.minusHours(2), now.minusHours(1),
                 now.plusHours(10), TEST_PREFIX + "student1", 60 * 60);
@@ -239,7 +239,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetParticipationWithLatestResult_afterExamResultsPublished() throws Exception {
+    void testGetParticipationWithLatestResult_showsResultsAfterExamResultsPublished() throws Exception {
         var now = ZonedDateTime.now();
         programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(10), now.minusHours(8), now.minusHours(7),
                 now.minusHours(1), TEST_PREFIX + "student1", 60 * 60);
@@ -368,7 +368,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetParticipationAllResults_duringExam() throws Exception {
+    void testGetParticipationAllResults_showsResultsDuringExam() throws Exception {
         var now = ZonedDateTime.now();
         programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(2), now.minusHours(1), now.plusHours(1),
                 now.plusHours(10), TEST_PREFIX + "student1", 120 * 60);
@@ -382,7 +382,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetParticipationAllResults_afterExam_beforeExamResultsPublished() throws Exception {
+    void testGetParticipationAllResults_afterExam_hidesResultsBeforeExamResultsPublished() throws Exception {
         var now = ZonedDateTime.now();
         programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(4), now.minusHours(2), now.minusHours(1),
                 now.plusHours(10), TEST_PREFIX + "student1", 60 * 60);
@@ -396,7 +396,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetParticipationAllResults_afterExamResultsPublished() throws Exception {
+    void testGetParticipationAllResults_showsResultsAfterExamResultsPublished() throws Exception {
         var now = ZonedDateTime.now();
         programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(10), now.minusHours(8), now.minusHours(7),
                 now.minusHours(1), TEST_PREFIX + "student1", 60 * 60);
@@ -420,7 +420,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetLatestResultWithFeedbacksAsStudent_duringExam() throws Exception {
+    void testGetLatestResultWithFeedbacksAsStudent_showsResultDuringExam() throws Exception {
         var now = ZonedDateTime.now();
         programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(2), now.minusHours(1), now.plusHours(1),
                 now.plusHours(10), TEST_PREFIX + "student1", 120 * 60);
@@ -433,7 +433,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetLatestResultWithFeedbacksAsStudent_afterExam_beforeExamResultsPublished() throws Exception {
+    void testGetLatestResultWithFeedbacksAsStudent_afterExam_hidesResultBeforeExamResultsPublished() throws Exception {
         var now = ZonedDateTime.now();
         programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(4), now.minusHours(2), now.minusHours(1),
                 now.plusHours(10), TEST_PREFIX + "student1", 60 * 60);
@@ -446,7 +446,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testGetLatestResultWithFeedbacksAsStudent_afterExamResultsPublished() throws Exception {
+    void testGetLatestResultWithFeedbacksAsStudent_showsResultAfterExamResultsPublished() throws Exception {
         var now = ZonedDateTime.now();
         programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(10), now.minusHours(8), now.minusHours(7),
                 now.minusHours(1), TEST_PREFIX + "student1", 60 * 60);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
@@ -211,6 +211,45 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
                 ProgrammingExerciseStudentParticipation.class);
     }
 
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetParticipationWithLatestResult_duringExam() throws Exception {
+        var now = ZonedDateTime.now();
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(2), now.minusHours(1), now.plusHours(1),
+                now.plusHours(10), TEST_PREFIX + "student1", 120 * 60);
+        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        StudentParticipation participation = (StudentParticipation) result.getParticipation();
+        var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-latest-result-and-feedbacks", HttpStatus.OK,
+                ProgrammingExerciseStudentParticipation.class);
+        assertThat(requestedParticipation.getResults()).hasSize(1);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetParticipationWithLatestResult_afterExam_beforeExamResultsPublished() throws Exception {
+        var now = ZonedDateTime.now();
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(4), now.minusHours(2), now.minusHours(1),
+                now.plusHours(10), TEST_PREFIX + "student1", 60 * 60);
+        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        StudentParticipation participation = (StudentParticipation) result.getParticipation();
+        var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-latest-result-and-feedbacks", HttpStatus.OK,
+                ProgrammingExerciseStudentParticipation.class);
+        assertThat(requestedParticipation.getResults()).isEmpty();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetParticipationWithLatestResult_afterExamResultsPublished() throws Exception {
+        var now = ZonedDateTime.now();
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(10), now.minusHours(8), now.minusHours(7),
+                now.minusHours(1), TEST_PREFIX + "student1", 60 * 60);
+        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        StudentParticipation participation = (StudentParticipation) result.getParticipation();
+        var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-latest-result-and-feedbacks", HttpStatus.OK,
+                ProgrammingExerciseStudentParticipation.class);
+        assertThat(requestedParticipation.getResults()).hasSize(1);
+    }
+
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @MethodSource("argumentsForGetParticipationResults")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
@@ -329,12 +368,93 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetParticipationAllResults_duringExam() throws Exception {
+        var now = ZonedDateTime.now();
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(2), now.minusHours(1), now.plusHours(1),
+                now.plusHours(10), TEST_PREFIX + "student1", 120 * 60);
+        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        StudentParticipation participation = (StudentParticipation) result.getParticipation();
+        participationUtilService.addResultToParticipation(AssessmentType.AUTOMATIC, now.minusMinutes(1), participation);
+        var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-all-results", HttpStatus.OK,
+                ProgrammingExerciseStudentParticipation.class);
+        assertThat(requestedParticipation.getResults()).hasSize(2);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetParticipationAllResults_afterExam_beforeExamResultsPublished() throws Exception {
+        var now = ZonedDateTime.now();
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(4), now.minusHours(2), now.minusHours(1),
+                now.plusHours(10), TEST_PREFIX + "student1", 60 * 60);
+        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        StudentParticipation participation = (StudentParticipation) result.getParticipation();
+        participationUtilService.addResultToParticipation(AssessmentType.AUTOMATIC, now.minusMinutes(1), participation);
+        var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-all-results", HttpStatus.OK,
+                ProgrammingExerciseStudentParticipation.class);
+        assertThat(requestedParticipation.getResults()).isEmpty();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetParticipationAllResults_afterExamResultsPublished() throws Exception {
+        var now = ZonedDateTime.now();
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(10), now.minusHours(8), now.minusHours(7),
+                now.minusHours(1), TEST_PREFIX + "student1", 60 * 60);
+        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        StudentParticipation participation = (StudentParticipation) result.getParticipation();
+        participationUtilService.addResultToParticipation(AssessmentType.AUTOMATIC, now.minusMinutes(1), participation);
+        var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-all-results", HttpStatus.OK,
+                ProgrammingExerciseStudentParticipation.class);
+        assertThat(requestedParticipation.getResults()).hasSize(2);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetLatestResultWithFeedbacksAsStudent() throws Exception {
         var result = addStudentParticipationWithResult(null, null);
         StudentParticipation participation = (StudentParticipation) result.getParticipation();
         var requestedResult = request.get(participationsBaseUrl + participation.getId() + "/latest-result-with-feedbacks", HttpStatus.OK, Result.class);
 
         assertThat(requestedResult.getFeedbacks()).noneMatch(Feedback::isInvisible);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetLatestResultWithFeedbacksAsStudent_duringExam() throws Exception {
+        var now = ZonedDateTime.now();
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(2), now.minusHours(1), now.plusHours(1),
+                now.plusHours(10), TEST_PREFIX + "student1", 120 * 60);
+        var result = addStudentParticipationWithResult(null, null);
+        StudentParticipation participation = (StudentParticipation) result.getParticipation();
+        var requestedResult = request.get(participationsBaseUrl + participation.getId() + "/latest-result-with-feedbacks", HttpStatus.OK, Result.class);
+
+        assertThat(requestedResult).isNotNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetLatestResultWithFeedbacksAsStudent_afterExam_beforeExamResultsPublished() throws Exception {
+        var now = ZonedDateTime.now();
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(4), now.minusHours(2), now.minusHours(1),
+                now.plusHours(10), TEST_PREFIX + "student1", 60 * 60);
+        var result = addStudentParticipationWithResult(null, null);
+        StudentParticipation participation = (StudentParticipation) result.getParticipation();
+        var requestedResult = request.get(participationsBaseUrl + participation.getId() + "/latest-result-with-feedbacks", HttpStatus.OK, Result.class);
+
+        assertThat(requestedResult).isNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetLatestResultWithFeedbacksAsStudent_afterExamResultsPublished() throws Exception {
+        var now = ZonedDateTime.now();
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(10), now.minusHours(8), now.minusHours(7),
+                now.minusHours(1), TEST_PREFIX + "student1", 60 * 60);
+        var result = addStudentParticipationWithResult(null, null);
+        StudentParticipation participation = (StudentParticipation) result.getParticipation();
+        var requestedResult = request.get(participationsBaseUrl + participation.getId() + "/latest-result-with-feedbacks", HttpStatus.OK, Result.class);
+
+        assertThat(requestedResult).isNotNull();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseParticipationIntegrationTest.java
@@ -214,10 +214,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetParticipationWithLatestResult_showsResultsDuringExam() throws Exception {
-        var now = ZonedDateTime.now();
-        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(2), now.minusHours(1), now.plusHours(1),
-                now.plusHours(10), TEST_PREFIX + "student1", 120 * 60);
-        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        var result = setupExamExerciseWithParticipationAndResult(1, TEST_PREFIX + "student1");
         StudentParticipation participation = (StudentParticipation) result.getParticipation();
         var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-latest-result-and-feedbacks", HttpStatus.OK,
                 ProgrammingExerciseStudentParticipation.class);
@@ -227,10 +224,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetParticipationWithLatestResult_afterExam_hidesResultsBeforeExamResultsPublished() throws Exception {
-        var now = ZonedDateTime.now();
-        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(4), now.minusHours(2), now.minusHours(1),
-                now.plusHours(10), TEST_PREFIX + "student1", 60 * 60);
-        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        var result = setupExamExerciseWithParticipationAndResult(4, TEST_PREFIX + "student1");
         StudentParticipation participation = (StudentParticipation) result.getParticipation();
         var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-latest-result-and-feedbacks", HttpStatus.OK,
                 ProgrammingExerciseStudentParticipation.class);
@@ -240,10 +234,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetParticipationWithLatestResult_showsResultsAfterExamResultsPublished() throws Exception {
-        var now = ZonedDateTime.now();
-        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(10), now.minusHours(8), now.minusHours(7),
-                now.minusHours(1), TEST_PREFIX + "student1", 60 * 60);
-        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        var result = setupExamExerciseWithParticipationAndResult(10, TEST_PREFIX + "student1");
         StudentParticipation participation = (StudentParticipation) result.getParticipation();
         var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-latest-result-and-feedbacks", HttpStatus.OK,
                 ProgrammingExerciseStudentParticipation.class);
@@ -369,12 +360,9 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetParticipationAllResults_showsResultsDuringExam() throws Exception {
-        var now = ZonedDateTime.now();
-        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(2), now.minusHours(1), now.plusHours(1),
-                now.plusHours(10), TEST_PREFIX + "student1", 120 * 60);
-        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        var result = setupExamExerciseWithParticipationAndResult(1, TEST_PREFIX + "student1");
         StudentParticipation participation = (StudentParticipation) result.getParticipation();
-        participationUtilService.addResultToParticipation(AssessmentType.AUTOMATIC, now.minusMinutes(1), participation);
+        participationUtilService.addResultToParticipation(AssessmentType.AUTOMATIC, ZonedDateTime.now().minusMinutes(1), participation);
         var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-all-results", HttpStatus.OK,
                 ProgrammingExerciseStudentParticipation.class);
         assertThat(requestedParticipation.getResults()).hasSize(2);
@@ -383,12 +371,9 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetParticipationAllResults_afterExam_hidesResultsBeforeExamResultsPublished() throws Exception {
-        var now = ZonedDateTime.now();
-        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(4), now.minusHours(2), now.minusHours(1),
-                now.plusHours(10), TEST_PREFIX + "student1", 60 * 60);
-        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        var result = setupExamExerciseWithParticipationAndResult(4, TEST_PREFIX + "student1");
         StudentParticipation participation = (StudentParticipation) result.getParticipation();
-        participationUtilService.addResultToParticipation(AssessmentType.AUTOMATIC, now.minusMinutes(1), participation);
+        participationUtilService.addResultToParticipation(AssessmentType.AUTOMATIC, ZonedDateTime.now().minusMinutes(1), participation);
         var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-all-results", HttpStatus.OK,
                 ProgrammingExerciseStudentParticipation.class);
         assertThat(requestedParticipation.getResults()).isEmpty();
@@ -397,12 +382,9 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetParticipationAllResults_showsResultsAfterExamResultsPublished() throws Exception {
-        var now = ZonedDateTime.now();
-        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(10), now.minusHours(8), now.minusHours(7),
-                now.minusHours(1), TEST_PREFIX + "student1", 60 * 60);
-        var result = addStudentParticipationWithResult(AssessmentType.AUTOMATIC, now.minusMinutes(2));
+        var result = setupExamExerciseWithParticipationAndResult(10, TEST_PREFIX + "student1");
         StudentParticipation participation = (StudentParticipation) result.getParticipation();
-        participationUtilService.addResultToParticipation(AssessmentType.AUTOMATIC, now.minusMinutes(1), participation);
+        participationUtilService.addResultToParticipation(AssessmentType.AUTOMATIC, ZonedDateTime.now().minusMinutes(1), participation);
         var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-all-results", HttpStatus.OK,
                 ProgrammingExerciseStudentParticipation.class);
         assertThat(requestedParticipation.getResults()).hasSize(2);
@@ -421,10 +403,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetLatestResultWithFeedbacksAsStudent_showsResultDuringExam() throws Exception {
-        var now = ZonedDateTime.now();
-        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(2), now.minusHours(1), now.plusHours(1),
-                now.plusHours(10), TEST_PREFIX + "student1", 120 * 60);
-        var result = addStudentParticipationWithResult(null, null);
+        var result = setupExamExerciseWithParticipationAndResult(1, TEST_PREFIX + "student1");
         StudentParticipation participation = (StudentParticipation) result.getParticipation();
         var requestedResult = request.get(participationsBaseUrl + participation.getId() + "/latest-result-with-feedbacks", HttpStatus.OK, Result.class);
 
@@ -434,10 +413,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetLatestResultWithFeedbacksAsStudent_afterExam_hidesResultBeforeExamResultsPublished() throws Exception {
-        var now = ZonedDateTime.now();
-        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(4), now.minusHours(2), now.minusHours(1),
-                now.plusHours(10), TEST_PREFIX + "student1", 60 * 60);
-        var result = addStudentParticipationWithResult(null, null);
+        var result = setupExamExerciseWithParticipationAndResult(4, TEST_PREFIX + "student1");
         StudentParticipation participation = (StudentParticipation) result.getParticipation();
         var requestedResult = request.get(participationsBaseUrl + participation.getId() + "/latest-result-with-feedbacks", HttpStatus.OK, Result.class);
 
@@ -447,10 +423,7 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetLatestResultWithFeedbacksAsStudent_showsResultAfterExamResultsPublished() throws Exception {
-        var now = ZonedDateTime.now();
-        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(now.minusHours(10), now.minusHours(8), now.minusHours(7),
-                now.minusHours(1), TEST_PREFIX + "student1", 60 * 60);
-        var result = addStudentParticipationWithResult(null, null);
+        var result = setupExamExerciseWithParticipationAndResult(10, TEST_PREFIX + "student1");
         StudentParticipation participation = (StudentParticipation) result.getParticipation();
         var requestedResult = request.get(participationsBaseUrl + participation.getId() + "/latest-result-with-feedbacks", HttpStatus.OK, Result.class);
 
@@ -800,6 +773,26 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpringInte
         Result result = participationUtilService.addResultToParticipation(AssessmentType.AUTOMATIC, null, programmingExerciseParticipation);
         participationUtilService.addVariousVisibilityFeedbackToResult(result);
         return (SolutionProgrammingExerciseParticipation) programmingExerciseParticipation;
+    }
+
+    /**
+     * Sets up an exam exercise with a participation and a result. The exam duration is two hours and the publishResultsDate is 10 hours after the exam start.
+     *
+     * @param hoursSinceExamStart The hours since the exam start.
+     * @param userLogin           The user login
+     * @return The result attached to the participation
+     */
+    private Result setupExamExerciseWithParticipationAndResult(int hoursSinceExamStart, String userLogin) {
+        var now = ZonedDateTime.now();
+        var startDate = now.minusHours(hoursSinceExamStart);
+        var endDate = startDate.plusHours(1);
+        var visibilityDate = startDate.minusHours(1);
+        var publishResultsDate = startDate.plusHours(10);
+        var workingTime = 120 * 60;
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(visibilityDate, startDate, endDate, publishResultsDate,
+                userLogin, workingTime);
+        programmingExerciseParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, userLogin);
+        return addStudentParticipationWithResult(AssessmentType.AUTOMATIC, startDate.plusMinutes(2));
     }
 
 }

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseResultJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseResultJenkinsIntegrationTest.java
@@ -185,6 +185,32 @@ class ProgrammingExerciseResultJenkinsIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void shouldCorrectlyNotifyStudentsAboutNewResultsInOngoingExamExercise() throws Exception {
+        programmingExerciseResultTestService.setupProgrammingExerciseForExam(false);
+        var exercise = programmingExerciseResultTestService.getProgrammingExercise();
+        var commit = new CommitDTO("abc123", "slug", DEFAULT_BRANCH);
+        String repoName = getRepoName(exercise, TEST_PREFIX + "student1");
+        String folderName = getFolderName(exercise, repoName);
+        var notification = ProgrammingExerciseFactory.generateTestResultDTO(folderName, repoName, null, ProgrammingLanguage.JAVA, false, List.of("test1", "test2"),
+                List.of("test3"), List.of(), List.of(commit), null);
+        programmingExerciseResultTestService.shouldCorrectlyNotifyStudentsAboutNewResults(notification, websocketMessagingService);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void shouldNotNotifyStudentsAboutNewResultsInEndedExamExercise() throws Exception {
+        programmingExerciseResultTestService.setupProgrammingExerciseForExam(true);
+        var exercise = programmingExerciseResultTestService.getProgrammingExercise();
+        var commit = new CommitDTO("abc123", "slug", DEFAULT_BRANCH);
+        String repoName = getRepoName(exercise, TEST_PREFIX + "student1");
+        String folderName = getFolderName(exercise, repoName);
+        var notification = ProgrammingExerciseFactory.generateTestResultDTO(folderName, repoName, null, ProgrammingLanguage.JAVA, false, List.of("test1", "test2"),
+                List.of("test3"), List.of(), List.of(commit), null);
+        programmingExerciseResultTestService.shouldNotNotifyStudentsAboutNewResults(notification, websocketMessagingService);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void shouldRemoveTestCaseNamesFromWebsocketNotification() throws Exception {
         var exercise = programmingExerciseResultTestService.getProgrammingExercise();
         var commit = new CommitDTO("abc123", "slug", DEFAULT_BRANCH);

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseUtilService.java
@@ -287,6 +287,29 @@ public class ProgrammingExerciseUtilService {
     }
 
     /**
+     * Creates and saves a course with an exam and an exercise group with a programming exercise.
+     *
+     * @param visibleDate       The visible date of the exam.
+     * @param startDate         The start date of the exam.
+     * @param endDate           The end date of the exam.
+     * @param publishResultDate The publish result date of the exam.
+     * @param userLogin         The login of the user for the student exam.
+     * @param workingTime       The working time of the student exam in seconds.
+     * @return The newly created exam programming exercise.
+     */
+    public ProgrammingExercise addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(ZonedDateTime visibleDate, ZonedDateTime startDate, ZonedDateTime endDate,
+            ZonedDateTime publishResultDate, String userLogin, int workingTime) {
+        var programmingExercise = this.addCourseExamExerciseGroupWithOneProgrammingExercise();
+        var exam = programmingExercise.getExerciseGroup().getExam();
+        examUtilService.setVisibleStartAndEndDateOfExam(exam, visibleDate, startDate, endDate);
+        exam.setPublishResultsDate(publishResultDate);
+        examRepository.save(exam);
+        var studentExam = examUtilService.addStudentExamWithUserAndWorkingTime(exam, userLogin, workingTime);
+        examUtilService.addExerciseToStudentExam(studentExam, programmingExercise);
+        return programmingExercise;
+    }
+
+    /**
      * Creates and saves an already submitted programming submission done manually.
      *
      * @param participation The exercise participation.

--- a/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/exercise/programming/ProgrammingExerciseUtilService.java
@@ -289,20 +289,20 @@ public class ProgrammingExerciseUtilService {
     /**
      * Creates and saves a course with an exam and an exercise group with a programming exercise.
      *
-     * @param visibleDate       The visible date of the exam.
-     * @param startDate         The start date of the exam.
-     * @param endDate           The end date of the exam.
-     * @param publishResultDate The publish result date of the exam.
-     * @param userLogin         The login of the user for the student exam.
-     * @param workingTime       The working time of the student exam in seconds.
+     * @param visibleDate        The visible date of the exam.
+     * @param startDate          The start date of the exam.
+     * @param endDate            The end date of the exam.
+     * @param publishResultsDate The publish results date of the exam.
+     * @param userLogin          The login of the user for the student exam.
+     * @param workingTime        The working time of the student exam in seconds.
      * @return The newly created exam programming exercise.
      */
     public ProgrammingExercise addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(ZonedDateTime visibleDate, ZonedDateTime startDate, ZonedDateTime endDate,
-            ZonedDateTime publishResultDate, String userLogin, int workingTime) {
+            ZonedDateTime publishResultsDate, String userLogin, int workingTime) {
         var programmingExercise = this.addCourseExamExerciseGroupWithOneProgrammingExercise();
         var exam = programmingExercise.getExerciseGroup().getExam();
         examUtilService.setVisibleStartAndEndDateOfExam(exam, visibleDate, startDate, endDate);
-        exam.setPublishResultsDate(publishResultDate);
+        exam.setPublishResultsDate(publishResultsDate);
         examRepository.save(exam);
         var studentExam = examUtilService.addStudentExamWithUserAndWorkingTime(exam, userLogin, workingTime);
         examUtilService.addExerciseToStudentExam(studentExam, programmingExercise);


### PR DESCRIPTION
### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#9152 hid the results of exam programming exercises after the exam, but before the results were released. That PR did not have any server tests.

### Description
<!-- Describe your changes in detail -->
Added server tests testing the behavior
- during the exam (results should be sent)
- after the exam, but before the results are published (results should not be sent)
- after the results are published (results should be sent)

Also checked that students
- receive websocket notifications about new results during the exam
- do not receive websocket notifications about new results after the exam

### Steps for Testing

Code review

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to create student exams with customizable working time.
	- Added functionality for managing courses that include exams and exercise groups with specific dates.
- **Bug Fixes**
	- Enhanced testing for student result notifications during and after exam scenarios, ensuring accurate visibility based on exam timing.
- **Tests**
	- Expanded test coverage for exam participation and result notifications to improve reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->