### PR TITLE
`Communication`: Add profile picture to user selector

### DIFF
--- a/src/main/webapp/app/shared/course-users-selector/course-users-selector.component.html
+++ b/src/main/webapp/app/shared/course-users-selector/course-users-selector.component.html
@@ -13,14 +13,14 @@
             [placeholder]="'artemisApp.userSelector.placeholderText' | artemisTranslate"
             [ngbTypeahead]="search"
             [inputFormatter]="usersFormatter"
-            [resultTemplate]="rt"
+            [resultTemplate]="resultTemplate"
             [editable]="false"
             [focusFirst]="false"
             (input)="onInputChange($event)"
             placement="bottom-start"
             #instance="ngbTypeahead"
         />
-        <ng-template #rt let-user="result" let-term="term">
+        <ng-template #resultTemplate let-user="result">
             <div class="d-flex align-items-center">
                 <jhi-profile-picture
                     [imageSizeInRem]="'1.1'"

--- a/src/main/webapp/app/shared/course-users-selector/course-users-selector.component.html
+++ b/src/main/webapp/app/shared/course-users-selector/course-users-selector.component.html
@@ -13,13 +13,30 @@
             [placeholder]="'artemisApp.userSelector.placeholderText' | artemisTranslate"
             [ngbTypeahead]="search"
             [inputFormatter]="usersFormatter"
-            [resultFormatter]="usersFormatter"
+            [resultTemplate]="rt"
             [editable]="false"
             [focusFirst]="false"
             (input)="onInputChange($event)"
             placement="bottom-start"
             #instance="ngbTypeahead"
         />
+        <ng-template #rt let-user="result" let-term="term">
+            <div class="d-flex align-items-center">
+                <jhi-profile-picture
+                    [imageSizeInRem]="'1.1'"
+                    [fontSizeInRem]="'0.5'"
+                    [imageId]="'sidebar-profile-picture'"
+                    [defaultPictureId]="'sidebar-default-profile-picture'"
+                    [isGray]="false"
+                    [authorId]="user.id"
+                    [authorName]="user.name"
+                    [imageUrl]="user.imageUrl"
+                    [isEditable]="false"
+                    class="me-2"
+                ></jhi-profile-picture>
+                <span>{{ getUserLabel(user) }}</span>
+            </div>
+        </ng-template>
         @if (isSearching) {
             <small class="form-text text-body-secondary" jhiTranslate="artemisApp.userSelector.searchingText"></small>
             <br />

--- a/src/main/webapp/app/shared/course-users-selector/course-users-selector.module.ts
+++ b/src/main/webapp/app/shared/course-users-selector/course-users-selector.module.ts
@@ -4,9 +4,10 @@ import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
 import { NgModule } from '@angular/core';
 import { CourseUsersSelectorComponent } from 'app/shared/course-users-selector/course-users-selector.component';
+import { ProfilePictureComponent } from 'app/shared/profile-picture/profile-picture.component';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, ReactiveFormsModule, ArtemisSharedModule, ArtemisSharedComponentModule],
+    imports: [CommonModule, FormsModule, ReactiveFormsModule, ArtemisSharedModule, ArtemisSharedComponentModule, ProfilePictureComponent],
     exports: [CourseUsersSelectorComponent],
     declarations: [CourseUsersSelectorComponent],
 })

--- a/src/test/javascript/spec/component/shared/course-users-selector/course-users-selector.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/course-users-selector/course-users-selector.component.spec.ts
@@ -6,7 +6,7 @@ import { NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
 import { HttpResponse } from '@angular/common/http';
-import { MockPipe, MockProvider } from 'ng-mocks';
+import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { CourseUsersSelectorComponent, SearchRoleGroup } from 'app/shared/course-users-selector/course-users-selector.component';
@@ -14,6 +14,7 @@ import { UserPublicInfoDTO } from 'app/core/user/user.model';
 import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
 import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { TranslateModule } from '@ngx-translate/core';
+import { ProfilePictureComponent } from '../../../../../../main/webapp/app/shared/profile-picture/profile-picture.component';
 
 @Component({
     template: `
@@ -48,7 +49,7 @@ describe('CourseUsersSelectorComponent', () => {
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
             imports: [CommonModule, FormsModule, ReactiveFormsModule, NgbTypeaheadModule, ArtemisSharedModule, ArtemisSharedComponentModule, TranslateModule.forRoot()],
-            declarations: [CourseUsersSelectorComponent, WrapperComponent, MockPipe(ArtemisTranslatePipe)],
+            declarations: [CourseUsersSelectorComponent, WrapperComponent, MockPipe(ArtemisTranslatePipe), MockComponent(ProfilePictureComponent)],
             providers: [MockProvider(CourseManagementService)],
         }).compileComponents();
     }));

--- a/src/test/javascript/spec/component/shared/course-users-selector/course-users-selector.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/course-users-selector/course-users-selector.component.spec.ts
@@ -14,7 +14,7 @@ import { UserPublicInfoDTO } from 'app/core/user/user.model';
 import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
 import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { TranslateModule } from '@ngx-translate/core';
-import { ProfilePictureComponent } from '../../../../../../main/webapp/app/shared/profile-picture/profile-picture.component';
+import { ProfilePictureComponent } from 'app/shared/profile-picture/profile-picture.component';
 
 @Component({
     template: `

--- a/src/test/javascript/spec/component/shared/course-users-selector/course-users-selector.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/course-users-selector/course-users-selector.component.spec.ts
@@ -143,6 +143,18 @@ describe('CourseUsersSelectorComponent', () => {
             expect(userSelectorComponent.selectedUsers).toEqual([exampleUserPublicInfoDTO]);
             expect(fixture.debugElement.query(By.css('.delete-user'))).toBeFalsy();
         }));
+
+        it('should render profile picture for users in dropdown', fakeAsync(() => {
+            const user = generateExampleUserPublicInfoDTO({});
+            searchUsersSpy.mockReturnValue(of(new HttpResponse({ body: [user], status: 200 })));
+
+            changeInput(fixture.debugElement.nativeElement, 'test');
+            tick(1000);
+            fixture.detectChanges();
+
+            const profilePicture = fixture.debugElement.query(By.directive(MockComponent(ProfilePictureComponent)));
+            expect(profilePicture).not.toBeNull();
+        }));
     });
 
     function getNativeInput(element: HTMLElement): HTMLInputElement {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] This is a small issue that I tested locally.
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



#### Client
- [X] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [X] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, when users select individuals to create a direct/group chat, only names are displayed, and profile pictures are not visible. This can make it harder to identify the correct person.

### Description
<!-- Describe your changes in detail -->
Added profile picture component to user selector to get relevant profile pictures.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor/Student
- 1 Course with Communication enabled

1. Log in to Artemis
2. Navigate to Communication section of a course
3. Click + button next to the search area to create direct/group chat.
4. Notice that when the user searches for names, the suggestions now contain relevant profile pictures.



### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
**direct chat dialog**
![image](https://github.com/user-attachments/assets/e98e73c8-c797-47f9-9f68-20b4fb0ebc85)

**group chat dialog**
![image](https://github.com/user-attachments/assets/d973189b-a513-416f-85aa-9771ad68aca7)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user selection display in the dropdown with profile pictures and user labels.
  
- **Bug Fixes**
	- Retained existing functionality for search status messages and user role filters.

- **Tests**
	- Updated test suite to include a mock for the ProfilePictureComponent, ensuring accurate testing of the CourseUsersSelectorComponent and verifying the rendering of profile pictures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->