### PR TITLE
`Programming exercises`: Fix an issue with access tokens for team exercises

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ParticipationVcsAccessTokenService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ParticipationVcsAccessTokenService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
+import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.exercise.repository.TeamRepository;
 import de.tum.cit.aet.artemis.programming.domain.ParticipationVCSAccessToken;
@@ -94,7 +95,9 @@ public class ParticipationVcsAccessTokenService {
      */
     private void loadTeamStudentsForTeamExercise(StudentParticipation participation) {
         if (participation.getTeam().isPresent()) {
-            participation.getTeam().get().setStudents(teamRepository.findWithStudentsById(participation.getTeam().get().getId()).get().getStudents());
+            Team team = participation.getTeam().get();
+            Team teamWithStudents = teamRepository.findWithStudentsByIdElseThrow(team.getId());
+            participation.getTeam().get().setStudents(teamWithStudents.getStudents());
         }
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/authentication/UserAccountLocalVcsIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/authentication/UserAccountLocalVcsIntegrationTest.java
@@ -40,6 +40,12 @@ class UserAccountLocalVcsIntegrationTest extends AbstractSpringIntegrationLocalC
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void getParticipationVcsAccessTokenByUserForTeamExercise() throws Exception {
+        userTestService.getAndCreateParticipationVcsAccessTokenForTeamExercise();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void createAndDeleteUserVcsAccessTokenByUser() throws Exception {
         userTestService.createAndDeleteUserVcsAccessToken();
     }

--- a/src/test/java/de/tum/cit/aet/artemis/core/user/util/UserTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/user/util/UserTestService.java
@@ -952,7 +952,7 @@ public class UserTestService {
         submissionRepository.delete(submission);
         participationVCSAccessTokenRepository.deleteAll();
         participationRepository.deleteById(submission.getParticipation().getId());
-        teamUtilService.deleteAll();
+        teamUtilService.deleteTeam(team);
     }
 
     // Test

--- a/src/test/java/de/tum/cit/aet/artemis/core/user/util/UserTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/user/util/UserTestService.java
@@ -46,7 +46,11 @@ import de.tum.cit.aet.artemis.core.test_repository.CourseTestRepository;
 import de.tum.cit.aet.artemis.core.test_repository.UserTestRepository;
 import de.tum.cit.aet.artemis.core.util.CourseUtilService;
 import de.tum.cit.aet.artemis.core.util.RequestUtilService;
+import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
 import de.tum.cit.aet.artemis.exercise.domain.SubmissionType;
+import de.tum.cit.aet.artemis.exercise.domain.Team;
+import de.tum.cit.aet.artemis.exercise.repository.ExerciseTestRepository;
+import de.tum.cit.aet.artemis.exercise.team.TeamUtilService;
 import de.tum.cit.aet.artemis.exercise.test_repository.ParticipationTestRepository;
 import de.tum.cit.aet.artemis.exercise.test_repository.SubmissionTestRepository;
 import de.tum.cit.aet.artemis.lti.service.LtiService;
@@ -92,6 +96,9 @@ public class UserTestService {
     private UserUtilService userUtilService;
 
     @Autowired
+    private TeamUtilService teamUtilService;
+
+    @Autowired
     private CourseUtilService courseUtilService;
 
     @Autowired
@@ -127,6 +134,9 @@ public class UserTestService {
 
     @Autowired
     private SubmissionTestRepository submissionRepository;
+
+    @Autowired
+    private ExerciseTestRepository exerciseTestRepository;
 
     public void setup(String testPrefix, MockDelegate mockDelegate) throws Exception {
         this.TEST_PREFIX = testPrefix;
@@ -913,6 +923,36 @@ public class UserTestService {
         submissionRepository.delete(submission);
         participationVCSAccessTokenRepository.deleteAll();
         participationRepository.deleteById(submission.getParticipation().getId());
+    }
+
+    // Test
+    public void getAndCreateParticipationVcsAccessTokenForTeamExercise() throws Exception {
+        User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
+        var course = courseUtilService.addEmptyCourse();
+        var exercise = programmingExerciseUtilService.addProgrammingExerciseToCourse(course);
+        exercise.setMode(ExerciseMode.TEAM);
+        exerciseTestRepository.save(exercise);
+        courseRepository.save(course);
+        User tutor1 = userTestRepository.findOneByLogin(TEST_PREFIX + "tutor1").orElseThrow();
+        Team team = teamUtilService.createTeam(Set.of(user), tutor1, exercise, "team1");
+
+        var submission = (ProgrammingSubmission) new ProgrammingSubmission().commitHash("abc").type(SubmissionType.MANUAL).submitted(true);
+        submission = programmingExerciseUtilService.addProgrammingSubmissionToTeamExercise(exercise, submission, team);
+
+        // request existing token
+        request.get("/api/account/participation-vcs-access-token?participationId=" + submission.getParticipation().getId(), HttpStatus.NOT_FOUND, String.class);
+
+        var token = request.putWithResponseBody("/api/account/participation-vcs-access-token?participationId=" + submission.getParticipation().getId(), null, String.class,
+                HttpStatus.OK);
+        assertThat(token).isNotNull();
+
+        var token2 = request.get("/api/account/participation-vcs-access-token?participationId=" + submission.getParticipation().getId(), HttpStatus.OK, String.class);
+        assertThat(token2).isEqualTo(token);
+
+        submissionRepository.delete(submission);
+        participationVCSAccessTokenRepository.deleteAll();
+        participationRepository.deleteById(submission.getParticipation().getId());
+        teamUtilService.deleteAll();
     }
 
     // Test

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/team/TeamUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/team/TeamUtilService.java
@@ -244,4 +244,11 @@ public class TeamUtilService {
         team.setExercise(exercise);
         return teamRepo.saveAndFlush(team);
     }
+
+    /**
+     * Deletes all teams
+     */
+    public void deleteAll() {
+        teamRepo.deleteAll();
+    }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/team/TeamUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/team/TeamUtilService.java
@@ -246,7 +246,7 @@ public class TeamUtilService {
     }
 
     /**
-     * Deletes all teams
+     * Deletes a team
      */
     public void deleteTeam(Team team) {
         teamRepo.delete(team);

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/team/TeamUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/team/TeamUtilService.java
@@ -248,7 +248,7 @@ public class TeamUtilService {
     /**
      * Deletes all teams
      */
-    public void deleteAll() {
-        teamRepo.deleteAll();
+    public void deleteTeam(Team team) {
+        teamRepo.delete(team);
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/team/TeamUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/team/TeamUtilService.java
@@ -245,9 +245,6 @@ public class TeamUtilService {
         return teamRepo.saveAndFlush(team);
     }
 
-    /**
-     * Deletes a team
-     */
     public void deleteTeam(Team team) {
         teamRepo.delete(team);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseUtilService.java
@@ -42,6 +42,7 @@ import de.tum.cit.aet.artemis.exam.repository.ExamRepository;
 import de.tum.cit.aet.artemis.exam.util.ExamUtilService;
 import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
 import de.tum.cit.aet.artemis.exercise.domain.SubmissionType;
+import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
@@ -736,6 +737,21 @@ public class ProgrammingExerciseUtilService {
      */
     public ProgrammingSubmission addProgrammingSubmission(ProgrammingExercise exercise, ProgrammingSubmission submission, String login) {
         StudentParticipation participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, login);
+        submission.setParticipation(participation);
+        submission = programmingSubmissionRepo.save(submission);
+        return submission;
+    }
+
+    /**
+     * Adds programming submission to provided programming exercise. The provided login is used to access or create a participation.
+     *
+     * @param exercise   The exercise to which the submission should be added.
+     * @param submission The submission which should be added to the programming exercise.
+     * @param team       The login of the user used to access or create an exercise participation.
+     * @return The created programming submission.
+     */
+    public ProgrammingSubmission addProgrammingSubmissionToTeamExercise(ProgrammingExercise exercise, ProgrammingSubmission submission, Team team) {
+        StudentParticipation participation = participationUtilService.addTeamParticipationForProgrammingExercise(exercise, team);
         submission.setParticipation(participation);
         submission = programmingSubmissionRepo.save(submission);
         return submission;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
For programming team exercises, the vcs access token did not load, as the team's students were not loaded when fetching the participation.

### Description
<!-- Describe your changes in detail -->
Fix the issue by loading the team's students, when the exercise is a team exercise.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
1. As an instructor create a team programming exercise
2. Create a team and add at least one student
3. With the student account, login and navigate to the exercise
4. Make sure the clone link in the code button is displayed with the VCS-access token.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

#### Server

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| ParticipationVcsAccessTokenService.java | 92% | ✅ ❌ |


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/user-attachments/assets/49ce9c2d-9e63-49fe-ab80-f77f7872d89d)
![image](https://github.com/user-attachments/assets/4d5d58bd-cc4c-4333-a2f4-7a56d5b84b2d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced functionality to manage team exercises, including loading team student data and creating access tokens for team participation.
  - Added methods to handle programming submissions specifically for team exercises.
  - Implemented a method to delete specific teams from the repository.

- **Bug Fixes**
  - Enhanced logic for retrieving and creating VCS access tokens to ensure team data is accurately processed.

- **Tests**
  - Added new test methods to verify the functionality related to team exercises and VCS access tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->