### PR TITLE
`Development`: Exclude xmlunit dependency due to transitive vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -506,6 +506,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test:${spring_boot_version}") {
         exclude group: "org.junit.vintage", module: "junit-vintage-engine"
         exclude group: "com.vaadin.external.google", module: "android-json"
+        exclude group: "org.xmlunit", module: "xmlunit-core"
     }
     testImplementation "org.springframework.security:spring-security-test:${spring_security_version}"
     testImplementation "org.springframework.boot:spring-boot-test:${spring_boot_version}"

--- a/supporting_scripts/course-scripts/quick-course-setup/requirements.txt
+++ b/supporting_scripts/course-scripts/quick-course-setup/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.32.3
-urllib3==2.2.2
+urllib3==2.2.3


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
Closes #9331
![grafik](https://github.com/user-attachments/assets/7a0e22ec-0194-4315-9ad6-6a02e3a51e98)


### Description
spring-boot-starter-test is a collection of many dependencies used for testing. We don't need xmlunit since we use the objectMapper for XML parsing. Since it creates a dependency warning, we now exclude it.


### Steps for Testing
see that the tests still pass.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Excluded `xmlunit-core` from testing dependencies to resolve conflicts during testing.
	- Updated `urllib3` version to address bugs and improve performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->