### PR TITLE
`Lectures`: Use attachment name for file downloads

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/web/FileResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/FileResource.java
@@ -219,7 +219,7 @@ public class FileResource {
     public ResponseEntity<byte[]> getMarkdownFile(@PathVariable String filename) {
         log.debug("REST request to get file : {}", filename);
         sanitizeFilenameElseThrow(filename);
-        return buildFileResponse(FilePathService.getMarkdownFilePath(), filename);
+        return buildFileResponse(FilePathService.getMarkdownFilePath(), filename, false);
     }
 
     /**
@@ -431,7 +431,7 @@ public class FileResource {
         // check if the user is authorized to access the requested attachment unit
         checkAttachmentAuthorizationOrThrow(course, attachment);
 
-        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink()), false);
+        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink()), Optional.of(attachment.getName()));
     }
 
     /**
@@ -470,13 +470,13 @@ public class FileResource {
 
     /**
      * GET files/attachments/attachment-unit/:attachmentUnitId/:filename : Get the lecture unit attachment
+     * Accesses to this endpoint are created by the server itself in the FilePathService
      *
      * @param attachmentUnitId ID of the attachment unit, the attachment belongs to
      * @return The requested file, 403 if the logged-in user is not allowed to access it, or 404 if the file doesn't exist
      */
     @GetMapping("files/attachments/attachment-unit/{attachmentUnitId}/*")
     @EnforceAtLeastStudent
-    // TODO: this method is kind of redundant to the method getAttachmentFile below, double check if both are actually needed
     public ResponseEntity<byte[]> getAttachmentUnitAttachment(@PathVariable Long attachmentUnitId) {
         log.debug("REST request to get the file for attachment unit {} for students", attachmentUnitId);
         AttachmentUnit attachmentUnit = attachmentUnitRepository.findByIdElseThrow(attachmentUnitId);
@@ -487,8 +487,7 @@ public class FileResource {
 
         // check if the user is authorized to access the requested attachment unit
         checkAttachmentAuthorizationOrThrow(course, attachment);
-
-        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink()), false);
+        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink()), Optional.of(attachment.getName()));
     }
 
     /**
@@ -567,17 +566,6 @@ public class FileResource {
     }
 
     /**
-     * Builds the response with headers, body and content type for specified path and file name
-     *
-     * @param path     to the file
-     * @param filename the name of the file
-     * @return response entity
-     */
-    private ResponseEntity<byte[]> buildFileResponse(Path path, String filename) {
-        return buildFileResponse(path, filename, false);
-    }
-
-    /**
      * Builds the response with headers, body and content type for specified path containing the file name
      *
      * @param path  to the file including the file name
@@ -585,18 +573,42 @@ public class FileResource {
      * @return response entity
      */
     private ResponseEntity<byte[]> buildFileResponse(Path path, boolean cache) {
-        return buildFileResponse(path.getParent(), path.getFileName().toString(), cache);
+        return buildFileResponse(path.getParent(), path.getFileName().toString(), Optional.empty(), cache);
     }
 
     /**
-     * Builds the response with headers, body and content type for specified path and file name
+     * Builds the response with headers, body and content type for specified path containing the file name
      *
-     * @param path     to the file
+     * @param path     to the file including the file name
      * @param filename the name of the file
      * @param cache    true if the response should contain a header that allows caching; false otherwise
      * @return response entity
      */
     private ResponseEntity<byte[]> buildFileResponse(Path path, String filename, boolean cache) {
+        return buildFileResponse(path, filename, Optional.empty(), cache);
+    }
+
+    /**
+     * Builds the response with headers, body and content type for specified path and file name
+     *
+     * @param path            to the file
+     * @param replaceFilename replaces the downloaded file's name, if provided
+     * @return response entity
+     */
+    private ResponseEntity<byte[]> buildFileResponse(Path path, Optional<String> replaceFilename) {
+        return buildFileResponse(path.getParent(), path.getFileName().toString(), replaceFilename, false);
+    }
+
+    /**
+     * Builds the response with headers, body and content type for specified path and file name
+     *
+     * @param path            to the file
+     * @param filename        the name of the file
+     * @param replaceFilename replaces the downloaded file's name, if provided
+     * @param cache           true if the response should contain a header that allows caching; false otherwise
+     * @return response entity
+     */
+    private ResponseEntity<byte[]> buildFileResponse(Path path, String filename, Optional<String> replaceFilename, boolean cache) {
         try {
             Path actualPath = path.resolve(filename);
             byte[] file = fileService.getFileForPath(actualPath);
@@ -611,7 +623,7 @@ public class FileResource {
             String contentType = lowerCaseFilename.endsWith("htm") || lowerCaseFilename.endsWith("html") || lowerCaseFilename.endsWith("svg") || lowerCaseFilename.endsWith("svgz")
                     ? "attachment"
                     : "inline";
-            headers.setContentDisposition(ContentDisposition.builder(contentType).filename(filename).build());
+            headers.setContentDisposition(ContentDisposition.builder(contentType).filename(replaceFilename.orElse(filename)).build());
 
             var response = ResponseEntity.ok().headers(headers).contentType(getMediaTypeFromFilename(filename)).header("filename", filename);
             if (cache) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Issue: In https://github.com/ls1intum/Artemis/pull/9721 the cryptic attachment text was removed from the filename. Unfortunately, only superficially. When actually saving the file, with Ctrl + S, the cryptic timestamp is still there.
In the URL:
![image](https://github.com/user-attachments/assets/8489a4a3-c642-429a-91b6-065ed2f9eb71)
But when saving:
![image](https://github.com/user-attachments/assets/7daae7a8-857c-4d9f-af18-d29eef223e93)

### Description
<!-- Describe your changes in detail -->
Fixes this issue, by simply using the defined attachment name.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
1. Instructor: upload files to lecture attachments, and to lecture unit attachments.
2. Download the files (really download it, not just look at the url, but use Ctrl + S / the download button)
![image](https://github.com/user-attachments/assets/65323a2e-c7c6-4a7f-90c7-c5cd90ec0af8)
3. Make sure the file name simply is the name specified when creating the attachment.
4. Please tick the test checkboxes


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
- [x] Test - Firefox
- [x] Test - Chrome
- [ ] Test - Safari


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

With the fix:
![image](https://github.com/user-attachments/assets/14d217e1-e098-4b5c-9d50-24b89095e4c4)
![image](https://github.com/user-attachments/assets/89b60782-924a-4bd0-9c81-032b9783991e)
![image](https://github.com/user-attachments/assets/74edbf39-80a3-43d8-8091-5b964cb92432)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved file handling with flexible filename options and enhanced caching behavior for file responses.
	- Streamlined response creation process for file handling.

- **Bug Fixes**
	- Adjusted caching settings for specific file response methods to ensure correct behavior.

- **Refactor**
	- Simplified method signatures for better clarity and maintainability in the `FileResource` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->