### PR TITLE
`Programming exercises`: Fix translation issue for participation modes in exam management

### DIFF
--- a/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.html
@@ -84,7 +84,7 @@
     @if (displayEditorModus) {
         <div>
             <div class="d-flex justify-content-between">
-                <span [jhiTranslate]="'artemisApp.programmingExercise.offlineIde'"></span>:
+                <span class="colon-suffix" [jhiTranslate]="'artemisApp.programmingExercise.offlineIde'"></span>
                 <span [jhiTranslate]="programmingExercise.allowOfflineIde ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
             </div>
             <div class="d-flex justify-content-between">

--- a/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.html
@@ -88,12 +88,12 @@
                 <span [jhiTranslate]="programmingExercise.allowOfflineIde ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
             </div>
             <div class="d-flex justify-content-between">
-                <span [jhiTranslate]="'artemisApp.programmingExercise.onlineEditor'"></span>:
+                <span class="colon-suffix" [jhiTranslate]="'artemisApp.programmingExercise.onlineEditor'"></span>
                 <span [jhiTranslate]="programmingExercise.allowOnlineEditor ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
             </div>
             @if (onlineIdeEnabled) {
                 <div class="d-flex justify-content-between">
-                    <span [jhiTranslate]="'artemisApp.programmingExercise.onlineIde'"></span>:
+                    <span class="colon-suffix" [jhiTranslate]="'artemisApp.programmingExercise.onlineIde'"></span>
                     <span [jhiTranslate]="programmingExercise.allowOnlineIde ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
                 </div>
             }

--- a/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.html
@@ -84,14 +84,19 @@
     @if (displayEditorModus) {
         <div>
             <div class="d-flex justify-content-between">
-                <span jhiTranslate="'artemisApp.programmingExercise.offlineIde'">: {{ programmingExercise.allowOfflineIde || false }}</span>
+                <span [jhiTranslate]="'artemisApp.programmingExercise.offlineIde'"></span>:
+                <span [jhiTranslate]="programmingExercise.allowOfflineIde ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
             </div>
             <div class="d-flex justify-content-between">
-                <span jhiTranslate="'artemisApp.programmingExercise.onlineEditor'">: {{ programmingExercise.allowOnlineEditor || false }}</span>
+                <span [jhiTranslate]="'artemisApp.programmingExercise.onlineEditor'"></span>:
+                <span [jhiTranslate]="programmingExercise.allowOnlineEditor ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
             </div>
-            <div class="d-flex justify-content-between">
-                <span jhiTranslate="'artemisApp.programmingExercise.onlineIde'">: {{ programmingExercise.allowOnlineIde || false }}</span>
-            </div>
+            @if (onlineIdeEnabled) {
+                <div class="d-flex justify-content-between">
+                    <span [jhiTranslate]="'artemisApp.programmingExercise.onlineIde'"></span>:
+                    <span [jhiTranslate]="programmingExercise.allowOnlineIde ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
+                </div>
+            }
         </div>
     }
 }

--- a/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.ts
+++ b/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.ts
@@ -9,7 +9,7 @@ import { ProgrammingExerciseInstructorRepositoryType, ProgrammingExerciseService
 import { downloadZipFileFromResponse } from 'app/shared/util/download.util';
 import { AlertService } from 'app/core/util/alert.service';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
-import { PROFILE_LOCALVC } from 'app/app.constants';
+import { PROFILE_LOCALVC, PROFILE_THEIA } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-programming-exercise-group-cell',
@@ -22,6 +22,7 @@ export class ProgrammingExerciseGroupCellComponent implements OnInit {
     programmingExercise: ProgrammingExercise;
 
     localVCEnabled = false;
+    onlineIdeEnabled = false;
 
     @Input()
     displayShortName = false;
@@ -48,6 +49,7 @@ export class ProgrammingExerciseGroupCellComponent implements OnInit {
     ngOnInit(): void {
         this.profileService.getProfileInfo().subscribe((profileInfo) => {
             this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
+            this.onlineIdeEnabled = profileInfo.activeProfiles.includes(PROFILE_THEIA);
             if (this.programmingExercise.projectKey) {
                 if (this.programmingExercise.solutionParticipation?.buildPlanId) {
                     this.programmingExercise.solutionParticipation!.buildPlanUrl = createBuildPlanUrl(

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -139,16 +139,16 @@
                         }
                         <td class="d-md-table-cell">
                             <div class="d-flex justify-content-between">
-                                <span [jhiTranslate]="'artemisApp.programmingExercise.offlineIde'"></span>:
+                                <span class="colon-suffix" [jhiTranslate]="'artemisApp.programmingExercise.offlineIde'"></span>
                                 <span [jhiTranslate]="programmingExercise.allowOfflineIde ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
                             </div>
                             <div class="d-flex justify-content-between">
-                                <span [jhiTranslate]="'artemisApp.programmingExercise.onlineEditor'"></span>:
+                                <span class="colon-suffix" [jhiTranslate]="'artemisApp.programmingExercise.onlineEditor'"></span>
                                 <span [jhiTranslate]="programmingExercise.allowOnlineEditor ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
                             </div>
                             @if (onlineIdeEnabled) {
                                 <div class="d-flex justify-content-between">
-                                    <span [jhiTranslate]="'artemisApp.programmingExercise.onlineIde'"></span>:
+                                    <span class="colon-suffix" [jhiTranslate]="'artemisApp.programmingExercise.onlineIde'"></span>
                                     <span [jhiTranslate]="programmingExercise.allowOnlineIde ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
                                 </div>
                             }

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -146,10 +146,12 @@
                                 <span [jhiTranslate]="'artemisApp.programmingExercise.onlineEditor'"></span>:
                                 <span [jhiTranslate]="programmingExercise.allowOnlineEditor ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
                             </div>
-                            <div class="d-flex justify-content-between">
-                                <span [jhiTranslate]="'artemisApp.programmingExercise.onlineIde'"></span>:
-                                <span [jhiTranslate]="programmingExercise.allowOnlineIde ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
-                            </div>
+                            @if (onlineIdeEnabled) {
+                                <div class="d-flex justify-content-between">
+                                    <span [jhiTranslate]="'artemisApp.programmingExercise.onlineIde'"></span>:
+                                    <span [jhiTranslate]="programmingExercise.allowOnlineIde ? 'artemisApp.exercise.yes' : 'artemisApp.exercise.no'"></span>
+                                </div>
+                            }
                         </td>
                         @if (course.presentationScore !== 0) {
                             <td class="d-md-table-cell">{{ programmingExercise.presentationScoreEnabled }}</td>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.ts
@@ -39,7 +39,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { CourseExerciseService } from 'app/exercises/shared/course-exercises/course-exercise.service';
 import { downloadZipFileFromResponse } from 'app/shared/util/download.util';
-import { PROFILE_LOCALCI, PROFILE_LOCALVC } from 'app/app.constants';
+import { PROFILE_LOCALCI, PROFILE_LOCALVC, PROFILE_THEIA } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-programming-exercise',
@@ -55,6 +55,7 @@ export class ProgrammingExerciseComponent extends ExerciseComponent implements O
     // Used to make the repository links download the repositories instead of linking to GitLab.
     localVCEnabled = false;
     localCIEnabled = false;
+    onlineIdeEnabled = false;
 
     // extension points, see shared/extension-point
     @ContentChild('overrideRepositoryAndBuildPlan') overrideRepositoryAndBuildPlan: TemplateRef<any>;
@@ -111,6 +112,7 @@ export class ProgrammingExerciseComponent extends ExerciseComponent implements O
                     this.buildPlanLinkTemplate = profileInfo.buildPlanURLTemplate;
                     this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
                     this.localCIEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALCI);
+                    this.onlineIdeEnabled = profileInfo.activeProfiles.includes(PROFILE_THEIA);
                 });
                 // reconnect exercise with course
                 this.programmingExercises.forEach((exercise) => {

--- a/src/test/javascript/spec/component/exam/manage/exercise-groups/programming-exercise-group-cell.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exercise-groups/programming-exercise-group-cell.component.spec.ts
@@ -11,6 +11,8 @@ import { of } from 'rxjs';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
 import { AlertService } from 'app/core/util/alert.service';
 import { MockAlertService } from '../../../../helpers/mocks/service/mock-alert.service';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
+import { PROFILE_THEIA } from 'app/app.constants';
 
 describe('Programming Exercise Group Cell Component', () => {
     let comp: ProgrammingExerciseGroupCellComponent;
@@ -43,12 +45,12 @@ describe('Programming Exercise Group Cell Component', () => {
                 // @ts-ignore
                 of({
                     buildPlanURLTemplate: 'https://example.com/{buildPlanId}/{projectKey}',
-                    activeProfiles: [],
+                    activeProfiles: [PROFILE_THEIA],
                 }),
         };
 
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule],
+            imports: [ArtemisTestModule, ArtemisSharedCommonModule],
             declarations: [ProgrammingExerciseGroupCellComponent, TranslatePipeMock],
             providers: [
                 { provide: ProfileService, useValue: mockedProfileService },
@@ -94,15 +96,15 @@ describe('Programming Exercise Group Cell Component', () => {
 
         const div0 = fixture.debugElement.query(By.css('div > div > div:first-child'));
         expect(div0).not.toBeNull();
-        expect(div0.nativeElement.textContent?.trim()).toBe(': true');
+        expect(div0.nativeElement.textContent?.trim()).toBe('artemisApp.programmingExercise.offlineIdeartemisApp.exercise.yes');
 
         const div1 = fixture.debugElement.query(By.css('div > div > div:nth-child(2)'));
         expect(div1).not.toBeNull();
-        expect(div1.nativeElement.textContent?.trim()).toBe(': true');
+        expect(div1.nativeElement.textContent?.trim()).toBe('artemisApp.programmingExercise.onlineEditorartemisApp.exercise.yes');
 
         const div2 = fixture.debugElement.query(By.css('div > div > div:nth-child(3)'));
         expect(div2).not.toBeNull();
-        expect(div2.nativeElement.textContent?.trim()).toBe(': false');
+        expect(div2.nativeElement.textContent?.trim()).toBe('artemisApp.programmingExercise.onlineIdeartemisApp.exercise.no');
     });
 
     it('should download the repository', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As discovered by @SimonEntholzer translations for the `Participation Modes` were faulty in the exam management. This PR fixes the translations and also hides informations about the Online IDE when it's not enabled on the respective server. 

### Description
<!-- Describe your changes in detail -->
I reused the implementation for the (correctly working and dev-approved) non-exam exercise management components and applied it to exams. As I touched the code anyways, I added a new check that only shows the Online IDE informations when the respective profile is active. 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->


#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 1 Exam with Exercise Groups and Programming Exercises

1. Navigate to the exercise group in the exam
2. Verify that the `Participation Mode` is well readable and no translation errors are shown

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [x] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Bugged view as reported by @SimonEntholzer 
![image](https://github.com/user-attachments/assets/d183d5fb-adb4-4a95-bff6-d31bce77c8c8)

New, fixed version on a server without `THEIA` profile enabled
![image](https://github.com/user-attachments/assets/e64c14c6-2d85-4515-a242-245c2b2c433d)


New, fixed version on a server with `THEIA` profile enabled
![image](https://github.com/user-attachments/assets/0c61130d-54e1-4463-b3a9-904a05f6d5b8)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced display logic for programming exercise settings, improving clarity on offline and online editor options.
	- Introduced conditional rendering for the online IDE feature, ensuring it only appears when relevant.
	- Added support for a new online IDE profile, allowing for a more versatile user experience.

- **Bug Fixes**
	- Improved responsiveness of the programming exercise management interface by preventing unnecessary rendering of UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->