### PR TITLE
`Communication`: Reduce height of channel and chat item card

### DIFF
--- a/src/main/webapp/app/shared/sidebar/conversation-options/conversation-options.component.html
+++ b/src/main/webapp/app/shared/sidebar/conversation-options/conversation-options.component.html
@@ -1,9 +1,9 @@
 <div class="option-buttons" (click)="$event.stopPropagation()">
-    <button class="favorite btn btn-outline-secondary sidebar-button px-0" (click)="onFavoriteClicked($event)" type="button">
+    <button class="favorite btn btn-outline-secondary sidebar-button p-0" (click)="onFavoriteClicked($event)" type="button">
         <fa-icon [icon]="conversation.isFavorite ? faHeartSolid : faHeartRegular" size="sm" />
     </button>
     <div ngbDropdown container="body" class="d-inline-block">
-        <button class="btn btn-outline-secondary dropdown-toggle sidebar-button" type="button" ngbDropdownToggle>
+        <button class="btn btn-outline-secondary dropdown-toggle sidebar-button py-0" type="button" ngbDropdownToggle>
             <fa-icon [icon]="faEllipsisVertical" size="sm" />
         </button>
         <div ngbDropdownMenu>

--- a/src/main/webapp/app/shared/sidebar/sidebar-card-item/sidebar-card-item.component.html
+++ b/src/main/webapp/app/shared/sidebar/sidebar-card-item/sidebar-card-item.component.html
@@ -1,6 +1,6 @@
 <!-- TODO: Refactor Special Case 'Exercise' -->
 @if (sidebarItem) {
-    <div class="mx-1 mb-1">
+    <div class="mx-1">
         @if (sidebarType === 'exam') {
             <div class="d-flex justify-content-between align-items-baseline">
                 <span id="test-sidebar-card-title" class="me-2 mb-2" [title]="sidebarItem.title">
@@ -46,7 +46,7 @@
                 </small>
             </div>
         } @else {
-            <div class="d-flex justify-content-between mb-1 align-items-baseline">
+            <div class="d-flex justify-content-between align-items-baseline">
                 <span id="test-sidebar-card-title" class="small fw-semibold text-truncate me-2" [title]="sidebarItem.title" [class.muted]="sidebarItem.conversation?.isMuted">
                     @if (sidebarItem.icon) {
                         <fa-icon [fixedWidth]="true" [icon]="sidebarItem.icon" />
@@ -59,7 +59,7 @@
                     }
                 </span>
             </div>
-            <div class="d-flex justify-content-between align-items-baseline small">
+            <div class="d-flex justify-content-between align-items-baseline small" [ngClass]="{ 'mt-1': sidebarItem.subtitleLeft }">
                 <small class="me-2 text-truncate">
                     {{ sidebarItem.subtitleLeft }}
                 </small>

--- a/src/main/webapp/app/shared/sidebar/sidebar-card-medium/sidebar-card-medium.component.html
+++ b/src/main/webapp/app/shared/sidebar/sidebar-card-medium/sidebar-card-medium.component.html
@@ -10,7 +10,7 @@
 } @else {
     <div
         id="test-sidebar-card-medium"
-        class="pointer rounded-3 col-12 px-1 pt-2 pb-1 border-start border-5 highlight-card bg-module"
+        class="pointer rounded-3 col-12 px-1 py-2 border-start border-5 highlight-card bg-module"
         [ngClass]="{
             'border-success': sidebarItem?.difficulty === DifficultyLevel.EASY,
             'border-warning': sidebarItem?.difficulty === DifficultyLevel.MEDIUM,

--- a/src/main/webapp/app/shared/sidebar/sidebar-card-small/sidebar-card-small.component.html
+++ b/src/main/webapp/app/shared/sidebar/sidebar-card-small/sidebar-card-small.component.html
@@ -9,7 +9,7 @@
     (click)="emitStoreAndRefresh(sidebarItem.id)"
     [routerLinkActive]="'bg-selected border-selected'"
 >
-    <div class="w-75">
+    <div class="w-75 align-self-center">
         <jhi-sidebar-card-item [sidebarType]="sidebarType" [sidebarItem]="sidebarItem" />
     </div>
     @if (sidebarItem.conversation) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The cards for the channels and chats had a lot of margin. As a result, only a few fit on one page, and there was a lot of scrolling. The height/padding has been reduced.

### Description
The margin for the communication sidebar items has been reduced.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student
- 1 Course with Communication enabled 

1. Log in to Artemis
2. Navigate to Course Communication
3. See Sidebar with Channels / Chats 
4. Verify that the Channel Chats are smaller 
5. Navigate to Exercises / Lectures
6. Verify that everything looks like before


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before: 
<img width="286" alt="image" src="https://github.com/user-attachments/assets/47494055-a8cb-40f6-8203-62577e98bcfa">

After: 
<img width="286" alt="image" src="https://github.com/user-attachments/assets/3f5a7346-0bff-44ed-95f2-ec940872c97b">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved button alignment and spacing in the sidebar components for a more consistent user interface.
	- Adjusted rendering logic for sidebar items based on their type to enhance layout consistency.

- **New Features**
	- Introduced conditional rendering for sidebar items, improving user interaction based on the sidebar type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->