### PR TITLE
`Development`: Extend documentation for configuring Artemis

### DIFF
--- a/docs/dev/setup/integrated-code-lifecycle.rst
+++ b/docs/dev/setup/integrated-code-lifecycle.rst
@@ -64,7 +64,7 @@ If you are running Artemis inside of a docker container, use ``tcp://host.docker
 Make sure that Artemis can access docker by activating the "Expose daemon on tcp://localhost:2375 without TLS" option under Settings > General in Docker Desktop.
 
 If you are running Artemis on Linux, and are using Docker Desktop, you also need to add a property ``artemis.continuous-integration.docker-connection-uri``.
-The value for that property should then be the path to your unix socket used for connecting to Docker daemon, as shown above.
+The value should be the path to your unix socket for connecting to the Docker daemon, as shown above.
 In IntelliJ this might require you to first go into "Settings => Build, Execution, Deployment => Docker", add a new instance by clicking the '+',
 select "Unix socket" and choose the Docker Desktop socket (by default should be named "desktop-linux").
 Now simply look at the path in grey and set that path as the value for the ``artemis.continuous-integration.docker-connection-uri`` property.

--- a/docs/dev/setup/integrated-code-lifecycle.rst
+++ b/docs/dev/setup/integrated-code-lifecycle.rst
@@ -65,7 +65,7 @@ Make sure that Artemis can access docker by activating the "Expose daemon on tcp
 
 If you are running Artemis on Linux, and are using Docker Desktop, you also need to add a property ``artemis.continuous-integration.docker-connection-uri``.
 The value should be the path to your unix socket for connecting to the Docker daemon, as shown above.
-In IntelliJ this might require you to first go into "Settings => Build, Execution, Deployment => Docker", add a new instance by clicking the '+',
+IntelliJ can help you to dermine the path by navigating into "Settings => Build, Execution, Deployment => Docker". Add a new instance by clicking the '+' icon,
 select "Unix socket" and choose the Docker Desktop socket (by default should be named "desktop-linux").
 Now simply look at the path in grey and set that path as the value for the ``artemis.continuous-integration.docker-connection-uri`` property.
 

--- a/docs/dev/setup/integrated-code-lifecycle.rst
+++ b/docs/dev/setup/integrated-code-lifecycle.rst
@@ -48,6 +48,9 @@ Create a file ``src/main/resources/config/application-local.yml`` with the follo
                image-architecture: arm64
                # Only necessary on Windows:
                docker-connection-uri: tcp://localhost:2375
+               # Only necessary on Linux if using Docker Desktop
+               # The value might deviate depending on installation path:
+               docker-connection-uri: unix:///home/<user>/.docker/desktop/docker.sock
        eureka:
            client:
                register-with-eureka: false
@@ -59,6 +62,12 @@ If you are running Artemis on Windows, you also need to add a property ``artemis
 with the value ``tcp://localhost:2375`` as shown above.
 If you are running Artemis inside of a docker container, use ``tcp://host.docker.internal:2375`` instead.
 Make sure that Artemis can access docker by activating the "Expose daemon on tcp://localhost:2375 without TLS" option under Settings > General in Docker Desktop.
+
+If you are running Artemis on Linux, and are using Docker Desktop, you also need to add a property ``artemis.continuous-integration.docker-connection-uri``.
+The value for that property should then be the path to your unix socket used for connecting to Docker daemon, as shown above.
+In IntelliJ this might require you to first go into "Settings => Build, Execution, Deployment => Docker", add a new instance by clicking the '+',
+select "Unix socket" and choose the Docker Desktop socket (by default should be named "desktop-linux").
+Now simply look at the path in grey and set that path as the value for the ``artemis.continuous-integration.docker-connection-uri`` property.
 
 When you start Artemis for the first time, it will automatically create an admin user called "artemis_admin". If this does not work, refer to the guide for the :ref:`Jenkins and GitLab Setup` to manually create an admin user in the database.
 You can then use that admin user to create further users in Artemis' internal user management system.


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
When using Docker Desktop on Linux, the server will fail to execute build jobs for programming exercises due to the following exception: `java.lang.RuntimeException: java.io.IOException: com.sun.jna.LastErrorException: [2] No such file or directory`.


### Description
Added an explanation for what to do if you're using Docker Desktop on Linux to [the documentation for how to set up a programming exercise environment based on the Integrated Code Lifecycle](https://docs.artemis.cit.tum.de/dev/setup/integrated-code-lifecycle.html#configure-artemis).


### Review Progress
#### Documentation Review
- [ ] Review 1
- [ ] Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Improved setup instructions for configuring Docker connections specifically for Linux users, introducing a new configuration line and detailed steps for IntelliJ integration.
	- Continued support for Windows users by maintaining existing guidance, ensuring comprehensive documentation for all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->