### PR TITLE
`Development`: Fix the login page e2e tests

### DIFF
--- a/src/test/playwright/support/pageobjects/LoginPage.ts
+++ b/src/test/playwright/support/pageobjects/LoginPage.ts
@@ -12,19 +12,33 @@ export class LoginPage {
     }
 
     /**
-     * Enters the specified username into the username input field.
-     * @param name - The username to be entered.
+     * Enters the specified value into the input field with the specified selector, then blurs the input field.
+     * This is necessary because the username and password fields are only validated on blur, e.g. when the user clicks
+     * elsewhere on the page or presses the Tab key.
+     * @param selector The selector of the input field.
+     * @param value The value to be entered.
+     * @private
      */
-    async enterUsername(name: string) {
-        await this.page.fill('#username', name);
+    private async fillThenBlurInput(selector: string, value: string) {
+        const locator = this.page.locator(selector);
+        await locator.fill(value);
+        await locator.blur();
     }
 
     /**
-     * Enters the specified password into the password input field.
+     * Enters the specified username into the username input field, then blurs the input field.
+     * @param name - The username to be entered.
+     */
+    async enterUsername(name: string) {
+        await this.fillThenBlurInput('#username', name);
+    }
+
+    /**
+     * Enters the specified password into the password input field, then blurs the input field.
      * @param password - The password to be entered.
      */
     async enterPassword(password: string) {
-        await this.page.fill('#password', password);
+        await this.fillThenBlurInput('#password', password);
     }
 
     /**


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Since #9270, the input of the password field is only validated on blur. This means that the "Sign in" button stays disabled until the user clicks away / tabs away from the password field, e.g. by trying to click on the "Sign in" button.

After typing the password, Playwright tries to click on the "Sign in" button but finds that it is disabled (because the password field hasn't been blurred yet). The tests fail as a result:

![image](https://github.com/user-attachments/assets/93cf8c16-3210-4ff0-92f4-cd09ac5dc6bc)

### Description
<!-- Describe your changes in detail -->
Ensures that we blur the input fields on the login page in the e2e tests.

### Steps for Testing

Check that no e2e tests fail for the login page.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved input handling for username and password fields in the login process.
	- Added a new method to streamline the filling and validation of input fields.

- **Refactor**
	- Enhanced code maintainability by centralizing input field logic, reducing duplication, and clarifying intent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->