### PR TITLE
`Lectures`: Fix an issue with undefined units when processing lecture units

### DIFF
--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.html
@@ -99,7 +99,7 @@
             />
         </div>
     </div>
-    @if (units && units.length < 1) {
+    @if (!units || (units && units.length < 1)) {
         <div class="alert alert-danger mt-3">
             <fa-icon [icon]="faExclamationTriangle" />
             {{ 'artemisApp.attachmentUnit.createAttachmentUnits.noUnitDetected' | artemisTranslate }}
@@ -109,7 +109,7 @@
         [ngbTooltip]="'artemisApp.attachmentUnit.createAttachmentUnits.processTimeInfo' | artemisTranslate"
         type="button"
         (click)="createAttachmentUnits()"
-        [disabled]="units.length < 1"
+        [disabled]="!units || units.length < 1"
         class="btn btn-primary"
     >
         <span jhiTranslate="entity.action.submit"></span>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.html
@@ -99,7 +99,7 @@
             />
         </div>
     </div>
-    @if (!units || units.length < 1) {
+    @if (!units || units!.length < 1) {
         <div class="alert alert-danger mt-3">
             <fa-icon [icon]="faExclamationTriangle" />
             {{ 'artemisApp.attachmentUnit.createAttachmentUnits.noUnitDetected' | artemisTranslate }}
@@ -109,7 +109,7 @@
         [ngbTooltip]="'artemisApp.attachmentUnit.createAttachmentUnits.processTimeInfo' | artemisTranslate"
         type="button"
         (click)="createAttachmentUnits()"
-        [disabled]="!units || units.length < 1"
+        [disabled]="!units || units!.length < 1"
         class="btn btn-primary"
     >
         <span jhiTranslate="entity.action.submit"></span>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.html
@@ -99,7 +99,7 @@
             />
         </div>
     </div>
-    @if (!units || (units && units.length < 1)) {
+    @if (!units || units.length < 1) {
         <div class="alert alert-danger mt-3">
             <fa-icon [icon]="faExclamationTriangle" />
             {{ 'artemisApp.attachmentUnit.createAttachmentUnits.noUnitDetected' | artemisTranslate }}

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.html
@@ -99,7 +99,7 @@
             />
         </div>
     </div>
-    @if (units!.length < 1) {
+    @if (units.length < 1) {
         <div class="alert alert-danger mt-3">
             <fa-icon [icon]="faExclamationTriangle" />
             {{ 'artemisApp.attachmentUnit.createAttachmentUnits.noUnitDetected' | artemisTranslate }}
@@ -109,7 +109,7 @@
         [ngbTooltip]="'artemisApp.attachmentUnit.createAttachmentUnits.processTimeInfo' | artemisTranslate"
         type="button"
         (click)="createAttachmentUnits()"
-        [disabled]="units!.length < 1"
+        [disabled]="units.length < 1"
         class="btn btn-primary"
     >
         <span jhiTranslate="entity.action.submit"></span>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.html
@@ -99,7 +99,7 @@
             />
         </div>
     </div>
-    @if (!units || units!.length < 1) {
+    @if (units!.length < 1) {
         <div class="alert alert-danger mt-3">
             <fa-icon [icon]="faExclamationTriangle" />
             {{ 'artemisApp.attachmentUnit.createAttachmentUnits.noUnitDetected' | artemisTranslate }}
@@ -109,7 +109,7 @@
         [ngbTooltip]="'artemisApp.attachmentUnit.createAttachmentUnits.processTimeInfo' | artemisTranslate"
         type="button"
         (click)="createAttachmentUnits()"
-        [disabled]="!units || units!.length < 1"
+        [disabled]="units!.length < 1"
         class="btn btn-primary"
     >
         <span jhiTranslate="entity.action.submit"></span>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.ts
@@ -117,7 +117,7 @@ export class AttachmentUnitsComponent implements OnInit {
             )
             .subscribe({
                 next: (res) => {
-                    this.units = res.body!.units;
+                    this.units = res.body?.units || this.units;
                     this.numberOfPages = res.body!.numberOfPages;
                     this.isLoading = false;
                 },

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-units/attachment-units.component.ts
@@ -117,7 +117,7 @@ export class AttachmentUnitsComponent implements OnInit {
             )
             .subscribe({
                 next: (res) => {
-                    this.units = res.body?.units || this.units;
+                    this.units = res.body!.units || this.units;
                     this.numberOfPages = res.body!.numberOfPages;
                     this.isLoading = false;
                 },


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This issue is created because when a new Lecture is created and Lecture Unit Processing is executed, if the PDF file does not have a page titled "Outline", then the units can not be created, therefore they become 'undefined'. Since there was no checks on the HTML page regarding the units being undefined, these checks needed to be added.

Problem Video:
https://github.com/user-attachments/assets/660d1380-4fee-43c5-b275-925fdc0ffe78


### Description
<!-- Describe your changes in detail -->

For **createAttachmentUnits()** button and **noUnitDetected** warning, one more check added, that checks if the units exists or not

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Navigate to 'Create Lecture' page
2. Select 'Automatic Unit Processing' 
3. Upload a PDF file without an "Outline" slide
4. Observe the page, it should not give an error and show "No units are found" warning
5. There should be no lecture units and Submit button should be disabled until you add a unit
6. Check if submits after creating at least 1 unit
7. Create a Lecture again and upload a file with "Outline" slide
8. The lecture units should be created, no warnings/errors should be shown 

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Before the Fix:**

![Screenshot 2024-10-11 at 02 26 15](https://github.com/user-attachments/assets/cc9acfe4-137c-48db-a26c-71ede64331fb)

![Screenshot 2024-10-11 at 02 26 36](https://github.com/user-attachments/assets/3ed0e04b-e200-4f63-91fd-e4937d8071ab)

**After the Fix:**

![Screenshot 2024-10-11 at 02 27 31](https://github.com/user-attachments/assets/5f267686-41ba-4f7c-bb64-7e01455cc3ce)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced handling of the `units` array to ensure existing units are preserved if the response does not contain new units.
	- Updated button states for creating and deleting attachment units to simplify conditions related to the `units` array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->