### PR TITLE
`Development`: Remove HttpClientTestingModule as it is deprecated

### DIFF
--- a/src/test/javascript/spec/component/admin/configuration.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/configuration.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 import { ConfigurationComponent } from 'app/admin/configuration/configuration.component';
 import { ConfigurationService } from 'app/admin/configuration/configuration.service';
 import { Bean, PropertySource } from 'app/admin/configuration/configuration.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Component Tests', () => {
     describe('ConfigurationComponent', () => {
@@ -13,9 +14,9 @@ describe('Component Tests', () => {
 
         beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
-                imports: [HttpClientTestingModule],
+                imports: [],
                 declarations: [ConfigurationComponent],
-                providers: [ConfigurationService],
+                providers: [provideHttpClient(), provideHttpClientTesting(), ConfigurationService],
             })
                 .overrideTemplate(ConfigurationComponent, '')
                 .compileComponents();

--- a/src/test/javascript/spec/component/admin/legal-document-service.spec.ts
+++ b/src/test/javascript/spec/component/admin/legal-document-service.spec.ts
@@ -1,10 +1,11 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 
 import { LegalDocumentService } from 'app/shared/service/legal-document.service';
 import { LegalDocument, LegalDocumentLanguage, LegalDocumentType } from 'app/entities/legal-document.model';
 import { PrivacyStatement } from 'app/entities/privacy-statement.model';
 import { Imprint } from 'app/entities/imprint.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('LegalDocumentService', () => {
     let service: LegalDocumentService;
@@ -12,7 +13,8 @@ describe('LegalDocumentService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(LegalDocumentService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/admin/logs.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/logs.component.spec.ts
@@ -1,10 +1,11 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 
 import { LogsComponent } from 'app/admin/logs/logs.component';
 import { LogsService } from 'app/admin/logs/logs.service';
 import { Log, LoggersResponse } from 'app/admin/logs/log.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Component Tests', () => {
     describe('LogsComponent', () => {
@@ -14,9 +15,9 @@ describe('Component Tests', () => {
 
         beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
-                imports: [HttpClientTestingModule],
+                imports: [],
                 declarations: [LogsComponent],
-                providers: [LogsService],
+                providers: [provideHttpClient(), provideHttpClientTesting(), LogsService],
             }).compileComponents();
         }));
 

--- a/src/test/javascript/spec/component/admin/user-management.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/user-management.component.spec.ts
@@ -11,7 +11,7 @@ import {
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
 import { ActivatedRoute, Router } from '@angular/router';
-import { HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
+import { HttpHeaders, HttpParams, HttpResponse, provideHttpClient } from '@angular/common/http';
 import { User } from 'app/core/user/user.model';
 import { Subscription, of } from 'rxjs';
 import { AbstractControl, ReactiveFormsModule } from '@angular/forms';
@@ -25,7 +25,7 @@ import { ArtemisTestModule } from '../../test.module';
 import { MockRouter } from '../../helpers/mocks/mock-router';
 import { MockRouterLinkDirective } from '../../helpers/mocks/directive/mock-router-link.directive';
 import { EventManager } from 'app/core/util/event-manager.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { MockLocalStorageService } from '../../helpers/mocks/service/mock-local-storage.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
@@ -62,7 +62,7 @@ describe('UserManagementComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, MockModule(ReactiveFormsModule), MockModule(NgbModule), HttpClientTestingModule],
+            imports: [ArtemisTestModule, MockModule(ReactiveFormsModule), MockModule(NgbModule)],
             declarations: [
                 UserManagementComponent,
                 MockRouterLinkDirective,
@@ -73,6 +73,8 @@ describe('UserManagementComponent', () => {
                 MockDirective(SortDirective),
             ],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 {
                     provide: ActivatedRoute,
                     useValue: route,

--- a/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-create-form.component.spec.ts
+++ b/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-create-form.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { Router } from '@angular/router';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ApollonDiagram } from 'app/entities/apollon-diagram.model';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { ApollonDiagramCreateFormComponent } from 'app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-create-form.component';
@@ -10,7 +10,7 @@ import { ApollonDiagramService } from 'app/exercises/quiz/manage/apollon-diagram
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { MockRouter } from '../../helpers/mocks/mock-router';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { UMLDiagramType } from '@ls1intum/apollon';
 
@@ -25,9 +25,11 @@ describe('ApollonDiagramCreateForm Component', () => {
         diagram.id = 1;
 
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             declarations: [ApollonDiagramCreateFormComponent],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 ApollonDiagramService,
                 NgbActiveModal,
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-list.component.spec.ts
+++ b/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-list.component.spec.ts
@@ -10,8 +10,8 @@ import { AlertService } from 'app/core/util/alert.service';
 import { SortService } from 'app/shared/service/sort.service';
 import { ApollonDiagramListComponent } from 'app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-list.component';
 import { ApollonDiagram } from 'app/entities/apollon-diagram.model';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
@@ -31,9 +31,11 @@ describe('ApollonDiagramList Component', () => {
         const route = { params: of({ courseId: 123 }), snapshot: { paramMap: convertToParamMap({ courseId: course.id }) } } as any as ActivatedRoute;
 
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             declarations: [ApollonDiagramListComponent],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 AlertService,
                 ApollonDiagramService,
                 MockProvider(SortService),

--- a/src/test/javascript/spec/component/apollon-diagrams/exercise-generation/quiz-exercise-generator.spec.ts
+++ b/src/test/javascript/spec/component/apollon-diagrams/exercise-generation/quiz-exercise-generator.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { Selection, UMLModel, UMLModelElement, findElement } from '@ls1intum/apollon';
@@ -40,9 +40,11 @@ describe('QuizExercise Generator', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             declarations: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(TranslateService),
                 {
                     provide: SessionStorageService,

--- a/src/test/javascript/spec/component/assessment-shared/assessment-locks.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assessment-locks.component.spec.ts
@@ -19,8 +19,9 @@ import { of } from 'rxjs';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { MockActivatedRoute } from '../../helpers/mocks/activated-route/mock-activated-route';
 import { ActivatedRoute } from '@angular/router';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ExamManagementService } from 'app/exam/manage/exam-management.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('AssessmentLocksComponent', () => {
     let component: AssessmentLocksComponent;
@@ -39,9 +40,11 @@ describe('AssessmentLocksComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [TranslateModule.forRoot(), HttpClientTestingModule],
+            imports: [TranslateModule.forRoot()],
             declarations: [AssessmentLocksComponent, MockPipe(ArtemisTranslatePipe), MockRouterLinkDirective, MockHasAnyAuthorityDirective, MockPipe(ArtemisDatePipe)],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(TextAssessmentService),
                 MockProvider(CourseManagementService),
                 MockProvider(ModelingAssessmentService),

--- a/src/test/javascript/spec/component/competencies/competency.service.spec.ts
+++ b/src/test/javascript/spec/component/competencies/competency.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
@@ -43,8 +43,10 @@ describe('CompetencyService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(LectureUnitService, {
                     convertLectureUnitArrayDatesFromServer<T extends LectureUnit>(res: T[]): T[] {
                         return res;

--- a/src/test/javascript/spec/component/competencies/course-competencies.component.spec.ts
+++ b/src/test/javascript/spec/component/competencies/course-competencies.component.spec.ts
@@ -7,12 +7,12 @@ import { Competency, CompetencyProgress, CourseCompetencyType } from 'app/entiti
 import { ActivatedRoute } from '@angular/router';
 import { AlertService } from 'app/core/util/alert.service';
 import { CourseCompetenciesComponent } from 'app/overview/course-competencies/course-competencies.component';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { TextUnit } from 'app/entities/lecture-unit/textUnit.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { User } from 'app/core/user/user.model';
 import { CourseStorageService } from 'app/course/manage/course-storage.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ArtemisTestModule } from '../../test.module';
 import { CompetencyCardStubComponent } from './competency-card-stub.component';
 import { FeatureToggleService } from 'app/shared/feature-toggle/feature-toggle.service';
@@ -50,9 +50,11 @@ describe('CourseCompetencies', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             declarations: [CourseCompetenciesComponent, CompetencyCardStubComponent, MockPipe(ArtemisTranslatePipe)],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(AlertService),
                 { provide: CourseStorageService, useValue: mockCourseStorageService },
                 MockProvider(CompetencyService),

--- a/src/test/javascript/spec/component/competencies/prerequisite.service.spec.ts
+++ b/src/test/javascript/spec/component/competencies/prerequisite.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
@@ -44,8 +44,10 @@ describe('PrerequisiteService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(LectureUnitService, {
                     convertLectureUnitArrayDatesFromServer<T extends LectureUnit>(res: T[]): T[] {
                         return res;

--- a/src/test/javascript/spec/component/complaints/complaint-response.service.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaint-response.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { ComplaintResponseService } from 'app/complaints/complaint-response.service';
@@ -23,8 +23,8 @@ describe('ComplaintResponseService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [MockProvider(AccountService)],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), MockProvider(AccountService)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/complaints/complaint.service.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaint.service.spec.ts
@@ -6,13 +6,14 @@ import { ComplaintResponse } from 'app/entities/complaint-response.model';
 import { User } from 'app/core/user/user.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import dayjs from 'dayjs/esm';
 import { Result } from 'app/entities/result.model';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { Course } from 'app/entities/course.model';
 import { AssessmentType } from 'app/entities/assessment-type.model';
 import { ComplaintRequestDTO } from 'app/entities/complaint-request-dto.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ComplaintService', () => {
     let complaintService: ComplaintService;
@@ -57,8 +58,8 @@ describe('ComplaintService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: AccountService, useClass: MockAccountService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: AccountService, useClass: MockAccountService }],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/course/course-admin.service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-admin.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -12,6 +12,7 @@ import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.s
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { CourseAdminService } from 'app/course/manage/course-admin.service';
 import { UMLDiagramType } from '@ls1intum/apollon';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Course Admin Service', () => {
     let courseAdminService: CourseAdminService;
@@ -23,8 +24,10 @@ describe('Course Admin Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: Router, useClass: MockRouter },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/course/course-for-import-dto-paging-service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-for-import-dto-paging-service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { AccountService } from 'app/core/auth/account.service';
@@ -6,6 +6,7 @@ import { MockAccountService } from '../../helpers/mocks/service/mock-account.ser
 import { CourseForImportDTOPagingService } from 'app/course/course-for-import-dto-paging-service';
 import { CourseForImportDTO } from 'app/entities/course.model';
 import { SortingOrder } from 'app/shared/table/pageable-table';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('CourseForImportDtoPagingService', () => {
     let pagingService: CourseForImportDTOPagingService;
@@ -14,8 +15,8 @@ describe('CourseForImportDtoPagingService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: AccountService, useClass: MockAccountService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: AccountService, useClass: MockAccountService }],
         });
 
         pagingService = TestBed.inject(CourseForImportDTOPagingService);

--- a/src/test/javascript/spec/component/course/course-management-tab-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management-tab-bar.component.spec.ts
@@ -2,13 +2,13 @@ import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
 import { Course } from 'app/entities/course.model';
 import { MockComponent, MockDirective, MockProvider } from 'ng-mocks';
 import { CourseManagementTabBarComponent } from 'app/course/manage/course-management-tab-bar/course-management-tab-bar.component';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { CourseAdminService } from 'app/course/manage/course-admin.service';
 import { EventManager } from 'app/core/util/event-manager.service';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { HeaderCourseComponent } from 'app/overview/header-course.component';
 import { ArtemisTestModule } from '../../test.module';
 import { CourseExamArchiveButtonComponent } from 'app/shared/components/course-exam-archive-button/course-exam-archive-button.component';
@@ -50,8 +50,10 @@ describe('Course Management Tab Bar Component', () => {
                 MockDirective(FeatureToggleLinkDirective),
                 MockDirective(FeatureToggleHideDirective),
             ],
-            imports: [HttpClientTestingModule, RouterModule, ArtemisTestModule],
+            imports: [RouterModule, ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 {
                     provide: ActivatedRoute,
                     useValue: {

--- a/src/test/javascript/spec/component/course/course-management.service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -28,6 +28,7 @@ import { CourseStorageService } from 'app/course/manage/course-storage.service';
 import { OnlineCourseDtoModel } from 'app/lti/online-course-dto.model';
 import { CoursesForDashboardDTO } from 'app/course/manage/courses-for-dashboard-dto';
 import { UMLDiagramType } from '@ls1intum/apollon';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Course Management Service', () => {
     let courseManagementService: CourseManagementService;
@@ -59,8 +60,10 @@ describe('Course Management Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: Router, useClass: MockRouter },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/course/course-overview.service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.service.spec.ts
@@ -6,7 +6,7 @@ import { UMLDiagramType } from '@ls1intum/apollon';
 import { Course } from 'app/entities/course.model';
 import dayjs from 'dayjs/esm';
 import { Lecture } from 'app/entities/lecture.model';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
@@ -14,6 +14,7 @@ import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.s
 import { TextExercise } from 'app/entities/text/text-exercise.model';
 import { Exam } from 'app/entities/exam/exam.model';
 import { ChannelDTO, ChannelSubType, getAsChannelDTO } from 'app/entities/metis/conversation/channel.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('CourseOverviewService', () => {
     let service: CourseOverviewService;
@@ -36,8 +37,10 @@ describe('CourseOverviewService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 CourseOverviewService,
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/course/course-update.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-update.component.spec.ts
@@ -1,4 +1,4 @@
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
@@ -37,7 +37,7 @@ import { By } from '@angular/platform-browser';
 import { EventManager } from 'app/core/util/event-manager.service';
 import { cloneDeep } from 'lodash-es';
 import { FeatureToggleHideDirective } from 'app/shared/feature-toggle/feature-toggle-hide.directive';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { MockNgbModalService } from '../../helpers/mocks/service/mock-ngb-modal.service';
 import { ImageCropperModalComponent } from 'app/course/manage/image-cropper-modal.component';
 import { FeatureToggle, FeatureToggleService } from 'app/shared/feature-toggle/feature-toggle.service';
@@ -840,16 +840,10 @@ describe('Course Management Student Course Analytics Dashboard Update', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [
-                ArtemisTestModule,
-                HttpClientTestingModule,
-                MockModule(ReactiveFormsModule),
-                MockModule(FormsModule),
-                ImageCropperModule,
-                MockDirective(NgbTypeahead),
-                MockModule(NgbTooltipModule),
-            ],
+            imports: [ArtemisTestModule, MockModule(ReactiveFormsModule), MockModule(FormsModule), ImageCropperModule, MockDirective(NgbTypeahead), MockModule(NgbTooltipModule)],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: AccountService, useClass: MockAccountService },
@@ -960,16 +954,10 @@ describe('Course Management Update Component Create', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [
-                ArtemisTestModule,
-                HttpClientTestingModule,
-                MockModule(ReactiveFormsModule),
-                MockModule(FormsModule),
-                ImageCropperModule,
-                MockDirective(NgbTypeahead),
-                MockModule(NgbTooltipModule),
-            ],
+            imports: [ArtemisTestModule, MockModule(ReactiveFormsModule), MockModule(FormsModule), ImageCropperModule, MockDirective(NgbTypeahead), MockModule(NgbTooltipModule)],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: AccountService, useClass: MockAccountService },

--- a/src/test/javascript/spec/component/exam/manage/exam-management.service.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-management.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { Course } from 'app/entities/course.model';
 import { ArtemisTestModule } from '../../../test.module';
 import { ExamManagementService } from 'app/exam/manage/exam-management.service';
@@ -17,6 +17,7 @@ import { TextExercise } from 'app/entities/text/text-exercise.model';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { ProgrammingExercise } from 'app/entities/programming/programming-exercise.model';
 import { UMLDiagramType } from '@ls1intum/apollon';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Exam Management Service Tests', () => {
     let service: ExamManagementService;
@@ -35,8 +36,8 @@ describe('Exam Management Service Tests', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            providers: [ExamManagementService],
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            providers: [provideHttpClient(), provideHttpClientTesting(), ExamManagementService],
+            imports: [ArtemisTestModule],
         });
 
         service = TestBed.inject(ExamManagementService);

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-checklist-exercisegroup-table.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-checklist-exercisegroup-table.component.spec.ts
@@ -6,12 +6,13 @@ import { Component } from '@angular/core';
 import { HasAnyAuthorityDirective } from 'app/shared/auth/has-any-authority.directive';
 import { ChecklistCheckComponent } from 'app/shared/components/checklist-check/checklist-check.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ProgressBarComponent } from 'app/shared/dashboards/tutor-participation-graph/progress-bar/progress-bar.component';
 import { ExamChecklistExerciseGroupTableComponent } from 'app/exam/manage/exams/exam-checklist-component/exam-checklist-exercisegroup-table/exam-checklist-exercisegroup-table.component';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ExerciseGroupVariantColumn } from 'app/entities/exercise-group-variant-column.model';
+import { provideHttpClient } from '@angular/common/http';
 
 @Component({
     template: '',
@@ -67,7 +68,6 @@ describe('ExamChecklistExerciseGroupTableComponent', () => {
                     { path: 'course-management/:courseId/exams/:examId/test-runs', component: DummyComponent },
                     { path: 'course-management/:courseId/exams/:examId/students', component: DummyComponent },
                 ]),
-                HttpClientTestingModule,
             ],
             declarations: [
                 DummyComponent,
@@ -80,7 +80,7 @@ describe('ExamChecklistExerciseGroupTableComponent', () => {
                 ProgressBarComponent,
                 MockComponent(FaIconComponent),
             ],
-            providers: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
@@ -1,5 +1,5 @@
 import { Location } from '@angular/common';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed, discardPeriodicTasks, fakeAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -23,7 +23,7 @@ import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { CourseExamArchiveButtonComponent } from 'app/shared/components/course-exam-archive-button/course-exam-archive-button.component';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ExamManagementService } from 'app/exam/manage/exam-management.service';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { DeleteButtonDirective } from 'app/shared/delete-dialog/delete-button.directive';
 import { MockAccountService } from '../../../../helpers/mocks/service/mock-account.service';
@@ -75,7 +75,6 @@ describe('ExamDetailComponent', () => {
                     { path: 'course-management/:courseId/exams/:examId/students', component: DummyComponent },
                     { path: 'course-management/:courseId/exams', component: DummyComponent },
                 ]),
-                HttpClientTestingModule,
                 ExerciseDetailDirective,
                 MockComponent(NoDataComponent),
             ],
@@ -101,6 +100,8 @@ describe('ExamDetailComponent', () => {
                 MockDirective(ExerciseDetailDirective),
             ],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 {
                     provide: ActivatedRoute,
                     useValue: {

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
@@ -6,7 +6,7 @@ import { StudentExam } from 'app/entities/student-exam.model';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { StudentExamService } from 'app/exam/manage/student-exams/student-exam.service';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { NgbModal, NgbModalRef, NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -24,7 +24,7 @@ import { ParticipationType } from 'app/entities/participation/participation.mode
 import { Result } from 'app/entities/result.model';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { StudentExamDetailTableRowComponent } from 'app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { DataTableComponent } from 'app/shared/data-table/data-table.component';
 import { AlertService } from 'app/core/util/alert.service';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
@@ -128,15 +128,7 @@ describe('StudentExamDetailComponent', () => {
         } as StudentExamWithGradeDTO;
 
         await TestBed.configureTestingModule({
-            imports: [
-                ArtemisTestModule,
-                RouterTestingModule.withRoutes([]),
-                NgbModule,
-                NgxDatatableModule,
-                ReactiveFormsModule,
-                TranslateModule.forRoot(),
-                HttpClientTestingModule,
-            ],
+            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([]), NgbModule, NgxDatatableModule, ReactiveFormsModule, TranslateModule.forRoot()],
             declarations: [
                 StudentExamDetailComponent,
                 MockComponent(DataTableComponent),
@@ -150,6 +142,8 @@ describe('StudentExamDetailComponent', () => {
                 StudentExamDetailTableRowComponent,
             ],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(StudentExamService, {
                     updateWorkingTime: () => {
                         return of(

--- a/src/test/javascript/spec/component/exam/manage/suspicious-behavior/suspicious-sessions.service.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/suspicious-behavior/suspicious-sessions.service.spec.ts
@@ -1,8 +1,9 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 
 import { SuspiciousSessionsService } from 'app/exam/manage/suspicious-behavior/suspicious-sessions.service';
 import { SuspiciousExamSessions, SuspiciousSessionReason, SuspiciousSessionsAnalysisOptions } from 'app/entities/exam/exam-session.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('SuspiciousSessionsService', () => {
     let service: SuspiciousSessionsService;
@@ -34,7 +35,8 @@ describe('SuspiciousSessionsService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(SuspiciousSessionsService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/exam/participate/summary/exercises/file-upload-exam-summary.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/summary/exercises/file-upload-exam-summary.component.spec.ts
@@ -2,11 +2,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FileUploadExamSummaryComponent } from 'app/exam/participate/summary/exercises/file-upload-exam-summary/file-upload-exam-summary.component';
 import { MockComponent, MockPipe } from 'ng-mocks';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { FileUploadSubmission } from 'app/entities/file-upload-submission.model';
 import { By } from '@angular/platform-browser';
 import { FileUploadSubmissionComponent } from 'app/exercises/file-upload/participate/file-upload-submission.component';
 import { FileUploadExercise } from 'app/entities/file-upload-exercise.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('FileUploadExamSummaryComponent', () => {
     let fixture: ComponentFixture<FileUploadExamSummaryComponent>;
@@ -16,8 +17,9 @@ describe('FileUploadExamSummaryComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             declarations: [FileUploadExamSummaryComponent, MockPipe(ArtemisTranslatePipe), MockComponent(FileUploadSubmissionComponent)],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exam/participate/summary/exercises/quiz-exam-summary.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/summary/exercises/quiz-exam-summary.component.spec.ts
@@ -1,4 +1,5 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { Exam } from 'app/entities/exam/exam.model';
@@ -77,9 +78,9 @@ describe('QuizExamSummaryComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, MockModule(ArtemisQuizQuestionTypesModule)],
+            imports: [MockModule(ArtemisQuizQuestionTypesModule)],
             declarations: [QuizExamSummaryComponent, MockPipe(ArtemisTranslatePipe)],
-            providers: [MockProvider(TranslateService), MockProvider(QuizExerciseService), MockProvider(ArtemisServerDateService)],
+            providers: [provideHttpClient(), provideHttpClientTesting(), MockProvider(TranslateService), MockProvider(QuizExerciseService), MockProvider(ArtemisServerDateService)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exam/participate/summary/result-overview/exam-result-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/summary/result-overview/exam-result-overview.component.spec.ts
@@ -13,7 +13,7 @@ import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { ProgrammingExercise } from 'app/entities/programming/programming-exercise.model';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Result } from 'app/entities/result.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { GradeType } from 'app/entities/grading-scale.model';
@@ -22,6 +22,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ExerciseResult, StudentExamWithGradeDTO } from 'app/exam/exam-scores/exam-score-dtos.model';
 import { GradingKeyTableComponent } from 'app/grading-system/grading-key-overview/grading-key/grading-key-table.component';
 import { CollapsibleCardComponent } from 'app/exam/participate/summary/collapsible-card.component';
+import { provideHttpClient } from '@angular/common/http';
 
 let fixture: ComponentFixture<ExamResultOverviewComponent>;
 let component: ExamResultOverviewComponent;
@@ -128,7 +129,7 @@ const textExerciseResult = {
 describe('ExamResultOverviewComponent', () => {
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([]), MockModule(NgbModule), HttpClientTestingModule],
+            imports: [RouterTestingModule.withRoutes([]), MockModule(NgbModule)],
             declarations: [
                 ExamResultOverviewComponent,
                 MockComponent(FaIconComponent),
@@ -136,7 +137,7 @@ describe('ExamResultOverviewComponent', () => {
                 MockComponent(GradingKeyTableComponent),
                 MockComponent(CollapsibleCardComponent),
             ],
-            providers: [MockProvider(ExerciseService)],
+            providers: [provideHttpClient(), provideHttpClientTesting(), MockProvider(ExerciseService)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-pool-mapping-question-list.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-pool-mapping-question-list.component.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
@@ -18,6 +18,7 @@ jest.mock('@angular/cdk/drag-drop', () => {
 });
 import * as DragDrop from '@angular/cdk/drag-drop';
 import { moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('QuizPoolMappingQuestionListComponent', () => {
     let fixture: ComponentFixture<QuizPoolMappingQuestionListComponent>;
@@ -25,9 +26,9 @@ describe('QuizPoolMappingQuestionListComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, DragDrop.DragDropModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule, DragDrop.DragDropModule],
             declarations: [QuizPoolMappingQuestionListComponent, MockPipe(ArtemisTranslatePipe), MockPipe(ArtemisDatePipe), MockDirective(TranslateDirective)],
-            providers: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-pool-mapping.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-pool-mapping.component.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ButtonComponent } from 'app/shared/components/button.component';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
@@ -13,6 +13,7 @@ import { QuizPoolMappingComponent } from 'app/exercises/quiz/manage/quiz-pool-ma
 import { QuizGroup } from 'app/entities/quiz/quiz-group.model';
 import { MultipleChoiceQuestion } from 'app/entities/quiz/multiple-choice-question.model';
 import { DeleteButtonDirective } from 'app/shared/delete-dialog/delete-button.directive';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('QuizPoolMappingComponent', () => {
     let fixture: ComponentFixture<QuizPoolMappingComponent>;
@@ -20,7 +21,7 @@ describe('QuizPoolMappingComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule, MockDirective(NgbTooltip)],
+            imports: [ArtemisTestModule, MockDirective(NgbTooltip)],
             declarations: [
                 QuizPoolMappingComponent,
                 ButtonComponent,
@@ -31,7 +32,7 @@ describe('QuizPoolMappingComponent', () => {
                 MockDirective(NgModel),
                 MockDirective(DeleteButtonDirective),
             ],
-            providers: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-pool.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-pool.component.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
@@ -9,7 +9,7 @@ import { QuizPoolComponent } from 'app/exercises/quiz/manage/quiz-pool.component
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { QuizPoolService } from 'app/exercises/quiz/manage/quiz-pool.service';
 import { of } from 'rxjs';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { QuizPool } from 'app/entities/quiz/quiz-pool.model';
 import { MultipleChoiceQuestion } from 'app/entities/quiz/multiple-choice-question.model';
 import { QuizGroup } from 'app/entities/quiz/quiz-group.model';
@@ -39,7 +39,7 @@ describe('QuizPoolComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule, NgbModule, FormsModule],
+            imports: [ArtemisTestModule, NgbModule, FormsModule],
             declarations: [
                 QuizPoolComponent,
                 MockComponent(QuizPoolMappingComponent),
@@ -48,7 +48,7 @@ describe('QuizPoolComponent', () => {
                 MockPipe(ArtemisDatePipe),
                 MockDirective(TranslateDirective),
             ],
-            providers: [{ provide: ActivatedRoute, useValue: route }, MockProvider(ChangeDetectorRef), MockProvider(AlertService)],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: ActivatedRoute, useValue: route }, MockProvider(ChangeDetectorRef), MockProvider(AlertService)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit-existing.component.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
@@ -9,7 +9,7 @@ import { CommonModule } from '@angular/common';
 import { QuizQuestionListEditExistingComponent, State } from 'app/exercises/quiz/manage/quiz-question-list-edit-existing.component';
 import { ExamManagementService } from 'app/exam/manage/exam-management.service';
 import { of } from 'rxjs';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { Exam } from 'app/entities/exam/exam.model';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { Course } from 'app/entities/course.model';
@@ -106,9 +106,9 @@ describe('QuizQuestionListEditExistingComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [CommonModule, ArtemisTestModule, HttpClientTestingModule, FormsModule],
+            imports: [CommonModule, ArtemisTestModule, FormsModule],
             declarations: [QuizQuestionListEditExistingComponent, MockPipe(ArtemisTranslatePipe), MockPipe(ArtemisDatePipe), MockDirective(TranslateDirective)],
-            providers: [MockProvider(NgbModal), MockProvider(ChangeDetectorRef)],
+            providers: [provideHttpClient(), provideHttpClientTesting(), MockProvider(NgbModal), MockProvider(ChangeDetectorRef)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/quiz-question-list-edit.component.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
@@ -10,6 +10,7 @@ import { CommonModule } from '@angular/common';
 import { QuizQuestionListEditExistingComponent } from 'app/exercises/quiz/manage/quiz-question-list-edit-existing.component';
 import { MultipleChoiceQuestion } from 'app/entities/quiz/multiple-choice-question.model';
 import { ShortAnswerQuestion } from 'app/entities/quiz/short-answer-question.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('QuizQuestionListEditComponent', () => {
     let fixture: ComponentFixture<QuizQuestionListEditComponent>;
@@ -24,7 +25,7 @@ describe('QuizQuestionListEditComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [CommonModule, ArtemisTestModule, HttpClientTestingModule],
+            imports: [CommonModule, ArtemisTestModule],
             declarations: [
                 QuizQuestionListEditComponent,
                 MockComponent(QuizQuestionListEditExistingComponent),
@@ -32,7 +33,7 @@ describe('QuizQuestionListEditComponent', () => {
                 MockPipe(ArtemisDatePipe),
                 MockDirective(TranslateDirective),
             ],
-            providers: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exercises/quiz/quiz-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/quiz-participation.component.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -139,9 +139,11 @@ describe('QuizParticipationComponent', () => {
     describe('live mode', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [ArtemisTestModule, HttpClientTestingModule, MockDirective(NgbTooltip)],
+                imports: [ArtemisTestModule, MockDirective(NgbTooltip)],
                 declarations: [testBedDeclarations, MockDirective(NgModel)],
                 providers: [
+                    provideHttpClient(),
+                    provideHttpClientTesting(),
                     {
                         provide: ActivatedRoute,
                         useValue: {
@@ -498,9 +500,11 @@ describe('QuizParticipationComponent', () => {
     describe('preview mode', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [ArtemisTestModule, HttpClientTestingModule, MockDirective(NgbTooltip)],
+                imports: [ArtemisTestModule, MockDirective(NgbTooltip)],
                 declarations: testBedDeclarations,
                 providers: [
+                    provideHttpClient(),
+                    provideHttpClientTesting(),
                     {
                         provide: ActivatedRoute,
                         useValue: {
@@ -577,9 +581,11 @@ describe('QuizParticipationComponent', () => {
     describe('practice mode', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [ArtemisTestModule, HttpClientTestingModule, MockDirective(NgbTooltip)],
+                imports: [ArtemisTestModule, MockDirective(NgbTooltip)],
                 declarations: testBedDeclarations,
                 providers: [
+                    provideHttpClient(),
+                    provideHttpClientTesting(),
                     {
                         provide: ActivatedRoute,
                         useValue: {
@@ -658,9 +664,11 @@ describe('QuizParticipationComponent', () => {
     describe('solution mode', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [ArtemisTestModule, HttpClientTestingModule, MockDirective(NgbTooltip)],
+                imports: [ArtemisTestModule, MockDirective(NgbTooltip)],
                 declarations: testBedDeclarations,
                 providers: [
+                    provideHttpClient(),
+                    provideHttpClientTesting(),
                     {
                         provide: ActivatedRoute,
                         useValue: {

--- a/src/test/javascript/spec/component/exercises/quiz/quiz-participation.service.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/quiz-participation.service.spec.ts
@@ -1,10 +1,11 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { QuizParticipationService } from 'app/exercises/quiz/participate/quiz-participation.service';
 import { QuizSubmission } from 'app/entities/quiz/quiz-submission.model';
 import { Result } from 'app/entities/result.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../../helpers/mocks/service/mock-account.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Quiz Participation Service', () => {
     let service: QuizParticipationService;
@@ -12,8 +13,8 @@ describe('Quiz Participation Service', () => {
     let exerciseId: number;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: AccountService, useClass: MockAccountService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: AccountService, useClass: MockAccountService }],
         });
         service = TestBed.inject(QuizParticipationService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/iris/iris-chat-http.service.spec.ts
+++ b/src/test/javascript/spec/component/iris/iris-chat-http.service.spec.ts
@@ -1,10 +1,11 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { irisExercise, mockClientMessage, mockConversation, mockServerMessage } from '../../helpers/sample/iris-sample-data';
 import { IrisUserMessage } from 'app/entities/iris/iris-message.model';
 import { IrisChatHttpService } from 'app/iris/iris-chat-http.service';
 import { ChatServiceMode } from 'app/iris/iris-chat.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Iris Chat Http Service', () => {
     let service: IrisChatHttpService;
@@ -12,8 +13,8 @@ describe('Iris Chat Http Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [IrisChatHttpService],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), IrisChatHttpService],
         });
         service = TestBed.inject(IrisChatHttpService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/iris/iris-status.service.spec.ts
+++ b/src/test/javascript/spec/component/iris/iris-status.service.spec.ts
@@ -1,9 +1,10 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
 import { of } from 'rxjs';
 import { IrisStatusService } from 'app/iris/iris-status.service';
 import { IrisRateLimitInformation } from 'app/entities/iris/iris-ratelimit-info.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('IrisStatusService', () => {
     let service: IrisStatusService;
@@ -11,8 +12,10 @@ describe('IrisStatusService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 IrisStatusService,
                 { provide: JhiWebsocketService, useValue: { connectionState: of({ connected: true, intendedDisconnect: false, wasEverConnectedBefore: true }) } },
             ],

--- a/src/test/javascript/spec/component/iris/settings/iris-settings.service.spec.ts
+++ b/src/test/javascript/spec/component/iris/settings/iris-settings.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { IrisSettingsService } from 'app/iris/settings/shared/iris-settings.service';
 import { mockSettings } from './mock-settings';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Iris Settings Service', () => {
     let service: IrisSettingsService;
@@ -10,8 +11,8 @@ describe('Iris Settings Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [IrisSettingsService],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), IrisSettingsService],
         });
         service = TestBed.inject(IrisSettingsService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/iris/ui/exercise-chatbot-button.component.spec.ts
+++ b/src/test/javascript/spec/component/iris/ui/exercise-chatbot-button.component.spec.ts
@@ -7,7 +7,7 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
 import { AccountService } from 'app/core/auth/account.service';
 import { Subject, of } from 'rxjs';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MockAccountService } from '../../../helpers/mocks/service/mock-account.service';
 import { ActivatedRoute } from '@angular/router';
 import { mockServerSessionHttpResponseWithId, mockWebsocketServerMessage } from '../../../helpers/sample/iris-sample-data';
@@ -19,6 +19,7 @@ import { IrisWebsocketService } from 'app/iris/iris-websocket.service';
 import { IrisStatusService } from 'app/iris/iris-status.service';
 import { UserService } from 'app/core/user/user.service';
 import dayjs from 'dayjs/esm';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ExerciseChatbotButtonComponent', () => {
     let component: IrisExerciseChatbotButtonComponent;
@@ -68,9 +69,11 @@ describe('ExerciseChatbotButtonComponent', () => {
         } as unknown as Overlay;
 
         await TestBed.configureTestingModule({
-            imports: [FormsModule, FontAwesomeModule, HttpClientTestingModule],
+            imports: [FormsModule, FontAwesomeModule],
             declarations: [IrisExerciseChatbotButtonComponent, MockComponent(IrisLogoComponent), MockPipe(ArtemisTranslatePipe)],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 IrisChatService,
                 MockProvider(IrisChatHttpService),
                 MockProvider(IrisWebsocketService),

--- a/src/test/javascript/spec/component/iris/websocket.service.spec.ts
+++ b/src/test/javascript/spec/component/iris/websocket.service.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
 import { MockProvider } from 'ng-mocks';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
 import { IrisWebsocketService } from 'app/iris/iris-websocket.service';
 import { defer, of } from 'rxjs';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('IrisWebsocketService', () => {
     let irisWebsocketService: IrisWebsocketService;
@@ -16,8 +17,14 @@ describe('IrisWebsocketService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [IrisWebsocketService, MockProvider(JhiWebsocketService), { provide: AccountService, useClass: MockAccountService }],
+            imports: [],
+            providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
+                IrisWebsocketService,
+                MockProvider(JhiWebsocketService),
+                { provide: AccountService, useClass: MockAccountService },
+            ],
         });
         irisWebsocketService = TestBed.inject(IrisWebsocketService);
         jhiWebsocketService = TestBed.inject(JhiWebsocketService);

--- a/src/test/javascript/spec/component/lecture-unit/attachment-unit/attachment-unit.service.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/attachment-unit/attachment-unit.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
@@ -20,8 +20,10 @@ describe('AttachmentUnitService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(LectureUnitService, {
                     convertLectureUnitResponseDatesFromServer<T extends LectureUnit>(res: HttpResponse<T>): HttpResponse<T> {
                         return res;

--- a/src/test/javascript/spec/component/lecture-unit/exercise-unit/exercise-unit.service.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/exercise-unit/exercise-unit.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
@@ -20,8 +20,10 @@ describe('ExerciseUnitService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(LectureUnitService, {
                     convertLectureUnitResponseDatesFromServer<T extends LectureUnit>(res: HttpResponse<T>): HttpResponse<T> {
                         return res;

--- a/src/test/javascript/spec/component/lecture-unit/lecture-unit.service.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/lecture-unit.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync } from '@angular/core/testing';
 import { Lecture } from 'app/entities/lecture.model';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
@@ -27,7 +27,8 @@ describe('LectureUnitService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         expectedResultArray = {} as HttpResponse<LectureUnit[]>;
         service = TestBed.inject(LectureUnitService);

--- a/src/test/javascript/spec/component/lecture-unit/online-unit/online-unit.service.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/online-unit/online-unit.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
@@ -18,8 +18,10 @@ describe('OnlineUnitService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(LectureUnitService, {
                     convertLectureUnitResponseDatesFromServer<T extends LectureUnit>(res: HttpResponse<T>): HttpResponse<T> {
                         if (res.body) {

--- a/src/test/javascript/spec/component/lecture-unit/text-unit/text-unit.service.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/text-unit/text-unit.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
@@ -17,8 +17,10 @@ describe('TextUnitService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(LectureUnitService, {
                     convertLectureUnitResponseDatesFromServer<T extends LectureUnit>(res: HttpResponse<T>): HttpResponse<T> {
                         if (res.body) {

--- a/src/test/javascript/spec/component/lecture-unit/video-unit/video-unit.service.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/video-unit/video-unit.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
@@ -17,8 +17,10 @@ describe('VideoUnitService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(LectureUnitService, {
                     convertLectureUnitResponseDatesFromServer<T extends LectureUnit>(res: HttpResponse<T>): HttpResponse<T> {
                         if (res.body) {

--- a/src/test/javascript/spec/component/lecture/lecture-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture/lecture-detail.component.spec.ts
@@ -13,9 +13,9 @@ import { MockTranslateService } from '../../helpers/mocks/service/mock-translate
 import { MockLocalStorageService } from '../../helpers/mocks/service/mock-local-storage.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { TranslateService } from '@ngx-translate/core';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { LectureService } from 'app/lecture/lecture.service';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { IrisSettingsService } from 'app/iris/settings/shared/iris-settings.service';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { PROFILE_IRIS } from 'app/app.constants';
@@ -49,8 +49,10 @@ describe('LectureDetailComponent', () => {
         };
 
         await TestBed.configureTestingModule({
-            declarations: [LectureDetailComponent, HtmlForMarkdownPipe, MockPipe(ArtemisDatePipe), MockModule(RouterModule), DetailOverviewListComponent, HttpClientTestingModule],
+            declarations: [LectureDetailComponent, HtmlForMarkdownPipe, MockPipe(ArtemisDatePipe), MockModule(RouterModule), DetailOverviewListComponent],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: ActivatedRoute, useValue: mockActivatedRoute },
                 MockProvider(SessionStorageService),
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/component/link-preview/link-preview.service.spec.ts
+++ b/src/test/javascript/spec/component/link-preview/link-preview.service.spec.ts
@@ -1,4 +1,5 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { LinkPreviewService } from 'app/shared/link-preview/services/link-preview.service';
 
@@ -8,8 +9,8 @@ describe('LinkPreviewService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [LinkPreviewService],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), LinkPreviewService],
         });
         service = TestBed.inject(LinkPreviewService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/localci/build-agents/build-agents.service.spec.ts
+++ b/src/test/javascript/spec/component/localci/build-agents/build-agents.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { MockTranslateService } from '../../../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
 import { BuildJob } from 'app/entities/programming/build-job.model';
@@ -10,6 +10,7 @@ import { BuildAgent } from 'app/entities/programming/build-agent.model';
 import { RepositoryInfo, TriggeredByPushTo } from 'app/entities/programming/repository-info.model';
 import { JobTimingInfo } from 'app/entities/job-timing-info.model';
 import { BuildConfig } from 'app/entities/programming/build-config.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('BuildAgentsService', () => {
     let service: BuildAgentsService;
@@ -75,8 +76,8 @@ describe('BuildAgentsService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: TranslateService, useClass: MockTranslateService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: TranslateService, useClass: MockTranslateService }],
         });
         service = TestBed.inject(BuildAgentsService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/localci/build-queue/build-queue.service.spec.ts
+++ b/src/test/javascript/spec/component/localci/build-queue/build-queue.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 
 import { BuildQueueService } from 'app/localci/build-queue/build-queue.service';
-import { HttpClientTestingModule, HttpTestingController, TestRequest } from '@angular/common/http/testing';
+import { HttpTestingController, TestRequest, provideHttpClientTesting } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
 import { MockRouter } from '../../../helpers/mocks/mock-router';
 import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
@@ -14,6 +14,7 @@ import { RepositoryInfo, TriggeredByPushTo } from 'app/entities/programming/repo
 import { JobTimingInfo } from 'app/entities/job-timing-info.model';
 import { BuildConfig } from 'app/entities/programming/build-config.model';
 import { FinishedBuildJobFilter } from 'app/localci/build-queue/build-queue.component';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('BuildQueueService', () => {
     let service: BuildQueueService;
@@ -42,8 +43,10 @@ describe('BuildQueueService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: Router, useClass: MockRouter },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/lti/lti13-dynamic-registration.component.spec.ts
+++ b/src/test/javascript/spec/component/lti/lti13-dynamic-registration.component.spec.ts
@@ -2,8 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisTestModule } from '../../test.module';
 import { Lti13DynamicRegistrationComponent } from 'app/lti/lti13-dynamic-registration.component';
 import { ActivatedRoute, ActivatedRouteSnapshot, Params, Router, convertToParamMap } from '@angular/router';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { HttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { MockRouter } from '../../helpers/mocks/mock-router';
 import { of, throwError } from 'rxjs';
 
@@ -20,11 +20,8 @@ describe('Lti13DynamicRegistrationComponentTest', () => {
         } as ActivatedRoute;
 
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
-            providers: [
-                { provide: ActivatedRoute, useValue: route },
-                { provide: Router, useClass: MockRouter },
-            ],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: ActivatedRoute, useValue: route }, { provide: Router, useClass: MockRouter }],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/lti/lti13-exercise-launch.component.spec.ts
+++ b/src/test/javascript/spec/component/lti/lti13-exercise-launch.component.spec.ts
@@ -2,8 +2,8 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { ArtemisTestModule } from '../../test.module';
 import { Lti13ExerciseLaunchComponent } from 'app/lti/lti13-exercise-launch.component';
 import { ActivatedRoute, ActivatedRouteSnapshot, Router, convertToParamMap } from '@angular/router';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { HttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { of, throwError } from 'rxjs';
 import { LoginService } from 'app/core/login/login.service';
 import { AccountService } from 'app/core/auth/account.service';
@@ -32,8 +32,10 @@ describe('Lti13ExerciseLaunchComponent', () => {
         window.sessionStorage.setItem('state', 'state');
 
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: ActivatedRoute, useValue: route },
                 { provide: LoginService, useValue: loginService },
                 { provide: AccountService, useClass: MockAccountService },

--- a/src/test/javascript/spec/component/manage/exercise-paging.service.spec.ts
+++ b/src/test/javascript/spec/component/manage/exercise-paging.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpClient } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
@@ -17,8 +17,10 @@ describe('Exercise Paging Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: LocalStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/modeling-editor/modeling-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-editor/modeling-editor.component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { Subject, of } from 'rxjs';
 import { ApollonDiagram } from 'app/entities/apollon-diagram.model';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ApollonEditor, Patch, UMLDiagramType, UMLModel } from '@ls1intum/apollon';
 import { Text } from '@ls1intum/apollon/lib/es5/utils/svg/text';
 import { ModelingEditorComponent } from 'app/exercises/modeling/shared/modeling-editor.component';
@@ -16,6 +16,7 @@ import { SimpleChange } from '@angular/core';
 import { MockComponent, MockProvider } from 'ng-mocks';
 import { ModelingExplanationEditorComponent } from 'app/exercises/modeling/shared/modeling-explanation-editor.component';
 import { associationUML, personUML, studentUML } from 'app/guided-tour/guided-tour-task.model';
+import { provideHttpClient } from '@angular/common/http';
 
 // has to be overridden, because jsdom does not provide a getBBox() function for SVGTextElements
 Text.size = () => {
@@ -35,9 +36,9 @@ describe('ModelingEditorComponent', () => {
         diagram.jsonRepresentation = JSON.stringify(classDiagram);
 
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, ArtemisTestModule],
+            imports: [ArtemisTestModule],
             declarations: [ModelingEditorComponent, MockComponent(ModelingExplanationEditorComponent)],
-            providers: [MockProvider(GuidedTourService), { provide: ActivatedRoute, useValue: route }],
+            providers: [provideHttpClient(), provideHttpClientTesting(), MockProvider(GuidedTourService), { provide: ActivatedRoute, useValue: route }],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/organization/organization-management.service.spec.ts
+++ b/src/test/javascript/spec/component/organization/organization-management.service.spec.ts
@@ -3,14 +3,14 @@ import { Organization } from 'app/entities/organization.model';
 import { MockRouter } from '../../helpers/mocks/mock-router';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
-import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { TranslateService } from '@ngx-translate/core';
 import { User } from 'app/core/user/user.model';
-import { fakeAsync, tick } from '@angular/core/testing';
 import { OrganizationCountDto } from 'app/admin/organization-management/organization-count-dto.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Organization Service', () => {
     let service: OrganizationManagementService;
@@ -19,8 +19,10 @@ describe('Organization Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: Router, useClass: MockRouter },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/overview/course-competencies/course-competencies-details.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-competencies/course-competencies-details.component.spec.ts
@@ -18,11 +18,11 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { FireworksComponent } from 'app/shared/fireworks/fireworks.component';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { MockRouter } from '../../../helpers/mocks/mock-router';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Competency, CompetencyProgress } from 'app/entities/competency.model';
 import { TextExercise } from 'app/entities/text/text-exercise.model';
 import { TextUnit } from 'app/entities/lecture-unit/textUnit.model';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { MockHasAnyAuthorityDirective } from '../../../helpers/mocks/directive/mock-has-any-authority.directive';
 import { By } from '@angular/platform-browser';
 import { HelpIconComponent } from 'app/shared/components/help-icon.component';
@@ -51,7 +51,7 @@ describe('CourseCompetenciesDetails', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule, MockModule(NgbTooltipModule)],
+            imports: [ArtemisTestModule, MockModule(NgbTooltipModule)],
             declarations: [
                 CourseCompetenciesDetailsComponent,
                 MockPipe(ArtemisTranslatePipe),
@@ -70,6 +70,8 @@ describe('CourseCompetenciesDetails', () => {
                 MockPipe(HtmlForMarkdownPipe),
             ],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(LectureUnitService),
                 MockProvider(AlertService),
                 MockProvider(FeatureToggleService),

--- a/src/test/javascript/spec/component/overview/course-conversations/services/channel.service.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-conversations/services/channel.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { map, take } from 'rxjs/operators';
 import { ChannelService } from 'app/shared/metis/conversations/channel.service';
@@ -10,6 +10,7 @@ import { MockTranslateService } from '../../../../helpers/mocks/service/mock-tra
 import { AccountService } from 'app/core/auth/account.service';
 import { NotificationService } from 'app/shared/notification/notification.service';
 import { MockNotificationService } from '../../../../helpers/mocks/service/mock-notification.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ChannelService', () => {
     let service: ChannelService;
@@ -18,8 +19,10 @@ describe('ChannelService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: AccountService, useClass: MockAccountService },
                 { provide: NotificationService, useClass: MockNotificationService },

--- a/src/test/javascript/spec/component/overview/course-conversations/services/conversation.service.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-conversations/services/conversation.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { map, take } from 'rxjs/operators';
 import { TranslateService } from '@ngx-translate/core';
@@ -10,6 +10,7 @@ import { ConversationUserDTO } from 'app/entities/metis/conversation/conversatio
 import { generateExampleChannelDTO, generateExampleGroupChatDTO, generateOneToOneChatDTO } from '../helpers/conversationExampleModels';
 import { NotificationService } from 'app/shared/notification/notification.service';
 import { MockNotificationService } from '../../../../helpers/mocks/service/mock-notification.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ConversationService', () => {
     let service: ConversationService;
@@ -17,8 +18,10 @@ describe('ConversationService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: AccountService, useClass: MockAccountService },
                 { provide: NotificationService, useClass: MockNotificationService },

--- a/src/test/javascript/spec/component/overview/course-conversations/services/group-chat.service.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-conversations/services/group-chat.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { generateExampleGroupChatDTO } from '../helpers/conversationExampleModels';
@@ -10,6 +10,7 @@ import { GroupChatService } from 'app/shared/metis/conversations/group-chat.serv
 import { GroupChatDTO } from 'app/entities/metis/conversation/group-chat.model';
 import { NotificationService } from 'app/shared/notification/notification.service';
 import { MockNotificationService } from '../../../../helpers/mocks/service/mock-notification.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('GroupChatService', () => {
     let service: GroupChatService;
@@ -18,8 +19,10 @@ describe('GroupChatService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: AccountService, useClass: MockAccountService },
                 { provide: NotificationService, useClass: MockNotificationService },

--- a/src/test/javascript/spec/component/overview/course-conversations/services/one-to-one-chat.service.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-conversations/services/one-to-one-chat.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { generateOneToOneChatDTO } from '../helpers/conversationExampleModels';
@@ -10,6 +10,7 @@ import { OneToOneChatService } from 'app/shared/metis/conversations/one-to-one-c
 import { OneToOneChatDTO } from 'app/entities/metis/conversation/one-to-one-chat.model';
 import { NotificationService } from 'app/shared/notification/notification.service';
 import { MockNotificationService } from '../../../../helpers/mocks/service/mock-notification.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('OneToOneChatService', () => {
     let service: OneToOneChatService;
@@ -18,8 +19,10 @@ describe('OneToOneChatService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: AccountService, useClass: MockAccountService },
                 { provide: NotificationService, useClass: MockNotificationService },

--- a/src/test/javascript/spec/component/presentation-score/presentation-score.component.spec.ts
+++ b/src/test/javascript/spec/component/presentation-score/presentation-score.component.spec.ts
@@ -3,7 +3,8 @@ import { PresentationScoreComponent } from 'app/exercises/shared/presentation-sc
 import { Course } from 'app/entities/course.model';
 import { Exercise } from 'app/entities/exercise.model';
 import { GradingSystemService } from 'app/grading-system/grading-system.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('PresentationScoreComponent', () => {
     let component: PresentationScoreComponent;
@@ -38,8 +39,8 @@ describe('PresentationScoreComponent', () => {
     beforeEach(() => {
         return TestBed.configureTestingModule({
             declarations: [PresentationScoreComponent],
-            imports: [HttpClientTestingModule],
-            providers: [GradingSystemService],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), GradingSystemService],
         })
             .overrideTemplate(PresentationScoreComponent, '')
             .compileComponents()

--- a/src/test/javascript/spec/component/programming-exercise/feedback-analysis/feedback-analysis.service.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/feedback-analysis/feedback-analysis.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { FeedbackAnalysisService, FeedbackDetail } from 'app/exercises/programming/manage/grading/feedback-analysis/feedback-analysis.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('FeedbackAnalysisService', () => {
     let service: FeedbackAnalysisService;
@@ -13,8 +14,8 @@ describe('FeedbackAnalysisService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [FeedbackAnalysisService],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), FeedbackAnalysisService],
         });
 
         service = TestBed.inject(FeedbackAnalysisService);

--- a/src/test/javascript/spec/component/settings/ide/ide-settings.component.spec.ts
+++ b/src/test/javascript/spec/component/settings/ide/ide-settings.component.spec.ts
@@ -4,7 +4,8 @@ import { of } from 'rxjs';
 import { IdeSettingsComponent } from 'app/shared/user-settings/ide-preferences/ide-settings.component';
 import { IdeSettingsService } from 'app/shared/user-settings/ide-preferences/ide-settings.service';
 import { ProgrammingLanguage } from 'app/entities/programming/programming-exercise.model';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('IdeSettingsComponent', () => {
     let component: IdeSettingsComponent;
@@ -19,9 +20,9 @@ describe('IdeSettingsComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             declarations: [IdeSettingsComponent],
-            providers: [{ provide: IdeSettingsService, useValue: mockIdeSettingsService }],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: IdeSettingsService, useValue: mockIdeSettingsService }],
             schemas: [CUSTOM_ELEMENTS_SCHEMA],
         }).compileComponents();
 

--- a/src/test/javascript/spec/component/shared/http/file.service.spec.ts
+++ b/src/test/javascript/spec/component/shared/http/file.service.spec.ts
@@ -1,7 +1,8 @@
 import { FileService } from 'app/shared/http/file.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { v4 as uuid } from 'uuid';
+import { provideHttpClient } from '@angular/common/http';
 
 jest.mock('uuid', () => ({
     v4: jest.fn(),
@@ -18,8 +19,8 @@ describe('FileService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [FileService],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), FileService],
         });
         fileService = TestBed.inject(FileService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/shared/metis/message-inline-input-component/message-inline-input.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/message-inline-input-component/message-inline-input.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { MetisService } from 'app/shared/metis/metis.service';
 import { MockModule, MockPipe } from 'ng-mocks';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MessageInlineInputComponent } from 'app/shared/metis/message/message-inline-input/message-inline-input.component';
 import { MockMetisService } from '../../../../helpers/mocks/service/mock-metis-service.service';
 import { directMessageUser1, metisPostToCreateUser1 } from '../../../../helpers/sample/metis-sample-data';
@@ -10,6 +10,7 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { throwError } from 'rxjs';
 import { MockSyncStorage } from '../../../../helpers/mocks/service/mock-sync-storage.service';
 import { LocalStorageService } from 'ngx-webstorage';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('MessageInlineInputComponent', () => {
     let component: MessageInlineInputComponent;
@@ -20,9 +21,15 @@ describe('MessageInlineInputComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, MockModule(FormsModule), MockModule(ReactiveFormsModule)],
+            imports: [MockModule(FormsModule), MockModule(ReactiveFormsModule)],
             declarations: [MessageInlineInputComponent, MockPipe(ArtemisTranslatePipe)],
-            providers: [FormBuilder, { provide: MetisService, useClass: MockMetisService }, { provide: LocalStorageService, useClass: MockSyncStorage }],
+            providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
+                FormBuilder,
+                { provide: MetisService, useClass: MockMetisService },
+                { provide: LocalStorageService, useClass: MockSyncStorage },
+            ],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/shared/metis/message-reply-inline-input/message-reply-inline-input.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/message-reply-inline-input/message-reply-inline-input.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { MetisService } from 'app/shared/metis/metis.service';
 import { MockModule, MockPipe } from 'ng-mocks';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MockMetisService } from '../../../../helpers/mocks/service/mock-metis-service.service';
 import { directMessageUser1, metisPostToCreateUser1 } from '../../../../helpers/sample/metis-sample-data';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
@@ -10,6 +10,7 @@ import { MessageReplyInlineInputComponent } from 'app/shared/metis/message/messa
 import { throwError } from 'rxjs';
 import { MockSyncStorage } from '../../../../helpers/mocks/service/mock-sync-storage.service';
 import { LocalStorageService } from 'ngx-webstorage';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('MessageReplyInlineInputComponent', () => {
     let component: MessageReplyInlineInputComponent;
@@ -20,9 +21,15 @@ describe('MessageReplyInlineInputComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, MockModule(FormsModule), MockModule(ReactiveFormsModule)],
+            imports: [MockModule(FormsModule), MockModule(ReactiveFormsModule)],
             declarations: [MessageReplyInlineInputComponent, MockPipe(ArtemisTranslatePipe)],
-            providers: [FormBuilder, { provide: MetisService, useClass: MockMetisService }, { provide: LocalStorageService, useClass: MockSyncStorage }],
+            providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
+                FormBuilder,
+                { provide: MetisService, useClass: MockMetisService },
+                { provide: LocalStorageService, useClass: MockSyncStorage },
+            ],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/shared/metis/posting-content/posting-content.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/posting-content/posting-content.component.spec.ts
@@ -3,7 +3,7 @@ import { PostingContentPartComponent } from 'app/shared/metis/posting-content/po
 import { MockComponent, MockPipe } from 'ng-mocks';
 import { PostingContentComponent } from 'app/shared/metis/posting-content/posting-content.components';
 import { MetisService } from 'app/shared/metis/metis.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MockMetisService } from '../../../../helpers/mocks/service/mock-metis-service.service';
 import { PatternMatch, PostingContentPart, ReferenceType } from 'app/shared/metis/metis.util';
 import { Observable, of } from 'rxjs';
@@ -12,6 +12,7 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { metisCourse, metisCoursePosts, metisExercisePosts, metisGeneralCourseWidePosts, metisLecturePosts } from '../../../../helpers/sample/metis-sample-data';
 import { Params } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('PostingContentComponent', () => {
     let component: PostingContentComponent;
@@ -20,8 +21,8 @@ describe('PostingContentComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: MetisService, useClass: MockMetisService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: MetisService, useClass: MockMetisService }],
             declarations: [PostingContentComponent, MockComponent(PostingContentPartComponent), MockComponent(FaIconComponent), MockPipe(ArtemisTranslatePipe)],
         })
             .compileComponents()

--- a/src/test/javascript/spec/component/shared/metis/postings-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.spec.ts
@@ -11,12 +11,13 @@ import { HelpIconComponent } from 'app/shared/components/help-icon.component';
 import { PostTagSelectorComponent } from 'app/shared/metis/posting-create-edit-modal/post-create-edit-modal/post-tag-selector/post-tag-selector.component';
 import { PageType } from 'app/shared/metis/metis.util';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ArtemisTestModule } from '../../../../../test.module';
 import { PostComponent } from 'app/shared/metis/post/post.component';
 import { metisCourse, metisExercise, metisPostLectureUser1, metisPostTechSupport, metisPostToCreateUser1 } from '../../../../../helpers/sample/metis-sample-data';
 import { MockNgbModalService } from '../../../../../helpers/mocks/service/mock-ngb-modal.service';
 import { Channel } from 'app/entities/metis/conversation/channel.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('PostCreateEditModalComponent', () => {
     let component: PostCreateEditModalComponent;
@@ -30,7 +31,7 @@ describe('PostCreateEditModalComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule, MockModule(FormsModule), MockModule(ReactiveFormsModule)],
+            imports: [ArtemisTestModule, MockModule(FormsModule), MockModule(ReactiveFormsModule)],
             declarations: [
                 PostCreateEditModalComponent,
                 MockPipe(ArtemisTranslatePipe),
@@ -40,7 +41,13 @@ describe('PostCreateEditModalComponent', () => {
                 MockComponent(HelpIconComponent),
                 MockComponent(PostTagSelectorComponent),
             ],
-            providers: [FormBuilder, { provide: MetisService, useClass: MockMetisService }, { provide: NgbModal, useClass: MockNgbModalService }],
+            providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
+                FormBuilder,
+                { provide: MetisService, useClass: MockMetisService },
+                { provide: NgbModal, useClass: MockNgbModalService },
+            ],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component.spec.ts
@@ -4,7 +4,7 @@ import { MetisService } from 'app/shared/metis/metis.service';
 import { MockComponent, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { Reaction } from 'app/entities/metis/reaction.model';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ReactionService } from 'app/shared/metis/reaction.service';
 import { MockReactionService } from '../../../../../helpers/mocks/service/mock-reaction.service';
 import { AccountService } from 'app/core/auth/account.service';
@@ -26,6 +26,7 @@ import { metisCourse, metisUser1, post } from '../../../../../helpers/sample/met
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { NotificationService } from 'app/shared/notification/notification.service';
 import { MockNotificationService } from '../../../../../helpers/mocks/service/mock-notification.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('AnswerPostReactionsBarComponent', () => {
     let component: AnswerPostReactionsBarComponent;
@@ -37,9 +38,11 @@ describe('AnswerPostReactionsBarComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, MockModule(OverlayModule), MockModule(EmojiModule), MockModule(PickerModule), MockModule(NgbTooltipModule)],
+            imports: [MockModule(OverlayModule), MockModule(EmojiModule), MockModule(PickerModule), MockModule(NgbTooltipModule)],
             declarations: [AnswerPostReactionsBarComponent, TranslatePipeMock, MockPipe(ReactingUsersOnPostingPipe), MockComponent(FaIconComponent), MockComponent(EmojiComponent)],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(SessionStorageService),
                 { provide: NotificationService, useClass: MockNotificationService },
                 { provide: MetisService, useClass: MetisService },

--- a/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/post-reactions-bar/post-reactions-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/post-reactions-bar/post-reactions-bar.component.spec.ts
@@ -7,7 +7,7 @@ import { getElement, getElements } from '../../../../../helpers/utils/general.ut
 import { PostReactionsBarComponent } from 'app/shared/metis/posting-reactions-bar/post-reactions-bar/post-reactions-bar.component';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { Reaction } from 'app/entities/metis/reaction.model';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ReactionService } from 'app/shared/metis/reaction.service';
 import { MockReactionService } from '../../../../../helpers/mocks/service/mock-reaction.service';
 import { AccountService } from 'app/core/auth/account.service';
@@ -32,6 +32,7 @@ import { MockNotificationService } from '../../../../../helpers/mocks/service/mo
 import { ConversationDTO, ConversationType } from 'app/entities/metis/conversation/conversation.model';
 import { ChannelDTO } from 'app/entities/metis/conversation/channel.model';
 import { User } from 'app/core/user/user.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('PostReactionsBarComponent', () => {
     let component: PostReactionsBarComponent;
@@ -51,9 +52,11 @@ describe('PostReactionsBarComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, MockModule(OverlayModule), MockModule(EmojiModule), MockModule(PickerModule), MockDirective(NgbTooltip)],
+            imports: [MockModule(OverlayModule), MockModule(EmojiModule), MockModule(PickerModule), MockDirective(NgbTooltip)],
             declarations: [PostReactionsBarComponent, TranslatePipeMock, MockPipe(ReactingUsersOnPostingPipe), MockComponent(FaIconComponent), EmojiComponent],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(SessionStorageService),
                 { provide: MetisService, useClass: MetisService },
                 { provide: ReactionService, useClass: MockReactionService },

--- a/src/test/javascript/spec/component/shared/navbar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/navbar.component.spec.ts
@@ -1,4 +1,4 @@
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ActivatedRoute, Router, UrlSerializer } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -37,7 +37,7 @@ import { SystemNotificationComponent } from 'app/shared/notification/system-noti
 import { NgbTooltipMocksModule } from '../../helpers/mocks/directive/ngbTooltipMocks.module';
 import { NgbCollapseMocksModule } from '../../helpers/mocks/directive/ngbCollapseMocks.module';
 import { NgbDropdownMocksModule } from '../../helpers/mocks/directive/ngbDropdownMocks.module';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
 class MockBreadcrumb {
@@ -93,7 +93,7 @@ describe('NavbarComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, NgbTooltipMocksModule, NgbCollapseMocksModule, NgbDropdownMocksModule],
+            imports: [NgbTooltipMocksModule, NgbCollapseMocksModule, NgbDropdownMocksModule],
             declarations: [
                 NavbarComponent,
                 MockDirective(HasAnyAuthorityDirective),
@@ -112,6 +112,8 @@ describe('NavbarComponent', () => {
                 MockComponent(FaIconComponent),
             ],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(UrlSerializer),
                 {
                     provide: AccountService,

--- a/src/test/javascript/spec/component/shared/user-settings/notification-settings.service.spec.ts
+++ b/src/test/javascript/spec/component/shared/user-settings/notification-settings.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { NotificationSetting } from 'app/shared/user-settings/notification-settings/notification-settings-structure';
 import { NotificationSettingsService, reloadNotificationSideBarMessage } from 'app/shared/user-settings/notification-settings/notification-settings.service';
@@ -6,7 +6,7 @@ import { COURSE_ARCHIVE_STARTED_TITLE, EXAM_ARCHIVE_STARTED_TITLE, EXERCISE_PRAC
 import { SettingId } from 'app/shared/constants/user-settings.constants';
 import { UserSettingsService } from 'app/shared/user-settings/user-settings.service';
 import { of } from 'rxjs';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { Setting } from 'app/shared/user-settings/user-settings.model';
 
 const notificationSettingA: NotificationSetting = {
@@ -28,7 +28,8 @@ describe('User Settings Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/shared/user-settings/science-settings.service.spec.ts
+++ b/src/test/javascript/spec/component/shared/user-settings/science-settings.service.spec.ts
@@ -1,9 +1,9 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { SettingId } from 'app/shared/constants/user-settings.constants';
 import { UserSettingsService } from 'app/shared/user-settings/user-settings.service';
 import { of } from 'rxjs';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { Setting } from 'app/shared/user-settings/user-settings.model';
 import { ScienceSetting } from 'app/shared/user-settings/science-settings/science-settings-structure';
 import { ScienceSettingsService } from 'app/shared/user-settings/science-settings/science-settings.service';
@@ -26,8 +26,8 @@ describe('ScienceSettingsService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: LocalStorageService, useClass: MockLocalStorageService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: LocalStorageService, useClass: MockLocalStorageService }],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/shared/user-settings/user-settings.directive.spec.ts
+++ b/src/test/javascript/spec/component/shared/user-settings/user-settings.directive.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AccountService } from 'app/core/auth/account.service';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
@@ -13,7 +13,7 @@ import { UserSettingsDirective } from 'app/shared/user-settings/user-settings.di
 import { MockRouter } from '../../../helpers/mocks/mock-router';
 import { Router } from '@angular/router';
 import { of, throwError } from 'rxjs';
-import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpResponse, provideHttpClient } from '@angular/common/http';
 import { MockProvider } from 'ng-mocks';
 import { MockUserSettingsService } from '../../../helpers/mocks/service/mock-user-settings.service';
 import { AlertService } from 'app/core/util/alert.service';
@@ -62,9 +62,11 @@ describe('User Settings Directive', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, TranslateTestingModule],
+            imports: [TranslateTestingModule],
             declarations: [UserSettingsMockComponent],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(ChangeDetectorRef),
                 { provide: JhiWebsocketService, useClass: MockWebsocketService },
                 { provide: AccountService, useClass: MockAccountService },

--- a/src/test/javascript/spec/component/shared/user-settings/user-settings.service.spec.ts
+++ b/src/test/javascript/spec/component/shared/user-settings/user-settings.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { AccountService } from 'app/core/auth/account.service';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
@@ -9,6 +9,7 @@ import { MockAccountService } from '../../../helpers/mocks/service/mock-account.
 import { TranslateTestingModule } from '../../../helpers/mocks/service/mock-translate.service';
 import { Setting, UserSettingsStructure } from 'app/shared/user-settings/user-settings.model';
 import { NotificationSetting, notificationSettingsStructure } from 'app/shared/user-settings/notification-settings/notification-settings-structure';
+import { provideHttpClient } from '@angular/common/http';
 
 const notificationSettingA: NotificationSetting = {
     settingId: SettingId.NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_OPEN_FOR_PRACTICE,
@@ -123,8 +124,10 @@ describe('User Settings Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, TranslateTestingModule],
+            imports: [TranslateTestingModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: JhiWebsocketService, useClass: MockWebsocketService },
                 { provide: AccountService, useClass: MockAccountService },
             ],

--- a/src/test/javascript/spec/component/standardized-competencies/admin-standardized-competency.service.spec.ts
+++ b/src/test/javascript/spec/component/standardized-competencies/admin-standardized-competency.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { AdminStandardizedCompetencyService } from 'app/admin/standardized-competencies/admin-standardized-competency.service';
 import { KnowledgeAreaDTO, KnowledgeAreasForImportDTO, StandardizedCompetencyDTO } from 'app/entities/competency/standardized-competency.model';
@@ -14,8 +14,8 @@ describe('AdminStandardizedCompetencyService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
 
         adminStandardizedCompetencyService = TestBed.inject(AdminStandardizedCompetencyService);

--- a/src/test/javascript/spec/component/standardized-competencies/standardized-competency.service.spec.ts
+++ b/src/test/javascript/spec/component/standardized-competencies/standardized-competency.service.spec.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { KnowledgeArea, KnowledgeAreaDTO, Source, StandardizedCompetency } from 'app/entities/competency/standardized-competency.model';
 import { take } from 'rxjs';
@@ -14,8 +14,8 @@ describe('StandardizedCompetencyService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
 
         standardizedCompetencyService = TestBed.inject(StandardizedCompetencyService);

--- a/src/test/javascript/spec/component/text-exercise/tutor-effort-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/tutor-effort-statistics.component.spec.ts
@@ -3,7 +3,7 @@ import { MockComponent, MockDirective, MockModule, MockPipe } from 'ng-mocks';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TutorEffortStatisticsComponent } from 'app/exercises/text/manage/tutor-effort/tutor-effort-statistics.component';
 import { ArtemisTestModule } from '../../test.module';
 import { MockHasAnyAuthorityDirective } from '../../helpers/mocks/directive/mock-has-any-authority.directive';
@@ -16,6 +16,7 @@ import { BarChartModule } from '@swimlane/ngx-charts';
 import { HelpIconComponent } from 'app/shared/components/help-icon.component';
 import { MockRouter } from '../../helpers/mocks/mock-router';
 import { of } from 'rxjs';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('TutorEffortStatisticsComponent', () => {
     let fixture: ComponentFixture<TutorEffortStatisticsComponent>;
@@ -49,9 +50,11 @@ describe('TutorEffortStatisticsComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule, MockModule(BarChartModule)],
+            imports: [ArtemisTestModule, MockModule(BarChartModule)],
             declarations: [TutorEffortStatisticsComponent, MockPipe(ArtemisTranslatePipe), MockDirective(MockHasAnyAuthorityDirective), MockComponent(HelpIconComponent)],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TranslateService, useClass: MockTranslateService },
                 {
                     provide: ActivatedRoute,

--- a/src/test/javascript/spec/component/tutorial-groups/services/tutorial-group-free-period.service.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/services/tutorial-group-free-period.service.spec.ts
@@ -1,9 +1,10 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { TutorialGroupFreePeriodDTO, TutorialGroupFreePeriodService } from 'app/course/tutorial-groups/services/tutorial-group-free-period.service';
 import { generateExampleTutorialGroupFreePeriod } from '../helpers/tutorialGroupFreePeriodExampleModel';
 import { TutorialGroupFreePeriod } from 'app/entities/tutorial-group/tutorial-group-free-day.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('TutorialGroupFreePeriodService', () => {
     let service: TutorialGroupFreePeriodService;
@@ -12,7 +13,8 @@ describe('TutorialGroupFreePeriodService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(TutorialGroupFreePeriodService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/tutorial-groups/services/tutorial-group-session.service.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/services/tutorial-group-session.service.spec.ts
@@ -1,9 +1,10 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { TutorialGroupSessionDTO, TutorialGroupSessionService } from 'app/course/tutorial-groups/services/tutorial-group-session.service';
 import { TutorialGroupSession } from 'app/entities/tutorial-group/tutorial-group-session.model';
 import { generateExampleTutorialGroupSession } from '../helpers/tutorialGroupSessionExampleModels';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('TutorialGroupSessionService', () => {
     let service: TutorialGroupSessionService;
@@ -12,7 +13,8 @@ describe('TutorialGroupSessionService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(TutorialGroupSessionService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/tutorial-groups/services/tutorial-group.service.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/services/tutorial-group.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { map, take } from 'rxjs/operators';
 import { TutorialGroupsService } from 'app/course/tutorial-groups/services/tutorial-groups.service';
@@ -8,6 +8,7 @@ import { TutorialGroupSessionService } from 'app/course/tutorial-groups/services
 import { TutorialGroupsConfigurationService } from 'app/course/tutorial-groups/services/tutorial-groups-configuration.service';
 import { TutorialGroupSession } from 'app/entities/tutorial-group/tutorial-group-session.model';
 import { TutorialGroupRegistrationImportDTO } from 'app/entities/tutorial-group/tutorial-group-import-dto.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('TutorialGroupService', () => {
     let service: TutorialGroupsService;
@@ -28,8 +29,10 @@ describe('TutorialGroupService', () => {
         };
 
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TutorialGroupSessionService, useValue: spySessionService },
                 { provide: TutorialGroupsConfigurationService, useValue: spyConfigService },
             ],

--- a/src/test/javascript/spec/component/tutorial-groups/services/tutorial-groups-configuration.service.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/services/tutorial-groups-configuration.service.spec.ts
@@ -1,10 +1,11 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { TutorialGroupSession } from 'app/entities/tutorial-group/tutorial-group-session.model';
 import { generateExampleTutorialGroupsConfiguration } from '../helpers/tutorialGroupsConfigurationExampleModels';
 import { TutorialGroupsConfigurationService } from 'app/course/tutorial-groups/services/tutorial-groups-configuration.service';
 import { TutorialGroupsConfiguration } from 'app/entities/tutorial-group/tutorial-groups-configuration.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('TutorialGroupsConfigurationService', () => {
     let service: TutorialGroupsConfigurationService;
@@ -13,7 +14,8 @@ describe('TutorialGroupsConfigurationService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(TutorialGroupsConfigurationService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/tutorial-groups/services/tutorial-groups.service.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/services/tutorial-groups.service.spec.ts
@@ -1,10 +1,11 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { map, take } from 'rxjs/operators';
 import { TutorialGroupsService } from 'app/course/tutorial-groups/services/tutorial-groups.service';
 import { TutorialGroup } from 'app/entities/tutorial-group/tutorial-group.model';
 import { StudentDTO } from 'app/entities/student-dto.model';
 import { generateExampleTutorialGroup } from '../helpers/tutorialGroupExampleModels';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('TutorialGroupService', () => {
     let service: TutorialGroupsService;
@@ -13,7 +14,8 @@ describe('TutorialGroupService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(TutorialGroupsService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/component/tutorial-groups/shared/tutorial-group-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/shared/tutorial-group-detail.component.spec.ts
@@ -5,7 +5,7 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
 import { ArtemisMarkdownService } from 'app/shared/markdown.service';
 import { generateExampleTutorialGroup } from '../helpers/tutorialGroupExampleModels';
-import { Component, Input, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, ViewChild } from '@angular/core';
 import { TutorialGroup } from 'app/entities/tutorial-group/tutorial-group.model';
 import { SortService } from 'app/shared/service/sort.service';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -15,12 +15,12 @@ import { RemoveSecondsPipe } from 'app/course/tutorial-groups/shared/remove-seco
 import { DetailOverviewListComponent } from 'app/detail-overview-list/detail-overview-list.component';
 import { MockTranslateService } from '../../../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MockLocalStorageService } from '../../../helpers/mocks/service/mock-local-storage.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import dayjs from 'dayjs/esm';
 import { TutorialGroupSessionStatus } from 'app/entities/tutorial-group/tutorial-group-session.model';
-import { ChangeDetectorRef } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 
 @Component({ selector: 'jhi-mock-header', template: '<div id="mockHeader"></div>' })
 class MockHeaderComponent {
@@ -57,7 +57,7 @@ describe('TutorialGroupDetailWrapperTest', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [NgbTooltipMocksModule, RouterTestingModule.withRoutes([]), HttpClientTestingModule],
+            imports: [NgbTooltipMocksModule, RouterTestingModule.withRoutes([])],
             declarations: [
                 TutorialGroupDetailComponent,
                 DetailOverviewListComponent,
@@ -69,6 +69,8 @@ describe('TutorialGroupDetailWrapperTest', () => {
                 MockComponent(TutorialGroupUtilizationIndicatorComponent),
             ],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(ArtemisMarkdownService),
                 MockProvider(SortService),
                 MockProvider(SessionStorageService),

--- a/src/test/javascript/spec/component/tutorial-groups/tutorial-groups-management/tutorial-group-management-resolve.service.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/tutorial-groups-management/tutorial-group-management-resolve.service.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { of } from 'rxjs';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { Course } from 'app/entities/course.model';
@@ -20,8 +20,10 @@ describe('TutorialGroupManagementResolve', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule, HttpClientTestingModule],
+            imports: [RouterTestingModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 TutorialGroupManagementResolve,
                 { provide: Router, useClass: MockRouter },
                 {

--- a/src/test/javascript/spec/service/admin-user.service.spec.ts
+++ b/src/test/javascript/spec/service/admin-user.service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { User } from 'app/core/user/user.model';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { AdminUserService } from 'app/core/user/admin-user.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('User Service', () => {
     let adminService: AdminUserService;
@@ -9,7 +10,8 @@ describe('User Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
 
         adminService = TestBed.inject(AdminUserService);

--- a/src/test/javascript/spec/service/apollon-diagram.service.spec.ts
+++ b/src/test/javascript/spec/service/apollon-diagram.service.spec.ts
@@ -1,8 +1,8 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ApollonDiagramService } from 'app/exercises/quiz/manage/apollon-diagrams/apollon-diagram.service';
 import { ApollonDiagram } from 'app/entities/apollon-diagram.model';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { UMLDiagramType } from '@ls1intum/apollon';
 
 const resourceUrl = 'api';
@@ -14,8 +14,8 @@ describe('ApollonDiagramService', () => {
     let httpTestingController: HttpTestingController;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [ApollonDiagramService],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), ApollonDiagramService],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/service/athena.service.spec.ts
+++ b/src/test/javascript/spec/service/athena.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { AthenaService } from 'app/assessment/athena.service';
 import { ArtemisTestModule } from '../test.module';
@@ -12,6 +12,7 @@ import { TextSubmission } from 'app/entities/text/text-submission.model';
 import { TextBlockRef } from 'app/entities/text/text-block-ref.model';
 import { Feedback, FeedbackType } from 'app/entities/feedback.model';
 import { ModelingSubmission } from 'app/entities/modeling-submission.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('AthenaService', () => {
     let athenaService: AthenaService;
@@ -51,8 +52,8 @@ describe('AthenaService', () => {
     } as Exercise;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
-            providers: [{ provide: ProfileService, useClass: MockProfileService }],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: ProfileService, useClass: MockProfileService }],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/service/attachment.service.spec.ts
+++ b/src/test/javascript/spec/service/attachment.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { take } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
@@ -21,8 +21,10 @@ describe('Attachment Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/service/audits.service.spec.ts
+++ b/src/test/javascript/spec/service/audits.service.spec.ts
@@ -2,7 +2,8 @@ import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 
 import { AuditsService } from 'app/admin/audits/audits.service';
 import { Audit } from 'app/admin/audits/audit.model';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Audits Service', () => {
     let service: AuditsService;
@@ -10,7 +11,8 @@ describe('Audits Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
 
         service = TestBed.inject(AuditsService);

--- a/src/test/javascript/spec/service/auth-jwt.service.spec.ts
+++ b/src/test/javascript/spec/service/auth-jwt.service.spec.ts
@@ -1,9 +1,10 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { AuthServerProvider, Credentials } from 'app/core/auth/auth-jwt.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
 import { MockLocalStorageService } from '../helpers/mocks/service/mock-local-storage.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('AuthServerProvider', () => {
     let service: AuthServerProvider;
@@ -19,8 +20,10 @@ describe('AuthServerProvider', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockLocalStorageService },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
             ],

--- a/src/test/javascript/spec/service/bonus.service.spec.ts
+++ b/src/test/javascript/spec/service/bonus.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { GradeType, GradingScale } from 'app/entities/grading-scale.model';
 import { take } from 'rxjs/operators';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -8,6 +8,7 @@ import { BonusService } from 'app/grading-system/bonus/bonus.service';
 import { Bonus, BonusExample, BonusStrategy } from 'app/entities/bonus.model';
 import { GradingSystemService } from 'app/grading-system/grading-system.service';
 import { cloneDeep } from 'lodash-es';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Bonus Service', () => {
     type GradeStepBuilder = {
@@ -90,7 +91,8 @@ describe('Bonus Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, RouterTestingModule],
+            imports: [RouterTestingModule],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(BonusService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/build-log.service.spec.ts
+++ b/src/test/javascript/spec/service/build-log.service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { BuildLogService } from 'app/exercises/programming/shared/service/build-log.service';
 import { BuildLogEntry, BuildLogType } from 'app/entities/programming/build-log.model';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Build Log Service', () => {
     let service: BuildLogService;
@@ -11,7 +12,8 @@ describe('Build Log Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
 
         service = TestBed.inject(BuildLogService);

--- a/src/test/javascript/spec/service/configuration.service.spec.ts
+++ b/src/test/javascript/spec/service/configuration.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { ConfigurationService } from 'app/admin/configuration/configuration.service';
 import { Bean, ConfigProps, Env, PropertySource } from 'app/admin/configuration/configuration.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Service Tests', () => {
     describe('Logs Service', () => {
@@ -12,7 +13,8 @@ describe('Service Tests', () => {
 
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [HttpClientTestingModule],
+                imports: [],
+                providers: [provideHttpClient(), provideHttpClientTesting()],
             });
 
             expectedResult = null;

--- a/src/test/javascript/spec/service/course-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/course-exercise.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -20,6 +20,7 @@ import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { of } from 'rxjs';
 import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
 import { UMLDiagramType } from '@ls1intum/apollon';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Course Management Service', () => {
     let service: CourseExerciseService;
@@ -45,8 +46,10 @@ describe('Course Management Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: Router, useClass: MockRouter },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/service/data-export.service.spec.ts
+++ b/src/test/javascript/spec/service/data-export.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { DataExportService } from 'app/core/legal/data-export/data-export.service';
 import { DataExport } from 'app/entities/data-export.model';
@@ -6,6 +6,7 @@ import { User } from 'app/core/user/user.model';
 import dayjs from 'dayjs/esm';
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('DataExportService', () => {
     let service: DataExportService;
@@ -13,8 +14,8 @@ describe('DataExportService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: TranslateService, useClass: MockTranslateService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: TranslateService, useClass: MockTranslateService }],
         });
         service = TestBed.inject(DataExportService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/exam-import-paging.service.spec.ts
+++ b/src/test/javascript/spec/service/exam-import-paging.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { SortingOrder } from 'app/shared/table/pageable-table';
@@ -8,6 +8,7 @@ import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.serv
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
 import { Exam } from 'app/entities/exam/exam.model';
 import { ExamImportPagingService } from 'app/exam/manage/exams/exam-import/exam-import-paging.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Exam Import Paging Service', () => {
     let service: ExamImportPagingService;
@@ -22,8 +23,10 @@ describe('Exam Import Paging Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: LocalStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/service/exam-participation-live-events.service.spec.ts
+++ b/src/test/javascript/spec/service/exam-participation-live-events.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { Subject, firstValueFrom } from 'rxjs';
 import { ConnectionState, JhiWebsocketService } from 'app/core/websocket/websocket.service';
 import { ExamParticipationService } from 'app/exam/participate/exam-participation.service';
@@ -7,6 +7,7 @@ import { ExamLiveEvent, ExamLiveEventType, ExamParticipationLiveEventsService } 
 import { LocalStorageService } from 'ngx-webstorage';
 import dayjs from 'dayjs/esm';
 import { MockWebsocketService } from '../helpers/mocks/service/mock-websocket.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ExamParticipationLiveEventsService', () => {
     let service: ExamParticipationLiveEventsService;
@@ -34,8 +35,10 @@ describe('ExamParticipationLiveEventsService', () => {
         mockWebsocketService = tmpMockWebsocketService as unknown as JhiWebsocketService;
 
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: JhiWebsocketService, useValue: mockWebsocketService },
                 { provide: ExamParticipationService, useValue: mockExamParticipationService },
                 { provide: LocalStorageService, useValue: mockLocalStorageService },

--- a/src/test/javascript/spec/service/exam-participation.service.spec.ts
+++ b/src/test/javascript/spec/service/exam-participation.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import dayjs from 'dayjs/esm';
 import { ExamParticipationService } from 'app/exam/participate/exam-participation.service';
@@ -19,6 +19,7 @@ import { Result } from 'app/entities/result.model';
 import { getLatestSubmissionResult } from 'app/entities/submission.model';
 import { StudentExamWithGradeDTO, StudentResult } from 'app/exam/exam-scores/exam-score-dtos.model';
 import { GradeType } from 'app/entities/grading-scale.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ExamParticipationService', () => {
     let service: ExamParticipationService;
@@ -30,8 +31,10 @@ describe('ExamParticipationService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, ArtemisTestModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/service/example-submission-import-paging.service.spec.ts
+++ b/src/test/javascript/spec/service/example-submission-import-paging.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { SortingOrder } from 'app/shared/table/pageable-table';
@@ -9,6 +9,7 @@ import { MockTranslateService } from '../helpers/mocks/service/mock-translate.se
 import { ExampleSubmissionImportPagingService } from 'app/exercises/shared/example-submission/example-submission-import/example-submission-import-paging.service';
 import { Exercise } from 'app/entities/exercise.model';
 import { TextSubmission } from 'app/entities/text/text-submission.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Example Submission Import Paging Service', () => {
     let service: ExampleSubmissionImportPagingService;
@@ -16,8 +17,10 @@ describe('Example Submission Import Paging Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: LocalStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/service/example-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/example-submission.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { take } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
 import { ExampleSubmissionService } from 'app/exercises/shared/example-submission/example-submission.service';
@@ -24,8 +24,8 @@ describe('Example Submission Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
-            providers: [{ provide: ExerciseService, useClass: MockExerciseService }, MockProvider(StringCountService)],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: ExerciseService, useClass: MockExerciseService }, MockProvider(StringCountService)],
         });
         service = TestBed.inject(ExampleSubmissionService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/exercise-hint.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise-hint.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { take } from 'rxjs/operators';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { ProgrammingExercise } from 'app/entities/programming/programming-exercise.model';
@@ -17,8 +17,8 @@ describe('ExerciseHint Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: ExerciseService, useClass: MockExerciseService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: ExerciseService, useClass: MockExerciseService }],
         });
         expectedResult = {} as HttpResponse<ExerciseHint>;
         service = TestBed.inject(ExerciseHintService);

--- a/src/test/javascript/spec/service/exercise-scores-chart.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise-scores-chart.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ArtemisTestModule } from '../test.module';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
@@ -7,6 +7,7 @@ import { SessionStorageService } from 'ngx-webstorage';
 import { TranslateService } from '@ngx-translate/core';
 import { take } from 'rxjs/operators';
 import { ExerciseScoresChartService, ExerciseScoresDTO } from 'app/overview/visualizations/exercise-scores-chart.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Exercise Scores Chart Service', () => {
     let service: ExerciseScoresChartService;
@@ -15,8 +16,10 @@ describe('Exercise Scores Chart Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },
             ],

--- a/src/test/javascript/spec/service/exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -24,6 +24,7 @@ import { Observable } from 'rxjs';
 import { AccountService } from 'app/core/auth/account.service';
 import { EntityTitleService } from 'app/shared/layouts/navbar/entity-title.service';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Exercise Service', () => {
     let service: ExerciseService;
@@ -64,8 +65,10 @@ describe('Exercise Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: Router, useClass: MockRouter },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/service/external-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/external-submission.service.spec.ts
@@ -1,6 +1,6 @@
 import { ArtemisTestModule } from '../test.module';
 import { ExternalSubmissionService } from 'app/exercises/shared/external-submission/external-submission.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { ExerciseType } from 'app/entities/exercise.model';
 import { Result } from 'app/entities/result.model';
@@ -8,6 +8,7 @@ import { User } from 'app/core/user/user.model';
 import { EntityResponseType, ResultService } from 'app/exercises/shared/result/result.service';
 import dayjs from 'dayjs/esm';
 import { ProgrammingExercise } from 'app/entities/programming/programming-exercise.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('External Submission Service', () => {
     let httpMock: HttpTestingController;
@@ -15,7 +16,8 @@ describe('External Submission Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(ExternalSubmissionService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/faq.service.spec.ts
+++ b/src/test/javascript/spec/service/faq.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { take } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
@@ -21,8 +21,10 @@ describe('Faq Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/service/file-type.service.spec.ts
+++ b/src/test/javascript/spec/service/file-type.service.spec.ts
@@ -1,13 +1,15 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { FileTypeService } from 'app/exercises/programming/shared/service/file-type.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('FileTypeService', () => {
     let service: FileTypeService;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
 
         service = TestBed.inject(FileTypeService);

--- a/src/test/javascript/spec/service/file-upload-assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/file-upload-assessment.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import dayjs from 'dayjs/esm';
 import { Result } from 'app/entities/result.model';
@@ -7,7 +7,7 @@ import { Feedback } from 'app/entities/feedback.model';
 import { FileUploadAssessmentService } from 'app/exercises/file-upload/assess/file-upload-assessment.service';
 import { ArtemisTestModule } from '../test.module';
 import { ComplaintResponse } from 'app/entities/complaint-response.model';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 
 describe('Modeling Assessment Service', () => {
     let httpMock: HttpTestingController;
@@ -18,7 +18,8 @@ describe('Modeling Assessment Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(FileUploadAssessmentService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/file-upload-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/file-upload-exercise.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { map, take } from 'rxjs/operators';
 
 import { FileUploadExerciseService } from 'app/exercises/file-upload/manage/file-upload-exercise.service';
@@ -12,6 +12,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Course } from 'app/entities/course.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { MockExerciseService } from '../helpers/mocks/service/mock-exercise.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('FileUploadExercise Service', () => {
     let service: FileUploadExerciseService;
@@ -25,8 +26,10 @@ describe('FileUploadExercise Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/service/file-upload-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/file-upload-submission.service.spec.ts
@@ -1,10 +1,11 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { map, take } from 'rxjs/operators';
 import { FileUploadSubmissionService } from 'app/exercises/file-upload/participate/file-upload-submission.service';
 import { FileUploadSubmission } from 'app/entities/file-upload-submission.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('FileUploadSubmission Service', () => {
     let service: FileUploadSubmissionService;
@@ -13,8 +14,8 @@ describe('FileUploadSubmission Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: AccountService, useClass: MockAccountService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: AccountService, useClass: MockAccountService }],
         });
         service = TestBed.inject(FileUploadSubmissionService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/grading-system.service.spec.ts
+++ b/src/test/javascript/spec/service/grading-system.service.spec.ts
@@ -1,12 +1,12 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { GradingSystemService } from 'app/grading-system/grading-system.service';
 import { GradeType, GradingScale } from 'app/entities/grading-scale.model';
 import { take } from 'rxjs/operators';
 import { RouterTestingModule } from '@angular/router/testing';
 import { GradeDTO, GradeStep, GradeStepsDTO } from 'app/entities/grade-step.model';
 import { of } from 'rxjs';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { cloneDeep } from 'lodash-es';
 
 describe('Grading System Service', () => {
@@ -42,7 +42,8 @@ describe('Grading System Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, RouterTestingModule],
+            imports: [RouterTestingModule],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(GradingSystemService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/lecture.service.spec.ts
+++ b/src/test/javascript/spec/service/lecture.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { take } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
@@ -21,8 +21,10 @@ describe('Lecture Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/service/logs.service.spec.ts
+++ b/src/test/javascript/spec/service/logs.service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { LogsService } from 'app/admin/logs/logs.service';
 import { Log } from 'app/admin/logs/log.model';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Logs Service', () => {
     let service: LogsService;
@@ -9,7 +10,8 @@ describe('Logs Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
 
         service = TestBed.inject(LogsService);

--- a/src/test/javascript/spec/service/lti-configuration.service.spec.ts
+++ b/src/test/javascript/spec/service/lti-configuration.service.spec.ts
@@ -1,9 +1,9 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { LtiPlatformConfiguration } from 'app/admin/lti-configuration/lti-configuration.model';
 import { LtiConfigurationService } from 'app/admin/lti-configuration/lti-configuration.service';
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
 
 describe('LtiConfigurationService', () => {
     let service: LtiConfigurationService;
@@ -11,8 +11,8 @@ describe('LtiConfigurationService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [LtiConfigurationService],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), LtiConfigurationService],
         });
         service = TestBed.inject(LtiConfigurationService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/metis/answer-post.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/answer-post.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { AnswerPostService } from 'app/shared/metis/answer-post.service';
 import { metisAnswerPostToCreateUser1, metisResolvingAnswerPostUser1 } from '../../helpers/sample/metis-sample-data';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('AnswerPost Service', () => {
     let service: AnswerPostService;
@@ -10,7 +11,8 @@ describe('AnswerPost Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(AnswerPostService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/metis/metis.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/metis.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Post } from 'app/entities/metis/post.model';
 import { Course } from 'app/entities/course.model';
 import { MockPostService } from '../../helpers/mocks/service/mock-post.service';
@@ -42,7 +42,7 @@ import {
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
 import { ChannelDTO, ChannelSubType } from 'app/entities/metis/conversation/channel.model';
 import { ConversationType } from 'app/entities/metis/conversation/conversation.model';
-import { HttpHeaders, HttpResponse } from '@angular/common/http';
+import { HttpHeaders, HttpResponse, provideHttpClient } from '@angular/common/http';
 import { ConversationService } from 'app/shared/metis/conversations/conversation.service';
 import { NotificationService } from 'app/shared/notification/notification.service';
 import { MockNotificationService } from '../../helpers/mocks/service/mock-notification.service';
@@ -66,8 +66,10 @@ describe('Metis Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(SessionStorageService),
                 MockProvider(ConversationService),
                 { provide: NotificationService, useClass: MockNotificationService },

--- a/src/test/javascript/spec/service/metis/post.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/post.service.spec.ts
@@ -1,10 +1,11 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { Post } from 'app/entities/metis/post.model';
 import { PostService } from 'app/shared/metis/post.service';
 import { DisplayPriority } from 'app/shared/metis/metis.util';
 import { metisCourse, metisCoursePosts, metisPostExerciseUser1, metisPostToCreateUser1, metisTags } from '../../helpers/sample/metis-sample-data';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Post Service', () => {
     let service: PostService;
@@ -12,7 +13,8 @@ describe('Post Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(PostService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/metis/reaction.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/reaction.service.spec.ts
@@ -1,9 +1,10 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { Reaction } from 'app/entities/metis/reaction.model';
 import { ReactionService } from 'app/shared/metis/reaction.service';
 import { metisReactionToCreate, metisReactionUser2 } from '../../helpers/sample/metis-sample-data';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Reaction Service', () => {
     let service: ReactionService;
@@ -11,7 +12,8 @@ describe('Reaction Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(ReactionService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/modeling-assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/modeling-assessment.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { take } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
@@ -106,8 +106,10 @@ describe('ModelingAssessmentService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/service/modeling-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/modeling-exercise.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { ModelingExerciseService } from 'app/exercises/modeling/manage/modeling-exercise.service';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
@@ -16,6 +16,7 @@ import { Router } from '@angular/router';
 import { MockRouter } from '../helpers/mocks/mock-router';
 import { lastValueFrom } from 'rxjs';
 import { UMLDiagramType } from '@ls1intum/apollon';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ModelingExercise Service', () => {
     let service: ModelingExerciseService;
@@ -26,8 +27,10 @@ describe('ModelingExercise Service', () => {
     const categories = [JSON.stringify(category) as unknown as ExerciseCategory] as ExerciseCategory[];
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: LocalStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/service/modeling-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/modeling-submission.service.spec.ts
@@ -1,10 +1,11 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ModelingSubmission } from 'app/entities/modeling-submission.model';
 import { ModelingSubmissionService } from 'app/exercises/modeling/participate/modeling-submission.service';
 import { take } from 'rxjs/operators';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ModelingSubmission Service', () => {
     let service: ModelingSubmissionService;
@@ -13,8 +14,8 @@ describe('ModelingSubmission Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: AccountService, useClass: MockAccountService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: AccountService, useClass: MockAccountService }],
         });
         service = TestBed.inject(ModelingSubmissionService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/notification.service.spec.ts
+++ b/src/test/javascript/spec/service/notification.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController, TestRequest } from '@angular/common/http/testing';
+import { HttpTestingController, TestRequest, provideHttpClientTesting } from '@angular/common/http/testing';
 import { NotificationService } from 'app/shared/notification/notification.service';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
 import { TestBed } from '@angular/core/testing';
@@ -40,6 +40,7 @@ import { Post } from 'app/entities/metis/post.model';
 import { User } from 'app/core/user/user.model';
 import { ConversationType } from 'app/entities/metis/conversation/conversation.model';
 import { Channel } from 'app/entities/metis/conversation/channel.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Notification Service', () => {
     const resourceUrl = 'api/notifications';
@@ -155,9 +156,11 @@ describe('Notification Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, TranslateTestingModule, RouterTestingModule.withRoutes([])],
+            imports: [TranslateTestingModule, RouterTestingModule.withRoutes([])],
             declarations: [MockPipe(ArtemisTranslatePipe)],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: Router, useClass: MockRouter },

--- a/src/test/javascript/spec/service/participation.service.spec.ts
+++ b/src/test/javascript/spec/service/participation.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpHeaders, HttpResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpHeaders, HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { map, take } from 'rxjs/operators';
 import dayjs from 'dayjs/esm';
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
@@ -24,8 +24,10 @@ describe('Participation Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: Router, useClass: MockRouter },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/service/plagiarism-cases.service.spec.ts
+++ b/src/test/javascript/spec/service/plagiarism-cases.service.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { PlagiarismCasesService } from 'app/course/plagiarism-cases/shared/plagiarism-cases.service';
 import { take } from 'rxjs/operators';
@@ -11,6 +11,7 @@ import { ModelingSubmissionElement } from 'app/exercises/shared/plagiarism/types
 import { PlagiarismCase } from 'app/exercises/shared/plagiarism/types/PlagiarismCase';
 import { PlagiarismSubmission } from 'app/exercises/shared/plagiarism/types/PlagiarismSubmission';
 import { PlagiarismVerdict } from 'app/exercises/shared/plagiarism/types/PlagiarismVerdict';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Plagiarism Cases Service', () => {
     let service: PlagiarismCasesService;
@@ -71,7 +72,8 @@ describe('Plagiarism Cases Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(PlagiarismCasesService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/plagiarism-results.service.spec.ts
+++ b/src/test/javascript/spec/service/plagiarism-results.service.spec.ts
@@ -1,4 +1,5 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { PlagiarismResultsService } from 'app/course/plagiarism-cases/shared/plagiarism-results.service';
 
@@ -7,7 +8,8 @@ describe('Plagiarism Results Service', () => {
     let httpMock: HttpTestingController;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(PlagiarismResultsService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/profile.service.spec.ts
+++ b/src/test/javascript/spec/service/profile.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
 import { MockRouter } from '../helpers/mocks/mock-router';
@@ -9,6 +9,7 @@ import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 import { ProgrammingLanguage, ProjectType } from 'app/entities/programming/programming-exercise.model';
 import { BrowserFingerprintService } from 'app/shared/fingerprint/browser-fingerprint.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ProfileService', () => {
     let service: ProfileService;
@@ -268,8 +269,10 @@ describe('ProfileService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: Router, useClass: MockRouter },

--- a/src/test/javascript/spec/service/programming-exercise-participation.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise-participation.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { AccountService } from 'app/core/auth/account.service';
 import { of } from 'rxjs';
 import { ProgrammingExerciseParticipationService } from 'app/exercises/programming/manage/services/programming-exercise-participation.service';
@@ -7,6 +7,7 @@ import { Submission } from 'app/entities/submission.model';
 import { ArtemisTestModule } from '../test.module';
 import { Result } from 'app/entities/result.model';
 import dayjs from 'dayjs/esm';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ProgrammingExerciseParticipation Service', () => {
     let service: ProgrammingExerciseParticipationService;
@@ -20,8 +21,8 @@ describe('ProgrammingExerciseParticipation Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
-            providers: [],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/service/programming-exercise-task.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise-task.service.spec.ts
@@ -1,7 +1,7 @@
 import { ProgrammingExerciseTaskService } from 'app/exercises/programming/manage/grading/tasks/programming-exercise-task.service';
 import { TestBed } from '@angular/core/testing';
 import { ArtemisTestModule } from '../test.module';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { AlertService } from 'app/core/util/alert.service';
 import { ProgrammingExerciseGradingService } from 'app/exercises/programming/manage/services/programming-exercise-grading.service';
 import { ProgrammingExercise } from 'app/entities/programming/programming-exercise.model';
@@ -13,6 +13,7 @@ import { ProgrammingExerciseTask } from 'app/exercises/programming/manage/gradin
 import { ProgrammingExerciseServerSideTask } from 'app/entities/hestia/programming-exercise-task.model';
 import { ProgrammingExerciseTestCase, ProgrammingExerciseTestCaseType, Visibility } from 'app/entities/programming/programming-exercise-test-case.model';
 import { firstValueFrom, of } from 'rxjs';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ProgrammingExerciseTask Service', () => {
     let service: ProgrammingExerciseTaskService;
@@ -127,8 +128,10 @@ describe('ProgrammingExerciseTask Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 ProgrammingExerciseTaskService,
                 { provide: ProgrammingExerciseGradingService, useClass: MockProgrammingExerciseGradingService },
                 MockProvider(AlertService),

--- a/src/test/javascript/spec/service/programming-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
 import { ProgrammingExercise } from 'app/entities/programming/programming-exercise.model';
@@ -20,6 +20,7 @@ import { SolutionProgrammingExerciseParticipation } from 'app/entities/participa
 import { Submission } from 'app/entities/submission.model';
 import { ProgrammingExerciseGitDiffReport } from 'app/entities/hestia/programming-exercise-git-diff-report.model';
 import { ProgrammingExerciseGitDiffEntry } from 'app/entities/hestia/programming-exercise-git-diff-entry.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ProgrammingExercise Service', () => {
     let service: ProgrammingExerciseService;
@@ -30,8 +31,10 @@ describe('ProgrammingExercise Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: LocalStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/service/programming-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-submission.service.spec.ts
@@ -16,10 +16,10 @@ import { StudentParticipation } from 'app/entities/participation/student-partici
 import { MockParticipationWebsocketService } from '../helpers/mocks/service/mock-participation-websocket.service';
 import { ProgrammingExerciseParticipationService } from 'app/exercises/programming/manage/services/programming-exercise-participation.service';
 import { MockProgrammingExerciseParticipationService } from '../helpers/mocks/service/mock-programming-exercise-participation.service';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
 describe('ProgrammingSubmissionService', () => {
     let websocketService: JhiWebsocketService;
@@ -54,8 +54,10 @@ describe('ProgrammingSubmissionService', () => {
         result2 = { id: 32, submission: currentSubmission2 } as any;
 
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: JhiWebsocketService, useClass: MockWebsocketService },
                 { provide: ParticipationWebsocketService, useClass: MockParticipationWebsocketService },
                 { provide: ProgrammingExerciseParticipationService, useClass: MockProgrammingExerciseParticipationService },

--- a/src/test/javascript/spec/service/quiz-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/quiz-exercise.service.spec.ts
@@ -1,7 +1,7 @@
 import { TranslateService } from '@ngx-translate/core';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController, TestRequest } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
+import { HttpTestingController, TestRequest, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { SessionStorageService } from 'ngx-webstorage';
 import { QuizExerciseService } from 'app/exercises/quiz/manage/quiz-exercise.service';
 import { QuizBatch, QuizExercise, QuizStatus } from 'app/entities/quiz/quiz-exercise.model';
@@ -43,8 +43,10 @@ describe('QuizExercise Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },
             ],

--- a/src/test/javascript/spec/service/quiz-pool.service.spec.ts
+++ b/src/test/javascript/spec/service/quiz-pool.service.spec.ts
@@ -1,9 +1,10 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { QuizPoolService } from 'app/exercises/quiz/manage/quiz-pool.service';
 import { ArtemisTestModule } from '../test.module';
 import { QuizPool } from 'app/entities/quiz/quiz-pool.model';
 import { firstValueFrom } from 'rxjs';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('QuizPoolService', () => {
     let quizPoolService: QuizPoolService;
@@ -11,8 +12,8 @@ describe('QuizPoolService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
-            providers: [QuizPoolService],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting(), QuizPoolService],
         });
         quizPoolService = TestBed.inject(QuizPoolService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/quiz-re-evaluate.service.spec.ts
+++ b/src/test/javascript/spec/service/quiz-re-evaluate.service.spec.ts
@@ -1,16 +1,17 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { QuizReEvaluateService } from 'app/exercises/quiz/manage/re-evaluate/quiz-re-evaluate.service';
 import { ArtemisTestModule } from '../test.module';
 import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('QuizReEvaluateService', () => {
     let service: QuizReEvaluateService;
     let httpMock: HttpTestingController;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
-            providers: [QuizReEvaluateService],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting(), QuizReEvaluateService],
         });
         service = TestBed.inject(QuizReEvaluateService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/rating.service.spec.ts
+++ b/src/test/javascript/spec/service/rating.service.spec.ts
@@ -1,10 +1,11 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
 import { RatingService } from 'app/exercises/shared/rating/rating.service';
 import { Rating } from 'app/entities/rating.model';
 import { Result } from 'app/entities/result.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Rating Service', () => {
     let service: RatingService;
@@ -12,7 +13,8 @@ describe('Rating Service', () => {
     let elemDefault: Rating;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(RatingService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/result.service.spec.ts
+++ b/src/test/javascript/spec/service/result.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpClient, HttpResponse, provideHttpClient } from '@angular/common/http';
 import { TranslateService } from '@ngx-translate/core';
 import { MockProvider } from 'ng-mocks';
 import { of } from 'rxjs';
@@ -129,8 +129,10 @@ describe('ResultService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 ResultService,
                 ExerciseService,
                 ParticipationService,

--- a/src/test/javascript/spec/service/settings/ide-settings.service.spec.ts
+++ b/src/test/javascript/spec/service/settings/ide-settings.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { IdeSettingsService } from 'app/shared/user-settings/ide-preferences/ide-settings.service';
 import { Ide, IdeMappingDTO } from 'app/shared/user-settings/ide-preferences/ide.model';
 import { ProgrammingLanguage } from 'app/entities/programming/programming-exercise.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('IdeSettingsService', () => {
     let service: IdeSettingsService;
@@ -10,8 +11,8 @@ describe('IdeSettingsService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [IdeSettingsService],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), IdeSettingsService],
         });
         service = TestBed.inject(IdeSettingsService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/structured-grading-criterion.service.spec.ts
+++ b/src/test/javascript/spec/service/structured-grading-criterion.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { StructuredGradingCriterionService } from 'app/exercises/shared/structured-grading-criterion/structured-grading-criterion.service';
 import { Feedback } from 'app/entities/feedback.model';
 import { GradingInstruction } from 'app/exercises/shared/structured-grading-criterion/grading-instruction.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Structured Grading Criteria Service', () => {
     let service: StructuredGradingCriterionService;
@@ -11,7 +12,8 @@ describe('Structured Grading Criteria Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(StructuredGradingCriterionService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/submission-export.service.spec.ts
+++ b/src/test/javascript/spec/service/submission-export.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { ArtemisTestModule } from '../test.module';
 import { SubmissionExportService } from 'app/exercises/shared/submission-export/submission-export.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ExerciseType } from 'app/entities/exercise.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Submission Export Service', () => {
     let service: SubmissionExportService;
@@ -12,7 +13,8 @@ describe('Submission Export Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(SubmissionExportService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/submission-policy.service.spec.ts
+++ b/src/test/javascript/spec/service/submission-policy.service.spec.ts
@@ -1,9 +1,10 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { SubmissionPolicyService } from 'app/exercises/programming/manage/services/submission-policy.service';
 import { LockRepositoryPolicy, SubmissionPolicyType } from 'app/entities/submission-policy.model';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ProgrammingExercise } from 'app/entities/programming/programming-exercise.model';
 import { take } from 'rxjs/operators';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Submission Policy Service', () => {
     let httpMock: HttpTestingController;
@@ -15,8 +16,8 @@ describe('Submission Policy Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: SubmissionPolicyService, useClass: SubmissionPolicyService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: SubmissionPolicyService, useClass: SubmissionPolicyService }],
         });
         httpMock = TestBed.inject(HttpTestingController);
         submissionPolicyService = TestBed.inject(SubmissionPolicyService);

--- a/src/test/javascript/spec/service/submission-version.service.spec.ts
+++ b/src/test/javascript/spec/service/submission-version.service.spec.ts
@@ -1,9 +1,10 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ArtemisTestModule } from '../test.module';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TextSubmission } from 'app/entities/text/text-submission.model';
 import dayjs from 'dayjs/esm';
 import { SubmissionVersionService } from 'app/exercises/shared/submission-version/submission-version.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('SubmissionVersion Service', () => {
     let service: SubmissionVersionService;
@@ -12,7 +13,8 @@ describe('SubmissionVersion Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         }).compileComponents();
 
         service = TestBed.inject(SubmissionVersionService);

--- a/src/test/javascript/spec/service/submission.service.spec.ts
+++ b/src/test/javascript/spec/service/submission.service.spec.ts
@@ -2,7 +2,7 @@ import { SubmissionService, SubmissionWithComplaintDTO } from 'app/exercises/sha
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
 import { TranslateService } from '@ngx-translate/core';
@@ -10,7 +10,7 @@ import { MockTranslateService } from '../helpers/mocks/service/mock-translate.se
 import { TextSubmission } from 'app/entities/text/text-submission.model';
 import { Result } from 'app/entities/result.model';
 import { Feedback, FeedbackType } from 'app/entities/feedback.model';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { Submission, SubmissionType, getLatestSubmissionResult } from 'app/entities/submission.model';
 import dayjs from 'dayjs/esm';
 import { Complaint } from 'app/entities/complaint.model';
@@ -23,8 +23,10 @@ describe('Submission Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
+            imports: [ArtemisTestModule],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/service/text-assessment-analytics.service.spec.ts
+++ b/src/test/javascript/spec/service/text-assessment-analytics.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TextAssessmentEventType } from 'app/entities/text/text-assesment-event.model';
 import { TextAssessmentAnalytics } from 'app/exercises/text/assess/analytics/text-assesment-analytics.service';
 import { FeedbackType } from 'app/entities/feedback.model';
@@ -14,6 +14,7 @@ import { ActivatedRoute } from '@angular/router';
 import { TextAssessmentService } from 'app/exercises/text/assess/text-assessment.service';
 import { throwError } from 'rxjs';
 import { Location } from '@angular/common';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('TextAssessmentAnalytics Service', () => {
     let service: TextAssessmentAnalytics;
@@ -32,8 +33,10 @@ describe('TextAssessmentAnalytics Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: Router, useClass: MockRouter },
                 {
                     provide: Location,

--- a/src/test/javascript/spec/service/text-assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/text-assessment.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { TextSubmission } from 'app/entities/text/text-submission.model';
 import { TextAssessmentService } from 'app/exercises/text/assess/text-assessment.service';
@@ -17,6 +17,7 @@ import { NewStudentParticipationResolver, StudentParticipationResolver } from 'a
 import { TextSubmissionService } from 'app/exercises/text/participate/text-submission.service';
 import { of } from 'rxjs';
 import { ActivatedRouteSnapshot, convertToParamMap } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('TextAssessment Service', () => {
     let service: TextAssessmentService;
@@ -64,8 +65,8 @@ describe('TextAssessment Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: AccountService, useClass: MockAccountService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: AccountService, useClass: MockAccountService }],
         });
         service = TestBed.inject(TextAssessmentService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/text-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/text-exercise.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { TextExerciseService } from 'app/exercises/text/manage/text-exercise/text-exercise.service';
 import { TextExercise } from 'app/entities/text/text-exercise.model';
@@ -10,7 +10,7 @@ import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { Router } from '@angular/router';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
 import { MockRouter } from '../helpers/mocks/mock-router';
-import { HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { PlagiarismOptions } from 'app/exercises/shared/plagiarism/types/PlagiarismOptions';
 import dayjs from 'dayjs/esm';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
@@ -26,8 +26,10 @@ describe('TextExercise Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: Router, useClass: MockRouter },
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: LocalStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/service/text-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/text-submission.service.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { TextSubmissionService } from 'app/exercises/text/participate/text-submission.service';
 import { TextSubmission } from 'app/entities/text/text-submission.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('TextSubmission Service', () => {
     let service: TextSubmissionService;
@@ -14,8 +15,8 @@ describe('TextSubmission Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [{ provide: AccountService, useClass: MockAccountService }],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: AccountService, useClass: MockAccountService }],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/service/tutor-participation.service.spec.ts
+++ b/src/test/javascript/spec/service/tutor-participation.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { isEmpty, take } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
 import { TutorParticipationService } from 'app/exercises/shared/dashboards/tutor/tutor-participation.service';
@@ -9,6 +9,7 @@ import { Exercise } from 'app/entities/exercise.model';
 import { Course } from 'app/entities/course.model';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
 import { AccountService } from 'app/core/auth/account.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('Rating Service', () => {
     let service: TutorParticipationService;
@@ -19,8 +20,8 @@ describe('Rating Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, HttpClientTestingModule],
-            providers: [{ provide: AccountService, useClass: MockAccountService }],
+            imports: [ArtemisTestModule],
+            providers: [provideHttpClient(), provideHttpClientTesting(), { provide: AccountService, useClass: MockAccountService }],
         });
         service = TestBed.inject(TutorParticipationService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/user-route-access.service.spec.ts
+++ b/src/test/javascript/spec/service/user-route-access.service.spec.ts
@@ -9,7 +9,7 @@ import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Mutable } from '../helpers/mutable';
 import { mockedActivatedRouteSnapshot } from '../helpers/mocks/activated-route/mock-activated-route-snapshot';
 import { CourseExerciseDetailsComponent } from 'app/overview/exercise-details/course-exercise-details.component';
@@ -17,6 +17,7 @@ import { Authority } from 'app/shared/constants/authority.constants';
 import { StateStorageService } from 'app/core/auth/state-storage.service';
 import { MockProvider } from 'ng-mocks';
 import { AlertService } from 'app/core/util/alert.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('UserRouteAccessService', () => {
     const routeStateMock: any = { snapshot: {}, url: '/courses/20/exercises/4512' };
@@ -39,7 +40,6 @@ describe('UserRouteAccessService', () => {
         TestBed.configureTestingModule({
             imports: [
                 ArtemisTestModule,
-                HttpClientTestingModule,
                 RouterTestingModule.withRoutes([
                     {
                         path: route,
@@ -49,6 +49,8 @@ describe('UserRouteAccessService', () => {
             ],
             declarations: [CourseExerciseDetailsComponent],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 mockedActivatedRouteSnapshot(route),
                 { provide: AccountService, useClass: MockAccountService },
                 { provide: LocalStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/service/user.service.spec.ts
+++ b/src/test/javascript/spec/service/user.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { UserService } from 'app/core/user/user.service';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { Authority } from 'app/shared/constants/authority.constants';
 import { AdminUserService } from 'app/core/user/admin-user.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('User Service', () => {
     let service: UserService;
@@ -11,7 +12,8 @@ describe('User Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
+            imports: [],
+            providers: [provideHttpClient(), provideHttpClientTesting()],
         });
 
         service = TestBed.inject(UserService);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`HttpClientTestingModule` is marked as deprecated.

### Description
<!-- Describe your changes in detail -->
This PR replaces all occurrences of `HttpClientTestingModule` with `provideHttpClient()` and `provideHttpClientTesting()` as providers

### Steps for Testing
Client tests must all pass

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged
