### PR TITLE
`Adaptive learning`: Unlink edited competencies from standardised competencies

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CourseCompetencyService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CourseCompetencyService.java
@@ -359,6 +359,7 @@ public class CourseCompetencyService {
         competencyToUpdate.setMasteryThreshold(competency.getMasteryThreshold());
         competencyToUpdate.setTaxonomy(competency.getTaxonomy());
         competencyToUpdate.setOptional(competency.isOptional());
+        competencyToUpdate.setLinkedStandardizedCompetency(null);
         final var persistedCompetency = courseCompetencyRepository.save(competencyToUpdate);
 
         // update competency progress if necessary

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/LoggingAspect.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/LoggingAspect.java
@@ -96,8 +96,8 @@ public class LoggingAspect {
     @Around("applicationPackagePointcut() && springBeanPointcut()")
     public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
         if (log.isDebugEnabled()) {
-            // log.debug("Enter: {}.{}() with argument[s] = {}", joinPoint.getSignature().getDeclaringTypeName(), joinPoint.getSignature().getName(),
-            // Arrays.toString(joinPoint.getArgs()));
+            log.debug("Enter: {}.{}() with argument[s] = {}", joinPoint.getSignature().getDeclaringTypeName(), joinPoint.getSignature().getName(),
+                    Arrays.toString(joinPoint.getArgs()));
         }
         try {
             Object result = joinPoint.proceed();

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/LoggingAspect.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/LoggingAspect.java
@@ -96,8 +96,8 @@ public class LoggingAspect {
     @Around("applicationPackagePointcut() && springBeanPointcut()")
     public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
         if (log.isDebugEnabled()) {
-            log.debug("Enter: {}.{}() with argument[s] = {}", joinPoint.getSignature().getDeclaringTypeName(), joinPoint.getSignature().getName(),
-                    Arrays.toString(joinPoint.getArgs()));
+            // log.debug("Enter: {}.{}() with argument[s] = {}", joinPoint.getSignature().getDeclaringTypeName(), joinPoint.getSignature().getName(),
+            // Arrays.toString(joinPoint.getArgs()));
         }
         try {
             Object result = joinPoint.proceed();

--- a/src/main/webapp/app/course/competencies/edit/edit-competency.component.html
+++ b/src/main/webapp/app/course/competencies/edit/edit-competency.component.html
@@ -9,7 +9,7 @@
         <h3 jhiTranslate="artemisApp.competency.edit.title"></h3>
         <jhi-competency-form
             [isEditMode]="true"
-            [hasLinkedStandardizedCompetency]="!!competency.linkedStandardizedCompetency"
+            [hasLinkedStandardizedCompetency]="!!competency?.linkedStandardizedCompetency"
             [formData]="formData"
             (formSubmitted)="updateCompetency($event)"
             [courseId]="courseId"

--- a/src/main/webapp/app/course/competencies/edit/edit-competency.component.html
+++ b/src/main/webapp/app/course/competencies/edit/edit-competency.component.html
@@ -9,6 +9,7 @@
         <h3 jhiTranslate="artemisApp.competency.edit.title"></h3>
         <jhi-competency-form
             [isEditMode]="true"
+            [hasLinkedStandardizedCompetency]="!!competency.linkedStandardizedCompetency"
             [formData]="formData"
             (formSubmitted)="updateCompetency($event)"
             [courseId]="courseId"

--- a/src/main/webapp/app/course/competencies/edit/edit-prerequisite.component.html
+++ b/src/main/webapp/app/course/competencies/edit/edit-prerequisite.component.html
@@ -9,6 +9,7 @@
         <h3 jhiTranslate="artemisApp.prerequisite.edit.title"></h3>
         <jhi-prerequisite-form
             [isEditMode]="true"
+            [hasLinkedStandardizedCompetency]="!!prerequisite?.linkedStandardizedCompetency"
             [formData]="formData"
             (formSubmitted)="updateCompetency($event)"
             [courseId]="courseId"

--- a/src/main/webapp/app/course/competencies/forms/competency/competency-form.component.html
+++ b/src/main/webapp/app/course/competencies/forms/competency/competency-form.component.html
@@ -4,23 +4,23 @@
             <form [formGroup]="form" (ngSubmit)="submitForm()">
                 <jhi-common-course-competency-form
                     [formData]="formData"
-                    [isEditMode]="isEditMode"
-                    [isInConnectMode]="isInConnectMode"
-                    [isInSingleLectureMode]="isInSingleLectureMode"
-                    [lecturesOfCourseWithLectureUnits]="lecturesOfCourseWithLectureUnits"
-                    [averageStudentScore]="averageStudentScore"
+                    [isEditMode]="isEditMode()"
+                    [isInConnectMode]="isInConnectMode()"
+                    [isInSingleLectureMode]="isInSingleLectureMode()"
+                    [lecturesOfCourseWithLectureUnits]="lecturesOfCourseWithLectureUnits()"
+                    [averageStudentScore]="averageStudentScore()"
                     [form]="form"
                     [competencyType]="CourseCompetencyType.COMPETENCY"
                     (onLectureUnitSelectionChange)="onLectureUnitSelectionChange($event)"
                 />
                 <div>
-                    @if (competency) {
-                        <div class="alert alert-danger" role="alert" jhiTranslate="artemisApp.forms.scheduleForm.scheduleChangeWarning"></div>
+                    @if (hasLinkedStandardizedCompetency()) {
+                        <div class="alert alert-warning" role="alert" jhiTranslate="artemisApp.courseCompetency.edit.unlinkStandardizedCompetenciesWarning"></div>
                     }
                     <button id="submitButton" class="btn btn-primary me-2" type="submit" [disabled]="!isSubmitPossible">
                         <span jhiTranslate="entity.action.submit"></span>
                     </button>
-                    @if (hasCancelButton) {
+                    @if (hasCancelButton()) {
                         <button type="button" (click)="cancelForm()" class="btn btn-default">
                             <fa-icon [icon]="faTimes" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
                         </button>

--- a/src/main/webapp/app/course/competencies/forms/competency/competency-form.component.html
+++ b/src/main/webapp/app/course/competencies/forms/competency/competency-form.component.html
@@ -14,6 +14,9 @@
                     (onLectureUnitSelectionChange)="onLectureUnitSelectionChange($event)"
                 />
                 <div>
+                    @if (competency) {
+                        <div class="alert alert-danger" role="alert" jhiTranslate="artemisApp.forms.scheduleForm.scheduleChangeWarning"></div>
+                    }
                     <button id="submitButton" class="btn btn-primary me-2" type="submit" [disabled]="!isSubmitPossible">
                         <span jhiTranslate="entity.action.submit"></span>
                     </button>

--- a/src/main/webapp/app/course/competencies/forms/competency/competency-form.component.ts
+++ b/src/main/webapp/app/course/competencies/forms/competency/competency-form.component.ts
@@ -39,7 +39,7 @@ export class CompetencyFormComponent extends CourseCompetencyFormComponent imple
 
     ngOnChanges(): void {
         this.initializeForm();
-        if (this.isEditMode && this.formData) {
+        if (this.isEditMode() && this.formData) {
             this.setFormValues(this.formData);
         }
     }

--- a/src/main/webapp/app/course/competencies/forms/course-competency-form.component.ts
+++ b/src/main/webapp/app/course/competencies/forms/course-competency-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Output, input } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { of } from 'rxjs';
 import { catchError, delay, map, switchMap } from 'rxjs/operators';
@@ -55,20 +55,14 @@ export interface CourseCompetencyFormData {
 export abstract class CourseCompetencyFormComponent {
     abstract formData: CourseCompetencyFormData;
 
-    @Input()
-    isEditMode = false;
-    @Input()
-    isInConnectMode = false;
-    @Input()
-    isInSingleLectureMode = false;
-    @Input()
-    courseId: number;
-    @Input()
-    lecturesOfCourseWithLectureUnits: Lecture[] = [];
-    @Input()
-    averageStudentScore?: number;
-    @Input()
-    hasCancelButton: boolean;
+    isEditMode = input<boolean>(false);
+    isInConnectMode = input<boolean>(false);
+    isInSingleLectureMode = input<boolean>(false);
+    hasLinkedStandardizedCompetency = input<boolean>(false);
+    courseId = input<number>();
+    lecturesOfCourseWithLectureUnits = input<Lecture[]>([]);
+    averageStudentScore = input<number | undefined>();
+    hasCancelButton = input<boolean>();
 
     @Output()
     onCancel: EventEmitter<any> = new EventEmitter<any>();
@@ -122,14 +116,14 @@ export abstract class CourseCompetencyFormComponent {
             return;
         }
         let initialTitle: string | undefined = undefined;
-        if (this.isEditMode && this.formData && this.formData.title) {
+        if (this.isEditMode() && this.formData && this.formData.title) {
             initialTitle = this.formData.title;
         }
         this.form = this.fb.nonNullable.group({
             title: [
                 undefined as string | undefined,
                 [Validators.required, Validators.maxLength(255)],
-                [titleUniqueValidator(this.courseCompetencyService, this.courseId, initialTitle)],
+                [titleUniqueValidator(this.courseCompetencyService, this.courseId()!, initialTitle)],
             ],
             description: [undefined as string | undefined, [Validators.maxLength(10000)]],
             softDueDate: [undefined],

--- a/src/main/webapp/app/course/competencies/forms/course-competency-form.component.ts
+++ b/src/main/webapp/app/course/competencies/forms/course-competency-form.component.ts
@@ -59,10 +59,10 @@ export abstract class CourseCompetencyFormComponent {
     isInConnectMode = input<boolean>(false);
     isInSingleLectureMode = input<boolean>(false);
     hasLinkedStandardizedCompetency = input<boolean>(false);
-    courseId = input<number>();
+    courseId = input.required<number>();
     lecturesOfCourseWithLectureUnits = input<Lecture[]>([]);
-    averageStudentScore = input<number | undefined>();
-    hasCancelButton = input<boolean>();
+    averageStudentScore = input<number>();
+    hasCancelButton = input<boolean>(true);
 
     @Output()
     onCancel: EventEmitter<any> = new EventEmitter<any>();
@@ -123,7 +123,7 @@ export abstract class CourseCompetencyFormComponent {
             title: [
                 undefined as string | undefined,
                 [Validators.required, Validators.maxLength(255)],
-                [titleUniqueValidator(this.courseCompetencyService, this.courseId()!, initialTitle)],
+                [titleUniqueValidator(this.courseCompetencyService, this.courseId(), initialTitle)],
             ],
             description: [undefined as string | undefined, [Validators.maxLength(10000)]],
             softDueDate: [undefined],

--- a/src/main/webapp/app/course/competencies/forms/prerequisite/prerequisite-form.component.html
+++ b/src/main/webapp/app/course/competencies/forms/prerequisite/prerequisite-form.component.html
@@ -4,20 +4,23 @@
             <form [formGroup]="form" (ngSubmit)="submitForm()">
                 <jhi-common-course-competency-form
                     [formData]="formData"
-                    [isEditMode]="isEditMode"
-                    [isInConnectMode]="isInConnectMode"
-                    [isInSingleLectureMode]="isInSingleLectureMode"
-                    [lecturesOfCourseWithLectureUnits]="lecturesOfCourseWithLectureUnits"
-                    [averageStudentScore]="averageStudentScore"
+                    [isEditMode]="isEditMode()"
+                    [isInConnectMode]="isInConnectMode()"
+                    [isInSingleLectureMode]="isInSingleLectureMode()"
+                    [lecturesOfCourseWithLectureUnits]="lecturesOfCourseWithLectureUnits()"
+                    [averageStudentScore]="averageStudentScore()"
                     [form]="form"
                     [competencyType]="CourseCompetencyType.PREREQUISITE"
                     (onLectureUnitSelectionChange)="onLectureUnitSelectionChange($event)"
                 />
                 <div>
+                    @if (hasLinkedStandardizedCompetency()) {
+                        <div class="alert alert-warning" role="alert" jhiTranslate="artemisApp.courseCompetency.edit.unlinkStandardizedCompetenciesWarning"></div>
+                    }
                     <button id="submitButton" class="btn btn-primary me-2" type="submit" [disabled]="!isSubmitPossible">
                         <span jhiTranslate="entity.action.submit"></span>
                     </button>
-                    @if (hasCancelButton) {
+                    @if (hasCancelButton()) {
                         <button type="button" (click)="cancelForm()" class="btn btn-default">
                             <fa-icon [icon]="faTimes" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
                         </button>

--- a/src/main/webapp/app/course/competencies/forms/prerequisite/prerequisite-form.component.ts
+++ b/src/main/webapp/app/course/competencies/forms/prerequisite/prerequisite-form.component.ts
@@ -39,7 +39,7 @@ export class PrerequisiteFormComponent extends CourseCompetencyFormComponent imp
 
     ngOnChanges(): void {
         this.initializeForm();
-        if (this.isEditMode && this.formData) {
+        if (this.isEditMode() && this.formData) {
             this.setFormValues(this.formData);
         }
     }

--- a/src/main/webapp/i18n/de/competency.json
+++ b/src/main/webapp/i18n/de/competency.json
@@ -211,7 +211,7 @@
                 }
             },
             "edit": {
-                "unlinkStandardizedCompetenciesWarning": "Das Bearbeiten wird dazu führen, dass die Verbindung zu standardisierten Kompetenzen gelöst wird!"
+                "unlinkStandardizedCompetenciesWarning": "Das Bearbeiten führt zum Lösen der Verbindung zur standardisierten Kompetenz!"
             }
         },
         "prerequisite": {

--- a/src/main/webapp/i18n/de/competency.json
+++ b/src/main/webapp/i18n/de/competency.json
@@ -209,6 +209,9 @@
                     "noOfParticipants": "Anzahl der Teilnehmenden",
                     "participationRate": "Teilnahmerate"
                 }
+            },
+            "edit": {
+                "unlinkStandardizedCompetenciesWarning": "Das Editieren wird dazu führen, dass die Verbindung zu standardisierten Kompetenzen gelöst wird!"
             }
         },
         "prerequisite": {

--- a/src/main/webapp/i18n/de/competency.json
+++ b/src/main/webapp/i18n/de/competency.json
@@ -211,7 +211,7 @@
                 }
             },
             "edit": {
-                "unlinkStandardizedCompetenciesWarning": "Das Editieren wird dazu führen, dass die Verbindung zu standardisierten Kompetenzen gelöst wird!"
+                "unlinkStandardizedCompetenciesWarning": "Das Bearbeiten wird dazu führen, dass die Verbindung zu standardisierten Kompetenzen gelöst wird!"
             }
         },
         "prerequisite": {

--- a/src/main/webapp/i18n/en/competency.json
+++ b/src/main/webapp/i18n/en/competency.json
@@ -198,6 +198,9 @@
                     "participationRate": "Participation Rate"
                 }
             },
+            "edit": {
+                "unlinkStandardizedCompetenciesWarning": "Editing will unlink the standardized competencie!"
+            },
             "taxonomies": {
                 "REMEMBER": "Remember",
                 "UNDERSTAND": "Understand",

--- a/src/main/webapp/i18n/en/competency.json
+++ b/src/main/webapp/i18n/en/competency.json
@@ -199,7 +199,7 @@
                 }
             },
             "edit": {
-                "unlinkStandardizedCompetenciesWarning": "Editing will unlink the standardized competencie!"
+                "unlinkStandardizedCompetenciesWarning": "Editing will unlink the standardized competency!"
             },
             "taxonomies": {
                 "REMEMBER": "Remember",

--- a/src/test/javascript/spec/component/competencies/competency-form.component.spec.ts
+++ b/src/test/javascript/spec/component/competencies/competency-form.component.spec.ts
@@ -105,7 +105,7 @@ describe('CompetencyFormComponent', () => {
     }));
 
     it('should correctly set form values in edit mode', () => {
-        competencyFormComponent.isEditMode = true;
+        competencyFormComponentFixture.componentRef.setInput('isEditMode', true);
         const textUnit = new TextUnit();
         textUnit.id = 1;
         const formData: CourseCompetencyFormData = {
@@ -169,7 +169,7 @@ describe('CompetencyFormComponent', () => {
         const competencyService = TestBed.inject(CompetencyService);
         const existingTitles = ['nameExisting'];
         jest.spyOn(competencyService, 'getCourseCompetencyTitles').mockReturnValue(of(new HttpResponse({ body: existingTitles, status: 200 })));
-        competencyFormComponent.isEditMode = true;
+        competencyFormComponentFixture.componentRef.setInput('isEditMode', true);
         competencyFormComponent.formData.title = 'initialName';
 
         competencyFormComponentFixture.detectChanges();

--- a/src/test/javascript/spec/component/competencies/prerequisite-form.component.spec.ts
+++ b/src/test/javascript/spec/component/competencies/prerequisite-form.component.spec.ts
@@ -12,7 +12,6 @@ import { ArtemisTestModule } from '../../test.module';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
 import dayjs from 'dayjs/esm';
-import { CompetencyFormComponent } from 'app/course/competencies/forms/competency/competency-form.component';
 import { CourseCompetencyFormData } from 'app/course/competencies/forms/course-competency-form.component';
 import { By } from '@angular/platform-browser';
 import { CommonCourseCompetencyFormComponent } from 'app/course/competencies/forms/common-course-competency-form.component';
@@ -30,7 +29,7 @@ describe('PrerequisiteFormComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [CompetencyFormComponent, ArtemisTestModule, ReactiveFormsModule, NgbDropdownModule],
+            imports: [PrerequisiteFormComponent, ArtemisTestModule, ReactiveFormsModule, NgbDropdownModule],
             providers: [MockProvider(PrerequisiteService), MockProvider(LectureUnitService), { provide: TranslateService, useClass: MockTranslateService }],
         })
             .overrideModule(ArtemisMarkdownEditorModule, {
@@ -106,7 +105,7 @@ describe('PrerequisiteFormComponent', () => {
     }));
 
     it('should correctly set form values in edit mode', () => {
-        prerequisiteFormComponent.isEditMode = true;
+        prerequisiteFormComponentFixture.componentRef.setInput('isEditMode', true);
         const textUnit = new TextUnit();
         textUnit.id = 1;
         const formData: CourseCompetencyFormData = {
@@ -170,7 +169,7 @@ describe('PrerequisiteFormComponent', () => {
         const prerequisiteService = TestBed.inject(PrerequisiteService);
         const existingTitles = ['nameExisting'];
         jest.spyOn(prerequisiteService, 'getCourseCompetencyTitles').mockReturnValue(of(new HttpResponse({ body: existingTitles, status: 200 })));
-        prerequisiteFormComponent.isEditMode = true;
+        prerequisiteFormComponentFixture.componentRef.setInput('isEditMode', true);
         prerequisiteFormComponent.formData.title = 'initialName';
 
         prerequisiteFormComponentFixture.detectChanges();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Competencies and prerequisites can be created using standardised competencies. If these imported competencies or prerequisites are edited later on, they should loose their link to the standardised competency, as they do no longer resemble the standardised competency.

### Description
<!-- Describe your changes in detail -->
When a competency is edited that is linked to a standardised competency, a warning is shown above the submit button that this change will unlink the competency. And on submit the competency is then actually unlinked.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- Standardised competencies (e.g. on ts3)

1. Log in to Artemis
2. Import a competency and/or prerequisite based on a standardised competency
3. Edit the imported competency/prerequisite
4. Edit it again and check that there is no longer a warning as it is no longer linked

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Performance Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1316" alt="Bildschirmfoto 2024-10-01 um 14 03 05" src="https://github.com/user-attachments/assets/5e0b57b7-6881-46d2-8772-007a5b335882">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a warning message for users when editing competencies, indicating that it will unlink standardized competencies.
	- Introduced a new property to the competency form to indicate linked standardized competencies.
	- Enhanced user feedback with a conditional alert for linked standardized competencies during form submission.

- **Bug Fixes**
	- Enhanced the handling of edit mode checks in various components for improved reliability.

- **Documentation**
	- Updated localization files for both German and English to reflect new warning messages and additional fields in the competency management sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->