### PR TITLE
`Adaptive learning`: Change mastery threshold to input field and validate values

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/atlas/web/PrerequisiteResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/web/PrerequisiteResource.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Set;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.ws.rs.BadRequestException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,9 +138,8 @@ public class PrerequisiteResource {
     @EnforceAtLeastInstructorInCourse
     public ResponseEntity<Prerequisite> createPrerequisite(@PathVariable long courseId, @RequestBody Prerequisite prerequisite) throws URISyntaxException {
         log.debug("REST request to create Prerequisite : {}", prerequisite);
-        if (prerequisite.getId() != null || prerequisite.getTitle() == null || prerequisite.getTitle().trim().isEmpty()) {
-            throw new BadRequestException();
-        }
+        checkPrerequisitesAttributesForCreation(prerequisite);
+
         var course = courseRepository.findWithEagerCompetenciesAndPrerequisitesByIdElseThrow(courseId);
 
         final var persistedPrerequisite = prerequisiteService.createCourseCompetency(prerequisite, course);
@@ -162,9 +160,7 @@ public class PrerequisiteResource {
     public ResponseEntity<List<Prerequisite>> createPrerequisite(@PathVariable Long courseId, @RequestBody List<Prerequisite> prerequisites) throws URISyntaxException {
         log.debug("REST request to create Prerequisites : {}", prerequisites);
         for (Prerequisite prerequisite : prerequisites) {
-            if (prerequisite.getId() != null || prerequisite.getTitle() == null || prerequisite.getTitle().trim().isEmpty()) {
-                throw new BadRequestException();
-            }
+            checkPrerequisitesAttributesForCreation(prerequisite);
         }
         var course = courseRepository.findWithEagerCompetenciesAndPrerequisitesByIdElseThrow(courseId);
 
@@ -303,9 +299,8 @@ public class PrerequisiteResource {
     @EnforceAtLeastInstructorInCourse
     public ResponseEntity<Prerequisite> updatePrerequisite(@PathVariable long courseId, @RequestBody Prerequisite prerequisite) {
         log.debug("REST request to update Prerequisite : {}", prerequisite);
-        if (prerequisite.getId() == null) {
-            throw new BadRequestException();
-        }
+        checkPrerequisitesAttributesForUpdate(prerequisite);
+
         var course = courseRepository.findByIdElseThrow(courseId);
         var existingPrerequisite = prerequisiteRepository.findByIdWithLectureUnitsElseThrow(prerequisite.getId());
         checkCourseForPrerequisite(course, existingPrerequisite);
@@ -335,6 +330,26 @@ public class PrerequisiteResource {
         courseCompetencyService.deleteCourseCompetency(prerequisite, course);
 
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, prerequisite.getTitle())).build();
+    }
+
+    private void checkPrerequisitesAttributesForCreation(Prerequisite prerequisite) {
+        if (prerequisite.getId() != null) {
+            throw new BadRequestAlertException("A new prerequiste should not have an id", ENTITY_NAME, "existingPrerequisiteId");
+        }
+        checkPrerequisitesAttributes(prerequisite);
+    }
+
+    private void checkPrerequisitesAttributesForUpdate(Prerequisite prerequisite) {
+        if (prerequisite.getId() == null) {
+            throw new BadRequestAlertException("An updated prerequiste should have an id", ENTITY_NAME, "missingPrerequisiteId");
+        }
+        checkPrerequisitesAttributes(prerequisite);
+    }
+
+    private void checkPrerequisitesAttributes(Prerequisite prerequisite) {
+        if (prerequisite.getTitle() == null || prerequisite.getTitle().trim().isEmpty() || prerequisite.getMasteryThreshold() < 1 || prerequisite.getMasteryThreshold() > 100) {
+            throw new BadRequestAlertException("The attributes of the competency are invalid!", ENTITY_NAME, "invalidPrerequisiteAttributes");
+        }
     }
 
     /**

--- a/src/main/webapp/app/course/competencies/forms/common-course-competency-form.component.html
+++ b/src/main/webapp/app/course/competencies/forms/common-course-competency-form.component.html
@@ -73,7 +73,7 @@
                     <small> ({{ 'artemisApp.courseCompetency.create.averageMastery' | artemisTranslate }}: {{ averageStudentScore }}%) </small>
                 }
             </label>
-            <input type="range" min="0" max="100" class="form-range" id="masteryThreshold" formControlName="masteryThreshold" />
+            <input required type="number" class="form-control" name="masteryThreshold" id="masteryThreshold" min="1" max="100" formControlName="masteryThreshold" />
         </div>
     }
     <div class="form-group">

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/competency/AbstractCompetencyPrerequisiteIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/competency/AbstractCompetencyPrerequisiteIntegrationTest.java
@@ -333,6 +333,7 @@ abstract class AbstractCompetencyPrerequisiteIntegrationTest extends AbstractSpr
         newCompetency.setTitle("Title");
         newCompetency.setDescription("Description");
         newCompetency.setCourse(course);
+        newCompetency.setMasteryThreshold(42);
         newCompetency = courseCompetencyRepository.save(newCompetency);
 
         TextExercise exercise = TextExerciseFactory.generateTextExercise(ZonedDateTime.now(), ZonedDateTime.now(), ZonedDateTime.now(), course);
@@ -355,6 +356,7 @@ abstract class AbstractCompetencyPrerequisiteIntegrationTest extends AbstractSpr
         newCompetency.setTitle("FreshlyCreatedCompetency");
         newCompetency.setDescription("This is an example of a freshly created competency");
         newCompetency.setCourse(course);
+        newCompetency.setMasteryThreshold(42);
         List<LectureUnit> allLectureUnits = lectureUnitRepository.findAll();
         Set<LectureUnit> connectedLectureUnits = new HashSet<>(allLectureUnits);
         newCompetency.setLectureUnits(connectedLectureUnits);
@@ -419,10 +421,12 @@ abstract class AbstractCompetencyPrerequisiteIntegrationTest extends AbstractSpr
         competency1.setDescription("This is an example competency");
         competency1.setTaxonomy(CompetencyTaxonomy.UNDERSTAND);
         competency1.setCourse(course);
+        competency1.setMasteryThreshold(42);
         competency2.setTitle("Competency2");
         competency2.setDescription("This is another example competency");
         competency2.setTaxonomy(CompetencyTaxonomy.REMEMBER);
         competency2.setCourse(course);
+        competency2.setMasteryThreshold(84);
 
         var competenciesToCreate = List.of(competency1, competency2);
 

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/competency/util/CompetencyUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/competency/util/CompetencyUtilService.java
@@ -56,6 +56,7 @@ public class CompetencyUtilService {
         competency.setDescription("Magna pars studiorum, prodita quaerimus.");
         competency.setTaxonomy(CompetencyTaxonomy.UNDERSTAND);
         competency.setCourse(course);
+        competency.setMasteryThreshold(42);
 
         return competencyRepo.save(competency);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/competency/util/PrerequisiteUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/competency/util/PrerequisiteUtilService.java
@@ -30,6 +30,7 @@ public class PrerequisiteUtilService {
         prerequisite.setTitle("Example Prerequisite");
         prerequisite.setDescription("Magna pars studiorum, prodita quaerimus.");
         prerequisite.setCourse(course);
+        prerequisite.setMasteryThreshold(42);
         return prerequisiteRepository.save(prerequisite);
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/learningpath/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/learningpath/LearningPathIntegrationTest.java
@@ -193,6 +193,7 @@ class LearningPathIntegrationTest extends AbstractSpringIntegrationIndependentTe
         competencyToCreate.setTitle("CompetencyToCreateTitle");
         competencyToCreate.setCourse(course);
         competencyToCreate.setLectureUnits(Set.of(textUnit));
+        competencyToCreate.setMasteryThreshold(42);
         return request.postWithResponseBody("/api/courses/" + course.getId() + "/competencies", competencyToCreate, Competency.class, HttpStatus.CREATED);
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
An input field is easier to manage and to select a specific value instead of an slider.

### Description
<!-- Describe your changes in detail -->
Replace the slide for the mastery threshold with an input field and validate the resulting value on the server and client.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Create/Edit a competency and set a new mastery threshoid value

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Performance Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1316" alt="Bildschirmfoto 2024-10-01 um 15 00 15" src="https://github.com/user-attachments/assets/8b61614d-0759-4c95-9412-b5596a276749">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for competency and prerequisite attributes during creation and updates.
	- Updated input type for mastery threshold to enforce a numeric range (1-100) in the competency form.
	- Default mastery threshold of 42 set for newly created competencies and prerequisites.

- **Bug Fixes**
	- Improved error messaging for invalid competency and prerequisite submissions.

- **Documentation**
	- Clarified validation requirements for competency titles and mastery thresholds in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->