### PR TITLE
`Development`: Fix course messages e2e tests

### DIFF
--- a/src/test/playwright/e2e/course/CourseMessages.spec.ts
+++ b/src/test/playwright/e2e/course/CourseMessages.spec.ts
@@ -108,7 +108,7 @@ test.describe('Course messages', () => {
                 await courseManagementAPIRequests.createLecture(course, 'Test Lecture');
                 await login(instructor, `/courses/${course.id}/communication`);
                 await courseMessages.browseChannelsButton('lectureChannels').click();
-                await courseMessages.checkChannelsExists('lecture-test-lecture');
+                await courseMessages.checkChannelsExists('test-lecture');
             });
 
             test('Check that channel is created when an exercise is created', async ({ login, courseMessages, exerciseAPIRequests }) => {
@@ -116,7 +116,7 @@ test.describe('Course messages', () => {
                 await exerciseAPIRequests.createTextExercise({ course }, 'Test Exercise');
                 await login(instructor, `/courses/${course.id}/communication`);
                 await courseMessages.browseChannelsButton('exerciseChannels').click();
-                await courseMessages.checkChannelsExists('exercise-test-exercise');
+                await courseMessages.checkChannelsExists('test-exercise');
             });
 
             test('Check that channel is created when an exam is created', async ({ login, courseMessages, examAPIRequests }) => {

--- a/src/test/playwright/e2e/course/CourseMessages.spec.ts
+++ b/src/test/playwright/e2e/course/CourseMessages.spec.ts
@@ -32,7 +32,7 @@ test.describe('Course messages', () => {
         test.describe('Create channel', () => {
             test('Check for pre-created channels', async ({ login, courseMessages }) => {
                 await login(instructor, `/courses/${course.id}/communication`);
-                await courseMessages.browseChannelsButton('generalChannels').click();
+                await courseMessages.browseChannelsButton();
                 await courseMessages.checkChannelsExists('tech-support');
                 await courseMessages.checkChannelsExists('organization');
                 await courseMessages.checkChannelsExists('random');
@@ -107,7 +107,7 @@ test.describe('Course messages', () => {
                 await login(admin);
                 await courseManagementAPIRequests.createLecture(course, 'Test Lecture');
                 await login(instructor, `/courses/${course.id}/communication`);
-                await courseMessages.browseChannelsButton('lectureChannels').click();
+                await courseMessages.browseChannelsButton();
                 await courseMessages.checkChannelsExists('test-lecture');
             });
 
@@ -115,7 +115,7 @@ test.describe('Course messages', () => {
                 await login(admin);
                 await exerciseAPIRequests.createTextExercise({ course }, 'Test Exercise');
                 await login(instructor, `/courses/${course.id}/communication`);
-                await courseMessages.browseChannelsButton('exerciseChannels').click();
+                await courseMessages.browseChannelsButton();
                 await courseMessages.checkChannelsExists('test-exercise');
             });
 
@@ -124,7 +124,7 @@ test.describe('Course messages', () => {
                 const examTitle = 'exam' + generateUUID();
                 await examAPIRequests.createExam({ course, title: examTitle });
                 await login(instructor, `/courses/${course.id}/communication`);
-                await courseMessages.browseChannelsButton('examChannels').click();
+                await courseMessages.browseChannelsButton();
                 await courseMessages.checkChannelsExists(titleLowercase(examTitle));
             });
         });
@@ -163,7 +163,7 @@ test.describe('Course messages', () => {
 
             test('Student should be joined into pre-created channels automatically', async ({ login, courseMessages }) => {
                 await login(studentOne, `/courses/${course.id}/communication`);
-                await courseMessages.browseChannelsButton('generalChannels').click();
+                await courseMessages.browseChannelsButton();
                 const techSupportChannelId = Number(await courseMessages.getChannelIdByName('tech-support'));
                 const techSupportJoinedBadge = courseMessages.getJoinedBadge(techSupportChannelId);
                 await expect(techSupportJoinedBadge).toBeVisible();
@@ -187,7 +187,7 @@ test.describe('Course messages', () => {
 
             test('Student should be able to join a public channel', async ({ login, courseMessages }) => {
                 await login(studentOne, `/courses/${course.id}/communication`);
-                await courseMessages.browseChannelsButton('generalChannels').click();
+                await courseMessages.browseChannelsButton();
                 await courseMessages.joinChannel(channel.id!);
                 const joinedBadge = courseMessages.getJoinedBadge(channel.id!);
                 await expect(joinedBadge).toBeVisible();
@@ -197,7 +197,7 @@ test.describe('Course messages', () => {
             test('Student should be able to leave a public channel', async ({ login, courseMessages, communicationAPIRequests }) => {
                 await login(studentOne, `/courses/${course.id}/communication`);
                 await communicationAPIRequests.joinUserIntoChannel(course, channel.id!, studentOne);
-                await courseMessages.browseChannelsButton('generalChannels').click();
+                await courseMessages.browseChannelsButton();
                 await courseMessages.leaveChannel(channel.id!);
                 await expect(courseMessages.getJoinedBadge(channel.id!)).toBeHidden();
             });

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -18,15 +18,15 @@ export class CourseMessagesPage {
      * Clicks the button to initiate channel creation.
      */
     async createChannelButton() {
-        await this.page.locator('#plusButton-generalChannels').click();
-        await this.page.locator('.modal-content #createChannel').click();
+        await this.page.click('.square-button > .ng-fa-icon');
+        await this.page.click('text=Create channel');
     }
 
     /**
      * Navigates to the channel overview section.
      */
     browseChannelsButton(channelGroup: string) {
-        return this.page.locator(`#plusButton-${channelGroup}`);
+        return this.page.locator(`#test-accordion-item-header-${channelGroup} > .my-2`);
     }
 
     /**
@@ -34,7 +34,7 @@ export class CourseMessagesPage {
      * @param name - The name of the channel to check for existence.
      */
     async checkChannelsExists(name: string) {
-        await expect(this.page.locator('.channels-overview .list-group-item').getByText(name)).toBeVisible();
+        await expect(this.page.locator('#test-sidebar-card-title').getByText(name)).toBeVisible();
     }
 
     /**
@@ -43,7 +43,7 @@ export class CourseMessagesPage {
      * @returns The ID of the channel.
      */
     async getChannelIdByName(name: string) {
-        const channelElement = this.page.locator('.channels-overview .list-group-item', { hasText: name });
+        const channelElement = this.page.locator('#test-sidebar-card-title', { hasText: name });
         const id = await channelElement.getAttribute('id');
         return id?.replace('channel-', '');
     }

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -25,8 +25,9 @@ export class CourseMessagesPage {
     /**
      * Navigates to the channel overview section.
      */
-    browseChannelsButton(channelGroup: string) {
-        return this.page.locator(`#test-accordion-item-header-${channelGroup} > .my-2`);
+    async browseChannelsButton() {
+        await this.page.locator('.btn-primary.btn-sm.square-button').click();
+        await this.page.locator('button', { hasText: 'Browse Channels' }).click();
     }
 
     /**
@@ -34,7 +35,7 @@ export class CourseMessagesPage {
      * @param name - The name of the channel to check for existence.
      */
     async checkChannelsExists(name: string) {
-        await expect(this.page.locator('#test-sidebar-card-title').getByText(name)).toBeVisible();
+        await expect(this.page.locator('.channels-overview .list-group-item').getByText(name)).toBeVisible();
     }
 
     /**
@@ -43,7 +44,7 @@ export class CourseMessagesPage {
      * @returns The ID of the channel.
      */
     async getChannelIdByName(name: string) {
-        const channelElement = this.page.locator('#test-sidebar-card-title', { hasText: name });
+        const channelElement = this.page.locator('.channels-overview .list-group-item', { hasText: name });
         const id = await channelElement.getAttribute('id');
         return id?.replace('channel-', '');
     }
@@ -288,7 +289,8 @@ export class CourseMessagesPage {
      * Clicks the button to initiate group chat creation.
      */
     async createGroupChatButton() {
-        await this.page.locator('#plusButton-groupChats').click();
+        await this.page.locator('.btn-primary.btn-sm.square-button').click();
+        await this.page.locator('button', { hasText: 'Create Group Chat' }).click();
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] This is a small issue that I tested locally.
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some of the tests in `CourseMessages.spec.ts` were failing after the changes in sidebar design. The tests could not identify the newly added button for create channel/browse channels.


### Description
<!-- Describe your changes in detail -->
`browseChannelButton()`, `createChannelButton()`, and `createGroupChatButton()` have been updated so that tests can identify these buttons again.



### Steps for Testing
Check that the test runs through correctly.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Streamlined method calls for browsing channels, enhancing test clarity and maintainability.
	- Adjusted expected channel names in assertions to match new naming conventions.

- **New Features**
	- Updated UI interactions for creating channels and group chats, aligning with the new button structures. 

These enhancements improve user experience by ensuring consistent channel management and clearer test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->