### PR TITLE
`Development`: Add Artemis icon and description to LTI's dynamic registration info

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/lti/Lti13ClientRegistration.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/lti/Lti13ClientRegistration.java
@@ -37,6 +37,9 @@ public class Lti13ClientRegistration {
     @JsonProperty("jwks_uri")
     private String jwksUri;
 
+    @JsonProperty("logo_uri")
+    private String logoUri;
+
     @JsonProperty("token_endpoint_auth_method")
     private String tokenEndpointAuthMethod;
 
@@ -67,6 +70,7 @@ public class Lti13ClientRegistration {
         this.setRedirectUris(List.of(serverUrl + "/" + CustomLti13Configurer.LTI13_LOGIN_REDIRECT_PROXY_PATH));
         this.setInitiateLoginUri(serverUrl + "/" + CustomLti13Configurer.LTI13_LOGIN_INITIATION_PATH + "/" + clientRegistrationId);
         this.setJwksUri(serverUrl + "/.well-known/jwks.json");
+        this.setLogoUri(serverUrl + "/public/images/logo.png");
 
         Lti13ToolConfiguration toolConfiguration = getLti13ToolConfiguration(serverUrl);
         this.setLti13ToolConfiguration(toolConfiguration);
@@ -83,6 +87,7 @@ public class Lti13ClientRegistration {
         }
         toolConfiguration.setDomain(domain);
         toolConfiguration.setTargetLinkUri(serverUrl + "/courses");
+        toolConfiguration.setDescription("Artemis: Interactive Learning with Individual Feedback");
         toolConfiguration.setClaims(Arrays.asList("iss", "email", "sub", "name", "given_name", "family_name"));
         Message deepLinkingMessage = new Message(CustomLti13Configurer.LTI13_DEEPLINK_MESSAGE_REQUEST, serverUrl + "/" + CustomLti13Configurer.LTI13_DEEPLINK_REDIRECT_PATH);
         toolConfiguration.setMessages(List.of(deepLinkingMessage));
@@ -145,6 +150,14 @@ public class Lti13ClientRegistration {
         this.jwksUri = jwksUri;
     }
 
+    public String getLogoUri() {
+        return logoUri;
+    }
+
+    public void setLogoUri(String logoUri) {
+        this.logoUri = logoUri;
+    }
+
     public String getTokenEndpointAuthMethod() {
         return tokenEndpointAuthMethod;
     }
@@ -179,6 +192,8 @@ public class Lti13ClientRegistration {
         @JsonProperty("target_link_uri")
         private String targetLinkUri;
 
+        private String description;
+
         private List<Message> messages;
 
         private List<String> claims;
@@ -197,6 +212,14 @@ public class Lti13ClientRegistration {
 
         public void setTargetLinkUri(String targetLinkUri) {
             this.targetLinkUri = targetLinkUri;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
         }
 
         public List<Message> getMessages() {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, there is no Artemis description or icon send during the dynamic registration of LTI.

The following screenshot shows a description placeholder and icon in Moodle:
![image](https://github.com/user-attachments/assets/901bcc14-b4e4-47a6-ae81-726d5d869bb4)


### Description
<!-- Describe your changes in detail -->
This PR adds an Artemis description and the URI to the Artemis Logo to the LTI's dynamic registration information.

The following screenshot shows a description for Artemis and the Artemis icon in Moodle:
![image](https://github.com/user-attachments/assets/fb8cc479-8e2b-4af7-992f-251c3c97d436)


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Access to Moodle
- Admin Access on a test server 

1. Log in to Artemis
2. Navigate to LTI Configuration
**3. If the Moodle instance is already registered, you need to delete it first**
4. Copy dynamic registration url
5. Login to Moodle
6. Navigate to Site Administration, Plugins, External Tools, Manage tools
**6. If the Artemis Testserver is already registered in Moodle, you need to delete if first**
7. Paste in the copied registration url and click on the _Add LTI Advantage_ button
8. The Artemis Testserver should be registered and the icon as well as the description should be displayed 


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance 
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for a logo URI in client registration, enhancing visual identification in user interfaces.
	- Introduced a description field for tools, allowing for more detailed information about the registered application.

These improvements enhance the configurability and usability of the LTI 1.3 client registration, providing essential metadata for better integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->