### PR TITLE
`Development`: Fix exam assessment e2e tests failing

### DIFF
--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -332,7 +332,6 @@ export async function prepareExam(course: Course, end: dayjs.Dayjs, exerciseType
         gracePeriod: 10,
     };
     exam = await examAPIRequests.createExam(examConfig);
-    await examAPIRequests.registerStudentForExam(exam, studentOne);
     let additionalData = {};
     switch (exerciseType) {
         case ExerciseType.PROGRAMMING:
@@ -347,6 +346,7 @@ export async function prepareExam(course: Course, end: dayjs.Dayjs, exerciseType
     }
 
     const exercise = await examExerciseGroupCreation.addGroupWithExercise(exam, exerciseType, additionalData);
+    await examAPIRequests.registerStudentForExam(exam, studentOne);
     await examAPIRequests.generateMissingIndividualExams(exam);
     await examAPIRequests.prepareExerciseStartForExam(exam);
     exercise.additionalData = additionalData;

--- a/src/test/playwright/e2e/exam/ExamDateVerification.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamDateVerification.spec.ts
@@ -68,9 +68,9 @@ test.describe('Exam date verification', () => {
                 endDate: dayjs().add(3, 'days'),
             };
             const exam = await examAPIRequests.createExam(examConfig);
-            await examAPIRequests.registerStudentForExam(exam, studentOne);
             const exerciseGroup = await examAPIRequests.addExerciseGroupForExam(exam);
             const exercise = await exerciseAPIRequests.createTextExercise({ exerciseGroup });
+            await examAPIRequests.registerStudentForExam(exam, studentOne);
             await examAPIRequests.generateMissingIndividualExams(exam);
             await examAPIRequests.prepareExerciseStartForExam(exam);
             await login(studentOne);
@@ -105,9 +105,9 @@ test.describe('Exam date verification', () => {
                 endDate: examEnd,
             };
             const exam = await examAPIRequests.createExam(examConfig);
-            await examAPIRequests.registerStudentForExam(exam, studentOne);
             const exerciseGroup = await examAPIRequests.addExerciseGroupForExam(exam);
             const exercise = await exerciseAPIRequests.createTextExercise({ exerciseGroup });
+            await examAPIRequests.registerStudentForExam(exam, studentOne);
             await examAPIRequests.generateMissingIndividualExams(exam);
             await examAPIRequests.prepareExerciseStartForExam(exam);
             await login(studentOne);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The exam assessment e2e tests broke due to the logic changes in the student exam creation in https://github.com/ls1intum/Artemis/pull/9123, as there is now a race condition, when the student exams are generated automatically. The playwright tests registered users before creating exercises, which lead to the student exams showing up without any exercises to the user.

### Description
<!-- Describe your changes in detail -->
Simply registering the students *after* creating the exercises, solves the issue.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
Run the playwright e2e test and make sure no tests fail.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before the students did not have any exercises in their exams:
![image](https://github.com/user-attachments/assets/b7164a1a-3bb2-4e0c-bcf1-47ace5926832)

After the fix: 
![image](https://github.com/user-attachments/assets/07f885b0-c6ca-4a99-b211-5e543d3b2acf)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the exam assessment process by ensuring students are registered for exams.
	- Introduced feedback mechanisms and verification steps for various exercise types.
	- Improved exam registration flow by ensuring students are registered before test interactions.

- **Bug Fixes**
	- Improved handling of exam timings using `dayjs` for accurate time management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->