### PR TITLE
`Lectures`: Fix undefined course issue in lecture attachments

### DIFF
--- a/src/main/webapp/app/lecture/attachment.service.ts
+++ b/src/main/webapp/app/lecture/attachment.service.ts
@@ -6,7 +6,7 @@ import { createRequestOption } from 'app/shared/util/request.util';
 import { Attachment } from 'app/entities/attachment.model';
 import { convertDateFromClient, convertDateFromServer } from 'app/utils/date.utils';
 import { objectToJsonBlob } from 'app/utils/blob-util';
-import _ from 'lodash';
+import { cloneDeep } from 'lodash-es';
 
 type EntityResponseType = HttpResponse<Attachment>;
 type EntityArrayResponseType = HttpResponse<Attachment[]>;
@@ -97,7 +97,8 @@ export class AttachmentService {
     }
 
     convertAttachmentDatesFromClient(attachment: Attachment): Attachment {
-        return Object.assign({}, _.cloneDeep(attachment), {
+        // Deep clone is applied to preserve all nested properties of the attachment
+        return Object.assign({}, cloneDeep(attachment), {
             releaseDate: convertDateFromClient(attachment.releaseDate),
             uploadDate: convertDateFromClient(attachment.uploadDate),
         });

--- a/src/main/webapp/app/lecture/attachment.service.ts
+++ b/src/main/webapp/app/lecture/attachment.service.ts
@@ -6,6 +6,7 @@ import { createRequestOption } from 'app/shared/util/request.util';
 import { Attachment } from 'app/entities/attachment.model';
 import { convertDateFromClient, convertDateFromServer } from 'app/utils/date.utils';
 import { objectToJsonBlob } from 'app/utils/blob-util';
+import _ from 'lodash';
 
 type EntityResponseType = HttpResponse<Attachment>;
 type EntityArrayResponseType = HttpResponse<Attachment[]>;
@@ -96,11 +97,10 @@ export class AttachmentService {
     }
 
     convertAttachmentDatesFromClient(attachment: Attachment): Attachment {
-        const copy: Attachment = Object.assign({}, attachment, {
+        return Object.assign({}, _.cloneDeep(attachment), {
             releaseDate: convertDateFromClient(attachment.releaseDate),
             uploadDate: convertDateFromClient(attachment.uploadDate),
         });
-        return copy;
     }
 
     convertAttachmentDatesFromServer(attachment?: Attachment) {

--- a/src/main/webapp/app/lecture/lecture-attachments.component.ts
+++ b/src/main/webapp/app/lecture/lecture-attachments.component.ts
@@ -138,6 +138,7 @@ export class LectureAttachmentsComponent implements OnInit, OnDestroy {
         } else {
             this.attachmentService.create(this.attachmentToBeCreated!, this.attachmentFile!).subscribe({
                 next: (attachmentRes: HttpResponse<Attachment>) => {
+                    attachmentRes.body!.lecture!.course = this.lecture.course;
                     this.attachments.push(attachmentRes.body!);
                     this.lectureService.findWithDetails(this.lecture.id!).subscribe((lectureResponse: HttpResponse<Lecture>) => {
                         this.lecture = lectureResponse.body!;

--- a/src/main/webapp/app/lecture/lecture-attachments.component.ts
+++ b/src/main/webapp/app/lecture/lecture-attachments.component.ts
@@ -138,7 +138,6 @@ export class LectureAttachmentsComponent implements OnInit, OnDestroy {
         } else {
             this.attachmentService.create(this.attachmentToBeCreated!, this.attachmentFile!).subscribe({
                 next: (attachmentRes: HttpResponse<Attachment>) => {
-                    attachmentRes.body!.lecture!.course = this.lecture.course;
                     this.attachments.push(attachmentRes.body!);
                     this.lectureService.findWithDetails(this.lecture.id!).subscribe((lectureResponse: HttpResponse<Lecture>) => {
                         this.lecture = lectureResponse.body!;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

**NOTE: Please only test on Non-Chromium Browsers! (Mozilla Firefox, Safari etc.)**

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Lecture Attachments component is used in 2 ways:
1. In Lecture Creation Wizard
2. As the main view

On the main view of Attachments page, when we add a new attachment and direct to the View page, and when we come back to the Attachments page right after, lecture.course element becomes undefined. Therefore Course name in the title disappears and as View url has Course id in it, that becomes unusable as well.

This doesn't happen in wizard because every time we invoke it, a database call is made to fetch full lecture details.

**1. Course name before (undefined)**
<img width="946" alt="Screenshot 2024-10-26 at 14 24 00" src="https://github.com/user-attachments/assets/c1a98e81-e995-4182-b79c-73eff4ca25ed">

**2. View button before**
<img width="1113" alt="Screenshot 2024-10-26 at 14 24 13" src="https://github.com/user-attachments/assets/2623425f-3c71-4612-a26c-c25f613d867c">

### Description
<!-- Describe your changes in detail -->

Course element also added to the ActivatedRoute property as data and then set as lecture's course again.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
3. Navigate to Course Administration
4. Navigate to a Course's Lectures
5. Navigate to Attachments of any lecture
6. Add a new attachment
7. Go back to the Attachments page using the breadcrumbs or Cancel button
8. Course name should be displayed correctly near lecture name and View button should work

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| lecture-attachments.component.ts | 96% | ✅              |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
