### PR TITLE
`Programming exercises`: Fix test case parsing of nested test suite elements

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/buildagent/service/TestResultXmlParserTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/buildagent/service/TestResultXmlParserTest.java
@@ -208,4 +208,38 @@ class TestResultXmlParserTest {
         assertThat(test.getName()).isEqualTo("mwe-name");
         assertThat(test.getTestMessages()).hasSize(1).contains("");
     }
+
+    @Test
+    void testNestedTestsuite() throws IOException {
+        String input = """
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <testsuites errors="0" failures="0" tests="12" time="0.013">
+                    <testsuite name="Tests" tests="12">
+                        <testsuite name="Properties" tests="9">
+                            <testsuite name="Checked by SmallCheck" tests="6">
+                                <testcase classname="Tests.Properties.Checked by SmallCheck" name="Testing filtering in A" time="0.004"/>
+                                <testcase classname="Tests.Properties.Checked by SmallCheck" name="Testing mapping in A" time="0.000"/>
+                                <testcase classname="Tests.Properties.Checked by SmallCheck" name="Testing filtering in B" time="0.003"/>
+                                <testcase classname="Tests.Properties.Checked by SmallCheck" name="Testing mapping in B" time="0.000"/>
+                                <testcase classname="Tests.Properties.Checked by SmallCheck" name="Testing filtering in C" time="0.001"/>
+                                <testcase classname="Tests.Properties.Checked by SmallCheck" name="Testing mapping in C" time="0.000"/>
+                            </testsuite>
+                            <testsuite name="Checked by QuickCheck" tests="3">
+                                <testcase classname="Tests.Properties.Checked by QuickCheck" name="Testing A against sample solution" time="0.001"/>
+                                <testcase classname="Tests.Properties.Checked by QuickCheck" name="Testing B against sample solution" time="0.001"/>
+                                <testcase classname="Tests.Properties.Checked by QuickCheck" name="Testing C against sample solution" time="0.001"/>
+                            </testsuite>
+                        </testsuite>
+                        <testsuite name="Unit Tests" tests="3">
+                            <testcase classname="Tests.Unit Tests" name="Testing selectAndReflectA (0,0) []" time="0.000"/>
+                            <testcase classname="Tests.Unit Tests" name="Testing selectAndReflectB (0,1) [(0,0)]" time="0.000"/>
+                            <testcase classname="Tests.Unit Tests" name="Testing selectAndReflectC (0,1) [(-1,-1)]" time="0.000"/>
+                        </testsuite>
+                    </testsuite>
+                </testsuites>
+                """;
+
+        TestResultXmlParser.processTestResultFile(input, failedTests, successfulTests);
+        assertThat(successfulTests).hasSize(12);
+    }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/buildagent/service/TestResultXmlParserTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/buildagent/service/TestResultXmlParserTest.java
@@ -240,6 +240,10 @@ class TestResultXmlParserTest {
                 """;
 
         TestResultXmlParser.processTestResultFile(input, failedTests, successfulTests);
-        assertThat(successfulTests).hasSize(12);
+        assertThat(successfulTests).hasSize(12).extracting(BuildResult.LocalCITestJobDTO::getName).containsExactlyInAnyOrder("Testing filtering in A", "Testing mapping in A",
+                "Testing filtering in B", "Testing mapping in B", "Testing filtering in C", "Testing mapping in C", "Testing A against sample solution",
+                "Testing B against sample solution", "Testing C against sample solution", "Testing selectAndReflectA (0,0) []", "Testing selectAndReflectB (0,1) [(0,0)]",
+                "Testing selectAndReflectC (0,1) [(-1,-1)]");
+        assertThat(failedTests).isEmpty();
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added a integration tests (Spring) related to the features (with a high test coverage).


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [x] I tested **all** changes and their related features with **all** corresponding user types on a _local_ server configured with **LocalVC** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The JUnit XML format allows `<testcase>` elements to contain other `<testcase>` elements. The current parser is not able to handle this.
The Haskell template, for example, produces such files and fails on LocalCI.

### Description
<!-- Describe your changes in detail -->
The handling of `<testcases>` and `<testcase>` elements can be generalized, such that both elements are handled the same.
This reduces special cases and simplifies the code as well.

Fixes #9159.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Create an Haskell exercise on a LocalCI server
2. Validate that the build plans on the template and solution repos finish successfully


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| TestResultXmlParser | 96% | ✅                           |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced parsing logic for test result files, now supporting nested test suites.
	- Improved handling of both single and multiple test suites for streamlined processing.

- **Bug Fixes**
	- Corrected the counting of successful tests in nested test suite scenarios.

- **Tests**
	- Added a new test case to validate the parsing of XML input with nested test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->