### PR TITLE
`Development`: Fix wrong result subscription for exam exercises

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/websocket/WebsocketConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/websocket/WebsocketConfiguration.java
@@ -64,7 +64,6 @@ import de.tum.cit.aet.artemis.core.security.jwt.JWTFilter;
 import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.exam.repository.ExamRepository;
-import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
@@ -309,8 +308,7 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
 
                 // TODO: Is it right that TAs are not allowed to subscribe to exam exercises?
                 if (exerciseRepository.isExamExercise(exerciseId)) {
-                    Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
-                    return authorizationCheckService.isAtLeastInstructorInCourse(login, exercise.getCourseViaExerciseGroupOrCourseMember().getId());
+                    return authorizationCheckService.isAtLeastInstructorInExercise(login, exerciseId);
                 }
                 else {
                     return authorizationCheckService.isAtLeastTeachingAssistantInExercise(login, exerciseId);

--- a/src/main/webapp/app/exam/participate/summary/exam-result-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-result-summary.component.html
@@ -190,6 +190,7 @@
                             [resultsPublished]="resultsArePublished"
                             [isPrinting]="isPrinting"
                             [isAfterResultsArePublished]="resultsArePublished"
+                            [instructorView]="instructorView"
                         />
                     }
                 }

--- a/src/main/webapp/app/exam/participate/summary/exercises/programming-exam-summary/programming-exam-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exercises/programming-exam-summary/programming-exam-summary.component.html
@@ -48,7 +48,7 @@
             <div class="col-md-8">
                 <h5 jhiTranslate="artemisApp.exam.examSummary.problemStatement"></h5>
                 @if (exercise.problemStatement) {
-                    <jhi-programming-exercise-instructions [exercise]="exercise" [participation]="participation" />
+                    <jhi-programming-exercise-instructions [exercise]="exercise" [participation]="participation" [personalParticipation]="!instructorView" />
                 }
             </div>
         </div>

--- a/src/main/webapp/app/exam/participate/summary/exercises/programming-exam-summary/programming-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/programming-exam-summary/programming-exam-summary.component.ts
@@ -39,6 +39,8 @@ export class ProgrammingExamSummaryComponent implements OnInit {
 
     @Input() isAfterResultsArePublished?: boolean = false;
 
+    @Input() instructorView?: boolean = false;
+
     readonly PROGRAMMING: ExerciseType = ExerciseType.PROGRAMMING;
 
     protected readonly AssessmentType = AssessmentType;


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
We noticed some log messages saying:
```
User with login '' tried to access the protected topic: /topic/exercise/14238/newResults
User with login '' tried to access the protected topic: /topic/exercise/10200/newResults
```

This PR fixes the cause of these warnings.

### Description
When opening the exam summary page, a subscription to result updates is initiated. The client incorrectly used the non-personal topic instead of the personal topic. This is now fixed.


### Steps for Testing
You can best test this locally or on a test server with access to the logs.

As a student, view your exams results summary. Then check the server and make sure none of the warnings as above are present.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `instructorView` property to enhance the exam result summary display for instructors.
	- Added a `personalParticipation` property to better manage participation visibility based on the instructor view.

- **Bug Fixes**
	- Streamlined authorization checks for user subscriptions to exercise results, improving logic clarity and efficiency.

- **Documentation**
	- Updated component signatures to reflect new input properties for better integration and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->