### PR TITLE
`General`: Fix an issue in Chrome when uploading files

### DIFF
--- a/src/main/webapp/app/lecture/attachment.service.ts
+++ b/src/main/webapp/app/lecture/attachment.service.ts
@@ -54,8 +54,11 @@ export class AttachmentService {
         const options = createRequestOption(req);
         const copy = this.convertAttachmentDatesFromClient(attachment);
 
+        /** Ngsw-worker is bypassed temporarily to fix Chromium file upload issue
+         * See: https://issues.chromium.org/issues/374550348
+         **/
         return this.http
-            .put<Attachment>(this.resourceUrl + '/' + attachmentId, this.createFormData(copy, file), { params: options, observe: 'response' })
+            .put<Attachment>(this.resourceUrl + '/' + attachmentId, this.createFormData(copy, file), { headers: { 'ngsw-bypass': 'true' }, params: options, observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.convertAttachmentResponseDatesFromServer(res)));
     }
 

--- a/src/main/webapp/app/lecture/attachment.service.ts
+++ b/src/main/webapp/app/lecture/attachment.service.ts
@@ -35,8 +35,11 @@ export class AttachmentService {
             copy.lecture.posts = undefined;
         }
 
+        /** Ngsw-worker is bypassed temporarily to fix Chromium file upload issue
+         * See: https://issues.chromium.org/issues/374550348
+         **/
         return this.http
-            .post<Attachment>(this.resourceUrl, this.createFormData(copy, file), { observe: 'response' })
+            .post<Attachment>(this.resourceUrl, this.createFormData(copy, file), { headers: { 'ngsw-bypass': 'true' }, observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.convertAttachmentResponseDatesFromServer(res)));
     }
 

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachmentUnit.service.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachmentUnit.service.ts
@@ -38,12 +38,15 @@ export class AttachmentUnitService {
     }
 
     update(lectureId: number, attachmentUnitId: number, formData: FormData, notificationText?: string): Observable<EntityResponseType> {
+        /** Ngsw-worker is bypassed temporarily to fix Chromium file upload issue
+         * See: https://issues.chromium.org/issues/374550348
+         **/
         return this.httpClient
             .put<AttachmentUnit>(
                 `${this.resourceURL}/lectures/${lectureId}/attachment-units/${attachmentUnitId}?keepFilename=true` +
                     (notificationText ? `&notificationText=${notificationText}` : ''),
                 formData,
-                { observe: 'response' },
+                { headers: { 'ngsw-bypass': 'true' }, observe: 'response' },
             )
             .pipe(map((res: EntityResponseType) => this.lectureUnitService.convertLectureUnitResponseDatesFromServer(res)));
     }

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachmentUnit.service.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachmentUnit.service.ts
@@ -26,8 +26,14 @@ export class AttachmentUnitService {
     }
 
     create(formData: FormData, lectureId: number): Observable<EntityResponseType> {
+        /** Ngsw-worker is bypassed temporarily to fix Chromium file upload issue
+         * See: https://issues.chromium.org/issues/374550348
+         **/
         return this.httpClient
-            .post<AttachmentUnit>(`${this.resourceURL}/lectures/${lectureId}/attachment-units?keepFilename=true`, formData, { observe: 'response' })
+            .post<AttachmentUnit>(`${this.resourceURL}/lectures/${lectureId}/attachment-units?keepFilename=true`, formData, {
+                headers: { 'ngsw-bypass': 'true' },
+                observe: 'response',
+            })
             .pipe(map((res: EntityResponseType) => this.lectureUnitService.convertLectureUnitResponseDatesFromServer(res)));
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

**Note: Please test it first on Chromium Browsers (Google Chrome, Arc etc.)!**

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Right now when users want to add an attachment on **Chromium browsers** (such as Chrome and Arc), they get a 404 Not Found error and their attachment is not uploaded. This is an issue occurring in Chromium's version 130, 132 and it is fix in version 132. However since it may take time until the release, a temporary solution was needed to tackle this problem.

See: https://issues.chromium.org/issues/374550348

### Description
<!-- Describe your changes in detail -->

In one of the Chromium forum comments, it is stated that a work around can be used by bypassing the service workers.

See: https://issues.chromium.org/issues/374550348#comment20

This is first tried on Chrome by bypassing service workers manually and shown that it is working. 

![image](https://github.com/user-attachments/assets/08240d7f-9c17-47ff-a43a-1e39227197d0)

After that Angular's "ngsw-bypass" header flag is found to fix the problem.

See: https://angular.dev/ecosystem/service-workers/devops#bypassing-the-service-worker

Fixes #9732 and #9168 and #9646

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to Lecture -> Attachments -> Add an attachment
4. Observe that it is added correctly
5. Edit Attachment and add another
6. Observe that it is added correctly
7. Navigate to Lecture -> Attachment Units -> Add an Attachment Unit
8. Observe that it is added correctly
9. Edit Attachment Unit and add another
10. Observe that it is added correctly
11. Create a Lecture > click Automatic Unit Processing
12. Observe that the file is added without an error

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Implemented a temporary workaround for a file upload issue in Chromium by adding a custom header to HTTP POST and PUT requests in the attachment services.

These changes enhance the file upload experience while maintaining existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->