### PR TITLE
`Adaptive learning`: Fix bulk creation of competencies

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/atlas/web/CompetencyResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/web/CompetencyResource.java
@@ -337,8 +337,12 @@ public class CompetencyResource {
     }
 
     private void checkCompetencyAttributes(Competency competency) {
-        if (competency.getTitle() == null || competency.getTitle().trim().isEmpty() || competency.getMasteryThreshold() < 1 || competency.getMasteryThreshold() > 100) {
-            throw new BadRequestAlertException("The attributes of the competency are invalid!", ENTITY_NAME, "invalidCompetencyAttributes");
+        if (competency.getTitle() == null || competency.getTitle().trim().isEmpty()) {
+            throw new BadRequestAlertException("The title of a competency is invalid!", ENTITY_NAME, "invalidCompetencyTitle");
+        }
+        if (competency.getMasteryThreshold() < 1 || competency.getMasteryThreshold() > 100) {
+            throw new BadRequestAlertException("The mastery threshold of the competency '" + competency.getTitle() + "' is invalid!", ENTITY_NAME,
+                    "invalidCompetencyMasteryThreshold");
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/web/CompetencyResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/web/CompetencyResource.java
@@ -338,7 +338,7 @@ public class CompetencyResource {
 
     private void checkCompetencyAttributes(Competency competency) {
         if (competency.getTitle() == null || competency.getTitle().trim().isEmpty() || competency.getMasteryThreshold() < 1 || competency.getMasteryThreshold() > 100) {
-            throw new BadRequestAlertException("The attributes of the competency are invalid!", ENTITY_NAME, "invalidPrerequisiteAttributes");
+            throw new BadRequestAlertException("The attributes of the competency are invalid!", ENTITY_NAME, "invalidCompetencyAttributes");
         }
     }
 

--- a/src/main/webapp/app/entities/competency.model.ts
+++ b/src/main/webapp/app/entities/competency.model.ts
@@ -80,6 +80,7 @@ export abstract class CourseCompetency extends BaseCompetency {
     protected constructor(type: CourseCompetencyType) {
         super();
         this.type = type;
+        this.masteryThreshold = 1;
     }
 }
 

--- a/src/main/webapp/app/entities/competency.model.ts
+++ b/src/main/webapp/app/entities/competency.model.ts
@@ -80,7 +80,7 @@ export abstract class CourseCompetency extends BaseCompetency {
     protected constructor(type: CourseCompetencyType) {
         super();
         this.type = type;
-        this.masteryThreshold = 1;
+        this.masteryThreshold = DEFAULT_MASTERY_THRESHOLD;
     }
 }
 

--- a/src/test/javascript/spec/component/competencies/create-competency.component.spec.ts
+++ b/src/test/javascript/spec/component/competencies/create-competency.component.spec.ts
@@ -8,7 +8,6 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { CompetencyService } from 'app/course/competencies/competency.service';
 import { LectureService } from 'app/lecture/lecture.service';
 import { MockRouter } from '../../helpers/mocks/mock-router';
-import { TextUnit } from 'app/entities/lecture-unit/textUnit.model';
 import { HttpResponse } from '@angular/common/http';
 import { Competency } from 'app/entities/competency.model';
 import { By } from '@angular/platform-browser';
@@ -106,12 +105,11 @@ describe('CreateCompetency', () => {
         const router: Router = TestBed.inject(Router);
         const competencyService = TestBed.inject(CompetencyService);
 
-        const textUnit: TextUnit = new TextUnit();
-        textUnit.id = 1;
         const formData: CourseCompetencyFormData = {
             title: 'Test',
             description: 'Lorem Ipsum',
             optional: true,
+            masteryThreshold: 100,
         };
 
         const response: HttpResponse<Competency> = new HttpResponse({

--- a/src/test/javascript/spec/component/competencies/create-prerequisite.component.spec.ts
+++ b/src/test/javascript/spec/component/competencies/create-prerequisite.component.spec.ts
@@ -6,7 +6,6 @@ import { of } from 'rxjs';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { LectureService } from 'app/lecture/lecture.service';
 import { MockRouter } from '../../helpers/mocks/mock-router';
-import { TextUnit } from 'app/entities/lecture-unit/textUnit.model';
 import { HttpResponse } from '@angular/common/http';
 import { By } from '@angular/platform-browser';
 import { DocumentationButtonComponent } from 'app/shared/components/documentation-button/documentation-button.component';
@@ -111,12 +110,11 @@ describe('CreatePrerequisite', () => {
         const router: Router = TestBed.inject(Router);
         const prerequisiteService = TestBed.inject(PrerequisiteService);
 
-        const textUnit: TextUnit = new TextUnit();
-        textUnit.id = 1;
         const formData: CourseCompetencyFormData = {
             title: 'Test',
             description: 'Lorem Ipsum',
             optional: true,
+            masteryThreshold: 100,
         };
 
         const response: HttpResponse<Prerequisite> = new HttpResponse({


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix the competency generation with iris

### Description
<!-- Describe your changes in detail -->
The competency generation with Iris does not set a mastery threshold. This is fixed now.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Course with Iris enabled for competencies

1. Log in to Artemis
2. Navigate to the competency management page in the course
3. Try to create some competencies using Iris
4. See that it works

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messaging for competency attribute validation, enhancing clarity for users.

- **New Features**
	- Default value for `masteryThreshold` in `CourseCompetency` is now set to `100`, ensuring consistent initialization for users.
	- Added `masteryThreshold` property to form data in competency creation and prerequisite handling tests, reflecting updated requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->