### PR TITLE
`Lectures`: Fix an issue when saving lecture units in guided mode without linked competency

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureUnitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureUnitService.java
@@ -247,6 +247,7 @@ public class LectureUnitService {
      * @return saved exercise
      */
     public <T extends LectureUnit> T saveWithCompetencyLinks(T lectureUnit, Function<T, T> saveFunction) {
+        // persist lecture Unit before linking it to the competency
         Set<CompetencyLectureUnitLink> links = lectureUnit.getCompetencyLinks();
         lectureUnit.setCompetencyLinks(new HashSet<>());
 

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureUnitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureUnitService.java
@@ -247,13 +247,12 @@ public class LectureUnitService {
      * @return saved exercise
      */
     public <T extends LectureUnit> T saveWithCompetencyLinks(T lectureUnit, Function<T, T> saveFunction) {
-        // persist lecture Unit before linking it to the competency
         Set<CompetencyLectureUnitLink> links = lectureUnit.getCompetencyLinks();
         lectureUnit.setCompetencyLinks(new HashSet<>());
 
         T savedLectureUnit = saveFunction.apply(lectureUnit);
 
-        if (Hibernate.isInitialized(links) && !links.isEmpty()) {
+        if (Hibernate.isInitialized(links) && links != null && !links.isEmpty()) {
             savedLectureUnit.setCompetencyLinks(links);
             reconnectCompetencyLectureUnitLinks(savedLectureUnit);
             savedLectureUnit.setCompetencyLinks(new HashSet<>(competencyLectureUnitLinkRepository.saveAll(links)));

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/LectureUnitServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/LectureUnitServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.user.util.UserUtilService;
+import de.tum.cit.aet.artemis.lecture.domain.AttachmentUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnitCompletion;
@@ -86,5 +87,19 @@ class LectureUnitServiceTest extends AbstractSpringIntegrationIndependentTest {
 
         assertThat(lectureUnitCompletionRepository.findByLectureUnitIdAndUserId(unit1.getId(), student1.getId())).isEmpty();
         assertThat(lectureUnitCompletionRepository.findByLectureUnitIdAndUserId(unit2.getId(), student1.getId())).isEmpty();
+    }
+
+    @Test
+    void testSaveWithCompetencyLinksWithNullLinks() {
+        AttachmentUnit lectureUnit = new AttachmentUnit();
+        lectureUnit.setCompetencyLinks(null);
+
+        LectureUnit savedLectureUnit = lectureUnitService.saveWithCompetencyLinks(lectureUnit, unit -> {
+            unit.setId(1L);
+            return unit;
+        });
+
+        assertThat(savedLectureUnit).isNotNull();
+        assertThat(savedLectureUnit.getCompetencyLinks()).isEmpty();
     }
 }


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
Found the bug when working on [Lectures: Add status bar to lecture creation and edit mode #9655](https://github.com/ls1intum/Artemis/pull/9655/files). 
If Lecture Units are created within the guided mode and no competency is linked, the server throws an internal server error.

### Description
This PR allows the creation of a lecture unit without linking it to a competency.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Create a lecture unit in guided mode
2. Try to add a lecture unit (e.g. text lecture unit) without defining a linked competency
3. Verify no error is thrown


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
#### Performance Review
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
#### Bug
![bugLectureUnitWithoutCompetency](https://github.com/user-attachments/assets/86d23567-9c90-4863-b829-9c5a1aa545a1)

#### With the Bugfix
![lectureUnitWithoutCompetencyBug-fixed](https://github.com/user-attachments/assets/b2735241-7f32-43b5-a58b-2b7698c4893a)


