### PR TITLE
`Programming exercises`: Do not always show the request feedback button in the online code editor

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/request-feedback-button/request-feedback-button.component.html
+++ b/src/main/webapp/app/overview/exercise-details/request-feedback-button/request-feedback-button.component.html
@@ -1,4 +1,4 @@
-@if (!isExamExercise) {
+@if (!isExamExercise && requestFeedbackEnabled) {
     @if (athenaEnabled) {
         @if (exercise().type === ExerciseType.TEXT) {
             <button

--- a/src/main/webapp/app/overview/exercise-details/request-feedback-button/request-feedback-button.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/request-feedback-button/request-feedback-button.component.ts
@@ -26,6 +26,7 @@ import { ParticipationService } from 'app/exercises/shared/participation/partici
 export class RequestFeedbackButtonComponent implements OnInit {
     faPenSquare = faPenSquare;
     athenaEnabled = false;
+    requestFeedbackEnabled = false;
     isExamExercise: boolean;
     participation?: StudentParticipation;
 
@@ -34,7 +35,6 @@ export class RequestFeedbackButtonComponent implements OnInit {
     exercise = input.required<Exercise>();
     generatingFeedback = output<void>();
 
-    private feedbackSent = false;
     private profileService = inject(ProfileService);
     private alertService = inject(AlertService);
     private courseExerciseService = inject(CourseExerciseService);
@@ -52,6 +52,7 @@ export class RequestFeedbackButtonComponent implements OnInit {
         if (this.isExamExercise || !this.exercise().id) {
             return;
         }
+        this.requestFeedbackEnabled = this.exercise().allowFeedbackRequests ?? false;
         this.updateParticipation();
     }
 
@@ -77,7 +78,6 @@ export class RequestFeedbackButtonComponent implements OnInit {
             next: (participation: StudentParticipation) => {
                 if (participation) {
                     this.generatingFeedback.emit();
-                    this.feedbackSent = true;
                     this.alertService.success('artemisApp.exercise.feedbackRequestSent');
                 }
             },

--- a/src/test/javascript/spec/component/overview/exercise-details/request-feedback-button/request-feedback-button.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/request-feedback-button/request-feedback-button.component.spec.ts
@@ -38,7 +38,6 @@ describe('RequestFeedbackButtonComponent', () => {
                 exerciseService = debugElement.injector.get(ExerciseService);
                 profileService = debugElement.injector.get(ProfileService);
                 alertService = debugElement.injector.get(AlertService);
-                component.requestFeedbackEnabled = true;
             });
     });
 

--- a/src/test/javascript/spec/component/overview/exercise-details/request-feedback-button/request-feedback-button.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/request-feedback-button/request-feedback-button.component.spec.ts
@@ -38,6 +38,7 @@ describe('RequestFeedbackButtonComponent', () => {
                 exerciseService = debugElement.injector.get(ExerciseService);
                 profileService = debugElement.injector.get(ProfileService);
                 alertService = debugElement.injector.get(AlertService);
+                component.requestFeedbackEnabled = true;
             });
     });
 

--- a/src/test/javascript/spec/component/overview/exercise-details/request-feedback-button/request-feedback-button.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/request-feedback-button/request-feedback-button.component.spec.ts
@@ -56,7 +56,7 @@ describe('RequestFeedbackButtonComponent', () => {
             submissions: [{ id: 1, submitted: true }],
             testRun: false,
         } as StudentParticipation;
-        const exercise = { id: 1, type: ExerciseType.TEXT, course: undefined, studentParticipations: [participation] } as Exercise;
+        const exercise = { id: 1, type: ExerciseType.TEXT, course: undefined, studentParticipations: [participation], allowFeedbackRequests: true } as Exercise;
         fixture.componentRef.setInput('exercise', exercise);
         mockExerciseDetails(exercise);
 
@@ -75,7 +75,7 @@ describe('RequestFeedbackButtonComponent', () => {
 
     it('should display the button when Athena is enabled and it is not an exam exercise', fakeAsync(() => {
         setAthenaEnabled(true);
-        const exercise = { id: 1, type: ExerciseType.TEXT, course: {} } as Exercise; // course undefined means exam exercise
+        const exercise = { id: 1, type: ExerciseType.TEXT, course: {}, allowFeedbackRequests: true } as Exercise; // course undefined means exam exercise
         fixture.componentRef.setInput('exercise', exercise);
         mockExerciseDetails(exercise);
 
@@ -104,7 +104,7 @@ describe('RequestFeedbackButtonComponent', () => {
 
     it('should disable the button when participation is missing', fakeAsync(() => {
         setAthenaEnabled(true);
-        const exercise = { id: 1, type: ExerciseType.TEXT, course: {}, studentParticipations: undefined } as Exercise;
+        const exercise = { id: 1, type: ExerciseType.TEXT, course: {}, studentParticipations: undefined, allowFeedbackRequests: true } as Exercise;
         fixture.componentRef.setInput('exercise', exercise);
         mockExerciseDetails(exercise);
 
@@ -123,7 +123,7 @@ describe('RequestFeedbackButtonComponent', () => {
             id: 1,
             submissions: [{ id: 1, submitted: true }],
         } as StudentParticipation;
-        const exercise = { id: 1, type: ExerciseType.TEXT, course: {}, studentParticipations: [participation] } as Exercise;
+        const exercise = { id: 1, type: ExerciseType.TEXT, course: {}, studentParticipations: [participation], allowFeedbackRequests: true } as Exercise;
         fixture.componentRef.setInput('exercise', exercise);
         component.isExamExercise = false;
         mockExerciseDetails(exercise);
@@ -146,7 +146,7 @@ describe('RequestFeedbackButtonComponent', () => {
             submissions: [{ id: 1, submitted: false }],
             testRun: false,
         } as StudentParticipation;
-        const exercise = { id: 1, type: ExerciseType.PROGRAMMING, studentParticipations: [participation], course: {} } as Exercise;
+        const exercise = { id: 1, type: ExerciseType.PROGRAMMING, studentParticipations: [participation], course: {}, allowFeedbackRequests: true } as Exercise;
         fixture.componentRef.setInput('exercise', exercise);
 
         mockExerciseDetails(exercise);
@@ -173,7 +173,7 @@ describe('RequestFeedbackButtonComponent', () => {
     it('should show an alert when requestFeedback() is called and conditions are not satisfied', fakeAsync(() => {
         setAthenaEnabled(true);
 
-        const exercise = { id: 1, type: ExerciseType.TEXT, course: {} } as Exercise;
+        const exercise = { id: 1, type: ExerciseType.TEXT, course: {}, allowFeedbackRequests: true } as Exercise;
         fixture.componentRef.setInput('exercise', exercise);
 
         jest.spyOn(component, 'hasAthenaResultForLatestSubmission').mockReturnValue(true);
@@ -191,7 +191,7 @@ describe('RequestFeedbackButtonComponent', () => {
             submissions: [{ id: 1, submitted: false }],
             testRun: false,
         } as StudentParticipation;
-        const exercise = { id: 1, type: ExerciseType.TEXT, studentParticipations: [participation], course: {} } as Exercise;
+        const exercise = { id: 1, type: ExerciseType.TEXT, studentParticipations: [participation], course: {}, allowFeedbackRequests: true } as Exercise;
         fixture.componentRef.setInput('exercise', exercise);
         fixture.componentRef.setInput('isGeneratingFeedback', false);
         mockExerciseDetails(exercise);
@@ -212,7 +212,7 @@ describe('RequestFeedbackButtonComponent', () => {
             submissions: [{ id: 1, submitted: true }],
             testRun: false,
         } as StudentParticipation;
-        const exercise = { id: 1, type: ExerciseType.TEXT, course: {}, studentParticipations: [participation] } as Exercise;
+        const exercise = { id: 1, type: ExerciseType.TEXT, course: {}, studentParticipations: [participation], allowFeedbackRequests: true } as Exercise;
         fixture.componentRef.setInput('exercise', exercise);
         fixture.componentRef.setInput('isGeneratingFeedback', false);
         mockExerciseDetails(exercise);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
Since #9324, the Request Feedback or the Request AI Feedback button was always shown in the online code editor, no matter if the corresponding setting was active or not.


### Description
Add a check to only show the button when the setting is active


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Programming exercise with online code editor enabled

1. Open the online code editor and make sure the Request Feedback or Request AI Feedback button is **not** shown
2. Change the setting of the programming exercise (add a due date, activate manual assessment and activate `Manual feedback requests`: 
3. Make sure the button is now shown in the online code editor

<img width="931" alt="image" src="https://github.com/user-attachments/assets/e161e331-c64b-4a23-a1c7-8eb6879b614b">

<img width="581" alt="image" src="https://github.com/user-attachments/assets/e2862612-092a-498e-a7e8-2d8caae29c94">


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
#### Code Review
- [x] Code Review 1
#### Manual Tests
- [x] Test 1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a conditional display for the feedback request button based on whether the feedback request feature is enabled.
  
- **Bug Fixes**
	- Simplified feedback request logic by removing unnecessary checks, improving user experience when sending feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->