### PR TITLE
`Development`: Fix course messages e2e tests

### DIFF
--- a/src/main/webapp/app/shared/metis/post/post.component.html
+++ b/src/main/webapp/app/shared/metis/post/post.component.html
@@ -149,11 +149,11 @@
         </button>
     }
     @if (mayEditOrDelete) {
-        <button class="dropdown-item d-flex" (click)="editPosting()">
+        <button class="dropdown-item d-flex editIcon" (click)="editPosting()">
             <fa-icon [icon]="faPencilAlt" class="item-icon"></fa-icon>
             <span jhiTranslate="artemisApp.metis.post.editMessage"></span>
         </button>
-        <button class="dropdown-item d-flex" (click)="deletePost()">
+        <button class="dropdown-item d-flex deleteIcon" (click)="deletePost()">
             <fa-icon [icon]="faTrash" class="item-icon"></fa-icon>
             <span jhiTranslate="artemisApp.metis.post.deleteMessage"></span>
         </button>

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -242,7 +242,15 @@ export class CourseMessagesPage {
      */
     async editMessage(messageId: number, message: string) {
         const postLocator = this.getSinglePost(messageId);
-        await postLocator.locator('.editIcon').click();
+        await postLocator.locator('.message-container').click({ button: 'right' });
+        await this.page.waitForSelector('.dropdown-menu.show');
+
+        const editButton = postLocator.locator('.dropdown-menu.show .editIcon');
+        if (await editButton.isVisible()) {
+            await editButton.click();
+        } else {
+            await postLocator.locator('.reaction-button.edit').click();
+        }
         const editorLocator = postLocator.locator('.markdown-editor .monaco-editor textarea');
         await editorLocator.fill(message);
         const responsePromise = this.page.waitForResponse(`${COURSE_BASE}/*/messages/*`);
@@ -256,9 +264,16 @@ export class CourseMessagesPage {
      */
     async deleteMessage(messageId: number) {
         const responsePromise = this.page.waitForResponse(`${COURSE_BASE}/*/messages/*`);
-        const deleteIcon = this.getSinglePost(messageId).locator('.deleteIcon');
-        await deleteIcon.click();
-        await deleteIcon.click();
+        const postLocator = this.getSinglePost(messageId);
+        await postLocator.locator('.message-container').click({ button: 'right' });
+        await this.page.waitForSelector('.dropdown-menu.show');
+
+        const deleteButton = postLocator.locator('.dropdown-menu.show .deleteIcon');
+        if (await deleteButton.isVisible()) {
+            await deleteButton.click();
+        } else {
+            await postLocator.locator('.reaction-button.delete').click();
+        }
         await responsePromise;
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Some of the tests in CourseMessages.spec.ts were failing after the changes in message design. The tests could not identify the relocated button for delete/edit messages.


### Description
<!-- Describe your changes in detail -->
`deleteMessage()` and `editMessage()` functions have been updated so that tests can identify these buttons again.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Check that the test runs through correctly.



### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced conditional rendering for UI elements in the post component, improving user experience based on various states.
	- Updated dropdown menu for editing and deleting messages to utilize a context menu approach for more intuitive interactions.

- **Bug Fixes**
	- Improved styling for edit and delete buttons in the dropdown menu.

- **Refactor**
	- Revised methods for editing and deleting messages to streamline interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->