### PR TITLE
`Draft`: Try to fix entity ID zero for ScienceEvent (and possibly others)

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/atlas/science/util/ScienceUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/science/util/ScienceUtilService.java
@@ -4,6 +4,8 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +15,8 @@ import de.tum.cit.aet.artemis.atlas.test_repository.ScienceEventTestRepository;
 
 @Service
 public class ScienceUtilService {
+
+    private final static Logger log = LoggerFactory.getLogger(ScienceUtilService.class);
 
     @Autowired
     private ScienceEventTestRepository scienceEventRepository;
@@ -31,7 +35,12 @@ public class ScienceUtilService {
         event.setTimestamp(timestamp);
         event.setType(type);
         event.setResourceId(resourceId);
-        return scienceEventRepository.save(event);
+        ScienceEvent saved = scienceEventRepository.save(event);
+        if (saved.getId() == null || saved.getId() == 0) {
+            log.error("Failed to save science event: " + saved);
+            return null;
+        }
+        return saved;
     }
 
     /**


### PR DESCRIPTION
### Checklist
#### General
In some Postgres-Tests, the id of a saved ScienceEvent is zero as denoted by the hash code after the expected entity, see [here for instance](https://github.com/ls1intum/Artemis/runs/31918636804).

This PR draft adds logging to saving the entities and opened to run the Postgres tests.

- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
