### PR TITLE
`Communication`: Fix element height in announcement channel

### DIFF
--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.html
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.html
@@ -67,7 +67,17 @@
                 <div
                     id="scrollableDiv"
                     #container
-                    [ngClass]="{ 'posting-infinite-scroll-container': posts.length !== 0, 'content-height-dev': contentHeightDev, 'is-fetching-posts': isFetchingPosts }"
+                    [ngClass]="{
+                        'posting-infinite-scroll-container': posts.length !== 0,
+                        'content-height-dev': contentHeightDev,
+                        'is-fetching-posts': isFetchingPosts,
+                        'hide-input-full':
+                            getAsChannel(_activeConversation)?.isAnnouncementChannel &&
+                            _activeConversation !== undefined &&
+                            !canCreateNewMessageInConversation(_activeConversation),
+                        'hide-input':
+                            getAsChannel(_activeConversation)?.isAnnouncementChannel && _activeConversation !== undefined && canCreateNewMessageInConversation(_activeConversation),
+                    }"
                     infinite-scroll
                     class="conversation-messages-message-list"
                     [scrollWindow]="false"

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.html
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.html
@@ -71,12 +71,8 @@
                         'posting-infinite-scroll-container': posts.length !== 0,
                         'content-height-dev': contentHeightDev,
                         'is-fetching-posts': isFetchingPosts,
-                        'hide-input-full':
-                            getAsChannel(_activeConversation)?.isAnnouncementChannel &&
-                            _activeConversation !== undefined &&
-                            !canCreateNewMessageInConversation(_activeConversation),
-                        'hide-input':
-                            getAsChannel(_activeConversation)?.isAnnouncementChannel && _activeConversation !== undefined && canCreateNewMessageInConversation(_activeConversation),
+                        'hide-input-full': isHiddenInputFull,
+                        'hide-input': isHiddenInputWithCallToAction,
                     }"
                     infinite-scroll
                     class="conversation-messages-message-list"

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.scss
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.scss
@@ -47,6 +47,14 @@
         max-height: calc(75vh - var(--message-input-height-prod) - var(--search-height) - var(--channel-header-height));
         overflow-y: auto;
 
+        &.hide-input-full {
+            max-height: calc(94vh - var(--message-input-height-prod) - var(--search-height) - var(--channel-header-height));
+        }
+
+        &.hide-input {
+            max-height: calc(87vh - var(--message-input-height-prod) - var(--search-height) - var(--channel-header-height));
+        }
+
         &.content-height-dev {
             max-height: calc(75vh - var(--message-input-height-dev) - var(--search-height) - var(--channel-header-height));
 
@@ -54,6 +62,14 @@
                 max-height: calc(90vh - var(--message-input-height-dev) - var(--search-height) - var(--channel-header-height));
                 max-height: calc(90dvh - var(--message-input-height-dev) - var(--search-height) - var(--channel-header-height));
             }
+        }
+
+        &.hide-input-full.content-height-dev {
+            max-height: calc(94vh - var(--message-input-height-dev) - var(--search-height) - var(--channel-header-height));
+        }
+
+        &.hide-input.content-height-dev {
+            max-height: calc(87vh - var(--message-input-height-dev) - var(--search-height) - var(--channel-header-height));
         }
 
         @include media-breakpoint-down(sm) {

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.ts
@@ -81,6 +81,8 @@ export class ConversationMessagesComponent implements OnInit, AfterViewInit, OnD
     faEnvelope = faEnvelope;
     faCircleNotch = faCircleNotch;
     isMobile = false;
+    isHiddenInputWithCallToAction = false;
+    isHiddenInputFull = false;
 
     private layoutService: LayoutService = inject(LayoutService);
 
@@ -145,6 +147,14 @@ export class ConversationMessagesComponent implements OnInit, AfterViewInit, OnD
     }
 
     private onActiveConversationChange() {
+        if (this._activeConversation !== undefined && this.getAsChannel(this._activeConversation)?.isAnnouncementChannel) {
+            this.isHiddenInputFull = !canCreateNewMessageInConversation(this._activeConversation);
+            this.isHiddenInputWithCallToAction = canCreateNewMessageInConversation(this._activeConversation);
+        } else {
+            this.isHiddenInputFull = false;
+            this.isHiddenInputWithCallToAction = false;
+        }
+
         if (this.course && this._activeConversation) {
             if (this.searchInput) {
                 this.searchInput.nativeElement.value = '';

--- a/src/test/javascript/spec/component/overview/course-conversations/layout/conversation-messages/conversation-messages.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-conversations/layout/conversation-messages/conversation-messages.component.spec.ts
@@ -144,6 +144,8 @@ examples.forEach((activeConversation) => {
             it('should display the "new announcement" button when the conversation is an announcement channel', fakeAsync(() => {
                 const announcementButton = fixture.debugElement.query(By.css('.btn.btn-md.btn-primary'));
                 expect(announcementButton).toBeTruthy(); // Check if the button is present
+                expect(component.isHiddenInputFull).toBeFalsy();
+                expect(component.isHiddenInputWithCallToAction).toBeTruthy();
 
                 const modal = fixture.debugElement.query(By.directive(PostCreateEditModalComponent));
                 expect(modal).toBeTruthy(); // Check if the modal is present


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, when accessing the announcement channel as a student, a big empty bar is at the bottom where the message input is supposed to be. This should not be there and instead the announcements should take over the entire height of the element.

Addresses #9597 

### Description
<!-- Describe your changes in detail -->
I added a check to see if the user is in the announcement channel and if so added a class that extends the height of the message area.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Students
- 1 Course with communication enabled

1. Log in to Artemis as the Instructor
2. Navigate to course
3. Navigate to the communication tab
4. Go to the announcements channel
5. Write announcements, such that the messages element grows to full height
6. Verify that the messages element is properly sized, with the "Create Announcement" button still being visible
7. Log into Artemis as the student
8. Navigate to the course
9. Navigate to the communication tab
10. Navigate to the announcement channel
11. Check if here the messages element is also full size, without the "Create Announcement" Button

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Instructor:
<img width="1240" alt="Bildschirmfoto 2024-11-03 um 23 22 07" src="https://github.com/user-attachments/assets/693fa754-4933-4c55-abc5-fe3906181b22">
Student:
<img width="1236" alt="Bildschirmfoto 2024-11-03 um 23 23 39" src="https://github.com/user-attachments/assets/33e20fb6-8809-4ed1-accb-2cf85203f6e1">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced conditional rendering for message input fields based on conversation type and user permissions.
	- Users can now see or hide input fields in announcement channels depending on their permission to create messages.

- **Style**
	- Introduced new CSS modifiers for better height management of the conversation messages component, improving layout flexibility.

- **Tests**
	- Expanded test coverage to include assertions for input visibility in announcement channels, ensuring correct behavior based on conversation type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->