### PR TITLE
`Learning paths`: Add explanation view for learning path users

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/atlas/domain/competency/LearningPath.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/domain/competency/LearningPath.java
@@ -31,6 +31,12 @@ public class LearningPath extends DomainObject {
     @Column(name = "progress")
     private int progress;
 
+    /**
+     * flag indicating if a student started the learning path
+     */
+    @Column(name = "started_by_student")
+    private boolean startedByStudent = false;
+
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
@@ -89,8 +95,16 @@ public class LearningPath extends DomainObject {
         this.competencies.remove(competency);
     }
 
+    public boolean isStartedByStudent() {
+        return startedByStudent;
+    }
+
+    public void setStartedByStudent(boolean startedByStudent) {
+        this.startedByStudent = startedByStudent;
+    }
+
     @Override
     public String toString() {
-        return "LearningPath{" + "id=" + getId() + ", user=" + user + ", course=" + course + ", competencies=" + competencies + '}';
+        return "LearningPath{" + "id=" + getId() + ", user=" + user + ", course=" + course + ", competencies=" + competencies + ", startedByStudent=" + startedByStudent + "}";
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/dto/LearningPathDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/dto/LearningPathDTO.java
@@ -1,0 +1,13 @@
+package de.tum.cit.aet.artemis.atlas.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.atlas.domain.competency.LearningPath;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record LearningPathDTO(long id, boolean startedByStudent, int progress) {
+
+    public static LearningPathDTO of(LearningPath learningPath) {
+        return new LearningPathDTO(learningPath.getId(), learningPath.isStartedByStudent(), learningPath.getProgress());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/learningpath/LearningPathService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/learningpath/LearningPathService.java
@@ -284,6 +284,9 @@ public class LearningPathService {
         if (!learningPath.getUser().equals(currentUser)) {
             throw new AccessForbiddenException("You are not allowed to start this learning path.");
         }
+        else if (learningPath.isStartedByStudent()) {
+            throw new BadRequestException("Learning path already started.");
+        }
         learningPath.setStartedByStudent(true);
         learningPathRepository.save(learningPath);
     }

--- a/src/main/resources/config/liquibase/changelog/20240924125742_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20240924125742_changelog.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="20240924125742" author="johannes_wt">
+        <addColumn tableName="learning_path">
+            <column name="started_by_student" defaultValueBoolean="false" type="boolean">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -23,7 +23,7 @@
     <include file="classpath:config/liquibase/changelog/20240708144500_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20240802091201_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20240804144500_changelog.xml" relativeToChangelogFile="false"/>
-
+    <include file="classpath:config/liquibase/changelog/20240924125742_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command 'date '+%Y%m%d%H%M%S'' to get the current date and time in the correct format -->

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.html
@@ -1,12 +1,12 @@
 <div class="col learning-path-student-page">
-    @if (isLearningPathIdLoading()) {
+    @if (isLearningPathLoading()) {
         <div class="row justify-content-center align-items-center h-100">
             <div class="spinner-border text-primary" role="status">
                 <span class="sr-only" jhiTranslate="loading"></span>
             </div>
         </div>
-    } @else if (learningPathId()) {
-        <jhi-learning-path-student-nav [learningPathId]="learningPathId()!" />
+    } @else if (learningPath() && learningPath()!.startedByStudent) {
+        <jhi-learning-path-student-nav [learningPathId]="learningPath()!.id" />
         <div class="learning-path-student-content">
             @if (currentLearningObject()?.type === LearningObjectType.LECTURE) {
                 <jhi-learning-path-lecture-unit [lectureUnitId]="currentLearningObject()!.id" />
@@ -27,10 +27,10 @@
                 <h3 class="mb-3" jhiTranslate="artemisApp.learningPath.generation.title"></h3>
                 <div jhiTranslate="artemisApp.learningPath.generation.description"></div>
                 <button
-                    (click)="generateLearningPath(this.courseId())"
+                    (click)="startLearningPath()"
                     type="button"
                     class="mt-4 btn btn-primary"
-                    id="generate-learning-path-button"
+                    id="start-learning-path-button"
                     jhiTranslate="artemisApp.learningPath.generation.generateButton"
                 ></button>
             </div>

--- a/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.ts
+++ b/src/main/webapp/app/course/learning-paths/pages/learning-path-student-page/learning-path-student-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, effect, inject, signal } from '@angular/core';
-import { LearningObjectType } from 'app/entities/competency/learning-path.model';
+import { LearningObjectType, LearningPathDTO } from 'app/entities/competency/learning-path.model';
 import { map } from 'rxjs';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
@@ -32,45 +32,49 @@ import { ArtemisSharedModule } from 'app/shared/shared.module';
 export class LearningPathStudentPageComponent {
     protected readonly LearningObjectType = LearningObjectType;
 
-    private readonly learningApiService: LearningPathApiService = inject(LearningPathApiService);
+    private readonly learningApiService = inject(LearningPathApiService);
     private readonly learningPathNavigationService = inject(LearningPathNavigationService);
-    private readonly alertService: AlertService = inject(AlertService);
-    private readonly activatedRoute: ActivatedRoute = inject(ActivatedRoute);
+    private readonly alertService = inject(AlertService);
+    private readonly activatedRoute = inject(ActivatedRoute);
 
-    readonly isLearningPathIdLoading = signal(false);
-    readonly learningPathId = signal<number | undefined>(undefined);
+    readonly isLearningPathLoading = signal(false);
+    readonly learningPath = signal<LearningPathDTO | undefined>(undefined);
     readonly courseId = toSignal(this.activatedRoute.parent!.parent!.params.pipe(map((params) => Number(params.courseId))), { requireSync: true });
     readonly currentLearningObject = this.learningPathNavigationService.currentLearningObject;
     readonly isLearningPathNavigationLoading = this.learningPathNavigationService.isLoading;
 
     constructor() {
-        effect(async () => await this.loadLearningPathId(this.courseId()), { allowSignalWrites: true });
+        effect(() => this.loadLearningPathId(this.courseId()), { allowSignalWrites: true });
     }
 
     private async loadLearningPathId(courseId: number): Promise<void> {
         try {
-            this.isLearningPathIdLoading.set(true);
-            const learningPathId = await this.learningApiService.getLearningPathId(courseId);
-            this.learningPathId.set(learningPathId);
+            this.isLearningPathLoading.set(true);
+            const learningPath = await this.learningApiService.getLearningPathForCurrentUser(courseId);
+            this.learningPath.set(learningPath);
         } catch (error) {
             // If learning path does not exist (404) ignore the error
             if (!(error instanceof EntityNotFoundError)) {
                 this.alertService.error(error);
             }
         } finally {
-            this.isLearningPathIdLoading.set(false);
+            this.isLearningPathLoading.set(false);
         }
     }
 
-    async generateLearningPath(courseId: number): Promise<void> {
+    async startLearningPath(): Promise<void> {
         try {
-            this.isLearningPathIdLoading.set(true);
-            const learningPathId = await this.learningApiService.generateLearningPath(courseId);
-            this.learningPathId.set(learningPathId);
+            this.isLearningPathLoading.set(true);
+            if (!this.learningPath()) {
+                const learningPath = await this.learningApiService.generateLearningPathForCurrentUser(this.courseId());
+                this.learningPath.set(learningPath);
+            }
+            await this.learningApiService.startLearningPathForCurrentUser(this.learningPath()!.id);
+            this.learningPath.update((learningPath) => ({ ...learningPath!, startedByStudent: true }));
         } catch (error) {
             this.alertService.error(error);
         } finally {
-            this.isLearningPathIdLoading.set(false);
+            this.isLearningPathLoading.set(false);
         }
     }
 }

--- a/src/main/webapp/app/course/learning-paths/services/base-api-http.service.ts
+++ b/src/main/webapp/app/course/learning-paths/services/base-api-http.service.ts
@@ -122,4 +122,34 @@ export abstract class BaseApiHttpService {
     ): Promise<T> {
         return await this.request<T>(HttpMethod.Post, url, { body: body, ...options });
     }
+
+    /**
+     * Constructs a `PUT` request that interprets the body as JSON and
+     * returns a Promise of an object of type `T`.
+     *
+     * @param url The endpoint URL excluding the base server url (/api).
+     * @param body The content to include in the body of the request.
+     * @param options The HTTP options to send with the request.
+     * @protected
+     *
+     * @return An `Promise` of type `Object` (T),
+     */
+    protected async patch<T>(
+        url: string,
+        body?: any,
+        options?: {
+            headers?:
+                | HttpHeaders
+                | {
+                      [header: string]: string | string[];
+                  };
+            params?:
+                | HttpParams
+                | {
+                      [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
+                  };
+        },
+    ): Promise<T> {
+        return await this.request<T>(HttpMethod.Patch, url, { body: body, ...options });
+    }
 }

--- a/src/main/webapp/app/course/learning-paths/services/learning-path-api.service.ts
+++ b/src/main/webapp/app/course/learning-paths/services/learning-path-api.service.ts
@@ -3,6 +3,7 @@ import {
     CompetencyGraphDTO,
     LearningObjectType,
     LearningPathCompetencyDTO,
+    LearningPathDTO,
     LearningPathNavigationDTO,
     LearningPathNavigationObjectDTO,
     LearningPathNavigationOverviewDTO,
@@ -14,8 +15,12 @@ import { BaseApiHttpService } from 'app/course/learning-paths/services/base-api-
     providedIn: 'root',
 })
 export class LearningPathApiService extends BaseApiHttpService {
-    async getLearningPathId(courseId: number): Promise<number> {
-        return await this.get<number>(`courses/${courseId}/learning-path-id`);
+    async getLearningPathForCurrentUser(courseId: number): Promise<LearningPathDTO> {
+        return await this.get<LearningPathDTO>(`courses/${courseId}/learning-path/me`);
+    }
+
+    async startLearningPathForCurrentUser(learningPathId: number): Promise<void> {
+        return await this.patch<void>(`learning-path/${learningPathId}/start`);
     }
 
     async getLearningPathNavigation(learningPathId: number): Promise<LearningPathNavigationDTO> {
@@ -35,8 +40,8 @@ export class LearningPathApiService extends BaseApiHttpService {
         return await this.get<LearningPathNavigationDTO>(`learning-path/${learningPathId}/relative-navigation`, { params: params });
     }
 
-    async generateLearningPath(courseId: number): Promise<number> {
-        return await this.post<number>(`courses/${courseId}/learning-path`);
+    async generateLearningPathForCurrentUser(courseId: number): Promise<LearningPathDTO> {
+        return await this.post<LearningPathDTO>(`courses/${courseId}/learning-path`);
     }
 
     async getLearningPathNavigationOverview(learningPathId: number): Promise<LearningPathNavigationOverviewDTO> {

--- a/src/main/webapp/app/entities/competency/learning-path.model.ts
+++ b/src/main/webapp/app/entities/competency/learning-path.model.ts
@@ -32,6 +32,12 @@ export interface LearningPathCompetencyDTO {
     masteryProgress: number;
 }
 
+export interface LearningPathDTO {
+    id: number;
+    progress: number;
+    startedByStudent: boolean;
+}
+
 export interface LearningPathNavigationObjectDTO {
     id: number;
     completed: boolean;

--- a/src/test/java/de/tum/cit/aet/artemis/competency/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/competency/LearningPathIntegrationTest.java
@@ -120,7 +120,9 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     private static final int NUMBER_OF_STUDENTS = 5;
 
-    private static final String STUDENT_OF_COURSE = TEST_PREFIX + "student1";
+    private static final String STUDENT1_OF_COURSE = TEST_PREFIX + "student1";
+
+    private static final String STUDENT2_OF_COURSE = TEST_PREFIX + "student2";
 
     private static final String TUTOR_OF_COURSE = TEST_PREFIX + "tutor1";
 
@@ -157,7 +159,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
         lecture.setCourse(course);
         lectureRepository.save(lecture);
 
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
 
         textUnit = createAndLinkTextUnit(student, competencies[0], true);
         textExercise = createAndLinkTextExercise(competencies[1], false);
@@ -215,7 +217,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testAll_asStudent() throws Exception {
         this.testAllPreAuthorize();
         request.get("/api/courses/" + course.getId() + "/learning-path-id", HttpStatus.BAD_REQUEST, Long.class);
@@ -314,7 +316,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = INSTRUCTOR_OF_COURSE, roles = "INSTRUCTOR")
     void testGetLearningPathsOnPageForCourseEmpty() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var search = pageableSearchUtilService.configureSearch(STUDENT_OF_COURSE + "SuffixThatAllowsTheResultToBeEmpty");
+        final var search = pageableSearchUtilService.configureSearch(STUDENT1_OF_COURSE + "SuffixThatAllowsTheResultToBeEmpty");
         final var result = request.getSearchResult("/api/courses/" + course.getId() + "/learning-paths", HttpStatus.OK, LearningPathInformationDTO.class,
                 pageableSearchUtilService.searchMapping(search));
         assertThat(result.getResultsOnPage()).isNullOrEmpty();
@@ -324,7 +326,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = INSTRUCTOR_OF_COURSE, roles = "INSTRUCTOR")
     void testGetLearningPathsOnPageForCourseExactlyStudent() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var search = pageableSearchUtilService.configureSearch(STUDENT_OF_COURSE);
+        final var search = pageableSearchUtilService.configureSearch(STUDENT1_OF_COURSE);
         final var result = request.getSearchResult("/api/courses/" + course.getId() + "/learning-paths", HttpStatus.OK, LearningPathInformationDTO.class,
                 pageableSearchUtilService.searchMapping(search));
         assertThat(result.getResultsOnPage()).hasSize(1);
@@ -358,7 +360,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
         final var newCompetency = restCall.apply(this);
 
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPathOptional = learningPathRepository.findWithEagerCompetenciesByCourseIdAndUserId(course.getId(), student.getId());
         assertThat(learningPathOptional).isPresent();
         assertThat(learningPathOptional.get().getCompetencies()).as("should contain new competency").contains(newCompetency);
@@ -376,7 +378,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
         final var competencyDTOs = importCompetenciesRESTCall(numberOfNewCompetencies);
         final var newCompetencies = competencyDTOs.stream().map(CompetencyWithTailRelationDTO::competency).toList();
 
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPathOptional = learningPathRepository.findWithEagerCompetenciesByCourseIdAndUserId(course.getId(), student.getId());
 
         assertThat(newCompetencies).hasSize(numberOfNewCompetencies);
@@ -394,7 +396,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
         deleteCompetencyRESTCall(competencies[0]);
 
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPathOptional = learningPathRepository.findWithEagerCompetenciesByCourseIdAndUserId(course.getId(), student.getId());
         assertThat(learningPathOptional).isPresent();
         assertThat(learningPathOptional.get().getCompetencies()).as("should not contain deleted competency").doesNotContain(competencies[0]);
@@ -411,7 +413,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
         // add competency with completed learning unit
         final var createdCompetency = createCompetencyRESTCall();
 
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         var learningPath = learningPathRepository.findWithEagerCompetenciesByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         assertThat(learningPath.getProgress()).as("contains no completed competency").isEqualTo(0);
 
@@ -431,16 +433,16 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningPathWithOwner() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         request.get("/api/learning-path/" + learningPath.getId(), HttpStatus.OK, NgxLearningPathDTO.class);
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningPathOfOtherUser() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
         final var otherStudent = userRepository.findOneByLogin(TEST_PREFIX + "student2").orElseThrow();
@@ -449,7 +451,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningPathCompetencyGraphOfOtherUser() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
         final var otherStudent = userRepository.findOneByLogin(TEST_PREFIX + "student2").orElseThrow();
@@ -458,10 +460,10 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningPathCompetencyGraph() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
 
         Arrays.stream(competencies).forEach(competency -> competencyProgressService.updateCompetencyProgress(competency.getId(), student));
@@ -487,10 +489,10 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @EnumSource(LearningPathResource.NgxRequestType.class)
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningPathNgxForLearningPathsDisabled(LearningPathResource.NgxRequestType type) throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         course.setLearningPathsEnabled(false);
         courseRepository.save(course);
@@ -502,7 +504,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = TEST_PREFIX + "student2", roles = "USER")
     void testGetLearningPathNgxForOtherStudent(LearningPathResource.NgxRequestType type) throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         request.get("/api/learning-path/" + learningPath.getId() + "/" + type, HttpStatus.FORBIDDEN, NgxLearningPathDTO.class);
     }
@@ -515,10 +517,10 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
      */
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @EnumSource(LearningPathResource.NgxRequestType.class)
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningPathNgxAsStudent(LearningPathResource.NgxRequestType type) throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         request.get("/api/learning-path/" + learningPath.getId() + "/" + type, HttpStatus.OK, NgxLearningPathDTO.class);
     }
@@ -566,7 +568,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = INSTRUCTOR_OF_COURSE, roles = "INSTRUCTOR")
     void testGetLearningPathNgxAsInstructor(LearningPathResource.NgxRequestType type) throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         request.get("/api/learning-path/" + learningPath.getId() + "/" + type, HttpStatus.OK, NgxLearningPathDTO.class);
     }
@@ -575,21 +577,21 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     class GetLearningPath {
 
         @Test
-        @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+        @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
         void shouldReturnExisting() throws Exception {
             course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-            final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+            final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
             final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
             final var result = request.get("/api/courses/" + course.getId() + "/learning-path/me", HttpStatus.OK, LearningPathDTO.class);
             assertThat(result).isEqualTo(LearningPathDTO.of(learningPath));
         }
 
         @Test
-        @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+        @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
         void shouldReturnNotFoundIfNotExists() throws Exception {
             course.setLearningPathsEnabled(true);
             course = courseRepository.save(course);
-            var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+            var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
             student = userRepository.findWithLearningPathsByIdElseThrow(student.getId());
             learningPathRepository.deleteAll(student.getLearningPaths());
             request.get("/api/courses/" + course.getId() + "/learning-path/me", HttpStatus.NOT_FOUND, LearningPathDTO.class);
@@ -600,44 +602,79 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     class GenerateLearningPath {
 
         @Test
-        @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+        @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
         void shouldReturnForbiddenIfNotEnabled() throws Exception {
             request.postWithResponseBody("/api/courses/" + course.getId() + "/learning-path", null, LearningPathDTO.class, HttpStatus.BAD_REQUEST);
         }
 
         @Test
-        @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+        @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
         void shouldReturnBadRequestIfAlreadyExists() throws Exception {
             course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
             request.postWithResponseBody("/api/courses/" + course.getId() + "/learning-path", null, LearningPathDTO.class, HttpStatus.BAD_REQUEST);
         }
 
         @Test
-        @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+        @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
         void shouldGenerateLearningPath() throws Exception {
             course.setLearningPathsEnabled(true);
             course = courseRepository.save(course);
             final var response = request.postWithResponseBody("/api/courses/" + course.getId() + "/learning-path", null, LearningPathDTO.class, HttpStatus.CREATED);
             assertThat(response).isNotNull();
-            final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+            final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
             final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
             assertThat(learningPath).isNotNull();
         }
     }
 
-    // TODO: Write tests for start learning path
+    @Nested
+    class StartLearningPath {
+
+        @BeforeEach
+        void setup() {
+            course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
+        }
+
+        @Test
+        @WithMockUser(username = STUDENT2_OF_COURSE, roles = "USER")
+        void shouldReturnForbiddenIfNotOwn() throws Exception {
+            final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
+            final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
+            request.patch("/api/learning-path/" + learningPath.getId() + "/start", null, HttpStatus.FORBIDDEN);
+        }
+
+        @Test
+        @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
+        void shouldReturnBadRequestIfAlreadyStarted() throws Exception {
+            final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
+            final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
+            learningPath.setStartedByStudent(true);
+            learningPathRepository.save(learningPath);
+            request.patch("/api/learning-path/" + learningPath.getId() + "/start", null, HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
+        void shouldStartLearningPath() throws Exception {
+            final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
+            final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
+            request.patch("/api/learning-path/" + learningPath.getId() + "/start", null, HttpStatus.NO_CONTENT);
+            final var updatedLearningPath = learningPathRepository.findByIdElseThrow(learningPath.getId());
+            assertThat(updatedLearningPath.isStartedByStudent()).isTrue();
+        }
+    }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student2", roles = "USER")
     void testGetCompetencyProgressForLearningPathByOtherStudent() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         request.get("/api/learning-path/" + learningPath.getId() + "/competency-progress", HttpStatus.FORBIDDEN, Set.class);
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetCompetencyProgressForLearningPathByOwner() throws Exception {
         testGetCompetencyProgressForLearningPath();
     }
@@ -649,10 +686,10 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningPathNavigation() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
 
         competencyProgressService.updateProgressByLearningObjectSync(textUnit, Set.of(student));
@@ -664,10 +701,10 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningPathNavigationEmptyCompetencies() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
 
         textExercise.setCompetencies(Set.of());
@@ -689,10 +726,10 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningPathNavigationDoesNotLeakUnreleasedLearningObjects() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
 
         textExercise.setCompetencies(Set.of());
@@ -737,10 +774,10 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetRelativeLearningPathNavigation() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         final var result = request.get("/api/learning-path/" + learningPath.getId() + "/relative-navigation?learningObjectId=" + textUnit.getId() + "&learningObjectType="
                 + LearningPathNavigationObjectDTO.LearningObjectType.LECTURE + "&competencyId=" + competencies[0].getId(), HttpStatus.OK, LearningPathNavigationDTO.class);
@@ -754,16 +791,16 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = TEST_PREFIX + "student1337", roles = "USER")
     void testGetLearningPathNavigationForOtherStudent() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         request.get("/api/learning-path/" + learningPath.getId() + "/navigation", HttpStatus.FORBIDDEN, LearningPathNavigationDTO.class);
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningPathNavigationOverview() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         final var result = request.get("/api/learning-path/" + learningPath.getId() + "/navigation-overview", HttpStatus.OK, LearningPathNavigationOverviewDTO.class);
 
@@ -777,26 +814,26 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = TEST_PREFIX + "student1337", roles = "USER")
     void testGetLearningPathNavigationOverviewForOtherStudent() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         request.get("/api/learning-path/" + learningPath.getId() + "/navigation-overview", HttpStatus.FORBIDDEN, LearningPathNavigationOverviewDTO.class);
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetCompetencyOrderForLearningPath() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         final var result = request.getList("/api/learning-path/" + learningPath.getId() + "/competencies", HttpStatus.OK, CompetencyNameDTO.class);
         assertThat(result).containsExactlyElementsOf(Arrays.stream(competencies).map(CompetencyNameDTO::of).toList());
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningObjectsForCompetency() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         var result = request.getList("/api/learning-path/" + learningPath.getId() + "/competencies/" + competencies[0].getId() + "/learning-objects", HttpStatus.OK,
                 LearningPathNavigationObjectDTO.class);
@@ -810,10 +847,10 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     @Test
-    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    @WithMockUser(username = STUDENT1_OF_COURSE, roles = "USER")
     void testGetLearningObjectsForCompetencyMultipleObjects() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
 
         List<LearningObject> completedLectureUnits = List.of(createAndLinkTextUnit(student, competencies[4], true), createAndLinkTextUnit(student, competencies[4], true));
@@ -844,7 +881,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     void testGetCompetencyProgressForLearningPath() throws Exception {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-        final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+        final var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         final var result = request.get("/api/learning-path/" + learningPath.getId() + "/competency-progress", HttpStatus.OK, Set.class);
         assertThat(result).hasSize(5);
@@ -855,7 +892,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
         Set<GradingCriterion> gradingCriteria = exerciseUtilService.addGradingInstructionsToExercise(textExercise);
         gradingCriterionRepository.saveAll(gradingCriteria);
         if (withAssessment) {
-            var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
+            var student = userRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
             studentScoreUtilService.createStudentScore(textExercise, student, 100.0);
         }
         competencyUtilService.linkExerciseToCompetency(competency, textExercise);

--- a/src/test/java/de/tum/cit/aet/artemis/competency/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/competency/LearningPathIntegrationTest.java
@@ -36,6 +36,7 @@ import de.tum.cit.aet.artemis.atlas.dto.CompetencyGraphNodeDTO;
 import de.tum.cit.aet.artemis.atlas.dto.CompetencyNameDTO;
 import de.tum.cit.aet.artemis.atlas.dto.CompetencyWithTailRelationDTO;
 import de.tum.cit.aet.artemis.atlas.dto.LearningPathCompetencyGraphDTO;
+import de.tum.cit.aet.artemis.atlas.dto.LearningPathDTO;
 import de.tum.cit.aet.artemis.atlas.dto.LearningPathHealthDTO;
 import de.tum.cit.aet.artemis.atlas.dto.LearningPathInformationDTO;
 import de.tum.cit.aet.artemis.atlas.dto.LearningPathNavigationDTO;
@@ -571,16 +572,16 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     @Nested
-    class GetLearningPathId {
+    class GetLearningPath {
 
         @Test
         @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
-        void shouldReturnExistingId() throws Exception {
+        void shouldReturnExisting() throws Exception {
             course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
             final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
             final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
-            final var result = request.get("/api/courses/" + course.getId() + "/learning-path-id", HttpStatus.OK, Long.class);
-            assertThat(result).isEqualTo(learningPath.getId());
+            final var result = request.get("/api/courses/" + course.getId() + "/learning-path/me", HttpStatus.OK, LearningPathDTO.class);
+            assertThat(result).isEqualTo(LearningPathDTO.of(learningPath));
         }
 
         @Test
@@ -591,7 +592,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
             var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
             student = userRepository.findWithLearningPathsByIdElseThrow(student.getId());
             learningPathRepository.deleteAll(student.getLearningPaths());
-            request.get("/api/courses/" + course.getId() + "/learning-path-id", HttpStatus.NOT_FOUND, Long.class);
+            request.get("/api/courses/" + course.getId() + "/learning-path/me", HttpStatus.NOT_FOUND, LearningPathDTO.class);
         }
     }
 
@@ -601,14 +602,14 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
         @Test
         @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
         void shouldReturnForbiddenIfNotEnabled() throws Exception {
-            request.postWithResponseBody("/api/courses/" + course.getId() + "/learning-path", null, Long.class, HttpStatus.BAD_REQUEST);
+            request.postWithResponseBody("/api/courses/" + course.getId() + "/learning-path", null, LearningPathDTO.class, HttpStatus.BAD_REQUEST);
         }
 
         @Test
         @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
         void shouldReturnBadRequestIfAlreadyExists() throws Exception {
             course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
-            request.postWithResponseBody("/api/courses/" + course.getId() + "/learning-path", null, Long.class, HttpStatus.BAD_REQUEST);
+            request.postWithResponseBody("/api/courses/" + course.getId() + "/learning-path", null, LearningPathDTO.class, HttpStatus.BAD_REQUEST);
         }
 
         @Test
@@ -616,13 +617,15 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
         void shouldGenerateLearningPath() throws Exception {
             course.setLearningPathsEnabled(true);
             course = courseRepository.save(course);
-            final var response = request.postWithResponseBody("/api/courses/" + course.getId() + "/learning-path", null, Long.class, HttpStatus.CREATED);
+            final var response = request.postWithResponseBody("/api/courses/" + course.getId() + "/learning-path", null, LearningPathDTO.class, HttpStatus.CREATED);
             assertThat(response).isNotNull();
             final var student = userRepository.findOneByLogin(STUDENT_OF_COURSE).orElseThrow();
             final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
             assertThat(learningPath).isNotNull();
         }
     }
+
+    // TODO: Write tests for start learning path
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student2", roles = "USER")

--- a/src/test/javascript/spec/component/learning-paths/pages/learning-path-student-page.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-paths/pages/learning-path-student-page.component.spec.ts
@@ -13,6 +13,7 @@ import { LearningPathApiService } from 'app/course/learning-paths/services/learn
 import { AlertService } from 'app/core/util/alert.service';
 import { MockAlertService } from '../../../helpers/mocks/service/mock-alert.service';
 import { EntityNotFoundError } from 'app/course/learning-paths/exceptions/entity-not-found.error';
+import { LearningPathDTO } from 'app/entities/competency/learning-path.model';
 
 describe('LearningPathStudentPageComponent', () => {
     let component: LearningPathStudentPageComponent;
@@ -20,7 +21,11 @@ describe('LearningPathStudentPageComponent', () => {
     let learningPathApiService: LearningPathApiService;
     let alertService: AlertService;
 
-    const learningPathId = 1;
+    const learningPath: LearningPathDTO = {
+        id: 1,
+        progress: 0,
+        startedByStudent: false,
+    };
     const courseId = 2;
 
     beforeEach(async () => {
@@ -42,6 +47,14 @@ describe('LearningPathStudentPageComponent', () => {
                 },
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: AlertService, useClass: MockAlertService },
+                {
+                    provide: LearningPathApiService,
+                    useValue: {
+                        getLearningPathForCurrentUser: jest.fn().mockResolvedValue(learningPath),
+                        generateLearningPathForCurrentUser: jest.fn().mockResolvedValue(learningPath),
+                        startLearningPathForCurrentUser: jest.fn().mockReturnValue(() => Promise.resolve()),
+                    },
+                },
             ],
         })
             .overrideComponent(LearningPathStudentPageComponent, {
@@ -70,18 +83,23 @@ describe('LearningPathStudentPageComponent', () => {
         expect(component.courseId()).toBe(courseId);
     });
 
-    it('should get learning path id', async () => {
-        const getLearningPathIdSpy = jest.spyOn(learningPathApiService, 'getLearningPathId').mockResolvedValue(learningPathId);
+    it('should get learning path', async () => {
+        const getLearningPathIdSpy = jest.spyOn(learningPathApiService, 'getLearningPathForCurrentUser').mockResolvedValue(learningPath);
 
         fixture.detectChanges();
         await fixture.whenStable();
 
         expect(getLearningPathIdSpy).toHaveBeenCalledWith(courseId);
-        expect(component.learningPathId()).toEqual(learningPathId);
+        expect(component.learningPath()).toEqual(learningPath);
     });
 
-    it('should show navigation on successful load', async () => {
-        jest.spyOn(learningPathApiService, 'getLearningPathId').mockResolvedValue(learningPathId);
+    it('should show navigation when learning path has been started', async () => {
+        const learningPath: LearningPathDTO = {
+            id: 1,
+            progress: 0,
+            startedByStudent: true,
+        };
+        jest.spyOn(learningPathApiService, 'getLearningPathForCurrentUser').mockResolvedValueOnce(learningPath);
 
         fixture.detectChanges();
         await fixture.whenStable();
@@ -91,8 +109,8 @@ describe('LearningPathStudentPageComponent', () => {
         expect(navComponent).toBeTruthy();
     });
 
-    it('should show error when learning path id could not be loaded', async () => {
-        const getLearningPathIdSpy = jest.spyOn(learningPathApiService, 'getLearningPathId').mockRejectedValue(new Error());
+    it('should show error when learning path could not be loaded', async () => {
+        const getLearningPathIdSpy = jest.spyOn(learningPathApiService, 'getLearningPathForCurrentUser').mockRejectedValue(new Error());
         const alertServiceErrorSpy = jest.spyOn(alertService, 'error');
 
         fixture.detectChanges();
@@ -103,8 +121,8 @@ describe('LearningPathStudentPageComponent', () => {
     });
 
     it('should set isLoading correctly during learning path load', async () => {
-        jest.spyOn(learningPathApiService, 'getLearningPathId').mockResolvedValue(learningPathId);
-        const loadingSpy = jest.spyOn(component.isLearningPathIdLoading, 'set');
+        jest.spyOn(learningPathApiService, 'getLearningPathForCurrentUser').mockResolvedValue(learningPath);
+        const loadingSpy = jest.spyOn(component.isLearningPathLoading, 'set');
 
         fixture.detectChanges();
         await fixture.whenStable();
@@ -113,28 +131,34 @@ describe('LearningPathStudentPageComponent', () => {
         expect(loadingSpy).toHaveBeenNthCalledWith(2, false);
     });
 
-    it('should generate learning path on click', async () => {
-        jest.spyOn(learningPathApiService, 'getLearningPathId').mockRejectedValue(new EntityNotFoundError());
-        const generateLearningPathSpy = jest.spyOn(learningPathApiService, 'generateLearningPath').mockResolvedValue(learningPathId);
-
-        fixture.detectChanges();
-        await fixture.whenStable();
-        fixture.detectChanges();
-
-        const generateLearningPathButton = fixture.debugElement.query(By.css('#generate-learning-path-button'));
-        generateLearningPathButton.nativeElement.click();
+    it('should generate learning path on start when not found', async () => {
+        jest.spyOn(learningPathApiService, 'getLearningPathForCurrentUser').mockReturnValueOnce(Promise.reject(new EntityNotFoundError()));
+        const generateLearningPathSpy = jest.spyOn(learningPathApiService, 'generateLearningPathForCurrentUser').mockResolvedValue(learningPath);
+        const startSpy = jest.spyOn(learningPathApiService, 'startLearningPathForCurrentUser');
 
         fixture.detectChanges();
         await fixture.whenStable();
 
-        expect(component.learningPathId()).toEqual(learningPathId);
-        expect(generateLearningPathSpy).toHaveBeenCalledWith(courseId);
+        await component.startLearningPath();
+
+        expect(component.learningPath()).toEqual({ ...learningPath, startedByStudent: true });
+        expect(generateLearningPathSpy).toHaveBeenCalledExactlyOnceWith(courseId);
+        expect(startSpy).toHaveBeenCalledExactlyOnceWith(learningPath.id);
     });
 
-    it('should set isLoading correctly during learning path generation', async () => {
-        jest.spyOn(learningPathApiService, 'getLearningPathId').mockRejectedValue(new EntityNotFoundError());
-        jest.spyOn(learningPathApiService, 'generateLearningPath').mockResolvedValue(learningPathId);
-        const loadingSpy = jest.spyOn(component.isLearningPathIdLoading, 'set');
+    it('should set learning path to started', async () => {
+        const startedSpy = jest.spyOn(learningPathApiService, 'startLearningPathForCurrentUser');
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        await component.startLearningPath();
+
+        expect(component.learningPath()).toEqual({ ...learningPath, startedByStudent: true });
+        expect(startedSpy).toHaveBeenCalledExactlyOnceWith(learningPath.id);
+    });
+
+    it('should set isLoading correctly during learning path start', async () => {
+        const loadingSpy = jest.spyOn(component.isLearningPathLoading, 'set');
 
         fixture.detectChanges();
         await fixture.whenStable();

--- a/src/test/javascript/spec/service/learning-path/learning-path-api.service.spec.ts
+++ b/src/test/javascript/spec/service/learning-path/learning-path-api.service.spec.ts
@@ -26,11 +26,11 @@ describe('LearningPathApiService', () => {
         httpClient.verify();
     });
 
-    it('should get learning path id', async () => {
+    it('should get learning path for current user', async () => {
         const courseId = 1;
 
-        const methodCall = learningPathApiService.getLearningPathId(courseId);
-        const response = httpClient.expectOne({ method: 'GET', url: `${baseUrl}/courses/${courseId}/learning-path-id` });
+        const methodCall = learningPathApiService.getLearningPathForCurrentUser(courseId);
+        const response = httpClient.expectOne({ method: 'GET', url: `${baseUrl}/courses/${courseId}/learning-path/me` });
         response.flush({});
         await methodCall;
     });
@@ -55,6 +55,13 @@ describe('LearningPathApiService', () => {
         await methodCall;
     });
 
+    it('should start learning path for current user', async () => {
+        const methodCall = learningPathApiService.startLearningPathForCurrentUser(learningPathId);
+        const response = httpClient.expectOne({ method: 'PATCH', url: `${baseUrl}/learning-path/${learningPathId}/start` });
+        response.flush({});
+        await methodCall;
+    });
+
     it('should get learning path navigation overview', async () => {
         const methodCall = learningPathApiService.getLearningPathNavigationOverview(learningPathId);
         const response = httpClient.expectOne({ method: 'GET', url: `${baseUrl}/learning-path/${learningPathId}/navigation-overview` });
@@ -62,8 +69,8 @@ describe('LearningPathApiService', () => {
         await methodCall;
     });
 
-    it('should generate learning path', async () => {
-        const methodCall = learningPathApiService.generateLearningPath(courseId);
+    it('should generate learning path for current user', async () => {
+        const methodCall = learningPathApiService.generateLearningPathForCurrentUser(courseId);
         const response = httpClient.expectOne({ method: 'POST', url: `${baseUrl}/courses/${courseId}/learning-path` });
         response.flush({});
         await methodCall;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [ ] I **strictly** followed the principle of **data economy** for all database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.


#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ ] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [ ] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


### Description
<!-- Describe your changes in detail -->


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://docs.artemis.cit.tum.de/user/exam_mode/) as reference.
4. ...

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
