### PR TITLE
`Development`: Fix several failing e2e tests

### DIFF
--- a/src/main/webapp/app/shared/monaco-editor/monaco-editor.component.ts
+++ b/src/main/webapp/app/shared/monaco-editor/monaco-editor.component.ts
@@ -11,6 +11,7 @@ import { MonacoEditorOptionPreset } from 'app/shared/monaco-editor/model/monaco-
 import { Disposable, EditorPosition, EditorRange, MonacoEditorTextModel } from 'app/shared/monaco-editor/model/actions/monaco-editor.util';
 import { MonacoTextEditorAdapter } from 'app/shared/monaco-editor/model/actions/adapter/monaco-text-editor.adapter';
 import { MonacoEditorService } from 'app/shared/monaco-editor/monaco-editor.service';
+import { getOS } from 'app/shared/util/os-detector.util';
 
 export const MAX_TAB_SIZE = 8;
 
@@ -121,7 +122,7 @@ export class MonacoEditorComponent implements OnInit, OnDestroy {
         this.blurEditorWidgetListener = this._editor.onDidBlurEditorWidget(() => {
             // On iOS, the editor does not lose focus when clicking outside of it. This listener ensures that the editor loses focus when the editor widget loses focus.
             // See https://github.com/microsoft/monaco-editor/issues/307
-            if (document.activeElement && 'blur' in document.activeElement && typeof document.activeElement.blur === 'function') {
+            if (getOS() === 'iOS' && document.activeElement && 'blur' in document.activeElement && typeof document.activeElement.blur === 'function') {
                 document.activeElement.blur();
             }
             this.onBlurEditor.emit();


### PR DESCRIPTION
### Checklist
#### General

- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Due to an interaction with Playwright, #9519 broke several e2e tests with a workaround designed for iOS.

### Description
<!-- Describe your changes in detail -->
Restricted the change to iOS.

### Steps for Testing

Code review. Check that the following e2e tests pass again:

![image](https://github.com/user-attachments/assets/4cf1e616-a471-47a5-aca8-f29e2804f10d)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage

Unchanged

### Screenshots

No UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced focus handling for iOS users in the Monaco Editor component to prevent unintended behavior when the editor loses focus.

- **Bug Fixes**
	- Added an OS check to ensure the blur functionality only triggers on non-iOS devices, improving user experience for iOS users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->