### PR TITLE
`Development`: Add check for public methods in controllers that are not endpoints

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/shared/architecture/module/ModuleArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/architecture/module/ModuleArchitectureTest.java
@@ -5,6 +5,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 
+import org.springframework.web.bind.annotation.RestController;
+
 import com.tngtech.archunit.lang.syntax.elements.ClassesThat;
 import com.tngtech.archunit.lang.syntax.elements.GivenClassesConjunction;
 import com.tngtech.archunit.lang.syntax.elements.GivenMethodsConjunction;
@@ -48,5 +50,10 @@ public interface ModuleArchitectureTest {
 
     default MethodsThat<? extends GivenMethodsConjunction> noMethodsOfThisModuleThat() {
         return noMethodsOfThisModule().and();
+    }
+
+    default GivenMethodsConjunction endpointsOfThisModule() {
+        // checking for public methods is sufficient since shouldHaveNoPublicMethodsExceptForEndpoints() would fail otherwise
+        return methodsOfThisModuleThat().areDeclaredInClassesThat().areAnnotatedWith(RestController.class).and().arePublic();
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
To maintain good code quality REST controllers should not provide any functionality for the service layer or other controllers. Thus all public methods should be endpoints. Thus developers are not tempted to call methods of the web layer from any other layer.

### Description
<!-- Describe your changes in detail -->
Adds architecture test to ensure REST controllers only contain public methods that are endpoints

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new test method to ensure public methods in REST controllers are properly annotated as endpoints.
	- Added a method to identify endpoint methods within the module architecture.

- **Bug Fixes**
	- Updated existing tests for improved accuracy in checking request mapping annotations.

- **Refactor**
	- Changed visibility of a method to indicate internal usage only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->