### PR TITLE
`Development`: Improve efficiency for deleting long manual feedback

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
@@ -639,6 +639,10 @@ public class ResultService {
      * overridden or updated. The deletion is performed only for feedback items with a non-null ID and an associated long feedback text.
      * <p>
      * This approach reduces the need for individual deletion calls and performs batch deletion in a single database operation.
+     * <p>
+     * **Note:** This method should only be used for manually assessed submissions, not for fully automatic assessments, due to its dependency on the
+     * {@link Result#updateAllFeedbackItems} method, which is designed for manual feedback management. Using this method with automatic assessments could
+     * lead to unintended behavior or data inconsistencies.
      *
      * @param feedbackList The list of {@link Feedback} objects for which the long feedback texts are to be deleted. Only feedback items that have long feedback texts and a
      *                         non-null ID will be processed.

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
@@ -650,10 +650,8 @@ public class ResultService {
         }
 
         List<Long> feedbackIdsWithLongText = feedbackList.stream().filter(feedback -> feedback.getHasLongFeedbackText() && feedback.getId() != null).map(Feedback::getId).toList();
-
         longFeedbackTextRepository.deleteByFeedbackIds(feedbackIdsWithLongText);
-
         List<Feedback> feedbacks = new ArrayList<>(feedbackList);
-        result.updateAllFeedbackItems(feedbacks, false);
+        result.updateAllFeedbackItems(feedbacks, true);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
@@ -648,7 +648,6 @@ public class ResultService {
         if (feedbackList == null) {
             return;
         }
-
         List<Long> feedbackIdsWithLongText = feedbackList.stream().filter(feedback -> feedback.getHasLongFeedbackText() && feedback.getId() != null).map(Feedback::getId).toList();
         longFeedbackTextRepository.deleteByFeedbackIds(feedbackIdsWithLongText);
         List<Feedback> feedbacks = new ArrayList<>(feedbackList);

--- a/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingAssessmentIntegrationTest.java
@@ -1013,8 +1013,8 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationLocalCI
         });
         assertThat(storedResult.getAssessmentType()).as("type of result is SEMI_AUTOMATIC").isEqualTo(AssessmentType.SEMI_AUTOMATIC);
         assertThat(manualFeedback).as("number of manual feedback elements is correct").hasSameSizeAs(newFeedback);
-        assertThat(automaticFeedback).as("number of automatic feedback elements is correct").hasSize(existingFeedback.size() - 2);
-        assertThat(adaptedFeedback).as("number of adapted feedback elements is correct").hasSize(2);
+        assertThat(automaticFeedback).as("number of automatic feedback elements is correct").hasSize(existingFeedback.size());
+        assertThat(adaptedFeedback).as("number of adapted feedback elements is correct").isEmpty();
         assertThat(manualUnreferencedFeedback).as("number of manual unreferenced feedback elements is correct").isEmpty();
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Follow up https://github.com/ls1intum/Artemis/pull/9562
While going through more refactor possibilities, I noticed a slightly more efficient implementation.


### Description
<!-- Describe your changes in detail -->
I changed the flag for automatic assesements to true, allowing the updateFeedback method to skip all automatic tests instead of iterating over them aswell.

Note: The saving of manual assesements for programming exercise needs further refactoring but this is not part of this PR!

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise 

1. Log in to Artemis as Instructor
2. Create a Programming Exercise
3. Log in as Student and participate in the Programming Exercise
4. Log in as Instructor and set the Due Date to now and set Manual Assesement 
5. Navigate to the Programming Exercise and press the View button in the TutorActions tab
6. Press the Assesement Dashboard button
7. Assess the Student Sumbission by creating a new Feedback with over 1000 characters
8. Save this and reload the page
9. Verify that the feedback box now displays the whole long feedback and no shortend version
10. Try to edit the long feedback and save again
11. Verify that the long feedback was changed
12. Do this for Modelling and Quiz and Text Exercises aswell

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
#### Manual Tests
- [x] Test 1
#### Performance Tests
- [x] Test 1

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
<img width="465" alt="image" src="https://github.com/user-attachments/assets/d033a679-70ad-4ff5-8f56-1df48454a8ae">
After:
<img width="476" alt="image" src="https://github.com/user-attachments/assets/07598d13-6c51-4701-8836-0954b0bab72f">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced feedback management process for improved storage and association with results.
	- Clarified handling of feedback visibility based on assessment types and due dates.
	- Introduced new test cases for assessment and feedback mechanisms, improving coverage and accuracy, including plagiarism checks.

- **Bug Fixes**
	- Resolved potential issues with feedback persistence and Hibernate exceptions.
	- Improved error handling and status code checks in assessment scenarios.

- **Refactor**
	- Updated internal logic for feedback handling methods to ensure correct functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->