### PR TITLE
`Exam mode`: Remove exercise title from solution containers 

### DIFF
--- a/src/main/webapp/app/exam/participate/exercises/file-upload/file-upload-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/file-upload/file-upload-exam-submission.component.html
@@ -15,7 +15,7 @@
     <hr />
     <jhi-resizeable-container [examTimeline]="examTimeline">
         <!--region Left Panel-->
-        <span class="exercise-title" left-header>{{ examTimeline ? exercise.title : (exercise?.exerciseGroup?.title ?? '-') }}</span>
+        <span class="exercise-title" left-header>{{ examTimeline ? exercise.title : ('artemisApp.exam.yourSolution' | artemisTranslate) }}</span>
         <div left-body class="px-2 pb-2 w-100">
             <div class="row">
                 @if (isActive && !result && exercise && studentSubmission && !readonly) {

--- a/src/main/webapp/app/exam/participate/exercises/modeling/modeling-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/modeling/modeling-exam-submission.component.html
@@ -16,7 +16,7 @@
 
     <jhi-resizeable-container class="col-12" [examTimeline]="examTimeline">
         <!--region Left Panel-->
-        <span class="exercise-title" left-header>{{ examTimeline ? exercise.title : (exercise?.exerciseGroup?.title ?? '-') }}</span>
+        <span class="exercise-title" left-header>{{ examTimeline ? exercise.title : ('artemisApp.exam.yourSolution' | artemisTranslate) }}</span>
         <div left-body class="submission-container d-flex flex-column ps-2 mt-3 w-100">
             <jhi-fullscreen>
                 <div class="row flex-grow-1">

--- a/src/main/webapp/app/exam/participate/exercises/text/text-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/text/text-exam-submission.component.html
@@ -16,7 +16,7 @@
     <!--resizable container-->
     <jhi-resizeable-container class="col-12" [examTimeline]="examTimeline">
         <!--region Left Panel-->
-        <span class="exercise-title" left-header>{{ examTimeline ? exercise.title : (exercise?.exerciseGroup?.title ?? '-') }}</span>
+        <span class="exercise-title" left-header>{{ examTimeline ? exercise.title : ('artemisApp.exam.yourSolution' | artemisTranslate) }}</span>
         <div left-body class="text-editor-grid mt-4 ps-2 pb-2 w-100">
             <div class="grid-area-main">
                 <div>

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -150,6 +150,7 @@
             "falseName": "Der angegebene Name ist nicht korrekt. Bitte versuche es erneut!",
             "notSet": "Nicht gesetzt",
             "startExamToolTip": "Button wird 5 Minuten vor der Klausur aktiviert.",
+            "yourSolution": "Deine Lösung",
             "cleanup": {
                 "title": "Aufräumen",
                 "question": "Möchtest du die Prüfung <strong>{{title}}</strong> wirklich bereinigen? Dadurch werden alle Studierenden-Repositories in der Prüfung gelöscht. Diese Aktion kann <strong class='text-danger'>NICHT</strong> rückgängig gemacht werden!"

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -150,6 +150,7 @@
             "falseName": "Entered name is incorrect. Please try again!",
             "notSet": "Not set",
             "startExamToolTip": "Button will be activated 5 minutes before the exam start.",
+            "yourSolution": "Your Solution",
             "cleanup": {
                 "title": "Cleanup",
                 "question": "Are you sure you want to clean up the exam <strong>{{ title }}</strong>? This will delete all student programming exercise repositories in the exam. This action can <strong class='text-danger'>NOT</strong> be undone!"

--- a/src/test/javascript/spec/component/exam/participate/exercises/file-upload-exam-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exercises/file-upload-exam-submission.component.spec.ts
@@ -77,10 +77,9 @@ describe('FileUploadExamSubmissionComponent', () => {
             expect(FileUploadExamSubmissionComponent).not.toBeNull();
         });
 
-        it('should show exercise group title', () => {
-            comp.exercise.exerciseGroup = { title: 'Test Group' } as ExerciseGroup;
+        it('should show static text in header', () => {
             fixture.detectChanges();
-            const el = fixture.debugElement.query((de) => de.nativeElement.textContent === comp.exercise.exerciseGroup?.title);
+            const el = fixture.debugElement.query((de) => de.nativeElement.textContent === 'artemisApp.exam.yourSolution');
             expect(el).not.toBeNull();
         });
 

--- a/src/test/javascript/spec/component/exam/participate/exercises/modeling-exam-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exercises/modeling-exam-submission.component.spec.ts
@@ -16,7 +16,6 @@ import { ArtemisTestModule } from '../../../../test.module';
 import { IncludedInScoreBadgeComponent } from 'app/exercises/shared/exercise-headers/included-in-score-badge.component';
 import { ExamExerciseUpdateHighlighterComponent } from 'app/exam/participate/exercises/exam-exercise-update-highlighter/exam-exercise-update-highlighter.component';
 import { NgbTooltipMocksModule } from '../../../../helpers/mocks/directive/ngbTooltipMocks.module';
-import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import { SubmissionVersion } from 'app/entities/submission-version.model';
 
 describe('ModelingExamSubmissionComponent', () => {
@@ -69,10 +68,9 @@ describe('ModelingExamSubmissionComponent', () => {
             expect(ModelingExamSubmissionComponent).not.toBeNull();
         });
 
-        it('should show exercise group title', () => {
-            comp.exercise.exerciseGroup = { title: 'Test Group' } as ExerciseGroup;
+        it('should show static text in header', () => {
             fixture.detectChanges();
-            const el = fixture.debugElement.query((de) => de.nativeElement.textContent === comp.exercise.exerciseGroup?.title);
+            const el = fixture.debugElement.query((de) => de.nativeElement.textContent === 'artemisApp.exam.yourSolution');
             expect(el).not.toBeNull();
         });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The title of an exercise is displayed three times during the exam (see screenshot), if the sidebar is not collapsed. Therefore, the exercise title in the solution container becomes unnecessary. 

### Description
<!-- Describe your changes in detail -->
Changed the exercise title displayed in the solution container to a static text "Your Solution", which is presented only in text, modeling, and file upload exercises.

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Exam with 3 exercises (text, modeling, and file upload)
- 1 Student

**(There is already an exam called 'Exam Title Container' under my course on TS4. Test users 1-5 are registered to the exam.)**

1. Log in to Artemis
2. Participate in the exam
3. Verify that you see 'Your Solution' or 'Deine Lösung' in the solution container header instead of the exercise title

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before
![Group 155](https://github.com/user-attachments/assets/7bf86606-9c3e-4f3e-967a-9967674bf052)

After
<img width="1251" alt="Screenshot 2024-10-08 at 21 32 31" src="https://github.com/user-attachments/assets/c5ec7d11-42e6-4ef9-aff0-6927b71f8ff3">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated exercise title display logic to show a translated string for "your solution" based on the exam timeline state.
	- Added new translation keys for "your solution" in both English and German.

- **Bug Fixes**
	- Improved clarity in user submissions by ensuring the correct title is displayed when the exam timeline is not available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->