### PR TITLE
`Development`: Fix profile for Apollon resource

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/modeling/repository/ApollonDiagramRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/repository/ApollonDiagramRepository.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.artemis.modeling.repository;
 
-import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_APOLLON;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.util.List;
 
@@ -16,7 +16,7 @@ import de.tum.cit.aet.artemis.modeling.domain.ApollonDiagram;
 /**
  * Spring Data JPA repository for the ApollonDiagram entity.
  */
-@Profile(PROFILE_APOLLON)
+@Profile(PROFILE_CORE)
 @Repository
 public interface ApollonDiagramRepository extends ArtemisJpaRepository<ApollonDiagram, Long> {
 

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/web/ApollonDiagramResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/web/ApollonDiagramResource.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.artemis.modeling.web;
 
-import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_APOLLON;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -35,7 +35,7 @@ import de.tum.cit.aet.artemis.modeling.repository.ApollonDiagramRepository;
 /**
  * REST controller for managing ApollonDiagram.
  */
-@Profile(PROFILE_APOLLON)
+@Profile(PROFILE_CORE)
 @RestController
 @RequestMapping("api/")
 public class ApollonDiagramResource {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In quiz exercieses, creating apollon drag and drop quizes does not work currently, if the `apollon` profile is not active.
This logically broke the e2e test, which checks, if that feature works: https://bamboo.ase.in.tum.de/browse/ARTEMIS-AEPTMA-DA-500

### Description
<!-- Describe your changes in detail -->
Fix the issue by reverting the used profiles in the two needed java classes

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
1. Course Management -> New Quiz Exercise
2. Add Apollon Drag and drop question -> create a new apollon diagram
3. If creation works the bug is resolved


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

How the error shows up on test servers: (No apollon dnd quiz question is created) 
![image](https://github.com/user-attachments/assets/6a652cb8-cc49-4131-825b-25af04607fc1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The `ApollonDiagramRepository` and `ApollonDiagramResource` are now configured to operate under the core application profile, enhancing their integration within the main functionalities of the app.
  
- **Bug Fixes**
	- Adjusted profile settings to ensure compatibility and correct functionality of the resources and repositories under the new operational context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->