### PR TITLE
`Development`: Fix exercise deletion with existing Iris sessions

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20241023456789_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20241023456789_changelog.xml
@@ -13,7 +13,7 @@
                 baseTableName="iris_session"
                 constraintName="fk_iris_session_exercise_id"/>
 
-        <!-- Add the foreign key with ON DELETE SET NULL -->
+        <!-- Add the foreign key with ON DELETE CASCADE -->
         <addForeignKeyConstraint
                 baseTableName="iris_session"
                 baseColumnNames="exercise_id"

--- a/src/main/resources/config/liquibase/changelog/20241023456789_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20241023456789_changelog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="20241023456789" author="michaeldyer">
+        <preConditions onFail="MARK_RAN">
+            <!-- Check if the foreign key exists before modifying -->
+            <foreignKeyConstraintExists foreignKeyName="fk_iris_session_exercise_id"/>
+        </preConditions>
+
+        <!-- Drop the existing foreign key -->
+        <dropForeignKeyConstraint
+                baseTableName="iris_session"
+                constraintName="fk_iris_session_exercise_id"/>
+
+        <!-- Add the foreign key with ON DELETE SET NULL -->
+        <addForeignKeyConstraint
+                baseTableName="iris_session"
+                baseColumnNames="exercise_id"
+                referencedTableName="exercise"
+                referencedColumnNames="id"
+                constraintName="fk_iris_session_exercise_id"
+                onDelete="SET NULL"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20241023456789_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20241023456789_changelog.xml
@@ -20,6 +20,6 @@
                 referencedTableName="exercise"
                 referencedColumnNames="id"
                 constraintName="fk_iris_session_exercise_id"
-                onDelete="SET NULL"/>
+                onDelete="CASCADE"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -28,6 +28,7 @@
     <include file="classpath:config/liquibase/changelog/20240902175045_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20240924125742_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20240816150000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20241023456789_changelog.xml" relativeToChangelogFile="false"/>
 
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisExerciseChatSessionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisExerciseChatSessionIntegrationTest.java
@@ -90,6 +90,14 @@ class IrisExerciseChatSessionIntegrationTest extends AbstractIrisIntegrationTest
         assertThat(request.get("/api/iris/status", HttpStatus.OK, IrisStatusDTO.class).active()).isFalse();
     }
 
+    @Test
+    void testDeleteExerciseWithIrisSession() throws Exception {
+        var irisSession = request.postWithResponseBody(exerciseChatUrl(exercise.getId()), null, IrisSession.class, HttpStatus.CREATED);
+        assertThat(irisExerciseChatSessionRepository.findByIdElseThrow(irisSession.getId())).isNotNull();
+        request.delete("/api/programming-exercises/" + exercise.getId(), HttpStatus.OK);
+        assertThat(irisExerciseChatSessionRepository.findById(irisSession.getId())).isEmpty();
+    }
+
     private static String exerciseChatUrl(long sessionId) {
         return "/api/iris/exercise-chat/" + sessionId + "/sessions";
     }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisExerciseChatSessionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisExerciseChatSessionIntegrationTest.java
@@ -91,6 +91,7 @@ class IrisExerciseChatSessionIntegrationTest extends AbstractIrisIntegrationTest
     }
 
     @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testDeleteExerciseWithIrisSession() throws Exception {
         var irisSession = request.postWithResponseBody(exerciseChatUrl(exercise.getId()), null, IrisSession.class, HttpStatus.CREATED);
         assertThat(irisExerciseChatSessionRepository.findByIdElseThrow(irisSession.getId())).isNotNull();

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisExerciseChatSessionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisExerciseChatSessionIntegrationTest.java
@@ -28,7 +28,7 @@ class IrisExerciseChatSessionIntegrationTest extends AbstractIrisIntegrationTest
 
     @BeforeEach
     void initTestCase() {
-        userUtilService.addUsers(TEST_PREFIX, 1, 0, 0, 0);
+        userUtilService.addUsers(TEST_PREFIX, 1, 0, 0, 1);
 
         final Course course = programmingExerciseUtilService.addCourseWithOneProgrammingExerciseAndTestCases();
         exercise = exerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
@@ -91,11 +91,13 @@ class IrisExerciseChatSessionIntegrationTest extends AbstractIrisIntegrationTest
     }
 
     @Test
-    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testDeleteExerciseWithIrisSession() throws Exception {
         var irisSession = request.postWithResponseBody(exerciseChatUrl(exercise.getId()), null, IrisSession.class, HttpStatus.CREATED);
         assertThat(irisExerciseChatSessionRepository.findByIdElseThrow(irisSession.getId())).isNotNull();
-        request.delete("/api/programming-exercises/" + exercise.getId(), HttpStatus.OK);
+        // Set the URL request parameters to prevent an internal server error which is irrelevant for this test
+        var url = "/api/programming-exercises/" + exercise.getId() + "?deleteStudentReposBuildPlans=false&deleteBaseReposBuildPlans=false";
+        request.delete(url, HttpStatus.OK);
         assertThat(irisExerciseChatSessionRepository.findById(irisSession.getId())).isEmpty();
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.




### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, we are unable to delete exercises which have any associated iris sessions in the database, due to a foreign key integrity violation. This PR adds a database migration to introduce a cascading delete on that foreign key, so when an exercise is deleted, all associated sessions are automatically deleted as well. This also triggers (already existing) cascading deletes of all of the session's messages, and all of those messages' contents.

_As far as I know_, there are no foreign keys referencing `iris_session` anywhere else in the database, so this change should not introduce further integrity issues.

### Description
<!-- Describe your changes in detail -->
- Added a liquibase changeset which drops the existing foreign key constraint and re-adds it with a cascading delete.
- Added an integration test to catch this issue in the future

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Artemis with Iris globally enabled
- 1 Course with Iris enabled
- 1 Exercise (either Programming or Text, as those are the ones where Iris is supported)

1. Start a chat with Iris in the exercise
2. Try to delete the exercise

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced a new test to verify the deletion of a programming exercise and its associated Iris session, enhancing integration test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->