### PR TITLE
`Development`: Remove deprecated router module in client tests

### DIFF
--- a/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ArtemisTestModule } from '../../test.module';
 import { MockComponent, MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
-import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule, convertToParamMap } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { SidePanelComponent } from 'app/shared/side-panel/side-panel.component';
@@ -57,7 +57,6 @@ import { MockTranslateValuesDirective } from '../../helpers/mocks/directive/mock
 import { PieChartModule } from '@swimlane/ngx-charts';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
-import { RouterTestingModule } from '@angular/router/testing';
 import { SortService } from 'app/shared/service/sort.service';
 import { ArtemisMarkdownService } from 'app/shared/markdown.service';
 import { AccountService } from 'app/core/auth/account.service';
@@ -211,7 +210,7 @@ describe('ExerciseAssessmentDashboardComponent', () => {
             }),
         },
     } as any as ActivatedRoute;
-    const imports = [ArtemisTestModule, RouterTestingModule.withRoutes([]), MockModule(PieChartModule)];
+    const imports = [ArtemisTestModule, MockModule(PieChartModule), RouterModule.forRoot([])];
 
     const declarations = [
         ExerciseAssessmentDashboardComponent,

--- a/src/test/javascript/spec/component/assessment-shared/assessment-header.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assessment-header.component.spec.ts
@@ -6,7 +6,6 @@ import { AssessmentHeaderComponent } from 'app/assessment/assessment-header/asse
 import { ArtemisTestModule } from '../../test.module';
 import { Result } from 'app/entities/result.model';
 import { AlertOverlayComponent } from 'app/shared/alert/alert-overlay.component';
-import { RouterTestingModule } from '@angular/router/testing';
 import { AssessmentWarningComponent } from 'app/assessment/assessment-warning/assessment-warning.component';
 import { MockProvider } from 'ng-mocks';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
@@ -25,6 +24,7 @@ import { MockTranslateValuesDirective } from '../../helpers/mocks/directive/mock
 import { NgbTooltipMocksModule } from '../../helpers/mocks/directive/ngbTooltipMocks.module';
 import { NgbAlertsMocksModule } from '../../helpers/mocks/directive/ngbAlertsMocks.module';
 import { AssessmentNote } from 'app/entities/assessment-note.model';
+import { RouterModule } from '@angular/router';
 
 describe('AssessmentHeaderComponent', () => {
     let component: AssessmentHeaderComponent;
@@ -49,7 +49,7 @@ describe('AssessmentHeaderComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule, NgbTooltipMocksModule, NgbAlertsMocksModule],
+            imports: [ArtemisTestModule, NgbTooltipMocksModule, NgbAlertsMocksModule, RouterModule.forRoot([])],
             declarations: [AssessmentHeaderComponent, AssessmentWarningComponent, AlertOverlayComponent, TranslateDirective, ArtemisTranslatePipe, MockTranslateValuesDirective],
             providers: [
                 {

--- a/src/test/javascript/spec/component/competencies/competency-management/competency-management.component.spec.ts
+++ b/src/test/javascript/spec/component/competencies/competency-management/competency-management.component.spec.ts
@@ -4,9 +4,8 @@ import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { of } from 'rxjs';
 import { Competency, CompetencyRelation, CompetencyWithTailRelationDTO, CourseCompetencyProgress, CourseCompetencyType } from 'app/entities/competency.model';
 import { CompetencyManagementComponent } from 'app/course/competencies/competency-management/competency-management.component';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 import { DeleteButtonDirective } from 'app/shared/delete-dialog/delete-button.directive';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TextUnit } from 'app/entities/lecture-unit/textUnit.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { ArtemisTestModule } from '../../../test.module';
@@ -47,7 +46,7 @@ describe('CompetencyManagementComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([]), NgbProgressbar],
+            imports: [ArtemisTestModule, NgbProgressbar],
             declarations: [
                 CompetencyManagementComponent,
                 MockHasAnyAuthorityDirective,
@@ -61,6 +60,7 @@ describe('CompetencyManagementComponent', () => {
                 MockDirective(DeleteButtonDirective),
             ],
             providers: [
+                provideRouter([]),
                 MockProvider(AccountService),
                 MockProvider(AlertService),
                 { provide: NgbModal, useClass: MockNgbModalService },

--- a/src/test/javascript/spec/component/competencies/competency-popover.component.spec.ts
+++ b/src/test/javascript/spec/component/competencies/competency-popover.component.spec.ts
@@ -3,11 +3,11 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockComponent, MockPipe } from 'ng-mocks';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CompetenciesPopoverComponent } from 'app/course/competencies/competencies-popover/competencies-popover.component';
 import { By } from '@angular/platform-browser';
 import { Component } from '@angular/core';
 import { NgbPopoverModule } from '@ng-bootstrap/ng-bootstrap';
+import { RouterModule } from '@angular/router';
 
 @Component({
     selector: 'jhi-statistics',
@@ -29,7 +29,7 @@ describe('CompetencyPopoverComponent', () => {
         TestBed.configureTestingModule({
             imports: [
                 NgbPopoverModule,
-                RouterTestingModule.withRoutes([
+                RouterModule.forRoot([
                     { path: 'courses/:courseId/competencies', component: DummyStatisticsComponent },
                     { path: 'course-management/:courseId/competency-management', component: DummyManagementComponent },
                 ]),

--- a/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
@@ -5,7 +5,6 @@ import { ComplaintsForTutorComponent } from 'app/complaints/complaints-for-tutor
 import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import { TextareaCounterComponent } from 'app/shared/textarea/textarea-counter.component';
 import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
-import { RouterTestingModule } from '@angular/router/testing';
 import { AlertService } from 'app/core/util/alert.service';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
@@ -18,6 +17,7 @@ import { of } from 'rxjs';
 import { Course } from 'app/entities/course.model';
 import { Exercise } from 'app/entities/exercise.model';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { provideRouter } from '@angular/router';
 
 describe('ComplaintsForTutorComponent', () => {
     let complaintsForTutorComponent: ComplaintsForTutorComponent;
@@ -29,7 +29,7 @@ describe('ComplaintsForTutorComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([]), FormsModule],
+            imports: [FormsModule],
             declarations: [
                 ComplaintsForTutorComponent,
                 MockPipe(ArtemisTranslatePipe),
@@ -37,7 +37,7 @@ describe('ComplaintsForTutorComponent', () => {
                 MockComponent(TextareaCounterComponent),
                 MockDirective(TranslateDirective),
             ],
-            providers: [MockProvider(ComplaintResponseService), MockProvider(ComplaintService), MockProvider(AlertService)],
+            providers: [provideRouter([]), MockProvider(ComplaintResponseService), MockProvider(ComplaintService), MockProvider(AlertService)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/course/course-exercises.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-exercises.component.spec.ts
@@ -6,7 +6,6 @@ import { of } from 'rxjs';
 import { Course } from 'app/entities/course.model';
 import { MockComponent, MockDirective, MockModule, MockPipe } from 'ng-mocks';
 import { OrionFilterDirective } from 'app/shared/orion/orion-filter.directive';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockHasAnyAuthorityDirective } from '../../helpers/mocks/directive/mock-has-any-authority.directive';
 import { TranslateService } from '@ngx-translate/core';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
@@ -15,7 +14,7 @@ import { CourseExercisesComponent } from 'app/overview/course-exercises/course-e
 import { CourseExerciseRowComponent } from 'app/overview/course-exercises/course-exercise-row.component';
 import { SidePanelComponent } from 'app/shared/side-panel/side-panel.component';
 import { MockTranslateService, TranslatePipeMock } from '../../helpers/mocks/service/mock-translate.service';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { Exercise } from 'app/entities/exercise.model';
 import dayjs from 'dayjs/esm';
@@ -45,7 +44,7 @@ describe('CourseExercisesComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, FormsModule, RouterTestingModule.withRoutes([]), MockModule(ReactiveFormsModule), MockDirective(TranslateDirective)],
+            imports: [ArtemisTestModule, FormsModule, RouterModule.forRoot([]), MockModule(ReactiveFormsModule), MockDirective(TranslateDirective)],
             declarations: [
                 CourseExercisesComponent,
                 SidebarComponent,

--- a/src/test/javascript/spec/component/course/course-management.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management.component.spec.ts
@@ -11,7 +11,6 @@ import { Course } from 'app/entities/course.model';
 import { GuidedTourService } from 'app/guided-tour/guided-tour.service';
 import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { OrionFilterDirective } from 'app/shared/orion/orion-filter.directive';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockHasAnyAuthorityDirective } from '../../helpers/mocks/directive/mock-has-any-authority.directive';
 import { TranslateService } from '@ngx-translate/core';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
@@ -25,6 +24,7 @@ import { SortByDirective } from 'app/shared/sort/sort-by.directive';
 import { SortDirective } from 'app/shared/sort/sort.directive';
 import { DocumentationButtonComponent } from 'app/shared/components/documentation-button/documentation-button.component';
 import { CourseAccessStorageService } from 'app/course/course-access-storage.service';
+import { provideRouter } from '@angular/router';
 
 describe('CourseManagementComponent', () => {
     let fixture: ComponentFixture<CourseManagementComponent>;
@@ -90,7 +90,7 @@ describe('CourseManagementComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([])],
+            imports: [ArtemisTestModule],
             declarations: [
                 CourseManagementComponent,
                 MockDirective(OrionFilterDirective),
@@ -104,6 +104,7 @@ describe('CourseManagementComponent', () => {
                 MockComponent(DocumentationButtonComponent),
             ],
             providers: [
+                provideRouter([]),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 MockProvider(TranslateService),

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -5,10 +5,9 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ArtemisTestModule } from '../../test.module';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
-import { ActivatedRoute, Params, Router } from '@angular/router';
+import { ActivatedRoute, Params, Router, RouterModule } from '@angular/router';
 import { Course, CourseInformationSharingConfiguration } from 'app/entities/course.model';
 import { MockComponent, MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockHasAnyAuthorityDirective } from '../../helpers/mocks/directive/mock-has-any-authority.directive';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { CourseExerciseRowComponent } from 'app/overview/course-exercises/course-exercise-row.component';
@@ -164,15 +163,9 @@ describe('CourseOverviewComponent', () => {
         router = new MockRouter();
 
         TestBed.configureTestingModule({
-            imports: [
-                ArtemisTestModule,
-                RouterTestingModule.withRoutes([]),
-                MockModule(MatSidenavModule),
-                MockModule(NgbTooltipModule),
-                MockModule(BrowserAnimationsModule),
-                NgbDropdownMocksModule,
-            ],
+            imports: [ArtemisTestModule, MockModule(MatSidenavModule), MockModule(NgbTooltipModule), MockModule(BrowserAnimationsModule), NgbDropdownMocksModule],
             declarations: [
+                RouterModule.forRoot([]),
                 CourseOverviewComponent,
                 MockDirective(MockHasAnyAuthorityDirective),
                 MockDirective(OrionFilterDirective),

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -163,9 +163,15 @@ describe('CourseOverviewComponent', () => {
         router = new MockRouter();
 
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, MockModule(MatSidenavModule), MockModule(NgbTooltipModule), MockModule(BrowserAnimationsModule), NgbDropdownMocksModule],
-            declarations: [
+            imports: [
                 RouterModule.forRoot([]),
+                ArtemisTestModule,
+                MockModule(MatSidenavModule),
+                MockModule(NgbTooltipModule),
+                MockModule(BrowserAnimationsModule),
+                NgbDropdownMocksModule,
+            ],
+            declarations: [
                 CourseOverviewComponent,
                 MockDirective(MockHasAnyAuthorityDirective),
                 MockDirective(OrionFilterDirective),

--- a/src/test/javascript/spec/component/course/course-statistics/course-management-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-statistics/course-management-statistics.component.spec.ts
@@ -3,7 +3,6 @@ import { ArtemisTestModule } from '../../../test.module';
 import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockHasAnyAuthorityDirective } from '../../../helpers/mocks/directive/mock-has-any-authority.directive';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
@@ -15,6 +14,7 @@ import { of } from 'rxjs';
 import { StatisticsAverageScoreGraphComponent } from 'app/shared/statistics-graph/statistics-average-score-graph.component';
 import { ExerciseType } from 'app/entities/exercise.model';
 import { DocumentationButtonComponent } from 'app/shared/components/documentation-button/documentation-button.component';
+import { RouterModule } from '@angular/router';
 
 describe('CourseManagementStatisticsComponent', () => {
     let fixture: ComponentFixture<CourseManagementStatisticsComponent>;
@@ -31,7 +31,7 @@ describe('CourseManagementStatisticsComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([])],
+            imports: [ArtemisTestModule, RouterModule.forRoot([])],
             declarations: [
                 CourseManagementStatisticsComponent,
                 MockComponent(StatisticsGraphComponent),

--- a/src/test/javascript/spec/component/course/course-unenrollment/course-unenrollment-modal.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-unenrollment/course-unenrollment-modal.component.spec.ts
@@ -12,9 +12,8 @@ import { By } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ReactiveFormsModule } from '@angular/forms';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
-import { Router } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 
 describe('CourseRegistrationButtonComponent', () => {
     let fixture: ComponentFixture<CourseUnenrollmentModalComponent>;
@@ -29,9 +28,9 @@ describe('CourseRegistrationButtonComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, ReactiveFormsModule, RouterTestingModule.withRoutes([])],
+            imports: [ArtemisTestModule, ReactiveFormsModule],
             declarations: [CourseUnenrollmentModalComponent, MockPipe(ArtemisTranslatePipe), MockPipe(ArtemisDatePipe)],
-            providers: [MockProvider(CourseManagementService), MockProvider(AlertService), MockProvider(TranslateService)],
+            providers: [provideRouter([]), MockProvider(CourseManagementService), MockProvider(AlertService), MockProvider(TranslateService)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/course/course.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course.component.spec.ts
@@ -1,9 +1,8 @@
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { Location } from '@angular/common';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { DueDateStat } from 'app/course/dashboards/due-date-stat.model';
 import { CourseForDashboardDTO } from 'app/course/manage/course-for-dashboard-dto';
@@ -93,7 +92,7 @@ describe('CoursesComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([{ path: 'courses/:courseId/exams/:examId', component: DummyComponent }])],
+            imports: [ArtemisTestModule, RouterModule.forRoot([{ path: 'courses/:courseId/exams/:examId', component: DummyComponent }])],
             declarations: [
                 CoursesComponent,
                 MockDirective(MockHasAnyAuthorityDirective),

--- a/src/test/javascript/spec/component/course/detail/course-detail-doughnut-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/course/detail/course-detail-doughnut-chart.component.spec.ts
@@ -1,4 +1,3 @@
-import { RouterTestingModule } from '@angular/router/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisTestModule } from '../../../test.module';
 import { CourseDetailDoughnutChartComponent } from 'app/course/manage/detail/course-detail-doughnut-chart.component';
@@ -7,6 +6,7 @@ import { MockModule, MockPipe } from 'ng-mocks';
 import { DoughnutChartType } from 'app/course/manage/detail/course-detail.component';
 import { Course } from 'app/entities/course.model';
 import { PieChartModule } from '@swimlane/ngx-charts';
+import { provideRouter } from '@angular/router';
 
 describe('CourseDetailDoughnutChartComponent', () => {
     let fixture: ComponentFixture<CourseDetailDoughnutChartComponent>;
@@ -19,8 +19,9 @@ describe('CourseDetailDoughnutChartComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([]), MockModule(PieChartModule)],
+            imports: [ArtemisTestModule, MockModule(PieChartModule)],
             declarations: [CourseDetailDoughnutChartComponent, MockPipe(ArtemisTranslatePipe)],
+            providers: [provideRouter([])],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exam/exam-scores/exam-scores-average-scores-graph.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/exam-scores/exam-scores-average-scores-graph.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { of } from 'rxjs';
@@ -16,6 +15,7 @@ import { NgxChartsSingleSeriesDataEntry } from 'app/shared/chart/ngx-charts-data
 import { ExerciseType } from 'app/entities/exercise.model';
 import { LocaleConversionService } from 'app/shared/service/locale-conversion.service';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { RouterModule } from '@angular/router';
 
 describe('ExamScoresAverageScoresGraphComponent', () => {
     let fixture: ComponentFixture<ExamScoresAverageScoresGraphComponent>;
@@ -55,7 +55,7 @@ describe('ExamScoresAverageScoresGraphComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([]), MockModule(BarChartModule)],
+            imports: [ArtemisTestModule, MockModule(BarChartModule), RouterModule.forRoot([])],
             declarations: [ExamScoresAverageScoresGraphComponent, MockPipe(ArtemisTranslatePipe), MockDirective(TranslateDirective)],
             providers: [
                 MockProvider(CourseManagementService, {

--- a/src/test/javascript/spec/component/exam/exam-update.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/exam-update.component.spec.ts
@@ -4,10 +4,9 @@ import { Component } from '@angular/core';
 import cloneDeep from 'lodash-es/cloneDeep';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute, Router, UrlSegment } from '@angular/router';
+import { ActivatedRoute, Router, UrlSegment, provideRouter } from '@angular/router';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { HttpClientModule, HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpResponse, provideHttpClient } from '@angular/common/http';
 import { MockComponent, MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 
 import { ExamUpdateComponent, prepareExamForImport } from 'app/exam/manage/exams/exam-update.component';
@@ -43,6 +42,7 @@ import { TitleChannelNameComponent } from 'app/shared/form/title-channel-name/ti
 import { UMLDiagramType } from '@ls1intum/apollon';
 import { TextExercise } from 'app/entities/text/text-exercise.model';
 import { MarkdownEditorMonacoComponent } from 'app/shared/markdown-editor/monaco/markdown-editor-monaco.component';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 @Component({
     template: '',
@@ -73,7 +73,7 @@ describe('ExamUpdateComponent', () => {
     describe('create and edit exams', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [RouterTestingModule.withRoutes(routes), MockModule(NgbModule), TranslateModule.forRoot(), FormsModule, HttpClientModule, ArtemisExamModePickerModule],
+                imports: [MockModule(NgbModule), TranslateModule.forRoot(), FormsModule, ArtemisExamModePickerModule],
                 declarations: [
                     ExamUpdateComponent,
                     MockComponent(FormDateTimePickerComponent),
@@ -89,6 +89,9 @@ describe('ExamUpdateComponent', () => {
                     MockComponent(TitleChannelNameComponent),
                 ],
                 providers: [
+                    provideHttpClient(),
+                    provideHttpClientTesting(),
+                    provideRouter(routes),
                     { provide: LocalStorageService, useClass: MockSyncStorage },
                     { provide: SessionStorageService, useClass: MockSyncStorage },
                     MockDirective(TranslateDirective),
@@ -601,7 +604,7 @@ describe('ExamUpdateComponent', () => {
 
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [RouterTestingModule.withRoutes(routes), MockModule(NgbModule), TranslateModule.forRoot(), FormsModule, HttpClientModule, ArtemisExamModePickerModule],
+                imports: [MockModule(NgbModule), TranslateModule.forRoot(), FormsModule, ArtemisExamModePickerModule],
                 declarations: [
                     ExamUpdateComponent,
                     ExamExerciseImportComponent,
@@ -621,6 +624,9 @@ describe('ExamUpdateComponent', () => {
                     MockComponent(TitleChannelNameComponent),
                 ],
                 providers: [
+                    provideHttpClient(),
+                    provideHttpClientTesting(),
+                    provideRouter(routes),
                     { provide: LocalStorageService, useClass: MockSyncStorage },
                     { provide: SessionStorageService, useClass: MockSyncStorage },
                     MockDirective(TranslateDirective),

--- a/src/test/javascript/spec/component/exam/manage/exam-students-attendance-check.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-students-attendance-check.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, Router, UrlSegment, convertToParamMap } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router, UrlSegment, convertToParamMap, provideRouter } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { User } from 'app/core/user/user.model';
 import { Course } from 'app/entities/course.model';
@@ -12,9 +11,8 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { SortService } from 'app/shared/service/sort.service';
 import { SortDirective } from 'app/shared/sort/sort.directive';
 import { HttpResponse } from '@angular/common/http';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { MockDirective, MockPipe } from 'ng-mocks';
-import { Observable } from 'rxjs';
 import { MockRouter } from '../../../helpers/mocks/mock-router';
 import { MockNgbModalService } from '../../../helpers/mocks/service/mock-ngb-modal.service';
 import { MockTranslateService } from '../../../helpers/mocks/service/mock-translate.service';
@@ -43,9 +41,10 @@ describe('ExamStudentsAttendanceCheckComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule],
+            imports: [ArtemisTestModule],
             declarations: [ExamStudentsAttendanceCheckComponent, MockDirective(TranslateDirective), MockDirective(SortDirective), MockPipe(ArtemisTranslatePipe)],
             providers: [
+                provideRouter([]),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: NgbModal, useClass: MockNgbModalService },
                 { provide: Router, useClass: MockRouter },

--- a/src/test/javascript/spec/component/exam/manage/exam-students.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-students.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, UrlSegment, convertToParamMap } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, UrlSegment, convertToParamMap, provideRouter } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { User } from 'app/core/user/user.model';
@@ -61,7 +60,7 @@ describe('ExamStudentsComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, NgxDatatableModule, RouterTestingModule],
+            imports: [ArtemisTestModule, NgxDatatableModule],
             declarations: [
                 ExamStudentsComponent,
                 MockComponent(UsersImportButtonComponent),
@@ -71,10 +70,7 @@ describe('ExamStudentsComponent', () => {
                 MockDirective(DeleteButtonDirective),
                 MockPipe(ArtemisTranslatePipe),
             ],
-            providers: [
-                { provide: TranslateService, useClass: MockTranslateService },
-                { provide: ActivatedRoute, useValue: route },
-            ],
+            providers: [provideRouter([]), { provide: TranslateService, useClass: MockTranslateService }, { provide: ActivatedRoute, useValue: route }],
         }).compileComponents();
 
         fixture = TestBed.createComponent(ExamStudentsComponent);

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-checklist-exercisegroup-table.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-checklist-exercisegroup-table.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { Component } from '@angular/core';
 import { HasAnyAuthorityDirective } from 'app/shared/auth/has-any-authority.directive';
@@ -13,6 +12,7 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ExerciseGroupVariantColumn } from 'app/entities/exercise-group-variant-column.model';
 import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 @Component({
     template: '',
@@ -58,17 +58,7 @@ describe('ExamChecklistExerciseGroupTableComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [
-                RouterTestingModule.withRoutes([
-                    { path: 'course-management/:courseId/exams/:examId/edit', component: DummyComponent },
-                    { path: 'course-management/:courseId/exams/:examId/exercise-groups', component: DummyComponent },
-                    { path: 'course-management/:courseId/exams/:examId/assessment-dashboard', component: DummyComponent },
-                    { path: 'course-management/:courseId/exams/:examId/scores', component: DummyComponent },
-                    { path: 'course-management/:courseId/exams/:examId/student-exams', component: DummyComponent },
-                    { path: 'course-management/:courseId/exams/:examId/test-runs', component: DummyComponent },
-                    { path: 'course-management/:courseId/exams/:examId/students', component: DummyComponent },
-                ]),
-            ],
+            imports: [],
             declarations: [
                 DummyComponent,
                 MockPipe(ArtemisTranslatePipe),
@@ -80,7 +70,19 @@ describe('ExamChecklistExerciseGroupTableComponent', () => {
                 ProgressBarComponent,
                 MockComponent(FaIconComponent),
             ],
-            providers: [provideHttpClient(), provideHttpClientTesting()],
+            providers: [
+                provideRouter([
+                    { path: 'course-management/:courseId/exams/:examId/edit', component: DummyComponent },
+                    { path: 'course-management/:courseId/exams/:examId/exercise-groups', component: DummyComponent },
+                    { path: 'course-management/:courseId/exams/:examId/assessment-dashboard', component: DummyComponent },
+                    { path: 'course-management/:courseId/exams/:examId/scores', component: DummyComponent },
+                    { path: 'course-management/:courseId/exams/:examId/student-exams', component: DummyComponent },
+                    { path: 'course-management/:courseId/exams/:examId/test-runs', component: DummyComponent },
+                    { path: 'course-management/:courseId/exams/:examId/students', component: DummyComponent },
+                ]),
+                provideHttpClient(),
+                provideHttpClientTesting(),
+            ],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
@@ -3,8 +3,7 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed, discardPeriodicTasks, fakeAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ActivatedRoute, Data, Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Data, Router, RouterModule } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { AccountService } from 'app/core/auth/account.service';
 import { Course } from 'app/entities/course.model';
@@ -62,7 +61,7 @@ describe('ExamDetailComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
-                RouterTestingModule.withRoutes([
+                RouterModule.forRoot([
                     { path: 'course-management/:courseId/exams/:examId/edit', component: DummyComponent },
                     { path: 'course-management/:courseId/exams/:examId/exercise-groups', component: DummyComponent },
                     {

--- a/src/test/javascript/spec/component/exam/manage/exercise-groups/exercise-groups.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exercise-groups/exercise-groups.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { faCheckDouble, faFileUpload, faFont, faKeyboard, faProjectDiagram } from '@fortawesome/free-solid-svg-icons';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { AlertService } from 'app/core/util/alert.service';
@@ -59,7 +58,7 @@ describe('Exercise Groups Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule],
+            imports: [ArtemisTestModule],
             declarations: [
                 ExerciseGroupsComponent,
                 MockComponent(ExamExerciseRowButtonsComponent),
@@ -74,6 +73,7 @@ describe('Exercise Groups Component', () => {
                 MockDirective(TranslateDirective),
             ],
             providers: [
+                provideRouter([]),
                 MockProvider(AlertService),
                 { provide: ActivatedRoute, useValue: route },
                 { provide: Router, useClass: MockRouter },

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail-table-row.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail-table-row.component.spec.ts
@@ -4,7 +4,6 @@ import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TranslateModule } from '@ngx-translate/core';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
@@ -24,6 +23,7 @@ import { AlertService } from 'app/core/util/alert.service';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { faCheckDouble, faFileUpload, faKeyboard, faProjectDiagram } from '@fortawesome/free-solid-svg-icons';
 import { UMLDiagramType } from '@ls1intum/apollon';
+import { provideRouter } from '@angular/router';
 
 describe('StudentExamDetailTableRowComponent', () => {
     let studentExamDetailTableRowComponentFixture: ComponentFixture<StudentExamDetailTableRowComponent>;
@@ -45,9 +45,9 @@ describe('StudentExamDetailTableRowComponent', () => {
         exercise.studentParticipations = [studentParticipation];
 
         return TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([]), NgbModule, NgxDatatableModule, ReactiveFormsModule, TranslateModule.forRoot()],
+            imports: [NgbModule, NgxDatatableModule, ReactiveFormsModule, TranslateModule.forRoot()],
             declarations: [StudentExamDetailTableRowComponent, MockComponent(DataTableComponent), MockTranslateValuesDirective, MockPipe(ArtemisTranslatePipe)],
-            providers: [MockProvider(AlertService), MockDirective(TranslateDirective)],
+            providers: [provideRouter([]), MockProvider(AlertService), MockDirective(TranslateDirective)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
@@ -8,7 +8,7 @@ import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { StudentExamService } from 'app/exam/manage/student-exams/student-exam.service';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
-import { ActivatedRoute, provideRouter } from '@angular/router';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { NgbModal, NgbModalRef, NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TranslateModule } from '@ngx-translate/core';
@@ -127,7 +127,7 @@ describe('StudentExamDetailComponent', () => {
         } as StudentExamWithGradeDTO;
 
         await TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, NgbModule, NgxDatatableModule, ReactiveFormsModule, TranslateModule.forRoot()],
+            imports: [ArtemisTestModule, NgbModule, NgxDatatableModule, ReactiveFormsModule, TranslateModule.forRoot(), RouterModule.forRoot([])],
             declarations: [
                 StudentExamDetailComponent,
                 MockComponent(DataTableComponent),
@@ -141,7 +141,6 @@ describe('StudentExamDetailComponent', () => {
                 StudentExamDetailTableRowComponent,
             ],
             providers: [
-                provideRouter([]),
                 provideHttpClient(),
                 provideHttpClientTesting(),
                 MockProvider(StudentExamService, {

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
@@ -8,11 +8,10 @@ import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { StudentExamService } from 'app/exam/manage/student-exams/student-exam.service';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 import { NgbModal, NgbModalRef, NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TranslateModule } from '@ngx-translate/core';
-import { RouterTestingModule } from '@angular/router/testing';
 import { NgForm, NgModel, ReactiveFormsModule } from '@angular/forms';
 import { Exercise } from 'app/entities/exercise.model';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
@@ -128,7 +127,7 @@ describe('StudentExamDetailComponent', () => {
         } as StudentExamWithGradeDTO;
 
         await TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([]), NgbModule, NgxDatatableModule, ReactiveFormsModule, TranslateModule.forRoot()],
+            imports: [ArtemisTestModule, NgbModule, NgxDatatableModule, ReactiveFormsModule, TranslateModule.forRoot()],
             declarations: [
                 StudentExamDetailComponent,
                 MockComponent(DataTableComponent),
@@ -142,6 +141,7 @@ describe('StudentExamDetailComponent', () => {
                 StudentExamDetailTableRowComponent,
             ],
             providers: [
+                provideRouter([]),
                 provideHttpClient(),
                 provideHttpClientTesting(),
                 MockProvider(StudentExamService, {

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exams.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exams.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, Params, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, Params, convertToParamMap, provideRouter } from '@angular/router';
 import { StudentExamsComponent } from 'app/exam/manage/student-exams/student-exams.component';
 import { ExamManagementService } from 'app/exam/manage/exam-management.service';
 import { MockComponent, MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
@@ -7,7 +7,6 @@ import { StudentExamService } from 'app/exam/manage/student-exams/student-exam.s
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { TranslateService } from '@ngx-translate/core';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ArtemisDurationFromSecondsPipe } from 'app/shared/pipes/artemis-duration-from-seconds.pipe';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { MockLocalStorageService } from '../../../../helpers/mocks/service/mock-local-storage.service';
@@ -49,6 +48,7 @@ describe('StudentExamsComponent', () => {
     const referenceDateNow = dayjs();
 
     const providers = [
+        provideRouter([]),
         MockProvider(ExamManagementService, {
             find: () => {
                 return of(
@@ -208,7 +208,7 @@ describe('StudentExamsComponent', () => {
         studentExams = [studentExamOne, studentExamTwo];
 
         return TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([]), MockModule(NgxDatatableModule)],
+            imports: [MockModule(NgxDatatableModule)],
             declarations: [
                 StudentExamsComponent,
                 MockComponent(StudentExamStatusComponent),

--- a/src/test/javascript/spec/component/exam/participate/exam-start-information/exam-start-information.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-start-information/exam-start-information.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { User } from 'app/core/user/user.model';
 import { Exam } from 'app/entities/exam/exam.model';
 import { StudentExam } from 'app/entities/student-exam.model';
@@ -15,6 +14,7 @@ import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
 import { ArtemisExamSharedModule } from 'app/exam/shared/exam-shared.module';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { provideRouter } from '@angular/router';
 
 let fixture: ComponentFixture<ExamStartInformationComponent>;
 let component: ExamStartInformationComponent;
@@ -40,7 +40,7 @@ describe('ExamStartInformationComponent', () => {
         studentExam = { id: 1, exam, user, workingTime: 60, submitted: true } as StudentExam;
 
         return TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([]), ArtemisSharedModule, ArtemisSharedComponentModule, ArtemisExamSharedModule],
+            imports: [ArtemisSharedModule, ArtemisSharedComponentModule, ArtemisExamSharedModule],
             declarations: [
                 ExamStartInformationComponent,
                 MockComponent(StudentExamWorkingTimeComponent),
@@ -50,6 +50,7 @@ describe('ExamStartInformationComponent', () => {
                 MockPipe(ArtemisDatePipe),
                 MockPipe(ArtemisDurationFromSecondsPipe),
             ],
+            providers: [provideRouter([])],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exam/participate/exercises/quiz-exam-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exercises/quiz-exam-submission.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { AnswerOption } from 'app/entities/quiz/answer-option.model';
 import { DragAndDropMapping } from 'app/entities/quiz/drag-and-drop-mapping.model';
 import { DragAndDropQuestion } from 'app/entities/quiz/drag-and-drop-question.model';
@@ -25,6 +24,7 @@ import { SubmissionVersion } from 'app/entities/submission-version.model';
 import { ModelingSubmission } from 'app/entities/modeling-submission.model';
 import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
 import { Course } from 'app/entities/course.model';
+import { provideRouter } from '@angular/router';
 
 describe('QuizExamSubmissionComponent', () => {
     let fixture: ComponentFixture<QuizExamSubmissionComponent>;
@@ -47,7 +47,7 @@ describe('QuizExamSubmissionComponent', () => {
         shortAnswerQuestion.id = 3;
 
         return TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([]), NgbTooltipMocksModule],
+            imports: [NgbTooltipMocksModule],
             declarations: [
                 QuizExamSubmissionComponent,
                 MockPipe(ArtemisTranslatePipe),
@@ -56,7 +56,7 @@ describe('QuizExamSubmissionComponent', () => {
                 MockComponent(DragAndDropQuestionComponent),
                 MockComponent(ShortAnswerQuestionComponent),
             ],
-            providers: [MockProvider(ArtemisQuizService)],
+            providers: [provideRouter([]), MockProvider(ArtemisQuizService)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exam/participate/general-information/exam-general-information.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/general-information/exam-general-information.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { User } from 'app/core/user/user.model';
 import { Exam } from 'app/entities/exam/exam.model';
 import { StudentExam } from 'app/entities/student-exam.model';
@@ -35,7 +35,6 @@ describe('ExamGeneralInformationComponent', () => {
         studentExam = { id: 1, exam, user, workingTime: 60, submitted: true } as StudentExam;
 
         return TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([])],
             declarations: [
                 ExamGeneralInformationComponent,
                 MockComponent(StudentExamWorkingTimeComponent),
@@ -43,6 +42,7 @@ describe('ExamGeneralInformationComponent', () => {
                 MockPipe(ArtemisDatePipe),
                 MockPipe(ArtemisDurationFromSecondsPipe),
             ],
+            providers: [provideRouter([])],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exam/participate/summary/exam-result-summary.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/summary/exam-result-summary.component.spec.ts
@@ -1,8 +1,7 @@
-import { HttpClientModule, HttpResponse } from '@angular/common/http';
+import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ComplaintsStudentViewComponent } from 'app/complaints/complaints-for-students/complaints-student-view.component';
 import { ThemeService } from 'app/core/theme/theme.service';
@@ -56,6 +55,7 @@ import { AlertService } from 'app/core/util/alert.service';
 import { ProgrammingExerciseExampleSolutionRepoDownloadComponent } from 'app/exercises/programming/shared/actions/programming-exercise-example-solution-repo-download.component';
 import * as ExamUtils from 'app/exam/participate/exam.utils';
 import { CollapsibleCardComponent } from 'app/exam/participate/summary/collapsible-card.component';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 let fixture: ComponentFixture<ExamResultSummaryComponent>;
 let component: ExamResultSummaryComponent;
@@ -172,7 +172,7 @@ const gradeInfo: StudentExamWithGradeDTO = {
 function sharedSetup(url: string[]) {
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([]), HttpClientModule, NgbCollapseMocksModule],
+            imports: [NgbCollapseMocksModule],
             declarations: [
                 ExamResultSummaryComponent,
                 MockComponent(TestRunRibbonComponent),
@@ -197,6 +197,9 @@ function sharedSetup(url: string[]) {
                 MockComponent(CollapsibleCardComponent),
             ],
             providers: [
+                provideRouter([]),
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 {
                     provide: ActivatedRoute,
                     useValue: {

--- a/src/test/javascript/spec/component/exam/participate/summary/result-overview/exam-result-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/summary/result-overview/exam-result-overview.component.spec.ts
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs/esm';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockComponent, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { User } from 'app/core/user/user.model';
@@ -23,6 +22,7 @@ import { ExerciseResult, StudentExamWithGradeDTO } from 'app/exam/exam-scores/ex
 import { GradingKeyTableComponent } from 'app/grading-system/grading-key-overview/grading-key/grading-key-table.component';
 import { CollapsibleCardComponent } from 'app/exam/participate/summary/collapsible-card.component';
 import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 let fixture: ComponentFixture<ExamResultOverviewComponent>;
 let component: ExamResultOverviewComponent;
@@ -129,7 +129,7 @@ const textExerciseResult = {
 describe('ExamResultOverviewComponent', () => {
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([]), MockModule(NgbModule)],
+            imports: [MockModule(NgbModule)],
             declarations: [
                 ExamResultOverviewComponent,
                 MockComponent(FaIconComponent),
@@ -137,7 +137,7 @@ describe('ExamResultOverviewComponent', () => {
                 MockComponent(GradingKeyTableComponent),
                 MockComponent(CollapsibleCardComponent),
             ],
-            providers: [provideHttpClient(), provideHttpClientTesting(), MockProvider(ExerciseService)],
+            providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting(), MockProvider(ExerciseService)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/exam/test-run/test-run-management.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/test-run/test-run-management.component.spec.ts
@@ -1,8 +1,7 @@
-import { HttpClientModule, HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpResponse, provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, RouterModule, convertToParamMap } from '@angular/router';
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -29,6 +28,7 @@ import { MockTranslateService } from '../../../helpers/mocks/service/mock-transl
 import { SortDirective } from 'app/shared/sort/sort.directive';
 import { AlertService } from 'app/core/util/alert.service';
 import { NgbTooltipMocksModule } from '../../../helpers/mocks/directive/ngbTooltipMocks.module';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 describe('Test Run Management Component', () => {
     let component: TestRunManagementComponent;
@@ -49,7 +49,7 @@ describe('Test Run Management Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([]), FontAwesomeTestingModule, TranslateModule.forRoot(), HttpClientModule, NgbTooltipMocksModule],
+            imports: [RouterModule.forRoot([]), FontAwesomeTestingModule, TranslateModule.forRoot(), NgbTooltipMocksModule],
 
             declarations: [
                 TestRunManagementComponent,
@@ -61,6 +61,8 @@ describe('Test Run Management Component', () => {
                 MockDirective(TranslateDirective),
             ],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/component/exercises/shared/exercise-scores/exercise-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/exercise-scores/exercise-scores.component.spec.ts
@@ -1,8 +1,7 @@
 import { HttpResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { NgModel } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { AssessmentType } from 'app/entities/assessment-type.model';
@@ -121,7 +120,7 @@ describe('Exercise Scores Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([]), MockModule(NgxDatatableModule)],
+            imports: [ArtemisTestModule, MockModule(NgxDatatableModule)],
             declarations: [
                 ExerciseScoresComponent,
                 MockComponent(ExerciseScoresExportButtonComponent),
@@ -137,6 +136,7 @@ describe('Exercise Scores Component', () => {
                 MockDirective(NgModel),
             ],
             providers: [
+                provideRouter([]),
                 { provide: ExerciseService, useClass: MockExerciseService },
                 { provide: ActivatedRoute, useValue: route },
                 { provide: ResultService, useClass: MockResultService },

--- a/src/test/javascript/spec/component/exercises/shared/exercise-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/exercise-statistics.component.spec.ts
@@ -3,7 +3,6 @@ import { ArtemisTestModule } from '../../../test.module';
 import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockHasAnyAuthorityDirective } from '../../../helpers/mocks/directive/mock-has-any-authority.directive';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
@@ -20,6 +19,7 @@ import { HttpResponse } from '@angular/common/http';
 import { Exercise } from 'app/entities/exercise.model';
 import { ExerciseDetailStatisticsComponent } from 'app/exercises/shared/statistics/exercise-detail-statistics.component';
 import { TranslateService } from '@ngx-translate/core';
+import { RouterModule } from '@angular/router';
 
 describe('ExerciseStatisticsComponent', () => {
     let fixture: ComponentFixture<ExerciseStatisticsComponent>;
@@ -53,7 +53,7 @@ describe('ExerciseStatisticsComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([])],
+            imports: [ArtemisTestModule, RouterModule.forRoot([])],
             declarations: [
                 ExerciseStatisticsComponent,
                 MockComponent(StatisticsGraphComponent),

--- a/src/test/javascript/spec/component/file-upload-assessment/file-upload-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-assessment/file-upload-assessment.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { JhiLanguageHelper } from 'app/core/language/language.helper';
 import { AccountService } from 'app/core/auth/account.service';
 import { of, throwError } from 'rxjs';
@@ -8,7 +7,7 @@ import dayjs from 'dayjs/esm';
 import { ArtemisTestModule } from '../../test.module';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockComponent, MockPipe } from 'ng-mocks';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FileUploadAssessmentComponent } from 'app/exercises/file-upload/assess/file-upload-assessment.component';
 import { DebugElement } from '@angular/core';
 import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
@@ -72,7 +71,7 @@ describe('FileUploadAssessmentComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([routes[0]])],
+            imports: [ArtemisTestModule, RouterModule.forRoot([routes[0]])],
             declarations: [
                 FileUploadAssessmentComponent,
                 MockComponent(UpdatingResultComponent),

--- a/src/test/javascript/spec/component/file-upload-exercise/file-upload-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-exercise/file-upload-exercise-detail.component.spec.ts
@@ -7,7 +7,6 @@ import { FileUploadExerciseDetailComponent } from 'app/exercises/file-upload/man
 import { MockFileUploadExerciseService, fileUploadExercise } from '../../helpers/mocks/service/mock-file-upload-exercise.service';
 import { JhiLanguageHelper } from 'app/core/language/language.helper';
 import { AlertService } from 'app/core/util/alert.service';
-import {} from '@angular/router/testing';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { FileUploadExerciseService } from 'app/exercises/file-upload/manage/file-upload-exercise.service';

--- a/src/test/javascript/spec/component/file-upload-exercise/file-upload-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-exercise/file-upload-exercise-detail.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { of } from 'rxjs';
 import { ArtemisTestModule } from '../../test.module';
@@ -7,7 +7,7 @@ import { FileUploadExerciseDetailComponent } from 'app/exercises/file-upload/man
 import { MockFileUploadExerciseService, fileUploadExercise } from '../../helpers/mocks/service/mock-file-upload-exercise.service';
 import { JhiLanguageHelper } from 'app/core/language/language.helper';
 import { AlertService } from 'app/core/util/alert.service';
-import { RouterTestingModule } from '@angular/router/testing';
+import {} from '@angular/router/testing';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { FileUploadExerciseService } from 'app/exercises/file-upload/manage/file-upload-exercise.service';
@@ -58,7 +58,7 @@ describe('FileUploadExercise Management Detail Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule],
+            imports: [ArtemisTestModule],
             declarations: [
                 FileUploadExerciseDetailComponent,
                 MockPipe(HtmlForMarkdownPipe),
@@ -68,6 +68,7 @@ describe('FileUploadExercise Management Detail Component', () => {
                 MockComponent(DocumentationButtonComponent),
             ],
             providers: [
+                provideRouter([]),
                 JhiLanguageHelper,
                 AlertService,
                 { provide: ActivatedRoute, useValue: route },

--- a/src/test/javascript/spec/component/file-upload-submission/file-upload-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-submission/file-upload-submission.component.spec.ts
@@ -1,12 +1,11 @@
 import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { AccountService } from 'app/core/auth/account.service';
 import { ArtemisTestModule } from '../../test.module';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockParticipationWebsocketService } from '../../helpers/mocks/service/mock-participation-websocket.service';
 import { MockComponent, MockPipe } from 'ng-mocks';
 import { AlertService } from 'app/core/util/alert.service';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
@@ -54,7 +53,7 @@ describe('FileUploadSubmissionComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, NgxDatatableModule, TranslateModule.forRoot(), RouterTestingModule.withRoutes([routes[0]])],
+            imports: [ArtemisTestModule, NgxDatatableModule, TranslateModule.forRoot(), RouterModule.forRoot([routes[0]])],
             declarations: [
                 FileUploadSubmissionComponent,
                 MockComponent(ComplaintsForTutorComponent),

--- a/src/test/javascript/spec/component/footer/footer.component.spec.ts
+++ b/src/test/javascript/spec/component/footer/footer.component.spec.ts
@@ -12,8 +12,8 @@ describe('FooterComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [FooterComponent, MockPipe(ArtemisTranslatePipe), RouterModule.forRoot([])],
-            imports: [ArtemisTestModule, TranslateModule.forRoot()],
+            declarations: [FooterComponent, MockPipe(ArtemisTranslatePipe)],
+            imports: [ArtemisTestModule, TranslateModule.forRoot(), RouterModule.forRoot([])],
             providers: [],
         }).compileComponents();
     });

--- a/src/test/javascript/spec/component/footer/footer.component.spec.ts
+++ b/src/test/javascript/spec/component/footer/footer.component.spec.ts
@@ -1,10 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { FooterComponent } from 'app/shared/layouts/footer/footer.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { ArtemisTestModule } from '../../test.module';
 import { MockPipe } from 'ng-mocks';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { RouterModule } from '@angular/router';
 
 describe('FooterComponent', () => {
     let component: FooterComponent;
@@ -12,8 +12,9 @@ describe('FooterComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [FooterComponent, MockPipe(ArtemisTranslatePipe)],
-            imports: [ArtemisTestModule, RouterTestingModule, TranslateModule.forRoot()],
+            declarations: [FooterComponent, MockPipe(ArtemisTranslatePipe), RouterModule.forRoot([])],
+            imports: [ArtemisTestModule, TranslateModule.forRoot()],
+            providers: [],
         }).compileComponents();
     });
 

--- a/src/test/javascript/spec/component/grading-system/grading-system.component.spec.ts
+++ b/src/test/javascript/spec/component/grading-system/grading-system.component.spec.ts
@@ -6,10 +6,9 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { GradingSystemInfoModalComponent } from 'app/grading-system/grading-system-info-modal/grading-system-info-modal.component';
 import { NgModel } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs';
-import { ActivatedRoute, Params } from '@angular/router';
+import { ActivatedRoute, Params, RouterModule } from '@angular/router';
 import { GradingSystemComponent } from 'app/grading-system/grading-system.component';
 import { BaseGradingSystemComponent } from 'app/grading-system/base-grading-system/base-grading-system.component';
-import { RouterTestingModule } from '@angular/router/testing';
 import { DocumentationButtonComponent } from 'app/shared/components/documentation-button/documentation-button.component';
 
 describe('Grading System Component', () => {
@@ -21,7 +20,7 @@ describe('Grading System Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule],
+            imports: [ArtemisTestModule, RouterModule.forRoot([])],
             declarations: [
                 GradingSystemComponent,
                 MockDirective(NgModel),

--- a/src/test/javascript/spec/component/iris/settings/iris-course-settings-update.component.spec.ts
+++ b/src/test/javascript/spec/component/iris/settings/iris-course-settings-update.component.spec.ts
@@ -8,8 +8,7 @@ import { ButtonComponent } from 'app/shared/components/button.component';
 import { IrisCommonSubSettingsUpdateComponent } from 'app/iris/settings/iris-settings-update/iris-common-sub-settings-update/iris-common-sub-settings-update.component';
 import { IrisGlobalAutoupdateSettingsUpdateComponent } from 'app/iris/settings/iris-settings-update/iris-global-autoupdate-settings-update/iris-global-autoupdate-settings-update.component';
 import { mockEmptySettings, mockSettings } from './mock-settings';
-import { ActivatedRoute, Params } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Params, provideRouter } from '@angular/router';
 import { NgModel } from '@angular/forms';
 import { IrisCourseSettingsUpdateComponent } from 'app/iris/settings/iris-course-settings-update/iris-course-settings-update.component';
 import { By } from '@angular/platform-browser';
@@ -29,7 +28,7 @@ describe('IrisCourseSettingsUpdateComponent Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule],
+            imports: [ArtemisTestModule],
             declarations: [
                 IrisCourseSettingsUpdateComponent,
                 IrisSettingsUpdateComponent,
@@ -38,7 +37,7 @@ describe('IrisCourseSettingsUpdateComponent Component', () => {
                 MockComponent(ButtonComponent),
                 MockDirective(NgModel),
             ],
-            providers: [MockProvider(IrisSettingsService), { provide: ActivatedRoute, useValue: route }],
+            providers: [provideRouter([]), MockProvider(IrisSettingsService), { provide: ActivatedRoute, useValue: route }],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/iris/settings/iris-enabled.component.spec.ts
+++ b/src/test/javascript/spec/component/iris/settings/iris-enabled.component.spec.ts
@@ -4,7 +4,6 @@ import { IrisSettingsService } from 'app/iris/settings/shared/iris-settings.serv
 import { MockProvider } from 'ng-mocks';
 import { of } from 'rxjs';
 import { mockSettings } from './mock-settings';
-import { RouterTestingModule } from '@angular/router/testing';
 import { IrisSettings } from 'app/entities/iris/settings/iris-settings.model';
 import { HttpResponse } from '@angular/common/http';
 import { IrisEnabledComponent } from 'app/iris/settings/shared/iris-enabled.component';
@@ -12,6 +11,7 @@ import { TranslatePipeMock } from '../../../helpers/mocks/service/mock-translate
 import { ProgrammingExercise } from 'app/entities/programming/programming-exercise.model';
 import { Course } from 'app/entities/course.model';
 import { IrisSubSettingsType } from 'app/entities/iris/settings/iris-sub-settings.model';
+import { provideRouter } from '@angular/router';
 
 describe('IrisEnabledComponent', () => {
     let comp: IrisEnabledComponent;
@@ -26,9 +26,9 @@ describe('IrisEnabledComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule],
+            imports: [ArtemisTestModule],
             declarations: [IrisEnabledComponent, TranslatePipeMock],
-            providers: [MockProvider(IrisSettingsService)],
+            providers: [provideRouter([]), MockProvider(IrisSettingsService)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/iris/settings/iris-exercise-settings-update.component.spec.ts
+++ b/src/test/javascript/spec/component/iris/settings/iris-exercise-settings-update.component.spec.ts
@@ -9,8 +9,7 @@ import { IrisCommonSubSettingsUpdateComponent } from 'app/iris/settings/iris-set
 import { IrisGlobalAutoupdateSettingsUpdateComponent } from 'app/iris/settings/iris-settings-update/iris-global-autoupdate-settings-update/iris-global-autoupdate-settings-update.component';
 import { mockSettings } from './mock-settings';
 import { IrisExerciseSettingsUpdateComponent } from 'app/iris/settings/iris-exercise-settings-update/iris-exercise-settings-update.component';
-import { ActivatedRoute, Params } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Params, provideRouter } from '@angular/router';
 import { NgModel } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { IrisSettings } from 'app/entities/iris/settings/iris-settings.model';
@@ -29,7 +28,7 @@ describe('IrisExerciseSettingsUpdateComponent Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule],
+            imports: [ArtemisTestModule],
             declarations: [
                 IrisExerciseSettingsUpdateComponent,
                 IrisSettingsUpdateComponent,
@@ -38,7 +37,7 @@ describe('IrisExerciseSettingsUpdateComponent Component', () => {
                 MockComponent(ButtonComponent),
                 MockDirective(NgModel),
             ],
-            providers: [MockProvider(IrisSettingsService), { provide: ActivatedRoute, useValue: route }],
+            providers: [provideRouter([]), MockProvider(IrisSettingsService), { provide: ActivatedRoute, useValue: route }],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/lecture-unit/unit-creation-card.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/unit-creation-card.component.spec.ts
@@ -3,18 +3,18 @@ import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { UnitCreationCardComponent } from 'app/lecture/lecture-unit/lecture-unit-management/unit-creation-card/unit-creation-card.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { RouterTestingModule } from '@angular/router/testing';
 import { DocumentationButtonComponent } from 'app/shared/components/documentation-button/documentation-button.component';
 import { TranslateService } from '@ngx-translate/core';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { LectureUnitType } from 'app/entities/lecture-unit/lectureUnit.model';
+import { RouterModule } from '@angular/router';
 
 describe('UnitCreationCardComponent', () => {
     let unitCreationCardComponentFixture: ComponentFixture<UnitCreationCardComponent>;
     let unitCreationCardComponent: UnitCreationCardComponent;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule],
+            imports: [RouterModule.forRoot([])],
             declarations: [
                 UnitCreationCardComponent,
                 MockPipe(ArtemisTranslatePipe),

--- a/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { ActivatedRoute, ParamMap, Router, convertToParamMap } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, ParamMap, Router, RouterModule, convertToParamMap } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { AssessmentLayoutComponent } from 'app/assessment/assessment-layout/assessment-layout.component';
 import { ComplaintService, EntityResponseType } from 'app/complaints/complaint.service';
@@ -63,7 +62,7 @@ describe('ModelingAssessmentEditorComponent', () => {
     beforeEach(() => {
         paramMapSubject = new BehaviorSubject(convertToParamMap({}));
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule],
+            imports: [ArtemisTestModule, RouterModule.forRoot([])],
             declarations: [
                 ModelingAssessmentEditorComponent,
                 MockComponent(AssessmentLayoutComponent),

--- a/src/test/javascript/spec/component/modeling-submission/modeling-submission-team.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-submission/modeling-submission-team.component.spec.ts
@@ -8,8 +8,7 @@ import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.s
 import { MockParticipationWebsocketService } from '../../helpers/mocks/service/mock-participation-websocket.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { TranslateService } from '@ngx-translate/core';
-import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { ParticipationWebsocketService } from 'app/overview/participation-websocket.service';
 import { ChangeDetectorRef, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
@@ -65,7 +64,7 @@ describe('ModelingSubmissionComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([routes[0]])],
+            imports: [ArtemisTestModule, RouterModule.forRoot([routes[0]])],
             declarations: [
                 ModelingSubmissionComponent,
                 MockComponent(ModelingEditorComponent),

--- a/src/test/javascript/spec/component/modeling-submission/modeling-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-submission/modeling-submission.component.spec.ts
@@ -8,8 +8,8 @@ import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.s
 import { MockParticipationWebsocketService } from '../../helpers/mocks/service/mock-participation-websocket.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { TranslateService } from '@ngx-translate/core';
-import { RouterTestingModule } from '@angular/router/testing';
-import { ActivatedRoute } from '@angular/router';
+import {} from '@angular/router/testing';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { ParticipationWebsocketService } from 'app/overview/participation-websocket.service';
 import { ChangeDetectorRef, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
@@ -61,7 +61,7 @@ describe('ModelingSubmissionComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([routes[0]])],
+            imports: [ArtemisTestModule, RouterModule.forRoot([routes[0]])],
             declarations: [
                 ModelingSubmissionComponent,
                 MockComponent(ModelingEditorComponent),

--- a/src/test/javascript/spec/component/modeling-submission/modeling-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-submission/modeling-submission.component.spec.ts
@@ -8,7 +8,6 @@ import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.s
 import { MockParticipationWebsocketService } from '../../helpers/mocks/service/mock-participation-websocket.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { TranslateService } from '@ngx-translate/core';
-import {} from '@angular/router/testing';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { ParticipationWebsocketService } from 'app/overview/participation-websocket.service';
 import { ChangeDetectorRef, DebugElement } from '@angular/core';

--- a/src/test/javascript/spec/component/overview/course-conversations/layout/conversation-header/conversation-header.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-conversations/layout/conversation-header/conversation-header.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { ConversationHeaderComponent } from 'app/overview/course-conversations/layout/conversation-header/conversation-header.component';
 import { Location } from '@angular/common';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
 import { ChannelIconComponent } from 'app/overview/course-conversations/other/channel-icon/channel-icon.component';
 import { GroupChatIconComponent } from 'app/overview/course-conversations/other/group-chat-icon/group-chat-icon.component';
@@ -28,6 +27,7 @@ import { MockMetisService } from '../../../../../helpers/mocks/service/mock-meti
 import { MetisModule } from 'app/shared/metis/metis.module';
 import { MockTranslateService } from '../../../../../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
+import { provideRouter } from '@angular/router';
 
 const examples: ConversationDTO[] = [
     generateOneToOneChatDTO({}),
@@ -54,14 +54,14 @@ examples.forEach((activeConversation) => {
                     MockComponent(GroupChatIconComponent),
                     MockComponent(FaIconComponent),
                     MockPipe(ArtemisTranslatePipe),
-                    RouterTestingModule.withRoutes([
+                ],
+                imports: [MetisModule],
+                providers: [
+                    provideRouter([
                         { path: 'courses/:courseId/lectures/:lectureId', component: CourseLectureDetailsComponent },
                         { path: 'courses/:courseId/exercises/:exerciseId', component: CourseExerciseDetailsComponent },
                         { path: 'courses/:courseId/exams/:examId', component: ExamDetailComponent },
                     ]),
-                ],
-                imports: [MetisModule],
-                providers: [
                     MockProvider(NgbModal),
                     MockProvider(MetisConversationService),
                     MockProvider(ConversationService),

--- a/src/test/javascript/spec/component/overview/course-exams/course-exams.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-exams/course-exams.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { Course } from 'app/entities/course.model';
 import { CourseExamsComponent } from 'app/overview/course-exams/course-exams.component';
 import { Exam } from 'app/entities/exam/exam.model';
@@ -15,7 +15,6 @@ import { CourseStorageService } from 'app/course/manage/course-storage.service';
 import { SidebarComponent } from 'app/shared/sidebar/sidebar.component';
 import { SearchFilterComponent } from 'app/shared/search-filter/search-filter.component';
 import { SearchFilterPipe } from 'app/shared/pipes/search-filter.pipe';
-import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MockRouter } from '../../../helpers/mocks/mock-router';
 import { CourseOverviewService } from 'app/overview/course-overview.service';
@@ -101,7 +100,7 @@ describe('CourseExamsComponent', () => {
         router.navigate.mockImplementation(() => Promise.resolve(true));
 
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule, MockModule(FormsModule), MockModule(ReactiveFormsModule), MockDirective(TranslateDirective)],
+            imports: [ArtemisTestModule, RouterModule.forRoot([]), MockModule(FormsModule), MockModule(ReactiveFormsModule), MockDirective(TranslateDirective)],
             declarations: [CourseExamsComponent, SidebarComponent, SearchFilterComponent, MockPipe(ArtemisTranslatePipe), MockPipe(SearchFilterPipe)],
             providers: [
                 { provide: Router, useValue: router },

--- a/src/test/javascript/spec/component/overview/course-exercises/course-exercise-row.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-exercises/course-exercise-row.component.spec.ts
@@ -30,9 +30,9 @@ import { IncludedInScoreBadgeComponent } from 'app/exercises/shared/exercise-hea
 import { ArtemisTimeAgoPipe } from 'app/shared/pipes/artemis-time-ago.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { OrionFilterDirective } from 'app/shared/orion/orion-filter.directive';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CourseExerciseService } from 'app/exercises/shared/course-exercises/course-exercise.service';
 import { ExerciseCategoriesComponent } from 'app/shared/exercise-categories/exercise-categories.component';
+import { RouterModule } from '@angular/router';
 
 @Component({
     template: '',
@@ -51,11 +51,11 @@ describe('CourseExerciseRowComponent', () => {
             imports: [
                 ArtemisTestModule,
                 TranslateModule.forRoot(),
-                NgbModule,
-                RouterTestingModule.withRoutes([
+                RouterModule.forRoot([
                     { path: 'courses/:courseId/exercises', component: DummyComponent },
                     { path: 'courses/:courseId/exercises/:exerciseId', component: DummyComponent },
                 ]),
+                NgbModule,
             ],
             declarations: [
                 MockComponent(SubmissionResultStatusComponent),

--- a/src/test/javascript/spec/component/overview/course-lectures/course-lecture-row.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-lectures/course-lecture-row.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { Course } from 'app/entities/course.model';
 import { Lecture } from 'app/entities/lecture.model';
@@ -12,7 +11,7 @@ import dayjs from 'dayjs/esm';
 import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
 import { Location } from '@angular/common';
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
@@ -29,11 +28,11 @@ describe('CourseLectureRow', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
-                RouterTestingModule.withRoutes([
+                MockDirective(NgbTooltip),
+                RouterModule.forRoot([
                     { path: 'courses/:courseId/lectures', component: DummyComponent },
                     { path: 'courses/:courseId/lectures/:lectureId', component: DummyComponent },
                 ]),
-                MockDirective(NgbTooltip),
             ],
             declarations: [
                 DummyComponent,

--- a/src/test/javascript/spec/component/overview/course-lectures/course-lectures.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-lectures/course-lectures.component.spec.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { NgbDropdownModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateService } from '@ngx-translate/core';
@@ -8,8 +8,8 @@ import { LocalStorageService } from 'ngx-webstorage';
 import { Course } from 'app/entities/course.model';
 import { Lecture } from 'app/entities/lecture.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
-import { CourseLecturesComponent } from '../../../../../../main/webapp/app/overview/course-lectures/course-lectures.component';
-import { SidebarComponent } from '../../../../../../main/webapp/app/shared/sidebar/sidebar.component';
+import { CourseLecturesComponent } from 'app/overview/course-lectures/course-lectures.component';
+import { SidebarComponent } from 'app/shared/sidebar/sidebar.component';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { SearchFilterPipe } from 'app/shared/pipes/search-filter.pipe';
@@ -21,14 +21,14 @@ import { MockTranslateService } from '../../../helpers/mocks/service/mock-transl
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { CourseStorageService } from 'app/course/manage/course-storage.service';
 import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
-import { CourseOverviewService } from '../../../../../../main/webapp/app/overview/course-overview.service';
-import { HttpClientModule } from '@angular/common/http';
-import { ProfileService } from '../../../../../../main/webapp/app/shared/layouts/profiles/profile.service';
+import { CourseOverviewService } from 'app/overview/course-overview.service';
+import { provideHttpClient } from '@angular/common/http';
+import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { MockProfileService } from '../../../helpers/mocks/service/mock-profile.service';
-import { ProfileInfo } from '../../../../../../main/webapp/app/shared/layouts/profiles/profile-info.model';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
 import { SearchFilterComponent } from 'app/shared/search-filter/search-filter.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 @Component({ selector: 'jhi-course-lecture-row', template: '' })
 class CourseLectureRowStubComponent {
@@ -67,7 +67,7 @@ describe('CourseLectures', () => {
         course.lectures = [lecture1, lecture2, lecture3];
 
         TestBed.configureTestingModule({
-            imports: [NgbDropdownModule, HttpClientModule, RouterTestingModule, MockModule(FormsModule), MockModule(ReactiveFormsModule), MockModule(NgbTooltipModule)],
+            imports: [NgbDropdownModule, RouterModule.forRoot([]), MockModule(FormsModule), MockModule(ReactiveFormsModule), MockModule(NgbTooltipModule)],
             declarations: [
                 CourseLecturesComponent,
                 CourseLectureRowStubComponent,
@@ -81,6 +81,8 @@ describe('CourseLectures', () => {
                 MockDirective(TranslateDirective),
             ],
             providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
                 MockProvider(CourseStorageService, {
                     getCourse: () => {
                         return course;

--- a/src/test/javascript/spec/component/overview/course-statistics/course-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-statistics/course-statistics.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { BarChartModule, PieChartModule } from '@swimlane/ngx-charts';
 import { CourseScores } from 'app/course/course-scores/course-scores';
@@ -329,7 +328,7 @@ describe('CourseStatisticsComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule, TreeviewModule.forRoot(), MockModule(PieChartModule), MockModule(BarChartModule), MockModule(NgbTooltipModule)],
+            imports: [ArtemisTestModule, TreeviewModule.forRoot(), MockModule(PieChartModule), MockModule(BarChartModule), MockModule(NgbTooltipModule)],
             declarations: [
                 CourseStatisticsComponent,
                 MockComponent(CourseCompetenciesComponent),
@@ -340,6 +339,7 @@ describe('CourseStatisticsComponent', () => {
                 TranslateDirective,
             ],
             providers: [
+                provideRouter([]),
                 MockProvider(ArtemisNavigationUtilService),
                 MockProvider(ChartCategoryFilter),
                 {

--- a/src/test/javascript/spec/component/overview/course-statistics/visualizations/exercise-scores-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-statistics/visualizations/exercise-scores-chart.component.spec.ts
@@ -5,9 +5,8 @@ import { MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { ChartNode, ExerciseScoresChartComponent } from 'app/overview/visualizations/exercise-scores-chart/exercise-scores-chart.component';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { of } from 'rxjs';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 import { ExerciseScoresChartService, ExerciseScoresDTO } from 'app/overview/visualizations/exercise-scores-chart.service';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ExerciseType } from 'app/entities/exercise.model';
 import dayjs from 'dayjs/esm';
 import { HttpResponse } from '@angular/common/http';
@@ -43,9 +42,10 @@ describe('ExerciseScoresChartComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, MockModule(LineChartModule), RouterTestingModule.withRoutes([]), MockModule(BrowserAnimationsModule)],
+            imports: [ArtemisTestModule, MockModule(LineChartModule), MockModule(BrowserAnimationsModule)],
             declarations: [ExerciseScoresChartComponent, MockPipe(ArtemisTranslatePipe), MockDirective(TranslateDirective)],
             providers: [
+                provideRouter([]),
                 MockProvider(AlertService),
                 MockProvider(ArtemisNavigationUtilService),
                 { provide: TranslateService, useClass: MockTranslateService },

--- a/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
@@ -5,7 +5,7 @@ import dayjs from 'dayjs/esm';
 import { ArtemisTestModule } from '../../test.module';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 import { UnreferencedFeedbackDetailComponent } from 'app/assessment/unreferenced-feedback-detail/unreferenced-feedback-detail.component';
 import { DebugElement } from '@angular/core';
@@ -21,7 +21,6 @@ import { UpdatingResultComponent } from 'app/exercises/shared/result/updating-re
 import { Submission, SubmissionExerciseType, SubmissionType } from 'app/entities/submission.model';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { TextSubmission } from 'app/entities/text/text-submission.model';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
@@ -89,7 +88,7 @@ describe('ParticipationSubmissionComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule, NgxDatatableModule],
+            imports: [ArtemisTestModule, NgxDatatableModule, RouterModule.forRoot([])],
             declarations: [
                 ParticipationSubmissionComponent,
                 MockComponent(UpdatingResultComponent),

--- a/src/test/javascript/spec/component/programming-assessment/code-editor-tutor-assessment-container.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/code-editor-tutor-assessment-container.component.spec.ts
@@ -32,12 +32,12 @@ import { Course } from 'app/entities/course.model';
 import { delay } from 'rxjs/operators';
 import { ProgrammingSubmissionService } from 'app/exercises/programming/participate/programming-submission.service';
 import { ComplaintResponse } from 'app/entities/complaint-response.model';
-import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
 import { CodeEditorRepositoryFileService } from 'app/exercises/programming/shared/code-editor/service/code-editor-repository.service';
 import { CodeEditorFileBrowserComponent } from 'app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component';
 import { FileType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
-import { RouterTestingModule } from '@angular/router/testing';
+import {} from '@angular/router/testing';
 import { CodeEditorContainerComponent } from 'app/exercises/programming/shared/code-editor/container/code-editor-container.component';
 import { ResultComponent } from 'app/exercises/shared/result/result.component';
 import { IncludedInScoreBadgeComponent } from 'app/exercises/shared/exercise-headers/included-in-score-badge.component';
@@ -173,7 +173,7 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule],
+            imports: [ArtemisTestModule],
             declarations: [
                 CodeEditorTutorAssessmentContainerComponent,
                 MockComponent(ProgrammingAssessmentRepoExportButtonComponent),
@@ -204,7 +204,7 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
                 ExtensionPointDirective,
             ],
             providers: [
-                MockProvider(Router),
+                provideRouter([]),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: ParticipationWebsocketService, useClass: MockParticipationWebsocketService },
                 { provide: RepositoryFileService, useClass: MockRepositoryFileService },

--- a/src/test/javascript/spec/component/programming-assessment/code-editor-tutor-assessment-container.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/code-editor-tutor-assessment-container.component.spec.ts
@@ -37,7 +37,6 @@ import { ProgrammingExerciseService } from 'app/exercises/programming/manage/ser
 import { CodeEditorRepositoryFileService } from 'app/exercises/programming/shared/code-editor/service/code-editor-repository.service';
 import { CodeEditorFileBrowserComponent } from 'app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component';
 import { FileType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
-import {} from '@angular/router/testing';
 import { CodeEditorContainerComponent } from 'app/exercises/programming/shared/code-editor/container/code-editor-container.component';
 import { ResultComponent } from 'app/exercises/shared/result/result.component';
 import { IncludedInScoreBadgeComponent } from 'app/exercises/shared/exercise-headers/included-in-score-badge.component';

--- a/src/test/javascript/spec/component/shared/code-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/code-button.component.spec.ts
@@ -26,9 +26,9 @@ import { MockProfileService } from '../../helpers/mocks/service/mock-profile.ser
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { ArtemisTestModule } from '../../test.module';
-import { RouterTestingModule } from '@angular/router/testing';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { provideRouter } from '@angular/router';
 
 describe('CodeButtonComponent', () => {
     let component: CodeButtonComponent;
@@ -91,7 +91,7 @@ describe('CodeButtonComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, ClipboardModule, NgbPopoverModule, RouterTestingModule.withRoutes([])],
+            imports: [ArtemisTestModule, ClipboardModule, NgbPopoverModule],
             declarations: [
                 CodeButtonComponent,
                 MockComponent(ExerciseActionButtonComponent),
@@ -102,6 +102,7 @@ describe('CodeButtonComponent', () => {
                 MockDirective(TranslateDirective),
             ],
             providers: [
+                provideRouter([]),
                 MockProvider(AlertService),
                 { provide: FeatureToggleService, useClass: MockFeatureToggleService },
                 { provide: AccountService, useClass: MockAccountService },

--- a/src/test/javascript/spec/component/shared/main.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/main.component.spec.ts
@@ -1,10 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { TranslateTestingModule } from '../../helpers/mocks/service/mock-translate.service';
+import { MockTranslateService, TranslateTestingModule } from '../../helpers/mocks/service/mock-translate.service';
 import { ArtemisTestModule } from '../../test.module';
 import { By } from '@angular/platform-browser';
 import { JhiMainComponent } from 'app/shared/layouts/main/main.component';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
-import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { TranslateService } from '@ngx-translate/core';
 import { ThemeService } from 'app/core/theme/theme.service';
@@ -13,7 +12,7 @@ import { MockComponent } from 'ng-mocks';
 import { AlertOverlayComponent } from 'app/shared/alert/alert-overlay.component';
 import { PageRibbonComponent } from 'app/shared/layouts/profiles/page-ribbon.component';
 import { NotificationPopupComponent } from 'app/shared/notification/notification-popup/notification-popup.component';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 
 // Mock the initialize method
 class MockThemeService {
@@ -28,7 +27,7 @@ describe('JhiMainComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, TranslateTestingModule, RouterTestingModule],
+            imports: [ArtemisTestModule, TranslateTestingModule, RouterModule.forRoot([])],
             declarations: [JhiMainComponent, MockComponent(AlertOverlayComponent), MockComponent(PageRibbonComponent), MockComponent(NotificationPopupComponent)],
             providers: [
                 { provide: LocalStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/shared/metis/post/post.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/post/post.component.spec.ts
@@ -23,11 +23,10 @@ import {
     unsortedAnswerArray,
 } from '../../../../helpers/sample/metis-sample-data';
 import { MockQueryParamsDirective, MockRouterLinkDirective } from '../../../../helpers/mocks/directive/mock-router-link.directive';
-import { RouterTestingModule } from '@angular/router/testing';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { MetisConversationService } from 'app/shared/metis/metis-conversation.service';
 import { OneToOneChatService } from 'app/shared/metis/conversations/one-to-one-chat.service';
-import { Router, RouterState } from '@angular/router';
+import { Router, RouterState, provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { OneToOneChatDTO } from 'app/entities/metis/conversation/one-to-one-chat.model';
 import { HttpResponse } from '@angular/common/http';
@@ -47,8 +46,9 @@ describe('PostComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [RouterTestingModule, MockDirective(NgbTooltip)],
+            imports: [MockDirective(NgbTooltip)],
             providers: [
+                provideRouter([]),
                 { provide: MetisService, useClass: MockMetisService },
                 { provide: Router, useClass: MockRouter },
                 MockProvider(MetisConversationService),

--- a/src/test/javascript/spec/component/shared/notification/notification-popup.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/notification/notification-popup.component.spec.ts
@@ -52,8 +52,8 @@ describe('Notification Popup Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule],
-            declarations: [NotificationPopupComponent, RouterModule.forRoot([]), MockPipe(ArtemisTranslatePipe)],
+            imports: [ArtemisTestModule, RouterModule.forRoot([])],
+            declarations: [NotificationPopupComponent, MockPipe(ArtemisTranslatePipe)],
             providers: [
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/shared/notification/notification-popup.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/notification/notification-popup.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { ReplaySubject } from 'rxjs';
@@ -11,7 +11,6 @@ import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storag
 import { MockNotificationService } from '../../../helpers/mocks/service/mock-notification.service';
 import { MockTranslateService } from '../../../helpers/mocks/service/mock-translate.service';
 import { NEW_MESSAGE_TITLE, Notification, QUIZ_EXERCISE_STARTED_TEXT, QUIZ_EXERCISE_STARTED_TITLE } from 'app/entities/notification.model';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockPipe } from 'ng-mocks';
 
@@ -53,8 +52,8 @@ describe('Notification Popup Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([])],
-            declarations: [NotificationPopupComponent, MockPipe(ArtemisTranslatePipe)],
+            imports: [ArtemisTestModule],
+            declarations: [NotificationPopupComponent, RouterModule.forRoot([]), MockPipe(ArtemisTranslatePipe)],
             providers: [
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/shared/sidebar/conversation-options.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/sidebar/conversation-options.component.spec.ts
@@ -14,7 +14,6 @@ import { CourseExerciseDetailsComponent } from 'app/overview/exercise-details/co
 import { ExamDetailComponent } from 'app/exam/manage/exams/exam-detail.component';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ConversationService } from 'app/shared/metis/conversations/conversation.service';
-import { RouterTestingModule } from '@angular/router/testing';
 import { AlertService } from 'app/core/util/alert.service';
 import { MetisService } from 'app/shared/metis/metis.service';
 import { MockMetisService } from '../../../helpers/mocks/service/mock-metis-service.service';
@@ -27,6 +26,7 @@ import { ConversationDetailDialogComponent } from 'app/overview/course-conversat
 import { MetisConversationService } from 'app/shared/metis/metis-conversation.service';
 import { isOneToOneChatDTO } from 'app/entities/metis/conversation/one-to-one-chat.model';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { provideRouter } from '@angular/router';
 
 const examples: (() => ConversationDTO)[] = [
     () => generateOneToOneChatDTO({}),
@@ -51,17 +51,14 @@ examples.forEach((conversation) => {
 
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [
-                    ArtemisSharedModule,
-                    NgbDropdownMocksModule,
-                    RouterTestingModule.withRoutes([
+                imports: [ArtemisSharedModule, NgbDropdownMocksModule],
+                declarations: [ConversationOptionsComponent, MockComponent(FaIconComponent), MockPipe(ArtemisTranslatePipe), MockDirective(TranslateDirective)],
+                providers: [
+                    provideRouter([
                         { path: 'courses/:courseId/lectures/:lectureId', component: CourseLectureDetailsComponent },
                         { path: 'courses/:courseId/exercises/:exerciseId', component: CourseExerciseDetailsComponent },
                         { path: 'courses/:courseId/exams/:examId', component: ExamDetailComponent },
                     ]),
-                ],
-                declarations: [ConversationOptionsComponent, MockComponent(FaIconComponent), MockPipe(ArtemisTranslatePipe), MockDirective(TranslateDirective)],
-                providers: [
                     MockProvider(ConversationService),
                     MockProvider(MetisConversationService),
                     MockProvider(AlertService),

--- a/src/test/javascript/spec/component/statistics/statistics-average-score-graph.component.spec.ts
+++ b/src/test/javascript/spec/component/statistics/statistics-average-score-graph.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisTestModule } from '../../test.module';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { PerformanceInterval, StatisticsAverageScoreGraphComponent } from 'app/shared/statistics-graph/statistics-average-score-graph.component';
@@ -13,6 +12,7 @@ import { ChartExerciseTypeFilter } from 'app/shared/chart/chart-exercise-type-fi
 import { ChartCategoryFilter } from 'app/shared/chart/chart-category-filter';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ExerciseCategory } from 'app/entities/exercise-category.model';
+import { provideRouter } from '@angular/router';
 
 describe('StatisticsAverageScoreGraphComponent', () => {
     let fixture: ComponentFixture<StatisticsAverageScoreGraphComponent>;
@@ -78,9 +78,9 @@ describe('StatisticsAverageScoreGraphComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([]), MockModule(BarChartModule)],
+            imports: [ArtemisTestModule, MockModule(BarChartModule)],
             declarations: [StatisticsAverageScoreGraphComponent, MockPipe(ArtemisTranslatePipe), MockDirective(TranslateDirective)],
-            providers: [MockProvider(ArtemisNavigationUtilService), MockProvider(ChartExerciseTypeFilter), MockProvider(ChartCategoryFilter)],
+            providers: [provideRouter([]), MockProvider(ArtemisNavigationUtilService), MockProvider(ChartExerciseTypeFilter), MockProvider(ChartCategoryFilter)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/statistics/statistics-graph.component.spec.ts
+++ b/src/test/javascript/spec/component/statistics/statistics-graph.component.spec.ts
@@ -1,7 +1,6 @@
 import { HttpTestingController } from '@angular/common/http/testing';
 import { SimpleChange } from '@angular/core';
 import { ArtemisTestModule } from '../../test.module';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { StatisticsGraphComponent } from 'app/shared/statistics-graph/statistics-graph.component';
 import { StatisticsService } from 'app/shared/statistics-graph/statistics.service';
@@ -13,6 +12,7 @@ import { of } from 'rxjs';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BarChartModule } from '@swimlane/ngx-charts';
+import { provideRouter } from '@angular/router';
 
 describe('StatisticsGraphComponent', () => {
     let fixture: ComponentFixture<StatisticsGraphComponent>;
@@ -22,9 +22,9 @@ describe('StatisticsGraphComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([]), MockModule(BarChartModule)],
+            imports: [ArtemisTestModule, MockModule(BarChartModule)],
             declarations: [StatisticsGraphComponent, MockPipe(ArtemisTranslatePipe)],
-            providers: [{ provide: TranslateService, useClass: MockTranslateService }],
+            providers: [provideRouter([]), { provide: TranslateService, useClass: MockTranslateService }],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/statistics/statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/statistics/statistics.component.spec.ts
@@ -3,13 +3,13 @@ import { ArtemisTestModule } from '../../test.module';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockHasAnyAuthorityDirective } from '../../helpers/mocks/directive/mock-has-any-authority.directive';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { StatisticsComponent } from 'app/admin/statistics/statistics.component';
 import { StatisticsGraphComponent } from 'app/shared/statistics-graph/statistics-graph.component';
 import { SpanType } from 'app/entities/statistics.model';
+import { provideRouter } from '@angular/router';
 
 describe('StatisticsComponent', () => {
     let fixture: ComponentFixture<StatisticsComponent>;
@@ -17,7 +17,7 @@ describe('StatisticsComponent', () => {
 
     beforeEach(fakeAsync(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([])],
+            imports: [ArtemisTestModule],
             declarations: [
                 StatisticsComponent,
                 MockComponent(StatisticsGraphComponent),
@@ -25,10 +25,7 @@ describe('StatisticsComponent', () => {
                 MockPipe(ArtemisTranslatePipe),
                 MockPipe(ArtemisDatePipe),
             ],
-            providers: [
-                { provide: LocalStorageService, useClass: MockSyncStorage },
-                { provide: SessionStorageService, useClass: MockSyncStorage },
-            ],
+            providers: [provideRouter([]), { provide: LocalStorageService, useClass: MockSyncStorage }, { provide: SessionStorageService, useClass: MockSyncStorage }],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/team/teams.component.spec.ts
+++ b/src/test/javascript/spec/component/team/teams.component.spec.ts
@@ -6,7 +6,7 @@ import { NgModel } from '@angular/forms';
 import { TeamService } from 'app/exercises/shared/team/team.service';
 import { TeamsComponent } from 'app/exercises/shared/team/teams.component';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
-import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { MockTeamService, mockTeams } from '../../helpers/mocks/service/mock-team.service';
 import { MockExerciseService } from '../../helpers/mocks/service/mock-exercise.service';
@@ -22,8 +22,6 @@ import { NgxDatatableModule } from '@siemens/ngx-datatable';
 import { TeamStudentsListComponent } from 'app/exercises/shared/team/team-participate/team-students-list.component';
 import { MockRouterLinkDirective } from '../../helpers/mocks/directive/mock-router-link.directive';
 import { TeamDeleteButtonComponent } from 'app/exercises/shared/team/team-update-dialog/team-delete-button.component';
-import { RouterTestingModule } from '@angular/router/testing';
-import { teamRoute } from 'app/exercises/shared/team/team.route';
 
 describe('TeamsComponent', () => {
     let comp: TeamsComponent;
@@ -38,7 +36,7 @@ describe('TeamsComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, MockModule(NgxDatatableModule), RouterTestingModule.withRoutes([teamRoute[0]])],
+            imports: [ArtemisTestModule, MockModule(NgxDatatableModule)],
             declarations: [
                 TeamsComponent,
                 MockDirective(NgModel),
@@ -52,6 +50,7 @@ describe('TeamsComponent', () => {
                 MockComponent(TeamDeleteButtonComponent),
             ],
             providers: [
+                provideRouter([]),
                 { provide: ActivatedRoute, useValue: route },
                 { provide: ParticipationService, useClass: MockParticipationService },
                 { provide: ExerciseService, useClass: MockExerciseService },

--- a/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
@@ -1,6 +1,6 @@
 import { DebugElement } from '@angular/core';
 import dayjs from 'dayjs/esm';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, RouterModule, convertToParamMap } from '@angular/router';
 import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { AlertService } from 'app/core/util/alert.service';
 import { ArtemisTestModule } from '../../test.module';
@@ -8,7 +8,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { MockTextEditorService } from '../../helpers/mocks/service/mock-text-editor.service';
 import { TextEditorService } from 'app/exercises/text/participate/text-editor.service';
 import { BehaviorSubject } from 'rxjs';
-import { RouterTestingModule } from '@angular/router/testing';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
@@ -65,7 +64,7 @@ describe('TextEditorComponent', () => {
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule.withRoutes([textEditorRoute[0]])],
+            imports: [ArtemisTestModule, RouterModule.forRoot([textEditorRoute[0]])],
             declarations: [
                 TextEditorComponent,
                 MockComponent(SubmissionResultStatusComponent),

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -26,7 +26,6 @@ import { TextBlock, TextBlockType } from 'app/entities/text/text-block.model';
 import { Feedback, FeedbackType } from 'app/entities/feedback.model';
 import { ComplaintResponse } from 'app/entities/complaint-response.model';
 import { AlertService } from 'app/core/util/alert.service';
-import {} from '@angular/router/testing';
 import { SubmissionService } from 'app/exercises/shared/submission/submission.service';
 import { GradingInstructionLinkIconComponent } from 'app/shared/grading-instruction-link-icon/grading-instruction-link-icon.component';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -17,7 +17,7 @@ import { TextSubmission } from 'app/entities/text/text-submission.model';
 import { Result } from 'app/entities/result.model';
 import dayjs from 'dayjs/esm';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
-import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { ConfirmIconComponent } from 'app/shared/confirm-icon/confirm-icon.component';
 import { Course } from 'app/entities/course.model';
 import { ManualTextblockSelectionComponent } from 'app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component';
@@ -26,7 +26,7 @@ import { TextBlock, TextBlockType } from 'app/entities/text/text-block.model';
 import { Feedback, FeedbackType } from 'app/entities/feedback.model';
 import { ComplaintResponse } from 'app/entities/complaint-response.model';
 import { AlertService } from 'app/core/util/alert.service';
-import { RouterTestingModule } from '@angular/router/testing';
+import {} from '@angular/router/testing';
 import { SubmissionService } from 'app/exercises/shared/submission/submission.service';
 import { GradingInstructionLinkIconComponent } from 'app/shared/grading-instruction-link-icon/grading-instruction-link-icon.component';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
@@ -146,7 +146,7 @@ describe('TextSubmissionAssessmentComponent', () => {
         } as unknown as ActivatedRoute;
 
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, RouterTestingModule],
+            imports: [ArtemisTestModule],
             declarations: [
                 TextSubmissionAssessmentComponent,
                 TextAssessmentAreaComponent,
@@ -164,6 +164,7 @@ describe('TextSubmissionAssessmentComponent', () => {
                 MockDirective(TranslateDirective),
             ],
             providers: [
+                provideRouter([]),
                 { provide: ActivatedRoute, useValue: mockActivatedRoute },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/tutorial-groups/course-tutorial-groups/course-tutorial-group-card.component.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/course-tutorial-groups/course-tutorial-group-card.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import {} from '@angular/router/testing';
 import { CourseTutorialGroupCardComponent } from 'app/overview/course-tutorial-groups/course-tutorial-group-card/course-tutorial-group-card.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateService } from '@ngx-translate/core';
@@ -10,6 +10,7 @@ import { Course } from 'app/entities/course.model';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { MockComponent, MockDirective } from 'ng-mocks';
 import { TranslatePipeMock } from '../../../helpers/mocks/service/mock-translate.service';
+import { RouterModule } from '@angular/router';
 
 describe('CourseTutorialGroupCardComponent', () => {
     let component: CourseTutorialGroupCardComponent;
@@ -19,7 +20,7 @@ describe('CourseTutorialGroupCardComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([])],
+            imports: [RouterModule.forRoot([])],
             declarations: [CourseTutorialGroupCardComponent, MockComponent(FaIconComponent), TranslatePipeMock, MockDirective(TranslateDirective)],
             providers: [
                 {

--- a/src/test/javascript/spec/component/tutorial-groups/course-tutorial-groups/course-tutorial-group-card.component.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/course-tutorial-groups/course-tutorial-group-card.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {} from '@angular/router/testing';
 import { CourseTutorialGroupCardComponent } from 'app/overview/course-tutorial-groups/course-tutorial-group-card/course-tutorial-group-card.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateService } from '@ngx-translate/core';

--- a/src/test/javascript/spec/component/tutorial-groups/shared/tutorial-group-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/shared/tutorial-group-detail.component.spec.ts
@@ -1,5 +1,5 @@
 import { TutorialGroupDetailComponent } from 'app/course/tutorial-groups/shared/tutorial-group-detail/tutorial-group-detail.component';
-import { RouterTestingModule } from '@angular/router/testing';
+import {} from '@angular/router/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
@@ -21,6 +21,7 @@ import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import dayjs from 'dayjs/esm';
 import { TutorialGroupSessionStatus } from 'app/entities/tutorial-group/tutorial-group-session.model';
 import { provideHttpClient } from '@angular/common/http';
+import { RouterModule } from '@angular/router';
 
 @Component({ selector: 'jhi-mock-header', template: '<div id="mockHeader"></div>' })
 class MockHeaderComponent {
@@ -57,7 +58,7 @@ describe('TutorialGroupDetailWrapperTest', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [NgbTooltipMocksModule, RouterTestingModule.withRoutes([])],
+            imports: [NgbTooltipMocksModule, RouterModule.forRoot([])],
             declarations: [
                 TutorialGroupDetailComponent,
                 DetailOverviewListComponent,
@@ -109,7 +110,7 @@ describe('TutorialGroupDetailComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [NgbTooltipMocksModule, RouterTestingModule.withRoutes([])],
+            imports: [NgbTooltipMocksModule, RouterModule.forRoot([])],
             declarations: [
                 TutorialGroupDetailComponent,
                 MockPipe(ArtemisTranslatePipe),

--- a/src/test/javascript/spec/component/tutorial-groups/shared/tutorial-group-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/shared/tutorial-group-detail.component.spec.ts
@@ -1,5 +1,4 @@
 import { TutorialGroupDetailComponent } from 'app/course/tutorial-groups/shared/tutorial-group-detail/tutorial-group-detail.component';
-import {} from '@angular/router/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';

--- a/src/test/javascript/spec/component/tutorial-groups/shared/tutorial-group-row.component.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/shared/tutorial-group-row.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TutorialGroupRowComponent } from 'app/course/tutorial-groups/shared/tutorial-groups-table/tutorial-group-row/tutorial-group-row.component';
 import { TutorialGroup } from 'app/entities/tutorial-group/tutorial-group.model';
 import { MockComponent, MockPipe } from 'ng-mocks';
@@ -8,6 +7,7 @@ import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { generateExampleTutorialGroup } from '../helpers/tutorialGroupExampleModels';
 import { TutorialGroupUtilizationIndicatorComponent } from 'app/course/tutorial-groups/shared/tutorial-group-utilization-indicator/tutorial-group-utilization-indicator.component';
 import { MeetingPatternPipe } from 'app/course/tutorial-groups/shared/meeting-pattern.pipe';
+import { RouterModule } from '@angular/router';
 
 describe('TutorialGroupRowComponent', () => {
     let component: TutorialGroupRowComponent;
@@ -16,7 +16,7 @@ describe('TutorialGroupRowComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [RouterTestingModule.withRoutes([])],
+            imports: [RouterModule.forRoot([])],
             declarations: [
                 TutorialGroupRowComponent,
                 MockComponent(TutorialGroupUtilizationIndicatorComponent),
@@ -24,6 +24,7 @@ describe('TutorialGroupRowComponent', () => {
                 MockPipe(ArtemisTranslatePipe),
                 MockPipe(MeetingPatternPipe),
             ],
+            providers: [],
         }).compileComponents();
 
         fixture = TestBed.createComponent(TutorialGroupRowComponent);

--- a/src/test/javascript/spec/component/tutorial-groups/tutorial-groups-management/tutorial-group-management-resolve.service.spec.ts
+++ b/src/test/javascript/spec/component/tutorial-groups/tutorial-groups-management/tutorial-group-management-resolve.service.spec.ts
@@ -1,12 +1,11 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
 
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { Course } from 'app/entities/course.model';
-import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, provideRouter } from '@angular/router';
 import { TutorialGroupManagementResolve } from 'app/course/tutorial-groups/tutorial-groups-management/tutorial-group-management-resolve.service';
 import { MockProvider } from 'ng-mocks';
 import { MockTranslateService } from '../../../helpers/mocks/service/mock-translate.service';
@@ -20,8 +19,9 @@ describe('TutorialGroupManagementResolve', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule],
+            imports: [],
             providers: [
+                provideRouter([]),
                 provideHttpClient(),
                 provideHttpClientTesting(),
                 TutorialGroupManagementResolve,

--- a/src/test/javascript/spec/integration/guided-tour/guided-tour.integration.spec.ts
+++ b/src/test/javascript/spec/integration/guided-tour/guided-tour.integration.spec.ts
@@ -9,7 +9,6 @@ import { GuidedTourComponent } from 'app/guided-tour/guided-tour.component';
 import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
-import { RouterTestingModule } from '@angular/router/testing';
 import { courseOverviewTour } from 'app/guided-tour/tours/course-overview-tour';
 import { CoursesComponent } from 'app/overview/courses.component';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
@@ -43,6 +42,7 @@ import { JhiConnectionWarningComponent } from 'app/shared/connection-warning/con
 import { NgbCollapse, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { NgbDropdownMocksModule } from '../../helpers/mocks/directive/ngbDropdownMocks.module';
 import { DocumentationButtonComponent } from 'app/shared/components/documentation-button/documentation-button.component';
+import { RouterModule } from '@angular/router';
 
 describe('Guided tour integration', () => {
     const user = { id: 1 } as User;
@@ -61,7 +61,7 @@ describe('Guided tour integration', () => {
         TestBed.configureTestingModule({
             imports: [
                 ArtemisTestModule,
-                RouterTestingModule.withRoutes([
+                RouterModule.forRoot([
                     {
                         path: 'courses',
                         component: MockComponent(CoursesComponent),

--- a/src/test/javascript/spec/service/bonus.service.spec.ts
+++ b/src/test/javascript/spec/service/bonus.service.spec.ts
@@ -2,13 +2,13 @@ import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { GradeType, GradingScale } from 'app/entities/grading-scale.model';
 import { take } from 'rxjs/operators';
-import { RouterTestingModule } from '@angular/router/testing';
 import { GradeStep, GradeStepsDTO } from 'app/entities/grade-step.model';
 import { BonusService } from 'app/grading-system/bonus/bonus.service';
 import { Bonus, BonusExample, BonusStrategy } from 'app/entities/bonus.model';
 import { GradingSystemService } from 'app/grading-system/grading-system.service';
 import { cloneDeep } from 'lodash-es';
 import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 describe('Bonus Service', () => {
     type GradeStepBuilder = {
@@ -91,8 +91,8 @@ describe('Bonus Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule],
-            providers: [provideHttpClient(), provideHttpClientTesting()],
+            imports: [],
+            providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(BonusService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/grading-system.service.spec.ts
+++ b/src/test/javascript/spec/service/grading-system.service.spec.ts
@@ -3,11 +3,11 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { GradingSystemService } from 'app/grading-system/grading-system.service';
 import { GradeType, GradingScale } from 'app/entities/grading-scale.model';
 import { take } from 'rxjs/operators';
-import { RouterTestingModule } from '@angular/router/testing';
 import { GradeDTO, GradeStep, GradeStepsDTO } from 'app/entities/grade-step.model';
 import { of } from 'rxjs';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { cloneDeep } from 'lodash-es';
+import { provideRouter } from '@angular/router';
 
 describe('Grading System Service', () => {
     let service: GradingSystemService;
@@ -42,8 +42,8 @@ describe('Grading System Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [RouterTestingModule],
-            providers: [provideHttpClient(), provideHttpClientTesting()],
+            imports: [],
+            providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting()],
         });
         service = TestBed.inject(GradingSystemService);
         httpMock = TestBed.inject(HttpTestingController);

--- a/src/test/javascript/spec/service/notification.service.spec.ts
+++ b/src/test/javascript/spec/service/notification.service.spec.ts
@@ -2,7 +2,7 @@ import { HttpTestingController, TestRequest, provideHttpClientTesting } from '@a
 import { NotificationService } from 'app/shared/notification/notification.service';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, provideRouter } from '@angular/router';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { TranslateTestingModule } from '../helpers/mocks/service/mock-translate.service';
 import {
@@ -16,7 +16,6 @@ import {
     Notification,
 } from 'app/entities/notification.model';
 import { MockRouter } from '../helpers/mocks/mock-router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { AccountService } from 'app/core/auth/account.service';
@@ -156,9 +155,10 @@ describe('Notification Service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [TranslateTestingModule, RouterTestingModule.withRoutes([])],
+            imports: [TranslateTestingModule],
             declarations: [MockPipe(ArtemisTranslatePipe)],
             providers: [
+                provideRouter([]),
                 provideHttpClient(),
                 provideHttpClientTesting(),
                 { provide: LocalStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/service/user-route-access.service.spec.ts
+++ b/src/test/javascript/spec/service/user-route-access.service.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
-import { ActivatedRouteSnapshot, Route, Router } from '@angular/router';
+import { ActivatedRouteSnapshot, Route, Router, RouterModule } from '@angular/router';
 import { ArtemisTestModule } from '../test.module';
 import { TranslateService } from '@ngx-translate/core';
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
@@ -8,7 +8,6 @@ import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.serv
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
-import { RouterTestingModule } from '@angular/router/testing';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Mutable } from '../helpers/mutable';
 import { mockedActivatedRouteSnapshot } from '../helpers/mocks/activated-route/mock-activated-route-snapshot';
@@ -40,7 +39,7 @@ describe('UserRouteAccessService', () => {
         TestBed.configureTestingModule({
             imports: [
                 ArtemisTestModule,
-                RouterTestingModule.withRoutes([
+                RouterModule.forRoot([
                     {
                         path: route,
                         component: CourseExerciseDetailsComponent,


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently a lot of client tests use the `RouterTestingModule` which is deprecated.

### Description
<!-- Describe your changes in detail -->
This PR replaces the `RouterTestingModule` with `provideRouter()` or `RouterModule.forRoot()` according to [Angular Documentation](https://v17.angular.io/api/router/testing/RouterTestingModule)

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
All client tests must pass

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated test setups across multiple components to replace `RouterTestingModule` with `RouterModule.forRoot()` or `provideRouter`, enhancing routing configuration in tests.
	- Streamlined import statements for improved clarity and maintainability.
- **Chores**
	- Consolidated imports and updated providers in various test files to reflect the new routing setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->