### PR TITLE
`Development`: Fix translation string check CI pipeline step

### DIFF
--- a/.github/workflows/check-translation-keys.yml
+++ b/.github/workflows/check-translation-keys.yml
@@ -18,7 +18,4 @@ jobs:
         with:
           python-version: "3.12"
       - name: Check if translation keys match
-        run: >
-          python .ci/translation-file-checker/translation_file_checker.py
-            --german-files src/main/webapp/i18n/de/
-            --english-files src/main/webapp/i18n/en/
+        run: python .ci/translation-file-checker/translation_file_checker.py --german-files src/main/webapp/i18n/de/ --english-files src/main/webapp/i18n/en/

--- a/src/main/webapp/i18n/de/visualizations.json
+++ b/src/main/webapp/i18n/de/visualizations.json
@@ -1,7 +1,7 @@
 {
     "artemisApp": {
         "exercise-scores-chart": {
-            "title": "Leistung in Aufgaben",
+            "title": "Leistung in Aufgaben DUMMY CHANGE TO TRIGGER CI ACTION, REVERT BEFORE MERGE",
             "yourScoreLabel": "Dein Ergebnis",
             "averageScoreLabel": "Durchschnittliches Ergebnis",
             "maximumScoreLabel": "Bestes Ergebnis",

--- a/src/main/webapp/i18n/de/visualizations.json
+++ b/src/main/webapp/i18n/de/visualizations.json
@@ -1,7 +1,7 @@
 {
     "artemisApp": {
         "exercise-scores-chart": {
-            "title": "Leistung in Aufgaben DUMMY CHANGE TO TRIGGER CI ACTION, REVERT BEFORE MERGE",
+            "title": "Leistung in Aufgaben",
             "yourScoreLabel": "Dein Ergebnis",
             "averageScoreLabel": "Durchschnittliches Ergebnis",
             "maximumScoreLabel": "Bestes Ergebnis",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix the CI pipeline step.

### Description
<!-- Describe your changes in detail -->
According to YAML specification, the `>` should do YAML folding and replace newlines with spaces. This does not seem to work for some reason due to how GitHub parses the YAML.

In the CI pipeline for a dummy commit that makes changes to the translation strings, the pipeline now works: https://github.com/ls1intum/Artemis/actions/runs/11177499145/job/31073102393?pr=9420

Since the last commit reverts the changes to the translations again, the latest pipeline status also shows the expected result.


### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

@coderabbitai ignore