### PR TITLE
`Quiz exercises`: Fix an error after using the practice mode

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/quiz/repository/QuizSubmissionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/repository/QuizSubmissionRepository.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.quiz.repository;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphType.LOAD;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -37,7 +38,7 @@ public interface QuizSubmissionRepository extends ArtemisJpaRepository<QuizSubmi
     QuizSubmission findWithEagerSubmittedAnswersById(long submissionId);
 
     @EntityGraph(type = LOAD, attributePaths = { "submittedAnswers" })
-    Optional<QuizSubmission> findWithEagerSubmittedAnswersByParticipationId(long participationId);
+    List<QuizSubmission> findWithEagerSubmittedAnswersByParticipationId(long participationId);
 
     @Query("""
             SELECT submission

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/repository/QuizSubmissionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/repository/QuizSubmissionRepository.java
@@ -39,6 +39,15 @@ public interface QuizSubmissionRepository extends ArtemisJpaRepository<QuizSubmi
     @EntityGraph(type = LOAD, attributePaths = { "submittedAnswers" })
     Optional<QuizSubmission> findWithEagerSubmittedAnswersByParticipationId(long participationId);
 
+    @Query("""
+            SELECT submission
+            FROM QuizSubmission submission
+                LEFT JOIN FETCH submission.submittedAnswers
+                JOIN submission.results r
+            WHERE r.id = :resultId
+            """)
+    Optional<QuizSubmission> findWithEagerSubmittedAnswersByResultId(@Param("resultId") long resultId);
+
     /**
      * Retrieve QuizSubmission for given quiz batch and studentLogin
      *

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizSubmissionService.java
@@ -147,7 +147,7 @@ public class QuizSubmissionService extends AbstractQuizSubmissionService<QuizSub
         log.info("Calculating results for quiz {}", quizExercise.getId());
         studentParticipationRepository.findByExerciseId(quizExercise.getId()).forEach(participation -> {
             participation.setExercise(quizExercise);
-            Optional<QuizSubmission> quizSubmissionOptional = quizSubmissionRepository.findWithEagerSubmittedAnswersByParticipationId(participation.getId());
+            Optional<QuizSubmission> quizSubmissionOptional = quizSubmissionRepository.findWithEagerSubmittedAnswersByParticipationId(participation.getId()).stream().findFirst();
 
             if (quizSubmissionOptional.isEmpty()) {
                 return;

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizParticipationResource.java
@@ -69,6 +69,8 @@ public class QuizParticipationResource {
 
     /**
      * POST /quiz-exercises/{exerciseId}/start-participation : start the quiz exercise participation
+     * TODO: This endpoint is also called when viewing the result of a quiz exercise.
+     * TODO: This does not make any sense, as the participation is already started.
      *
      * @param exerciseId the id of the quiz exercise
      * @return The created participation

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizParticipationResource.java
@@ -92,7 +92,14 @@ public class QuizParticipationResource {
 
         // NOTE: starting exercise prevents that two participation will exist, but ensures that a submission is created
         var result = resultRepository.findFirstByParticipationIdAndRatedOrderByCompletionDateDesc(participation.getId(), true).orElse(new Result());
-        result.setSubmission(quizSubmissionRepository.findWithEagerSubmittedAnswersByParticipationId(participation.getId()).orElseThrow());
+        if (result.getId() == null) {
+            // Load the live submission of the participation
+            result.setSubmission(quizSubmissionRepository.findWithEagerSubmittedAnswersByParticipationId(participation.getId()).orElseThrow());
+        }
+        else {
+            // Load the actual submission of the result
+            result.setSubmission(quizSubmissionRepository.findWithEagerSubmittedAnswersByResultId(result.getId()).orElseThrow());
+        }
 
         participation.setResults(Set.of(result));
         participation.setExercise(exercise);

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizParticipationResource.java
@@ -96,7 +96,7 @@ public class QuizParticipationResource {
         var result = resultRepository.findFirstByParticipationIdAndRatedOrderByCompletionDateDesc(participation.getId(), true).orElse(new Result());
         if (result.getId() == null) {
             // Load the live submission of the participation
-            result.setSubmission(quizSubmissionRepository.findWithEagerSubmittedAnswersByParticipationId(participation.getId()).orElseThrow());
+            result.setSubmission(quizSubmissionRepository.findWithEagerSubmittedAnswersByParticipationId(participation.getId()).stream().findFirst().orElseThrow());
         }
         else {
             // Load the actual submission of the result


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage). -> Follow-up
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We encountered a bug today on production which prevented students from viewing their quiz result after they also participated in the practice mode.


### Description
<!-- Describe your changes in detail -->
This was caused by a small change in the endpoint where we tried to load a single submission of a participation. This does not work, as participations can have multiple submissions when it is not fully new. I now changed it to instead load the submission of the fetched result if it has any.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Participate in a quiz
3. View the result -> Works
4. Practice the quiz
5. View the result -> Works

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
-> Integration test will be done in a follow-up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to retrieve quiz submissions along with submitted answers based on a specific result ID, enhancing data retrieval capabilities.

- **Improvements**
	- Updated logic in the quiz participation handling to ensure correct submission loading based on the existence of a result, improving user experience during quiz participation.
	- Enhanced the handling of quiz submissions by ensuring the correct optional value is returned, streamlining data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->