### PR TITLE
`Programming exercises`: Fix performance bug of ide preferences in scores page 

### DIFF
--- a/src/main/webapp/app/shared/components/code-button/code-button.component.html
+++ b/src/main/webapp/app/shared/components/code-button/code-button.component.html
@@ -12,6 +12,7 @@
         [autoClose]="'outside'"
         placement="right auto"
         container="body"
+        (shown)="onShow()"
     ></button>
     <ng-template #popContent>
         @if (useSsh && !copyEnabled) {

--- a/src/main/webapp/app/shared/user-settings/ide-preferences/ide-settings.component.html
+++ b/src/main/webapp/app/shared/user-settings/ide-preferences/ide-settings.component.html
@@ -1,10 +1,9 @@
 <h1 jhiTranslate="artemisApp.userSettings.categories.IDE_PREFERENCES"></h1>
 <div class="list-group d-block">
     <div class="list-group-item pb-3">
-        <dt>
-            <span jhiTranslate="artemisApp.userSettings.idePreferencesPage.description"></span>
-            <jhi-help-icon placement="right auto" text="artemisApp.userSettings.idePreferencesPage.jetbrainsHelp" />
-        </dt>
+        <span jhiTranslate="artemisApp.userSettings.idePreferencesPage.description"></span>
+        <br />
+        <span jhiTranslate="artemisApp.userSettings.idePreferencesPage.jetbrainsHelp"></span>
         <h5 class="py-2" jhiTranslate="artemisApp.userSettings.idePreferencesPage.default"></h5>
         <ng-container *ngTemplateOutlet="ideButtonRow; context: { language: ProgrammingLanguage.EMPTY }"></ng-container>
     </div>

--- a/src/main/webapp/app/shared/user-settings/ide-preferences/ide-settings.scss
+++ b/src/main/webapp/app/shared/user-settings/ide-preferences/ide-settings.scss
@@ -1,7 +1,3 @@
-dt {
-    font-weight: 500;
-}
-
 span {
     color: var(--secondary);
 }

--- a/src/test/javascript/spec/component/settings/ide/ide-settings.component.spec.ts
+++ b/src/test/javascript/spec/component/settings/ide/ide-settings.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
 import { IdeSettingsComponent } from 'app/shared/user-settings/ide-preferences/ide-settings.component';
@@ -34,33 +34,27 @@ describe('IdeSettingsComponent', () => {
         jest.resetAllMocks();
     });
 
-    it('should load predefined IDEs and IDE preferences on init', fakeAsync(() => {
+    it('should load predefined IDEs and IDE preferences on init', () => {
         const predefinedIdes = [
             { name: 'VS Code', deepLink: 'vscode://vscode.git/clone?url={cloneUrl}' },
             { name: 'IntelliJ', deepLink: 'jetbrains://idea/checkout/git?idea.required.plugins.id=Git4Idea&checkout.repo={cloneUrl}' },
         ];
         const idePreferences = new Map([[ProgrammingLanguage.JAVA, predefinedIdes[0]]]);
-        const loadedIdePreferences = new Map([
-            [ProgrammingLanguage.JAVA, predefinedIdes[0]],
-            [ProgrammingLanguage.EMPTY, predefinedIdes[0]],
-        ]);
 
         mockIdeSettingsService.loadPredefinedIdes.mockReturnValue(of(predefinedIdes));
-        mockIdeSettingsService.loadIdePreferences.mockReturnValue(Promise.resolve(idePreferences));
+        mockIdeSettingsService.loadIdePreferences.mockReturnValue(of(idePreferences));
 
         component.ngOnInit();
-
-        tick();
 
         expect(mockIdeSettingsService.loadPredefinedIdes).toHaveBeenCalledOnce();
         expect(mockIdeSettingsService.loadIdePreferences).toHaveBeenCalledOnce();
         expect(component.PREDEFINED_IDE).toEqual(predefinedIdes);
-        expect(component.programmingLanguageToIde()).toEqual(loadedIdePreferences);
+        expect(component.programmingLanguageToIde()).toEqual(idePreferences);
         expect(component.assignedProgrammingLanguages).toEqual([ProgrammingLanguage.JAVA]);
         expect(component.remainingProgrammingLanguages).toEqual(
             Object.values(ProgrammingLanguage).filter((x) => x !== ProgrammingLanguage.JAVA && x !== ProgrammingLanguage.EMPTY),
         );
-    }));
+    });
 
     it('should add a programming language and update the lists', () => {
         const programmingLanguage = ProgrammingLanguage.JAVA;

--- a/src/test/javascript/spec/service/settings/ide-settings.service.spec.ts
+++ b/src/test/javascript/spec/service/settings/ide-settings.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { IdeSettingsService } from 'app/shared/user-settings/ide-preferences/ide-settings.service';
 import { Ide, IdeMappingDTO } from 'app/shared/user-settings/ide-preferences/ide.model';
@@ -34,22 +34,20 @@ describe('IdeSettingsService', () => {
         req.flush(mockIdes);
     });
 
-    it('should load IDE preferences', fakeAsync(() => {
+    it('should load IDE preferences', () => {
         const mockIdeMappingDTO: IdeMappingDTO[] = [
             { programmingLanguage: ProgrammingLanguage.JAVA, ide: { name: 'VS Code', deepLink: 'vscode://vscode.git/clone?url={cloneUrl}' } },
         ];
         const expectedMap = new Map<ProgrammingLanguage, Ide>([[ProgrammingLanguage.JAVA, { name: 'VS Code', deepLink: 'vscode://vscode.git/clone?url={cloneUrl}' }]]);
 
-        service.loadIdePreferences().then((ideMap) => {
+        service.loadIdePreferences().subscribe((ideMap) => {
             expect(ideMap).toEqual(expectedMap);
         });
-
-        tick();
 
         const req = httpMock.expectOne(service.ideSettingsUrl);
         expect(req.request.method).toBe('GET');
         req.flush(mockIdeMappingDTO);
-    }));
+    });
 
     it('should save IDE preference', () => {
         const programmingLanguage = ProgrammingLanguage.JAVA;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.

### Description
Fixes an issue where request to fetch ide preferences on the scores page where send per code button. This closes https://github.com/ls1intum/Artemis/issues/9559.
In addition display tooltip for intelliJ IDEs directly and not in the question mark icon. Closes https://github.com/ls1intum/Artemis/issues/9541

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with more than one participation

1. Log in to Artemis
2. Navigate to Course Management
3. Click on a course and a programming exercise
4. Click on the scores button
5. Verify that only one request to ide-preferences is sent
6. click on one code button -> verify that an additional request to ide-preferences was made


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced enhanced interactivity with the `CodeButtonComponent` through a new event binding.
	- Improved handling of IDE preferences with a subscription-based approach in the `IdeSettingsComponent`.

- **Bug Fixes**
	- Resolved potential memory leaks by implementing proper subscription management in both `CodeButtonComponent` and `IdeSettingsComponent`.

- **Style**
	- Updated layout of IDE settings for better user experience by reorganizing HTML elements.

- **Documentation**
	- Enhanced internal documentation to reflect changes in subscription handling and component lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->