### PR TITLE
`Communication`: Fix link in email notification

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/NotificationTargetFactory.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/NotificationTargetFactory.java
@@ -339,11 +339,11 @@ public class NotificationTargetFactory {
      * If the post is not associated with a conversation or messaging is disabled in the course, the URL leads to the communication page.
      *
      * @param post    which information will be needed to create the URL
-     * @param baseUrl the prefix (depends on current set up (e.g. "http://localhost:9000/courses"))
+     * @param baseUrl the prefix (depends on current set up (e.g. "http://localhost:9000"))
      * @return viable URL to the notification related page
      */
     public static String extractNotificationUrl(Post post, String baseUrl) {
-        // e.g. http://localhost:8080/courses/1/messages?conversationId=123
-        return baseUrl + "/courses/" + post.getConversation().getCourse().getId() + "/messages?conversationId=" + post.getConversation().getId();
+        // e.g. http://localhost:8080/courses/1/communication?conversationId=123
+        return baseUrl + "/courses/" + post.getConversation().getCourse().getId() + "/communication?conversationId=" + post.getConversation().getId();
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/notification/NotificationTargetFactoryTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/NotificationTargetFactoryTest.java
@@ -58,8 +58,6 @@ class NotificationTargetFactoryTest {
 
     private static final String BASE_URL = "https://artemistest.ase.in.tum.de";
 
-    private static final String MESSAGES_CONVERSATION = "messages?conversationId=";
-
     private String resultingURL;
 
     private static final String PROBLEM_STATEMENT = "problem statement";
@@ -74,8 +72,8 @@ class NotificationTargetFactoryTest {
 
     // expected/correct URLs
 
-    // e.g. https://artemistest.ase.in.tum.de/courses/477/discussion?searchText=%232000
-    private static final String EXPECTED_POST_URL = BASE_URL_COURSES_COURSE_ID + "/" + MESSAGES_CONVERSATION + CHANNEL_ID;
+    // e.g. https://artemistest.ase.in.tum.de/courses/477/communication?conversationId=2000
+    private static final String EXPECTED_POST_URL = BASE_URL_COURSES_COURSE_ID + "/" + "communication?conversationId=" + CHANNEL_ID;
 
     // e.g. https://artemistest.ase.in.tum.de/courses/477/lectures/199
     private static final String EXPECTED_ATTACHMENT_CHANGED_URL = BASE_URL_COURSES_COURSE_ID + "/" + LECTURES_TEXT + "/" + LECTURE_ID;


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
Fixes #9211

### Description
Changed the endpoint to be the correct one.


### Steps for Testing
Send someone a message who has email notification activated.
Click the link in the email and check that it works.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated notification URLs to enhance flexibility and clarity, now directing users to a unified communication page.

- **Bug Fixes**
  - Adjusted URL structure in tests to reflect the new API endpoint, ensuring consistency and correctness in functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->