### PR TITLE
`Programming exercises`: Use server time for exercise details dates

### DIFF
--- a/src/main/webapp/app/shared/server-date.service.ts
+++ b/src/main/webapp/app/shared/server-date.service.ts
@@ -36,7 +36,7 @@ export class ArtemisServerDateService implements ServerDateService {
         const now = dayjs(new Date());
         if (this.recentClientDates.length > 4) {
             // only if some recent client dates (i.e. recent syncs) are older than 60s
-            shouldSync = this.recentClientDates.some((recentClientDate) => now.diff(recentClientDate, 's') > 60);
+            shouldSync = this.recentClientDates.some((recentClientDate) => Math.abs(now.diff(recentClientDate, 's')) > 60);
         } else {
             // definitely sync if we do not have 5 elements yet
             shouldSync = true;

--- a/src/main/webapp/app/utils/date.utils.ts
+++ b/src/main/webapp/app/utils/date.utils.ts
@@ -75,6 +75,7 @@ export function dayOfWeekZeroSundayToZeroMonday(dayOfWeekZeroSunday: number): nu
     return (dayOfWeekZeroSunday + 6) % 7;
 }
 
-export function isDateLessThanAWeekInTheFuture(date: dayjs.Dayjs): boolean {
-    return date.isBetween(dayjs().add(1, 'week'), dayjs());
+export function isDateLessThanAWeekInTheFuture(date: dayjs.Dayjs, compareTime?: dayjs.Dayjs): boolean {
+    const now = compareTime ?? dayjs();
+    return date.isBetween(now.add(1, 'week'), now);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and on a testserverand was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
If a student manually changes the time on their computer (without changing the time zone), the time until an exercise starts, is due, etc., was displayed incorrectly.

### Description
<!-- Describe your changes in detail -->
To avoid this, the server time is fetched and used instead of using dayjs().

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor/student
- 1 Programming Exercise with dates (start date, due date, assessment date, complaint date)

1. Log in to Artemis
2. Navigate to Course Exercises
3. See the current dates
4. Change the date/time of your computer (manually and by changing the time zone)
5. Verify that the dates are still displayed correctly

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced server time integration for enhanced date handling in the exercise headers component.
	- Updated date comparison logic to ensure consistency with server time.

- **Bug Fixes**
	- Improved flexibility of date comparison functions to accept user-defined reference times.

- **Refactor**
	- Centralized date logic to reduce redundancy and improve maintainability.
	- Enhanced synchronization checks in the server date service for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->