### PR TITLE
`Communication`: Add unread message notification icon to sidebar accordion

### DIFF
--- a/src/main/webapp/app/overview/course-overview.component.html
+++ b/src/main/webapp/app/overview/course-overview.component.html
@@ -259,7 +259,7 @@
         [id]="sidebarItem.testId ?? ''"
         [ngClass]="{
             'guided-tour': sidebarItem.guidedTour,
-            newMessage: !communicationRouteLoaded && hasUnreadMessages && sidebarItem.title === 'Communication',
+            newMessage: hasUnreadMessages && sidebarItem.title === 'Communication',
             collapsed: isNavbarCollapsed,
         }"
         jhiOrionFilter

--- a/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.html
+++ b/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.html
@@ -14,6 +14,7 @@
                     ({{ (groupedData[groupKey].entityData | searchFilter: ['title', 'type'] : searchValue)?.length }})
                 </div>
                 <div class="icon-container pe-3">
+                    <span *ngIf="totalUnreadMessagesPerGroup[groupKey] > 0" class="newMessage"></span>
                     <fa-icon [icon]="faChevronRight" class="rotate-icon chevron-position" [class.rotated]="!collapseState[groupKey]" />
                 </div>
             </div>

--- a/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.html
+++ b/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.html
@@ -15,7 +15,7 @@
                 </div>
                 <div class="icon-container pe-3">
                     @if (totalUnreadMessagesPerGroup[groupKey] > 0) {
-                        <span class="newMessage"></span>
+                        <span style="margin-right: 0.5rem">{{ totalUnreadMessagesPerGroup[groupKey] }}</span>
                     }
                     <fa-icon [icon]="faChevronRight" class="rotate-icon chevron-position" [class.rotated]="!collapseState[groupKey]" />
                 </div>

--- a/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.html
+++ b/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.html
@@ -14,7 +14,9 @@
                     ({{ (groupedData[groupKey].entityData | searchFilter: ['title', 'type'] : searchValue)?.length }})
                 </div>
                 <div class="icon-container pe-3">
-                    <span *ngIf="totalUnreadMessagesPerGroup[groupKey] > 0" class="newMessage"></span>
+                    @if (totalUnreadMessagesPerGroup[groupKey] > 0) {
+                        <span class="newMessage"></span>
+                    }
                     <fa-icon [icon]="faChevronRight" class="rotate-icon chevron-position" [class.rotated]="!collapseState[groupKey]" />
                 </div>
             </div>

--- a/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.html
+++ b/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.html
@@ -14,8 +14,8 @@
                     ({{ (groupedData[groupKey].entityData | searchFilter: ['title', 'type'] : searchValue)?.length }})
                 </div>
                 <div class="icon-container pe-3">
-                    @if (totalUnreadMessagesPerGroup[groupKey] > 0) {
-                        <span style="margin-right: 0.5rem">{{ totalUnreadMessagesPerGroup[groupKey] }}</span>
+                    @if (totalUnreadMessagesPerGroup[groupKey] > 0 && collapseState[groupKey]) {
+                        <span class="unread-count me-2">{{ totalUnreadMessagesPerGroup[groupKey] }}</span>
                     }
                     <fa-icon [icon]="faChevronRight" class="rotate-icon chevron-position" [class.rotated]="!collapseState[groupKey]" />
                 </div>

--- a/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.scss
+++ b/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.scss
@@ -5,3 +5,15 @@
 hr {
     border-top-color: var(--overview-light-border-color);
 }
+
+.newMessage {
+    width: 10px;
+    height: 10px;
+    position: relative;
+    padding-left: 0.7rem;
+    right: 1rem;
+    background-color: var(--bs-danger);
+    border-radius: 50%;
+    transform: translate(50%, -50%);
+    font-size: xx-small;
+}

--- a/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.scss
+++ b/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.scss
@@ -6,14 +6,21 @@ hr {
     border-top-color: var(--overview-light-border-color);
 }
 
-.newMessage {
-    width: 10px;
-    height: 10px;
-    position: relative;
-    padding-left: 0.7rem;
-    right: 1rem;
-    background-color: var(--bs-danger);
+.unread-count {
+    background-color: var(--bs-primary);
+    color: var(--bs-white);
     border-radius: 50%;
-    transform: translate(50%, -50%);
-    font-size: xx-small;
+    font-size: 0.6rem;
+    width: 1.1rem;
+    height: 1.1rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+.icon-container {
+    display: flex;
+    align-items: center;
 }

--- a/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.ts
+++ b/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.ts
@@ -32,7 +32,6 @@ export class SidebarAccordionComponent implements OnChanges, OnInit {
     ngOnInit() {
         this.expandGroupWithSelectedItem();
         this.setStoredCollapseState();
-        this.calculateTotalUnreadMessages();
     }
 
     ngOnChanges() {
@@ -41,7 +40,7 @@ export class SidebarAccordionComponent implements OnChanges, OnInit {
         } else {
             this.setStoredCollapseState();
         }
-        this.calculateTotalUnreadMessages();
+        this.calculateUnreadMessages();
     }
 
     setStoredCollapseState() {
@@ -70,16 +69,17 @@ export class SidebarAccordionComponent implements OnChanges, OnInit {
         }
     }
 
-    calculateTotalUnreadMessages(): void {
+    calculateUnreadMessages(): void {
         if (!this.groupedData) {
             this.totalUnreadMessagesPerGroup = {};
             return;
         }
 
         Object.keys(this.groupedData).forEach((groupKey) => {
-            this.totalUnreadMessagesPerGroup[groupKey] = this.groupedData[groupKey].entityData.filter(
-                (item: SidebarCardElement) => item.conversation?.unreadMessagesCount && item.conversation?.unreadMessagesCount > 0,
-            ).length;
+            // Sum the unread messages for each item in the group
+            this.totalUnreadMessagesPerGroup[groupKey] = this.groupedData[groupKey].entityData
+                .filter((item: SidebarCardElement) => item.conversation?.unreadMessagesCount)
+                .reduce((sum, item) => sum + (item.conversation?.unreadMessagesCount || 0), 0);
         });
     }
 

--- a/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.ts
+++ b/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.ts
@@ -40,7 +40,7 @@ export class SidebarAccordionComponent implements OnChanges, OnInit {
         } else {
             this.setStoredCollapseState();
         }
-        this.calculateUnreadMessages();
+        this.calculateUnreadMessagesOfGroup();
     }
 
     setStoredCollapseState() {
@@ -69,14 +69,13 @@ export class SidebarAccordionComponent implements OnChanges, OnInit {
         }
     }
 
-    calculateUnreadMessages(): void {
+    calculateUnreadMessagesOfGroup(): void {
         if (!this.groupedData) {
             this.totalUnreadMessagesPerGroup = {};
             return;
         }
 
         Object.keys(this.groupedData).forEach((groupKey) => {
-            // Sum the unread messages for each item in the group
             this.totalUnreadMessagesPerGroup[groupKey] = this.groupedData[groupKey].entityData
                 .filter((item: SidebarCardElement) => item.conversation?.unreadMessagesCount)
                 .reduce((sum, item) => sum + (item.conversation?.unreadMessagesCount || 0), 0);

--- a/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.ts
+++ b/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.ts
@@ -27,10 +27,12 @@ export class SidebarAccordionComponent implements OnChanges, OnInit {
 
     readonly faChevronRight = faChevronRight;
     readonly faFile = faFile;
+    totalUnreadMessagesPerGroup: { [key: string]: number } = {};
 
     ngOnInit() {
         this.expandGroupWithSelectedItem();
         this.setStoredCollapseState();
+        this.calculateTotalUnreadMessages();
     }
 
     ngOnChanges() {
@@ -39,6 +41,7 @@ export class SidebarAccordionComponent implements OnChanges, OnInit {
         } else {
             this.setStoredCollapseState();
         }
+        this.calculateTotalUnreadMessages();
     }
 
     setStoredCollapseState() {
@@ -65,6 +68,19 @@ export class SidebarAccordionComponent implements OnChanges, OnInit {
                 }
             }
         }
+    }
+
+    calculateTotalUnreadMessages() {
+        if (!this.groupedData) {
+            this.totalUnreadMessagesPerGroup = {};
+            return;
+        }
+
+        Object.keys(this.groupedData).forEach((groupKey) => {
+            this.totalUnreadMessagesPerGroup[groupKey] = this.groupedData[groupKey].entityData.filter(
+                (item: SidebarCardElement) => item.conversation?.unreadMessagesCount && item.conversation?.unreadMessagesCount > 0,
+            ).length;
+        });
     }
 
     toggleGroupCategoryCollapse(groupCategoryKey: string) {

--- a/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.ts
+++ b/src/main/webapp/app/shared/sidebar/sidebar-accordion/sidebar-accordion.component.ts
@@ -70,7 +70,7 @@ export class SidebarAccordionComponent implements OnChanges, OnInit {
         }
     }
 
-    calculateTotalUnreadMessages() {
+    calculateTotalUnreadMessages(): void {
         if (!this.groupedData) {
             this.totalUnreadMessagesPerGroup = {};
             return;

--- a/src/main/webapp/app/shared/sidebar/sidebar-card-item/sidebar-card-item.component.scss
+++ b/src/main/webapp/app/shared/sidebar/sidebar-card-item/sidebar-card-item.component.scss
@@ -12,6 +12,7 @@
     border-radius: 50%;
     font-size: 0.6rem;
     width: 1.1rem;
+    min-width: 1.1rem;
     height: 1.1rem;
     display: flex;
     justify-content: center;

--- a/src/test/javascript/spec/component/shared/sidebar/sidebar-accordion.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/sidebar/sidebar-accordion.component.spec.ts
@@ -39,16 +39,16 @@ describe('SidebarAccordionComponent', () => {
 
         component.groupedData = {
             current: {
-                entityData: [{ title: 'Title 1', type: 'Type A', id: 1, size: 'M' }],
+                entityData: [{ title: 'Title 1', type: 'Type A', id: 1, size: 'M', conversation: { unreadMessagesCount: 1 } }],
             },
             past: {
-                entityData: [{ title: 'Title 2', type: 'Type B', id: 2, size: 'M' }],
+                entityData: [{ title: 'Title 2', type: 'Type B', id: 2, size: 'M', conversation: { unreadMessagesCount: 0 } }],
             },
             future: {
-                entityData: [{ title: 'Title 3', type: 'Type C', id: 3, size: 'M' }],
+                entityData: [{ title: 'Title 3', type: 'Type C', id: 3, size: 'M', conversation: { unreadMessagesCount: 1 } }],
             },
             noDate: {
-                entityData: [{ title: 'Title 4', type: 'Type D', id: 4, size: 'M' }],
+                entityData: [{ title: 'Title 4', type: 'Type D', id: 4, size: 'M', conversation: { unreadMessagesCount: 0 } }],
             },
         };
         component.routeParams = { exerciseId: 3 };
@@ -143,5 +143,14 @@ describe('SidebarAccordionComponent', () => {
     it('should expand the group containing the selected item', () => {
         component.expandGroupWithSelectedItem();
         expect(component.collapseState['future']).toBeFalse();
+    });
+
+    it('should calculate total unread messages correctly', () => {
+        component.calculateTotalUnreadMessages();
+
+        expect(component.totalUnreadMessagesPerGroup['current']).toBe(1);
+        expect(component.totalUnreadMessagesPerGroup['past']).toBe(0);
+        expect(component.totalUnreadMessagesPerGroup['future']).toBe(1);
+        expect(component.totalUnreadMessagesPerGroup['noDate']).toBe(0);
     });
 });

--- a/src/test/javascript/spec/component/shared/sidebar/sidebar-accordion.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/sidebar/sidebar-accordion.component.spec.ts
@@ -55,6 +55,7 @@ describe('SidebarAccordionComponent', () => {
         component.collapseState = { current: false, dueSoon: false, past: false, future: true, noDate: true };
         fixture.componentRef.setInput('sidebarItemAlwaysShow', { current: false, dueSoon: false, past: false, future: false, noDate: false });
         fixture.detectChanges();
+        component.calculateUnreadMessagesOfGroup();
     });
 
     afterEach(() => {
@@ -145,9 +146,7 @@ describe('SidebarAccordionComponent', () => {
         expect(component.collapseState['future']).toBeFalse();
     });
 
-    it('should calculate total unread messages correctly', () => {
-        component.calculateTotalUnreadMessages();
-
+    it('should calculate unread messages of each group correctly', () => {
         expect(component.totalUnreadMessagesPerGroup['current']).toBe(1);
         expect(component.totalUnreadMessagesPerGroup['past']).toBe(0);
         expect(component.totalUnreadMessagesPerGroup['future']).toBe(1);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] This is a small issue that I tested locally.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [X] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [X] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [X] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [X] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- When a new message arrives, if the relevant accordion in the sidebar is collapsed, users cannot see which section contains the unread message without manually expanding each section.
- The red notification circle on the communication tab disappears when the user clicks on the tab, even if there are unread messages.


### Description
<!-- Describe your changes in detail -->
- Added a red notification circle to sidebar accordion sections that contain conversations with unread messages. (Closes #9498)
- Fixed the bug of red notification circle on the communication tab, it is now visible even when the user is on communication tab. (Closes #9724)
- Fixed the issue where the unread messages notification icon would shrink when the sidebar card title was long by adding a `min-width` property. 


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 2 Instructors/Students
- 1 Course with Communication enabled

1. Log in to Artemis
2. Navigate to Communication section of a course
3. Send messages to some conversations, such as exercise/lecture channels, or direct/group messages.
4. Log in with another account—the one to which you sent a message in the previous step
5. Notice the red circle icon on the communication tab that indicates unread messages. Click on the tab and observe that the circle remains visible.
6. Notice the red circle icons next to the sidebar accordion titles, indicating that there are unread messages in the conversations within those sections.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| sidebar-accordion.component.ts | 95.12% | ✅ ❌ |


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
**updated sidebar accordions with notification icon**
![image](https://github.com/user-attachments/assets/6a7dfbf7-bb96-4a24-badc-1f691896465e)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a notification indicator for unread messages in the sidebar accordion, enhancing user awareness of unread messages.
	- Simplified logic for displaying the `newMessage` class in the course overview component.

- **Bug Fixes**
	- Updated conditions for displaying unread message notifications to improve clarity and functionality.

- **Style**
	- Added a new CSS class for a visual indicator of unread messages in the sidebar accordion.
	- Adjusted minimum width for unread message count display to ensure consistent appearance.

- **Tests**
	- Enhanced test coverage for unread message calculations in the sidebar accordion component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->