### PR TITLE
`General`: Add csrf protection + sameSite none cookie

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -35,6 +35,7 @@ import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
 
 import de.tum.cit.aet.artemis.core.security.DomainUserDetailsService;
 import de.tum.cit.aet.artemis.core.security.Role;
+import de.tum.cit.aet.artemis.core.security.filter.CsrfArtemisFilter;
 import de.tum.cit.aet.artemis.core.security.filter.SpaWebFilter;
 import de.tum.cit.aet.artemis.core.security.jwt.JWTConfigurer;
 import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
@@ -53,6 +54,8 @@ public class SecurityConfiguration {
     private final PasswordService passwordService;
 
     private final CorsFilter corsFilter;
+
+    private final CsrfArtemisFilter csrfArtemisFilter = new CsrfArtemisFilter();
 
     private final ProfileService profileService;
 
@@ -171,7 +174,9 @@ public class SecurityConfiguration {
             // Disables CSRF (Cross-Site Request Forgery) protection; useful in stateless APIs where the token management is unnecessary.
             .csrf(AbstractHttpConfigurer::disable)
             // Adds a CORS (Cross-Origin Resource Sharing) filter before the username/password authentication to handle cross-origin requests.
+            // sets the filter chain: CorsFilter -> CsrfArtemisFilter -> UsernamePasswordAuthenticationFilter
             .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(csrfArtemisFilter, UsernamePasswordAuthenticationFilter.class)
             // Configures exception handling with a custom entry point and access denied handler for authentication issues.
             .exceptionHandling(handler -> handler.authenticationEntryPoint(securityProblemSupport).accessDeniedHandler(securityProblemSupport))
             // Adds a custom filter for Single Page Applications (SPA), i.e. the client, after the basic authentication filter.

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/WebConfigurer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/WebConfigurer.java
@@ -117,7 +117,8 @@ public class WebConfigurer implements ServletContextInitializer, WebServerFactor
     public CorsFilter corsFilter() {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = jHipsterProperties.getCors();
-        if (config.getAllowedOrigins() != null && !config.getAllowedOrigins().isEmpty()) {
+        if ((config.getAllowedOrigins() != null && !config.getAllowedOrigins().isEmpty())
+                || (config.getAllowedOriginPatterns() != null && !config.getAllowedOriginPatterns().isEmpty())) {
             log.debug("Registering CORS filter");
             source.registerCorsConfiguration("/api/**", config);
             source.registerCorsConfiguration("/management/**", config);

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/WebConfigurer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/WebConfigurer.java
@@ -117,8 +117,7 @@ public class WebConfigurer implements ServletContextInitializer, WebServerFactor
     public CorsFilter corsFilter() {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = jHipsterProperties.getCors();
-        if ((config.getAllowedOrigins() != null && !config.getAllowedOrigins().isEmpty())
-                || (config.getAllowedOriginPatterns() != null && !config.getAllowedOriginPatterns().isEmpty())) {
+        if (config.getAllowedOrigins() != null && !config.getAllowedOrigins().isEmpty()) {
             log.debug("Registering CORS filter");
             source.registerCorsConfiguration("/api/**", config);
             source.registerCorsConfiguration("/management/**", config);

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/filter/CsrfArtemisFilter.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/filter/CsrfArtemisFilter.java
@@ -27,4 +27,10 @@ public class CsrfArtemisFilter extends OncePerRequestFilter {
             response.sendError(HttpServletResponse.SC_FORBIDDEN, "Missing CSRF protection header");
         }
     }
+
+    // exclude all non api calls such as git, ...
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return !request.getRequestURI().startsWith("/api/");
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/filter/CsrfArtemisFilter.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/filter/CsrfArtemisFilter.java
@@ -1,0 +1,30 @@
+package de.tum.cit.aet.artemis.core.security.filter;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class CsrfArtemisFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(CsrfArtemisFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        // Check if the custom CSRF header is present in the request
+        if (request.getHeader("X-ARTEMIS-CSRF") != null) {
+            filterChain.doFilter(request, response);
+        }
+        else {
+            // Reject the request if the header is missing
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Missing CSRF protection header");
+        }
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/jwt/JWTCookieService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/jwt/JWTCookieService.java
@@ -5,11 +5,8 @@ import static de.tum.cit.aet.artemis.core.security.jwt.JWTFilter.JWT_COOKIE_NAME
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.Collection;
 
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -18,15 +15,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class JWTCookieService {
 
-    private static final String DEVELOPMENT_PROFILE = "dev";
-
     private final TokenProvider tokenProvider;
 
-    private final Environment environment;
-
-    public JWTCookieService(TokenProvider tokenProvider, Environment environment) {
+    public JWTCookieService(TokenProvider tokenProvider) {
         this.tokenProvider = tokenProvider;
-        this.environment = environment;
     }
 
     /**
@@ -59,12 +51,9 @@ public class JWTCookieService {
      */
     private ResponseCookie buildJWTCookie(String jwt, Duration duration) {
 
-        Collection<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
-        boolean isSecure = !activeProfiles.contains(DEVELOPMENT_PROFILE);
-
         return ResponseCookie.from(JWT_COOKIE_NAME, jwt).httpOnly(true) // Must be httpOnly
-                .sameSite("Lax") // Must be Lax to allow navigation links to Artemis to work
-                .secure(isSecure) // Must be secure
+                .sameSite("None") // Must be None to allow cross-site requests to Artemis from the VS Code plugin
+                .secure(true) // Must be secure to allow sameSite=None
                 .path("/") // Must be "/" to be sent in ALL request
                 .maxAge(duration) // Duration should match the duration of the jwt
                 .build(); // Build cookie

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -284,13 +284,16 @@ jhipster:
     clientApp:
         name: 'artemisApp'
     # By default CORS is disabled. Uncomment to enable.
-    #cors:
-        #allowed-origin-patterns: "*"
-        #allowed-methods: "*"
-        #allowed-headers: "*"
-        #exposed-headers: "Authorization,Link,X-Total-Count"
-        #allow-credentials: true
-        #max-age: 1800
+    cors:
+        allowed-methods: "*"
+        allowed-headers: "*"
+        exposed-headers: "Authorization,Link,X-Total-Count,Set-Cookie"
+        allow-credentials: true
+        max-age: 1800
+        allowed-origins:
+          - "vscode-file://vscode-app"
+          - "vscode-webview://*"
+
     mail:
         from: artemis@localhost
     registry:

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -284,15 +284,13 @@ jhipster:
     clientApp:
         name: 'artemisApp'
     # By default CORS is disabled. Uncomment to enable.
-    cors:
-        allowed-methods: "*"
-        allowed-headers: "*"
-        exposed-headers: "Authorization,Link,X-Total-Count,Set-Cookie"
-        allow-credentials: true
-        max-age: 1800
-        allowed-origins:
-          - "vscode-file://vscode-app"
-          - "vscode-webview://*"
+    #cors:
+        #allowed-origin-patterns: "*"
+        #allowed-methods: "*"
+        #allowed-headers: "*"
+        #exposed-headers: "Authorization,Link,X-Total-Count"
+        #allow-credentials: true
+        #max-age: 1800
 
     mail:
         from: artemis@localhost

--- a/src/main/webapp/app/app.module.ts
+++ b/src/main/webapp/app/app.module.ts
@@ -26,6 +26,8 @@ import { ArtemisSharedComponentModule } from 'app/shared/components/shared-compo
 import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { artemisIconPack } from 'src/main/webapp/content/icons/icons';
 import { ScrollingModule } from '@angular/cdk/scrolling';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { CsrfInterceptor } from 'app/core/csrf/csrf.interceptor';
 
 // NOTE: this module should only include the most important modules for normal users, all course management, admin and account functionality should be lazy loaded if possible
 @NgModule({
@@ -59,6 +61,7 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
         SystemNotificationComponent,
         LoadingNotificationComponent,
     ],
+    providers: [{ provide: HTTP_INTERCEPTORS, useClass: CsrfInterceptor, multi: true }],
     bootstrap: [JhiMainComponent],
 })
 export class ArtemisAppModule {

--- a/src/main/webapp/app/core/csrf/csrf.interceptor.ts
+++ b/src/main/webapp/app/core/csrf/csrf.interceptor.ts
@@ -1,0 +1,12 @@
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export class CsrfInterceptor implements HttpInterceptor {
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        // https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#employing-custom-request-headers-for-ajaxapi
+        // Clone the request and add the CSRF token header
+        const csrfReq = req.clone({ headers: req.headers.set('X-ARTEMIS-CSRF', 'Dennis ist schuld') });
+
+        return next.handle(csrfReq);
+    }
+}


### PR DESCRIPTION
# THIS PR IS STALED BECAUSE OF CHANGED REQUIREMENTS IN THE VSCODE PLUGIN
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.


#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ ] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [ ] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.


### Description
For the VSCode plugin it is important that the `sameSite` attribute is set to `none`, so that the cookie is send with request coming from an iframe. Because this would make artemis vulnerable to CSRF attacks a CSRF measure with custom header was implemented ([refer to OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#employing-custom-request-headers-for-ajaxapi)). The custom header `X-ARTEMIS-CSRF` is needed now for every request, which triggers a CORS discovery and protects against CSRF attacks.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
This PR contains mostly config changes which are hard to test. So code reviews are appreciated as well as just general functionality checks in the client that everything works like before.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a CSRF protection mechanism with a new `CsrfArtemisFilter` on the server-side.
	- Added an HTTP interceptor, `CsrfInterceptor`, to the client-side for enhanced CSRF protection by appending custom headers to requests.

- **Improvements**
	- Updated cookie settings in `JWTCookieService` for better security and cross-site request compatibility.

These enhancements improve the overall security of the application by ensuring that only authorized requests are processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->