### PR TITLE
Draft: `Programming`: Provide theia clone information on redirect

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingExerciseBuildConfig.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingExerciseBuildConfig.java
@@ -25,6 +25,7 @@ import de.tum.cit.aet.artemis.programming.service.vcs.AbstractVersionControlServ
 @Entity
 @Table(name = "programming_exercise_build_config")
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(value = { "programmingExercise" })
 public class ProgrammingExerciseBuildConfig extends DomainObject {
 
     private static final Logger log = LoggerFactory.getLogger(ProgrammingExerciseBuildConfig.class);
@@ -58,7 +59,6 @@ public class ProgrammingExerciseBuildConfig extends DomainObject {
     private String dockerFlags;
 
     @OneToOne(mappedBy = "buildConfig")
-    @JsonIgnoreProperties("buildConfig")
     private ProgrammingExercise programmingExercise;
 
     @Column(name = "testwise_coverage_enabled")

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseBuildConfigRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseBuildConfigRepository.java
@@ -35,4 +35,14 @@ public interface ProgrammingExerciseBuildConfigRepository extends ArtemisJpaRepo
     default void loadAndSetBuildConfig(ProgrammingExercise programmingExercise) {
         programmingExercise.setBuildConfig(getProgrammingExerciseBuildConfigElseThrow(programmingExercise));
     }
+
+    /**
+     * Find a build config by its programming exercise's id and throw an Exception if it cannot be found
+     *
+     * @param programmingExerciseId of the programming exercise.
+     * @return The programming exercise related to the given id
+     */
+    default ProgrammingExerciseBuildConfig findByExerciseIdElseThrow(long programmingExerciseId) {
+        return getValueElseThrow(findByProgrammingExerciseId(programmingExerciseId));
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseResource.java
@@ -58,6 +58,7 @@ import de.tum.cit.aet.artemis.core.security.Role;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastEditor;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastInstructor;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastTutor;
+import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInExercise.EnforceAtLeastStudentInExercise;
 import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInExercise.EnforceAtLeastTutorInExercise;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.core.service.CourseService;
@@ -71,6 +72,7 @@ import de.tum.cit.aet.artemis.exercise.service.ExerciseService;
 import de.tum.cit.aet.artemis.plagiarism.service.PlagiarismDetectionConfigHelper;
 import de.tum.cit.aet.artemis.programming.domain.AuxiliaryRepository;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseBuildConfig;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseTestCase;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage;
 import de.tum.cit.aet.artemis.programming.dto.BuildLogStatisticsDTO;
@@ -78,6 +80,7 @@ import de.tum.cit.aet.artemis.programming.dto.CheckoutDirectoriesDTO;
 import de.tum.cit.aet.artemis.programming.dto.ProgrammingExerciseResetOptionsDTO;
 import de.tum.cit.aet.artemis.programming.dto.ProgrammingExerciseTestCaseStateDTO;
 import de.tum.cit.aet.artemis.programming.repository.BuildLogStatisticsEntryRepository;
+import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseBuildConfigRepository;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.cit.aet.artemis.programming.repository.SolutionProgrammingExerciseParticipationRepository;
@@ -113,6 +116,8 @@ public class ProgrammingExerciseResource {
     private final ProgrammingExerciseRepository programmingExerciseRepository;
 
     private final ProgrammingExerciseTestCaseRepository programmingExerciseTestCaseRepository;
+
+    private final ProgrammingExerciseBuildConfigRepository programmingExerciseBuildConfigRepository;
 
     private final UserRepository userRepository;
 
@@ -157,9 +162,9 @@ public class ProgrammingExerciseResource {
     private final Environment environment;
 
     public ProgrammingExerciseResource(ProgrammingExerciseRepository programmingExerciseRepository, ProgrammingExerciseTestCaseRepository programmingExerciseTestCaseRepository,
-            UserRepository userRepository, AuthorizationCheckService authCheckService, CourseService courseService,
-            Optional<ContinuousIntegrationService> continuousIntegrationService, Optional<VersionControlService> versionControlService, ExerciseService exerciseService,
-            ExerciseDeletionService exerciseDeletionService, ProgrammingExerciseService programmingExerciseService,
+            ProgrammingExerciseBuildConfigRepository programmingExerciseBuildConfigRepository, UserRepository userRepository, AuthorizationCheckService authCheckService,
+            CourseService courseService, Optional<ContinuousIntegrationService> continuousIntegrationService, Optional<VersionControlService> versionControlService,
+            ExerciseService exerciseService, ExerciseDeletionService exerciseDeletionService, ProgrammingExerciseService programmingExerciseService,
             ProgrammingExerciseRepositoryService programmingExerciseRepositoryService, ProgrammingExerciseTaskService programmingExerciseTaskService,
             StudentParticipationRepository studentParticipationRepository, StaticCodeAnalysisService staticCodeAnalysisService,
             GradingCriterionRepository gradingCriterionRepository, CourseRepository courseRepository, GitService gitService, AuxiliaryRepositoryService auxiliaryRepositoryService,
@@ -170,6 +175,7 @@ public class ProgrammingExerciseResource {
         this.programmingExerciseTaskService = programmingExerciseTaskService;
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.programmingExerciseTestCaseRepository = programmingExerciseTestCaseRepository;
+        this.programmingExerciseBuildConfigRepository = programmingExerciseBuildConfigRepository;
         this.userRepository = userRepository;
         this.courseService = courseService;
         this.authCheckService = authCheckService;
@@ -490,6 +496,21 @@ public class ProgrammingExerciseResource {
         programmingExerciseTaskService.replaceTestIdsWithNames(programmingExercise);
 
         return ResponseEntity.ok().body(programmingExercise);
+    }
+
+    /**
+     * GET /programming-exercises/:exerciseId/build-config : get the build config of "exerciseId" programmingExercise.
+     *
+     * @param exerciseId the id of the programmingExercise to retrieve the config for
+     * @return the ResponseEntity with status 200 (OK) and with body the programmingExerciseBuildConfig, or with status 404 (Not Found)
+     */
+    @GetMapping("programming-exercises/{exerciseId}/build-config")
+    @EnforceAtLeastStudentInExercise
+    public ResponseEntity<ProgrammingExerciseBuildConfig> getBuildConfig(@PathVariable long exerciseId) {
+        log.debug("REST request to get build config of ProgrammingExercise : {}", exerciseId);
+        var buildConfig = programmingExerciseBuildConfigRepository.findByExerciseIdElseThrow(exerciseId);
+
+        return ResponseEntity.ok().body(buildConfig);
     }
 
     /**

--- a/src/main/webapp/app/exercises/programming/manage/services/programming-exercise.service.ts
+++ b/src/main/webapp/app/exercises/programming/manage/services/programming-exercise.service.ts
@@ -27,6 +27,7 @@ import { Participation } from 'app/entities/participation/participation.model';
 import { PlagiarismResultDTO } from 'app/exercises/shared/plagiarism/types/PlagiarismResultDTO';
 import { ImportOptions } from 'app/types/programming-exercises';
 import { CheckoutDirectoriesDto } from 'app/entities/programming/checkout-directories-dto';
+import { ProgrammingExerciseBuildConfig } from 'app/entities/programming/programming-exercise-build.config';
 
 export type EntityResponseType = HttpResponse<ProgrammingExercise>;
 export type EntityArrayResponseType = HttpResponse<ProgrammingExercise[]>;
@@ -658,6 +659,10 @@ export class ProgrammingExerciseService {
 
     getBuildLogStatistics(exerciseId: number): Observable<BuildLogStatisticsDTO> {
         return this.http.get<BuildLogStatisticsDTO>(`${this.resourceUrl}/${exerciseId}/build-log-statistics`);
+    }
+
+    getBuildConfig(exerciseId: number): Observable<ProgrammingExerciseBuildConfig> {
+        return this.http.get<ProgrammingExerciseBuildConfig>(`${this.resourceUrl}/${exerciseId}/build-config`);
     }
 
     /** Imports a programming exercise from a given zip file **/

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
@@ -129,12 +129,6 @@
                                 [useParticipationVcsAccessToken]="true"
                             />
                         }
-                        @if (theiaEnabled) {
-                            <a class="btn btn-primary" [class.btn-sm]="smallButtons" (click)="startOnlineIDE()" target="_blank" rel="noopener noreferrer">
-                                <fa-icon [icon]="faDesktop" [fixedWidth]="true" />
-                                <span class="d-none d-md-inline" jhiTranslate="artemisApp.exerciseActions.openOnlineIDE"></span>
-                            </a>
-                        }
                         @if (exercise.allowFeedbackRequests) {
                             @if (athenaEnabled) {
                                 <a

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -11,14 +11,14 @@ import { ProgrammingExercise } from 'app/entities/programming/programming-exerci
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { ArtemisQuizService } from 'app/shared/quiz/quiz.service';
 import { finalize } from 'rxjs/operators';
-import { faCodeBranch, faDesktop, faEye, faFolderOpen, faPenSquare, faPlayCircle, faRedo, faUsers } from '@fortawesome/free-solid-svg-icons';
+import { faCodeBranch, faEye, faFolderOpen, faPenSquare, faPlayCircle, faRedo, faUsers } from '@fortawesome/free-solid-svg-icons';
 import { CourseExerciseService } from 'app/exercises/shared/course-exercises/course-exercise.service';
 import { TranslateService } from '@ngx-translate/core';
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
 import dayjs from 'dayjs/esm';
 import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
-import { PROFILE_ATHENA, PROFILE_LOCALVC, PROFILE_THEIA } from 'app/app.constants';
+import { PROFILE_ATHENA, PROFILE_LOCALVC } from 'app/app.constants';
 import { AssessmentType } from 'app/entities/assessment-type.model';
 
 @Component({
@@ -60,9 +60,6 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
     routerLink: string;
     repositoryLink: string;
 
-    theiaEnabled: boolean = false;
-    theiaPortalURL: string;
-
     // Icons
     readonly faFolderOpen = faFolderOpen;
     readonly faUsers = faUsers;
@@ -70,7 +67,6 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
     readonly faPlayCircle = faPlayCircle;
     readonly faRedo = faRedo;
     readonly faCodeBranch = faCodeBranch;
-    readonly faDesktop = faDesktop;
     readonly faPenSquare = faPenSquare;
 
     private feedbackSent = false;
@@ -110,29 +106,6 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
             this.profileService.getProfileInfo().subscribe((profileInfo) => {
                 this.localVCEnabled = profileInfo.activeProfiles?.includes(PROFILE_LOCALVC);
                 this.athenaEnabled = profileInfo.activeProfiles?.includes(PROFILE_ATHENA);
-
-                // The online IDE is only available with correct SpringProfile and if it's enabled for this exercise
-                if (profileInfo.activeProfiles?.includes(PROFILE_THEIA) && this.programmingExercise) {
-                    this.theiaEnabled = true;
-
-                    // Set variables now, sanitize later on
-                    this.theiaPortalURL = profileInfo.theiaPortalURL ?? '';
-
-                    // Verify that Theia's portal URL is set
-                    if (this.theiaPortalURL === '') {
-                        this.theiaEnabled = false;
-                    }
-
-                    // Verify that the exercise allows the online IDE
-                    if (!this.programmingExercise.allowOnlineIde) {
-                        this.theiaEnabled = false;
-                    }
-
-                    // Verify that the exercise has a theia blueprint configured
-                    if (!this.programmingExercise.buildConfig?.theiaImage) {
-                        this.theiaEnabled = false;
-                    }
-                }
             });
         } else if (this.exercise.type === ExerciseType.MODELING) {
             this.editorLabel = 'openModelingEditor';
@@ -154,10 +127,6 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
     ngOnChanges() {
         this.updateParticipations();
         this.isTeamAvailable = !!(this.exercise.teamMode && this.exercise.studentAssignedTeamIdComputed && this.exercise.studentAssignedTeamId);
-    }
-
-    startOnlineIDE() {
-        window.open(this.theiaPortalURL, '_blank');
     }
 
     receiveNewParticipation(newParticipation: StudentParticipation) {

--- a/src/main/webapp/app/shared/components/code-button/code-button.component.html
+++ b/src/main/webapp/app/shared/components/code-button/code-button.component.html
@@ -99,6 +99,11 @@
             style="min-width: 100px"
             jhiTranslate="{{ wasCopied ? 'artemisApp.exerciseActions.copiedUrl' : 'artemisApp.exerciseActions.copyUrl' }}"
         ></button>
+        @if (theiaEnabled) {
+            <a class="btn btn-primary btn-sm me-2" (click)="startOnlineIDE()" target="_blank" rel="noopener noreferrer">
+                <span class="d-none d-md-inline" jhiTranslate="artemisApp.exerciseActions.openOnlineIDE"></span>
+            </a>
+        }
         <a
             class="btn btn-primary btn-sm"
             target="hidden-iframe"

--- a/src/main/webapp/app/shared/components/code-button/code-button.component.ts
+++ b/src/main/webapp/app/shared/components/code-button/code-button.component.ts
@@ -16,6 +16,7 @@ import { isPracticeMode } from 'app/entities/participation/student-participation
 import { faCode, faDesktop, faExternalLink } from '@fortawesome/free-solid-svg-icons';
 import { IdeSettingsService } from 'app/shared/user-settings/ide-preferences/ide-settings.service';
 import { Ide } from 'app/shared/user-settings/ide-preferences/ide.model';
+import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
 
 @Component({
     selector: 'jhi-code-button',
@@ -88,6 +89,7 @@ export class CodeButtonComponent implements OnInit, OnChanges {
         private localStorage: LocalStorageService,
         private participationService: ParticipationService,
         private ideSettingsService: IdeSettingsService,
+        private programmingExerciseService: ProgrammingExerciseService,
     ) {}
 
     ngOnInit() {
@@ -138,30 +140,33 @@ export class CodeButtonComponent implements OnInit, OnChanges {
 
             // The online IDE is only available with correct SpringProfile and if it's enabled for this exercise
             if (profileInfo.activeProfiles?.includes(PROFILE_THEIA) && this.exercise) {
-                // console.log('Theia Profile is enabled');
-                this.theiaEnabled = true;
+                // Theia requires the Build Config of the programming exercise to be set
+                this.programmingExerciseService.getBuildConfig(this.exercise.id!).subscribe((buildConfig) => {
+                    if (this.exercise) {
+                        this.exercise.buildConfig = buildConfig;
+                        this.theiaEnabled = true;
 
-                // Set variables now, sanitize later on
-                this.theiaPortalURL = profileInfo.theiaPortalURL ?? '';
+                        // Set variables now, sanitize later on
+                        this.theiaPortalURL = profileInfo.theiaPortalURL ?? '';
 
-                // Verify that Theia's portal URL is set
-                if (this.theiaPortalURL === '') {
-                    this.theiaEnabled = false;
-                    // console.log('Theia portal URL is null');
-                }
+                        // Verify that Theia's portal URL is set
+                        if (this.theiaPortalURL === '') {
+                            this.theiaEnabled = false;
+                        }
 
-                // Verify that the exercise allows the online IDE
-                if (!this.exercise.allowOnlineIde) {
-                    this.theiaEnabled = false;
-                    // console.log('Theia allowOnlineIde is false');
-                }
+                        // Verify that the exercise allows the online IDE
+                        if (!this.exercise.allowOnlineIde) {
+                            this.theiaEnabled = false;
+                        }
 
-                // Verify that the exercise has a theia blueprint configured
-                if (!this.exercise.buildConfig?.theiaImage) {
-                    //this.theiaEnabled = false;
-                    // console.log('Theia Image is null');
-                    // console.log(this.exercise.buildConfig);
-                }
+                        // Verify that the exercise has a theia blueprint configured
+                        if (!this.exercise.buildConfig?.theiaImage) {
+                            this.theiaEnabled = false;
+                        }
+                    } else {
+                        this.theiaEnabled = false;
+                    }
+                });
             }
         });
 

--- a/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
@@ -34,7 +34,6 @@ import { MockCourseExerciseService } from '../../../helpers/mocks/service/mock-c
 import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
 import { ArtemisTestModule } from '../../../test.module';
 import { AssessmentType } from 'app/entities/assessment-type.model';
-import { PROFILE_THEIA } from 'app/app.constants';
 import { Submission } from 'app/entities/submission.model';
 
 describe('ExerciseDetailsStudentActionsComponent', () => {
@@ -640,86 +639,5 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
 
         expect(alertServiceSpy).toHaveBeenCalledOnce();
         expect(result).toBeFalse();
-    });
-
-    it.each([
-        [
-            'start theia button should be visible when profile is active and theia is configured',
-            {
-                activeProfiles: [PROFILE_THEIA],
-                theiaPortalURL: 'https://theia.test',
-            },
-            {
-                allowOnlineIde: true,
-            },
-            {
-                theiaImage: 'this-is-a-theia-image',
-            },
-            true,
-        ],
-        [
-            'start theia button should not be visible when profile is active but theia is ill-configured',
-            {
-                activeProfiles: [PROFILE_THEIA],
-                theiaPortalURL: 'https://theia.test',
-            },
-            {
-                allowOnlineIde: true,
-            },
-            {
-                theiaImage: undefined,
-            },
-            false,
-        ],
-        [
-            'start theia button should not be visible when profile is active but onlineIde is not activated',
-            {
-                activeProfiles: [PROFILE_THEIA],
-                theiaPortalURL: 'https://theia.test',
-            },
-            {
-                allowOnlineIde: false,
-            },
-            {
-                theiaImage: 'this-is-an-old-image',
-            },
-            false,
-        ],
-        [
-            'start theia button should not be visible when profile is active but url is not set',
-            {
-                activeProfiles: [PROFILE_THEIA],
-            },
-            {
-                allowOnlineIde: true,
-            },
-            {
-                theiaImage: 'this-is-a-theia-image',
-            },
-            false,
-        ],
-        [
-            'start theia button should not be visible when profile is not active but url is set',
-            {
-                theiaPortalURL: 'https://theia.test',
-            },
-            {
-                allowOnlineIde: true,
-            },
-            {
-                theiaImage: 'this-is-a-theia-image',
-            },
-            false,
-        ],
-    ])('%s', (description, profileInfo, programmingExercise, buildConfig, expectedVisibility) => {
-        getProfileInfoSub = jest.spyOn(profileService, 'getProfileInfo');
-        getProfileInfoSub.mockReturnValue(of(profileInfo as ProfileInfo));
-
-        // Expand the programmingExercise by given properties
-        comp.exercise = { ...exercise, ...programmingExercise, buildConfig: buildConfig } as ProgrammingExercise;
-
-        fixture.detectChanges();
-
-        expect(comp.theiaEnabled).toBe(expectedVisibility);
     });
 });

--- a/src/test/javascript/spec/component/shared/code-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/code-button.component.spec.ts
@@ -31,12 +31,16 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { PROFILE_THEIA } from 'app/app.constants';
 import { ProgrammingExercise } from 'app/entities/programming/programming-exercise.model';
+import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
+import { MockProgrammingExerciseService } from '../../helpers/mocks/service/mock-programming-exercise.service';
+import { ProgrammingExerciseBuildConfig } from 'app/entities/programming/programming-exercise-build.config';
 
 describe('CodeButtonComponent', () => {
     let component: CodeButtonComponent;
     let fixture: ComponentFixture<CodeButtonComponent>;
     let profileService: ProfileService;
     let accountService: AccountService;
+    let programmingExerciseService: ProgrammingExerciseService;
 
     let localStorageUseSshRetrieveStub: jest.SpyInstance;
     let localStorageUseSshObserveStub: jest.SpyInstance;
@@ -45,6 +49,7 @@ describe('CodeButtonComponent', () => {
     let getVcsAccessTokenSpy: jest.SpyInstance;
     let createVcsAccessTokenSpy: jest.SpyInstance;
     let getProfileInfoSub: jest.SpyInstance;
+    let getBuildConfigSub: jest.SpyInstance;
 
     const vcsToken: string = 'vcpat-xlhBs26D4F2CGlkCM59KVU8aaV9bYdX5Mg4IK6T8W3aT';
 
@@ -119,6 +124,7 @@ describe('CodeButtonComponent', () => {
                 { provide: ProfileService, useClass: MockProfileService },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },
+                { provide: ProgrammingExerciseService, useClass: MockProgrammingExerciseService },
             ],
         })
             .compileComponents()
@@ -131,6 +137,7 @@ describe('CodeButtonComponent', () => {
         component = fixture.componentInstance;
         profileService = TestBed.inject(ProfileService);
         accountService = TestBed.inject(AccountService);
+        programmingExerciseService = TestBed.inject(ProgrammingExerciseService);
 
         const localStorageMock = fixture.debugElement.injector.get(LocalStorageService);
         localStorageUseSshRetrieveStub = jest.spyOn(localStorageMock, 'retrieve');
@@ -540,8 +547,11 @@ describe('CodeButtonComponent', () => {
         getProfileInfoSub = jest.spyOn(profileService, 'getProfileInfo');
         getProfileInfoSub.mockReturnValue(of(profileInfo as ProfileInfo));
 
+        getBuildConfigSub = jest.spyOn(programmingExerciseService, 'getBuildConfig');
+        getBuildConfigSub.mockReturnValue(of(buildConfig as ProgrammingExerciseBuildConfig));
+
         // Expand the programmingExercise by given properties
-        component.exercise = { ...exercise, ...programmingExercise, buildConfig: buildConfig } as ProgrammingExercise;
+        component.exercise = { ...exercise, ...programmingExercise } as ProgrammingExercise;
 
         fixture.detectChanges();
 

--- a/src/test/javascript/spec/helpers/mocks/service/mock-programming-exercise.service.ts
+++ b/src/test/javascript/spec/helpers/mocks/service/mock-programming-exercise.service.ts
@@ -2,6 +2,7 @@ import { of } from 'rxjs';
 import { ProgrammingExerciseInstructorRepositoryType } from 'app/exercises/programming/manage/services/programming-exercise.service';
 import { Participation } from 'app/entities/participation/participation.model';
 import { ProgrammingLanguage } from 'app/entities/programming/programming-exercise.model';
+import { ProgrammingExerciseBuildConfig } from 'app/entities/programming/programming-exercise-build.config';
 
 export class MockProgrammingExerciseService {
     updateProblemStatement = (exerciseId: number, problemStatement: string) => of();
@@ -18,6 +19,7 @@ export class MockProgrammingExerciseService {
     deleteTasksWithSolutionEntries = (exerciseId: number) => of();
     getDiffReport = (exerciseId: number) => of({});
     getBuildLogStatistics = (exerciseId: number) => of({});
+    getBuildConfig = (exerciseId: number) => of({});
     createStructuralSolutionEntries = (exerciseId: number) => of({});
     createBehavioralSolutionEntries = (exerciseId: number) => of({});
     getLatestResult = (participation: Participation) => of({});


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Theia User-Flow aims to integrate seamlessly into the existing Artemis exercise flow. When users click on the Open Online IDE button, we want to require as few clicks as possible before the exercise can be worked. In https://github.com/ls1intum/Artemis/issues/8723, we defined that no further login should be required - at least for working with the repository.
In separate repositories, I already implemented the Theia LandingPage which can accept the git clone token for the user and instantly spawn a new session with the repo cloned using the token.



### Description
<!-- Describe your changes in detail -->
This PR clears up the UI, moving the `Open in Online IDE` button into the existing `<Code>` button. Catering to the required data-sharing, the user's clone token, the user's exercise repo, and the configured Theia Settings are passed to the Landing Page. 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://docs.artemis.cit.tum.de/user/exam_mode/) as reference.
4. ...

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
