### PR TITLE
`Adaptive Learning`: Allow editors to edit the competency link weight

### DIFF
--- a/src/main/webapp/app/shared/competency-selection/competency-selection.component.html
+++ b/src/main/webapp/app/shared/competency-selection/competency-selection.component.html
@@ -32,6 +32,17 @@
                                 <fa-icon [icon]="getIcon(competencyLink.competency.taxonomy)" [fixedWidth]="true" />
                                 {{ competencyLink.competency.title }}
                             </label>
+                            @if (checkboxStates[competencyLink.competency.id]) {
+                                <select
+                                    [ngModel]="competencyLink.weight < 0.375 ? 0.25 : competencyLink.weight < 0.75 ? 0.5 : 1"
+                                    (ngModelChange)="updateLinkWeight(competencyLink, $event)"
+                                    ngbTooltip="{{ 'artemisApp.competency.link.weightTooltip' | artemisTranslate }}"
+                                >
+                                    <option [ngValue]="0.25" [jhiTranslate]="'artemisApp.competency.link.weightLabels.low'"></option>
+                                    <option [ngValue]="0.5" [jhiTranslate]="'artemisApp.competency.link.weightLabels.medium'"></option>
+                                    <option [ngValue]="1" [jhiTranslate]="'artemisApp.competency.link.weightLabels.high'"></option>
+                                </select>
+                            }
                         </div>
                     }
                 }

--- a/src/main/webapp/app/shared/competency-selection/competency-selection.component.ts
+++ b/src/main/webapp/app/shared/competency-selection/competency-selection.component.ts
@@ -122,7 +122,19 @@ export class CompetencySelectionComponent implements OnInit, ControlValueAccesso
         }
     }
 
+    updateLinkWeight(link: CompetencyLearningObjectLink, value: number) {
+        link.weight = value;
+
+        this._onChange(this.selectedCompetencyLinks);
+        this.valueChange.emit(this.selectedCompetencyLinks);
+    }
+
     writeValue(value?: CompetencyLearningObjectLink[]): void {
+        this.competencyLinks?.forEach((link) => {
+            const selectedLink = value?.find((value) => value.competency?.id === link.competency?.id);
+            link.weight = selectedLink?.weight ?? 0.5;
+        });
+
         if (value && this.competencyLinks) {
             // Compare the ids of the competencies instead of the whole objects
             const ids = value.map((el) => el.competency?.id);

--- a/src/main/webapp/i18n/de/competency.json
+++ b/src/main/webapp/i18n/de/competency.json
@@ -117,7 +117,13 @@
             "link": {
                 "title": "Verbundene Kompetenzen",
                 "lectureUnit": "Verbinde diese Vorlesungseinheit wahlweise mit einer oder mehreren Kompetenzen.",
-                "exercise": "Verbinde diese Übung wahlweise mit einer oder mehreren Kompetenzen."
+                "exercise": "Verbinde diese Übung wahlweise mit einer oder mehreren Kompetenzen.",
+                "weightTooltip": "Die Relevanz dieses Lernobjektes für die Kompetenz.",
+                "weightLabels": {
+                    "low": "Niedrig",
+                    "medium": "Mittel",
+                    "high": "Hoch"
+                }
             },
             "competencyCard": {
                 "connectedLectureUnits": "Verbundene Vorlesungseinheiten",

--- a/src/main/webapp/i18n/en/competency.json
+++ b/src/main/webapp/i18n/en/competency.json
@@ -117,7 +117,13 @@
             "link": {
                 "title": "Linked Competencies",
                 "lectureUnit": "Optionally link this lecture unit to one or more competencies.",
-                "exercise": "Optionally link this exercise to one or more competencies."
+                "exercise": "Optionally link this exercise to one or more competencies.",
+                "weightTooltip": "The relevance of this learning object for the competency.",
+                "weightLabels": {
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
+                }
             },
             "competencyCard": {
                 "connectedLectureUnits": "Linked Lecture Units",

--- a/src/test/javascript/spec/component/shared/competency-selection.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/competency-selection.component.spec.ts
@@ -14,6 +14,7 @@ import { By } from '@angular/platform-browser';
 import { CourseStorageService } from 'app/course/manage/course-storage.service';
 import { ChangeDetectorRef } from '@angular/core';
 import { CourseCompetencyService } from 'app/course/competencies/course-competency.service';
+import { Prerequisite } from 'app/entities/prerequisite.model';
 
 describe('CompetencySelection', () => {
     let fixture: ComponentFixture<CompetencySelectionComponent>;
@@ -120,6 +121,22 @@ describe('CompetencySelection', () => {
         component.writeValue([new CompetencyLearningObjectLink({ id: 1, title: 'other' } as Competency, 1)]);
         expect(component.selectedCompetencyLinks).toBeArrayOfSize(1);
         expect(component.selectedCompetencyLinks?.first()?.competency?.title).toBe('test');
+    });
+
+    it('should update link weight when value is written', () => {
+        jest.spyOn(courseStorageService, 'getCourse').mockReturnValue({
+            competencies: [{ id: 1, title: 'test' } as Competency, { id: 2, title: 'testAgain' } as Prerequisite, { id: 3, title: 'testMore' } as Competency],
+        });
+
+        fixture.detectChanges();
+
+        component.writeValue([
+            new CompetencyLearningObjectLink({ id: 1, title: 'other' } as Competency, 0.5),
+            new CompetencyLearningObjectLink({ id: 3, title: 'otherMore' } as Competency, 1),
+        ]);
+        expect(component.selectedCompetencyLinks).toBeArrayOfSize(2);
+        expect(component.selectedCompetencyLinks?.first()?.weight).toBe(0.5);
+        expect(component.selectedCompetencyLinks?.last()?.weight).toBe(1);
     });
 
     it('should trigger change detection after loading competencies', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#9446
continuation of #9517

### Description
<!-- Describe your changes in detail -->
#9517 changed the database and object structure to support weights between competencies and learning objects.
This PR now adds a dropdown for all selected competencies to allow the user to choose between a 'low', 'medium' and 'high' weight of the link.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Exercise or Lecture Unit
- Competencies/Prerequisites

1. Log in to Artemis
2. Create/Update the learning object and select some competencies or prerequisites to link
3. Change the weight via the dropdown
4. Check that after saving and reentering the edit view of the learning object the competencies are linked with the weight you choose

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Weight dropdown only for selected competencies:
<img width="257" alt="Bildschirmfoto 2024-10-22 um 21 14 48" src="https://github.com/user-attachments/assets/6ddffe67-7490-4b18-8286-88769aea9bb9">

Tooltip explaining the weight:
<img width="282" alt="Bildschirmfoto 2024-10-22 um 21 14 59" src="https://github.com/user-attachments/assets/33efb2de-7d07-4008-937b-bbd6a2f3d87d">