### PR TITLE
`Development`: Fix default URL for telemetry service

### DIFF
--- a/docs/admin/telemetry.rst
+++ b/docs/admin/telemetry.rst
@@ -26,7 +26,7 @@ Example configuration in `application-prod.yml`:
         telemetry:
             enabled: true
             sendAdminDetails: false
-            destination: telemetry.artemis.cit.tum.de
+            destination: https://telemetry.artemis.cit.tum.de
 
     info:
         contact: contactMailAddress@cit.tum.de

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -146,4 +146,4 @@ artemis:
     telemetry:
         enabled: false # Disable sending any telemetry information to the telemetry service by setting this to false
         sendAdminDetails: false # Include the admins email and name in the telemetry data. Set to false to disable
-        destination: telemetry.artemis.cit.tum.de
+        destination: https://telemetry.artemis.cit.tum.de

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -20,7 +20,7 @@ artemis:
     telemetry:
         enabled: true # Disable sending any telemetry information to the telemetry service by setting this to false
         sendAdminDetails: true # Include personal identifiable information of the admin, including email and name in the telemetry data
-        destination: telemetry.artemis.cit.tum.de
+        destination: https://telemetry.artemis.cit.tum.de
 
 spring:
     devtools:


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

With the current default URL, the telemetry sending did not work:
```
artemis | 2024-09-28T16:08:58.749Z ERROR 1 --- [Artemis] [ artemis-task-1] .a.i.SimpleAsyncUncaughtExceptionHandler : Unexpected exception occurred invoking async method: public void de.tum.cit.aet.artemis.core.service.TelemetrySendingService.sendTelemetryByPostRequest() throws java.lang.Exception
artemis | 
artemis | java.lang.IllegalArgumentException: URI is not absolute
artemis | 	at java.base/java.net.URL.of(URL.java:862)
artemis | 	at java.base/java.net.URI.toURL(URI.java:1172)
artemis | 	at org.springframework.http.client.SimpleClientHttpRequestFactory.createRequest(SimpleClientHttpRequestFactory.java:154)
```

### Description
<!-- Describe your changes in detail -->
Adds the `https://` at the start to turn it into a proper URL.

Related PR: https://github.com/ls1intum/artemis-ansible-collection/pull/102


### Steps for Testing
Start a server in production config. It should not log the error above.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
unchanged

@coderabbitai ignore