### PR TITLE
`Development`: Fix architecture tests for exam deletion summary

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/web/admin/AdminCourseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/admin/AdminCourseResource.java
@@ -189,7 +189,6 @@ public class AdminCourseResource {
      * @return the ResponseEntity with status 200 (OK) and the deletion summary in the body
      */
     @GetMapping("courses/{courseId}/deletion-summary")
-    @EnforceAdmin
     public ResponseEntity<CourseDeletionSummaryDTO> getDeletionSummary(@PathVariable long courseId) {
         log.debug("REST request to get deletion summary course: {}", courseId);
         final Course course = courseRepository.findByIdWithEagerExercisesElseThrow(courseId);

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/CourseServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/CourseServiceTest.java
@@ -38,7 +38,7 @@ import de.tum.cit.aet.artemis.exercise.test_repository.SubmissionTestRepository;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParticipation;
 import de.tum.cit.aet.artemis.programming.domain.build.BuildJob;
-import de.tum.cit.aet.artemis.programming.repository.BuildJobRepository;
+import de.tum.cit.aet.artemis.programming.test_repository.BuildJobTestRepository;
 import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseFactory;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationLocalCILocalVCTest;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
@@ -61,7 +61,7 @@ class CourseServiceTest extends AbstractSpringIntegrationLocalCILocalVCTest {
     private StudentParticipationTestRepository studentParticipationRepo;
 
     @Autowired
-    private BuildJobRepository buildJobRepo;
+    private BuildJobTestRepository buildJobRepo;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExamDeletionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExamDeletionIntegrationTest.java
@@ -19,8 +19,8 @@ import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.exam.domain.Exam;
 import de.tum.cit.aet.artemis.exam.domain.StudentExam;
 import de.tum.cit.aet.artemis.exam.dto.ExamDeletionSummaryDTO;
-import de.tum.cit.aet.artemis.exam.repository.StudentExamRepository;
 import de.tum.cit.aet.artemis.exam.service.ExamSessionService;
+import de.tum.cit.aet.artemis.exam.test_repository.StudentExamTestRepository;
 import de.tum.cit.aet.artemis.exam.util.ExamUtilService;
 import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
@@ -28,7 +28,7 @@ import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilServi
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParticipation;
 import de.tum.cit.aet.artemis.programming.domain.build.BuildJob;
-import de.tum.cit.aet.artemis.programming.repository.BuildJobRepository;
+import de.tum.cit.aet.artemis.programming.test_repository.BuildJobTestRepository;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -43,13 +43,13 @@ class ExamDeletionIntegrationTest extends AbstractSpringIntegrationIndependentTe
     private ExamSessionService examSessionService;
 
     @Autowired
-    private StudentExamRepository studentExamRepository;
+    private StudentExamTestRepository studentExamRepository;
 
     @Autowired
     private ParticipationUtilService participationUtilService;
 
     @Autowired
-    private BuildJobRepository buildJobRepository;
+    private BuildJobTestRepository buildJobRepository;
 
     private static final int NUMBER_OF_STUDENTS = 4;
 

--- a/src/test/java/de/tum/cit/aet/artemis/exam/util/ExamUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/util/ExamUtilService.java
@@ -19,8 +19,8 @@ import de.tum.cit.aet.artemis.communication.domain.AnswerPost;
 import de.tum.cit.aet.artemis.communication.domain.Post;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Channel;
 import de.tum.cit.aet.artemis.communication.repository.AnswerPostRepository;
-import de.tum.cit.aet.artemis.communication.repository.PostRepository;
 import de.tum.cit.aet.artemis.communication.test_repository.ConversationTestRepository;
+import de.tum.cit.aet.artemis.communication.test_repository.PostTestRepository;
 import de.tum.cit.aet.artemis.communication.util.ConversationFactory;
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.domain.Language;
@@ -137,7 +137,7 @@ public class ExamUtilService {
     private ConversationTestRepository conversationRepository;
 
     @Autowired
-    private PostRepository postRepository;
+    private PostTestRepository postRepository;
 
     @Autowired
     private AnswerPostRepository answerPostRepository;


### PR DESCRIPTION
### Checklist
#### Motivation

After merging #9185, some architecture tests fail. These changes fixes that.

#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Access to the course deletion summary has been simplified, allowing potentially non-admin users to view it.

- **Bug Fixes**
	- No specific bug fixes were mentioned.

- **Tests**
	- Updated test classes to use test-specific repositories, enhancing isolation and reliability of test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->