### PR TITLE
`Development`: Fix the exam results overview playwright test

### DIFF
--- a/src/test/playwright/e2e/exam/ExamResults.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamResults.spec.ts
@@ -82,7 +82,7 @@ test.describe('Exam Results', () => {
                     }
                     exercise = await examExerciseGroupCreation.addGroupWithExercise(exam, testCase.exerciseType, additionalData);
                     await examAPIRequests.registerStudentForExam(exam, studentOne);
-                    const studentExams = await examAPIRequests.generateMissingIndividualExams(exam);
+                    const studentExams = await examAPIRequests.getAllStudentExams(exam);
                     studentExam = studentExams[0];
                     await examAPIRequests.prepareExerciseStartForExam(exam);
                 });

--- a/src/test/playwright/support/requests/ExamAPIRequests.ts
+++ b/src/test/playwright/support/requests/ExamAPIRequests.ts
@@ -166,6 +166,15 @@ export class ExamAPIRequests {
     }
 
     /**
+     * Get all student-exams of an exam
+     * @param exam the exam for which the student-exams are fetched
+     */
+    async getAllStudentExams(exam: Exam) {
+        const response = await this.page.request.get(`${COURSE_BASE}/${exam.course!.id}/exams/${exam.id}/student-exams`);
+        return await response.json();
+    }
+
+    /**
      * Prepares individual exercises for exam start
      * @param exam the exam for which the exercises are prepared
      */


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The  _Results › Check exam exercise results › Check exam results for text exercise › Check exam result overview_ e2e test is still failing.
This is caused by the test relying on the `generate-missing-student-exams` request to obtain the student exam id, of the student participating in the exam. Since the student exams are already generated automatically, this request yields an empty array, which causes the test to fail as it tries to access the id property of an undefined student exam.

### Description
<!-- Describe your changes in detail -->
Instead of relying on the result of the student-exam generation, the student exams are explicitly fetched with the
 `.../exams/${exam.id}/student-exams` endpoint

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Check that the test runs through correctly.



### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to retrieve all student exams associated with a specific exam.
- **Bug Fixes**
	- Updated logic for fetching student exams to ensure accurate data retrieval after adding exercises to exams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->