### PR TITLE
`Communication`: Fix visibility of the edit message option for non-authors

### DIFF
--- a/src/main/webapp/app/shared/metis/answer-post/answer-post.component.html
+++ b/src/main/webapp/app/shared/metis/answer-post/answer-post.component.html
@@ -32,7 +32,8 @@
                         [isThreadSidebar]="isThreadSidebar"
                         (openPostingCreateEditModal)="createAnswerPostModal.open()"
                         (reactionsUpdated)="onReactionsUpdated($event)"
-                        (mayEditOrDeleteOutput)="onMayEditOrDelete($event)"
+                        (mayDeleteOutput)="onMayDelete($event)"
+                        (mayEditOutput)="onMayEdit($event)"
                         (isDeleteEvent)="onDeleteEvent(true)"
                     />
                 </div>
@@ -64,11 +65,13 @@
         <fa-icon [icon]="faSmile" class="item-icon"></fa-icon>
         <span jhiTranslate="artemisApp.metis.post.addReaction"></span>
     </button>
-    @if (mayEditOrDelete) {
+    @if (mayEdit) {
         <button class="dropdown-item d-flex" (click)="editPosting()">
             <fa-icon [icon]="faPencilAlt" class="item-icon"></fa-icon>
             <span jhiTranslate="artemisApp.metis.post.editMessage"></span>
         </button>
+    }
+    @if (mayDelete) {
         <button class="dropdown-item d-flex" (click)="deletePost()">
             <fa-icon [icon]="faTrash" class="item-icon"></fa-icon>
             <span jhiTranslate="artemisApp.metis.post.deleteMessage"></span>

--- a/src/main/webapp/app/shared/metis/answer-post/answer-post.component.ts
+++ b/src/main/webapp/app/shared/metis/answer-post/answer-post.component.ts
@@ -52,7 +52,8 @@ export class AnswerPostComponent extends PostingDirective<AnswerPost> {
     readonly faTrash = faTrash;
     readonly faThumbtack = faThumbtack;
     static activeDropdownPost: AnswerPostComponent | null = null;
-    mayEditOrDelete: boolean = false;
+    mayEdit: boolean = false;
+    mayDelete: boolean = false;
     @ViewChild(AnswerPostReactionsBarComponent) private reactionsBarComponent!: AnswerPostReactionsBarComponent;
 
     constructor(
@@ -95,8 +96,12 @@ export class AnswerPostComponent extends PostingDirective<AnswerPost> {
         }
     }
 
-    onMayEditOrDelete(value: boolean) {
-        this.mayEditOrDelete = value;
+    onMayDelete(value: boolean) {
+        this.mayDelete = value;
+    }
+
+    onMayEdit(value: boolean) {
+        this.mayEdit = value;
     }
 
     onRightClick(event: MouseEvent) {

--- a/src/main/webapp/app/shared/metis/post/post.component.html
+++ b/src/main/webapp/app/shared/metis/post/post.component.html
@@ -80,7 +80,8 @@
                                     (openPostingCreateEditModal)="openCreateAnswerPostModal()"
                                     (openThread)="openThread.emit()"
                                     (isModalOpen)="displayInlineInput = true"
-                                    (mayEditOrDeleteOutput)="onMayEditOrDelete($event)"
+                                    (mayEditOutput)="onMayEdit($event)"
+                                    (mayDeleteOutput)="onMayDelete($event)"
                                     (canPinOutput)="onCanPin($event)"
                                     (isDeleteEvent)="onDeleteEvent(true)"
                                 />
@@ -148,11 +149,13 @@
             <span [jhiTranslate]="checkIfPinned() === DisplayPriority.PINNED ? 'artemisApp.metis.post.unpinMessage' : 'artemisApp.metis.post.pinMessage'"></span>
         </button>
     }
-    @if (mayEditOrDelete) {
+    @if (mayEdit) {
         <button class="dropdown-item d-flex editIcon" (click)="editPosting()">
             <fa-icon [icon]="faPencilAlt" class="item-icon"></fa-icon>
             <span jhiTranslate="artemisApp.metis.post.editMessage"></span>
         </button>
+    }
+    @if (mayDelete) {
         <button class="dropdown-item d-flex deleteIcon" (click)="deletePost()">
             <fa-icon [icon]="faTrash" class="item-icon"></fa-icon>
             <span jhiTranslate="artemisApp.metis.post.deleteMessage"></span>

--- a/src/main/webapp/app/shared/metis/post/post.component.ts
+++ b/src/main/webapp/app/shared/metis/post/post.component.ts
@@ -77,7 +77,8 @@ export class PostComponent extends PostingDirective<Post> implements OnInit, OnC
     contextInformation: ContextInformation;
     readonly PageType = PageType;
     readonly DisplayPriority = DisplayPriority;
-    mayEditOrDelete: boolean = false;
+    mayEdit: boolean = false;
+    mayDelete: boolean = false;
     canPin: boolean = false;
 
     // Icons
@@ -112,8 +113,12 @@ export class PostComponent extends PostingDirective<Post> implements OnInit, OnC
         return this.posting.displayPriority === DisplayPriority.PINNED;
     }
 
-    onMayEditOrDelete(value: boolean) {
-        this.mayEditOrDelete = value;
+    onMayEdit(value: boolean) {
+        this.mayEdit = value;
+    }
+
+    onMayDelete(value: boolean) {
+        this.mayDelete = value;
     }
 
     onCanPin(value: boolean) {

--- a/src/main/webapp/app/shared/metis/posting-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component.html
+++ b/src/main/webapp/app/shared/metis/posting-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component.html
@@ -73,11 +73,12 @@
                     }
                 </button>
             }
-            @if (mayEditOrDelete) {
+            @if (mayEdit) {
                 <button class="reaction-button clickable px-2 fs-small edit" (click)="editPosting()" [ngbTooltip]="'artemisApp.metis.editPosting' | artemisTranslate">
                     <fa-icon [icon]="faPencilAlt" cdkOverlayOrigin></fa-icon>
                 </button>
-
+            }
+            @if (mayDelete) {
                 <button class="reaction-button clickable px-2 fs-small delete">
                     <jhi-confirm-icon
                         iconSize="sm"

--- a/src/main/webapp/app/shared/metis/posting-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, output } from '@angular/core';
 import { Reaction } from 'app/entities/metis/reaction.model';
 import { PostingsReactionsBarDirective } from 'app/shared/metis/posting-reactions-bar/posting-reactions-bar.directive';
 import { AnswerPost } from 'app/entities/metis/answer-post.model';
@@ -22,8 +22,10 @@ export class AnswerPostReactionsBarComponent extends PostingsReactionsBarDirecti
     @Output() openPostingCreateEditModal = new EventEmitter<void>();
     isAuthorOfOriginalPost: boolean;
     isAnswerOfAnnouncement: boolean;
-    @Output() mayEditOrDeleteOutput = new EventEmitter<boolean>();
-    mayEditOrDelete: boolean;
+    mayDeleteOutput = output<boolean>();
+    mayDelete: boolean;
+    mayEditOutput = output<boolean>();
+    mayEdit: boolean;
     readonly faPencilAlt = faPencilAlt;
     @Input() isEmojiCount: boolean = false;
     @Output() postingUpdated = new EventEmitter<void>();
@@ -34,12 +36,14 @@ export class AnswerPostReactionsBarComponent extends PostingsReactionsBarDirecti
 
     ngOnInit() {
         super.ngOnInit();
-        this.setMayEditOrDelete();
+        this.setMayEdit();
+        this.setMayDelete();
     }
 
     ngOnChanges() {
         super.ngOnChanges();
-        this.setMayEditOrDelete();
+        this.setMayEdit();
+        this.setMayDelete();
     }
 
     isAnyReactionCountAboveZero(): boolean {
@@ -64,7 +68,7 @@ export class AnswerPostReactionsBarComponent extends PostingsReactionsBarDirecti
         return reaction;
     }
 
-    setMayEditOrDelete(): void {
+    setMayDelete(): void {
         // determines if the current user is the author of the original post, that the answer belongs to
         this.isAuthorOfOriginalPost = this.metisService.metisUserIsAuthorOfPosting(this.posting.post!);
         this.isAnswerOfAnnouncement = getAsChannelDTO(this.posting.post?.conversation)?.isAnnouncementChannel ?? false;
@@ -72,8 +76,13 @@ export class AnswerPostReactionsBarComponent extends PostingsReactionsBarDirecti
         const isAtLeastInstructorInCourse = this.metisService.metisUserIsAtLeastInstructorInCourse();
         const mayEditOrDeleteOtherUsersAnswer =
             (isCourseWideChannel && isAtLeastInstructorInCourse) || (getAsChannelDTO(this.metisService.getCurrentConversation())?.hasChannelModerationRights ?? false);
-        this.mayEditOrDelete = !this.isReadOnlyMode && (this.isAuthorOfPosting || mayEditOrDeleteOtherUsersAnswer);
-        this.mayEditOrDeleteOutput.emit(this.mayEditOrDelete);
+        this.mayDelete = !this.isReadOnlyMode && (this.isAuthorOfPosting || mayEditOrDeleteOtherUsersAnswer);
+        this.mayDeleteOutput.emit(this.mayDelete);
+    }
+
+    setMayEdit() {
+        this.mayEdit = this.isAuthorOfPosting;
+        this.mayEditOutput.emit(this.mayEdit);
     }
 
     editPosting() {

--- a/src/main/webapp/app/shared/metis/posting-reactions-bar/post-reactions-bar/post-reactions-bar.component.html
+++ b/src/main/webapp/app/shared/metis/posting-reactions-bar/post-reactions-bar/post-reactions-bar.component.html
@@ -108,7 +108,7 @@
             </ng-container>
         }
 
-        @if (!isEmojiCount && mayEditOrDelete) {
+        @if (!isEmojiCount && mayEdit) {
             <button
                 class="reaction-button clickable px-2 fs-small edit"
                 [disabled]="readOnlyMode"
@@ -119,7 +119,7 @@
             </button>
         }
         <jhi-post-create-edit-modal #createEditModal [posting]="posting" [isCommunicationPage]="isCommunicationPage" (isModalOpen)="isModalOpen.emit()" />
-        @if (!isEmojiCount && mayEditOrDelete) {
+        @if (!isEmojiCount && mayDelete) {
             <button class="reaction-button clickable fs-small">
                 <jhi-confirm-icon
                     iconSize="sm"

--- a/src/main/webapp/app/shared/metis/posting-reactions-bar/post-reactions-bar/post-reactions-bar.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-reactions-bar/post-reactions-bar/post-reactions-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, ViewChild, output } from '@angular/core';
 import { Reaction } from 'app/entities/metis/reaction.model';
 import { Post } from 'app/entities/metis/post.model';
 import { PostingsReactionsBarDirective } from 'app/shared/metis/posting-reactions-bar/posting-reactions-bar.directive';
@@ -44,9 +44,11 @@ export class PostReactionsBarComponent extends PostingsReactionsBarDirective<Pos
     @Output() openThread = new EventEmitter<void>();
     @Input() previewMode: boolean;
     isAtLeastInstructorInCourse: boolean;
-    @Output() mayEditOrDeleteOutput = new EventEmitter<boolean>();
+    mayDeleteOutput = output<boolean>();
+    mayEditOutput = output<boolean>();
     @Output() canPinOutput = new EventEmitter<boolean>();
-    mayEditOrDelete: boolean;
+    mayEdit: boolean;
+    mayDelete: boolean;
     @ViewChild(PostCreateEditModalComponent) postCreateEditModal?: PostCreateEditModalComponent;
     @Input() isEmojiCount = false;
     @Input() hoverBar: boolean = true;
@@ -71,8 +73,9 @@ export class PostReactionsBarComponent extends PostingsReactionsBarDirective<Pos
 
         const currentConversation = this.metisService.getCurrentConversation();
         this.setCanPin(currentConversation);
+        this.setMayDelete();
+        this.setMayEdit();
         this.resetTooltipsAndPriority();
-        this.setMayEditOrDelete();
     }
 
     ngOnDestroy() {
@@ -106,7 +109,8 @@ export class PostReactionsBarComponent extends PostingsReactionsBarDirective<Pos
     ngOnChanges() {
         super.ngOnChanges();
         this.resetTooltipsAndPriority();
-        this.setMayEditOrDelete();
+        this.setMayDelete();
+        this.setMayEdit();
     }
 
     /**
@@ -185,12 +189,17 @@ export class PostReactionsBarComponent extends PostingsReactionsBarDirective<Pos
         }
     }
 
-    setMayEditOrDelete(): void {
+    setMayDelete(): void {
         this.isAtLeastInstructorInCourse = this.metisService.metisUserIsAtLeastInstructorInCourse();
         const isCourseWideChannel = getAsChannelDTO(this.posting.conversation)?.isCourseWide ?? false;
-        const mayEditOrDeleteOtherUsersAnswer =
+        const mayDeleteOtherUsersAnswer =
             (isCourseWideChannel && this.isAtLeastInstructorInCourse) || (getAsChannelDTO(this.metisService.getCurrentConversation())?.hasChannelModerationRights ?? false);
-        this.mayEditOrDelete = !this.readOnlyMode && !this.previewMode && (this.isAuthorOfPosting || mayEditOrDeleteOtherUsersAnswer);
-        this.mayEditOrDeleteOutput.emit(this.mayEditOrDelete);
+        this.mayDelete = !this.readOnlyMode && !this.previewMode && (this.isAuthorOfPosting || mayDeleteOtherUsersAnswer);
+        this.mayDeleteOutput.emit(this.mayDelete);
+    }
+
+    setMayEdit(): void {
+        this.mayEdit = this.isAuthorOfPosting;
+        this.mayEditOutput.emit(this.mayEdit);
     }
 }

--- a/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component.spec.ts
@@ -128,15 +128,34 @@ describe('AnswerPostReactionsBarComponent', () => {
         expect(getDeleteButton()).not.toBeNull();
     });
 
-    it('should display edit and delete options to instructor if posting is in course-wide channel from a student', () => {
+    it('should display the delete option to instructor if posting is in course-wide channel from a student', () => {
         metisServiceUserIsAtLeastInstructorMock.mockReturnValue(true);
         metisServiceUserPostingAuthorMock.mockReturnValue(false);
         component.posting = { ...metisResolvingAnswerPostUser1, post: { ...metisPostInChannel } };
         component.posting.authorRole = UserRole.USER;
         component.ngOnInit();
         fixture.detectChanges();
-        expect(getEditButton()).not.toBeNull();
         expect(getDeleteButton()).not.toBeNull();
+    });
+
+    it('should not display the edit option to user (even instructor) if s/he is not the author of posting', () => {
+        metisServiceUserIsAtLeastInstructorMock.mockReturnValue(true);
+        metisServiceUserPostingAuthorMock.mockReturnValue(false);
+
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        expect(getEditButton()).toBeNull();
+    });
+
+    it('should display the edit option to user if s/he is the author of posting', () => {
+        metisServiceUserIsAtLeastInstructorMock.mockReturnValue(false);
+        metisServiceUserPostingAuthorMock.mockReturnValue(true);
+
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        expect(getEditButton()).not.toBeNull();
     });
 
     it('should not display edit and delete options to tutor if posting is in course-wide channel from a student', () => {

--- a/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/post-reactions-bar/post-reactions-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/post-reactions-bar/post-reactions-bar.component.spec.ts
@@ -149,7 +149,7 @@ describe('PostReactionsBarComponent', () => {
         expect(getEditButton()).not.toBeNull();
     });
 
-    it('should display edit and delete options to user with channel moderation rights when not the author', () => {
+    it('should display the delete option to user with channel moderation rights when not the author', () => {
         component.readOnlyMode = false;
         component.previewMode = false;
         component.isEmojiCount = false;
@@ -166,8 +166,47 @@ describe('PostReactionsBarComponent', () => {
         component.ngOnInit();
         fixture.detectChanges();
 
-        expect(getEditButton()).not.toBeNull();
         expect(getDeleteButton()).not.toBeNull();
+    });
+
+    it('should not display the edit option to user (even instructor) if s/he is not the author of posting', () => {
+        component.readOnlyMode = false;
+        component.previewMode = false;
+        component.isEmojiCount = false;
+
+        const channelConversation = {
+            type: ConversationType.CHANNEL,
+            hasChannelModerationRights: true,
+        } as ChannelDTO;
+
+        jest.spyOn(metisService, 'metisUserIsAuthorOfPosting').mockReturnValue(false);
+        jest.spyOn(metisService, 'metisUserIsAtLeastInstructorInCourse').mockReturnValue(true);
+        jest.spyOn(metisService, 'getCurrentConversation').mockReturnValue(channelConversation);
+
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        expect(getEditButton()).toBeNull();
+    });
+
+    it('should display the edit option to user if s/he is the author of posting', () => {
+        component.readOnlyMode = false;
+        component.previewMode = false;
+        component.isEmojiCount = false;
+
+        const channelConversation = {
+            type: ConversationType.CHANNEL,
+            hasChannelModerationRights: true,
+        } as ChannelDTO;
+
+        jest.spyOn(metisService, 'metisUserIsAuthorOfPosting').mockReturnValue(true);
+        jest.spyOn(metisService, 'metisUserIsAtLeastInstructorInCourse').mockReturnValue(false);
+        jest.spyOn(metisService, 'getCurrentConversation').mockReturnValue(channelConversation);
+
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        expect(getEditButton()).not.toBeNull();
     });
 
     it('should not display edit and delete options when user is not the author and lacks permissions', () => {
@@ -198,6 +237,7 @@ describe('PostReactionsBarComponent', () => {
 
     it('should not display edit and delete options to tutor if posting is announcement', () => {
         metisServiceUserIsAtLeastInstructorStub.mockReturnValue(false);
+        metisServiceUserIsAuthorOfPostingStub.mockReturnValue(false);
         component.posting = metisAnnouncement;
         component.ngOnInit();
         fixture.detectChanges();
@@ -205,8 +245,9 @@ describe('PostReactionsBarComponent', () => {
         expect(getDeleteButton()).toBeNull();
     });
 
-    it('should display edit and delete options to instructor if posting is announcement', () => {
+    it('should display edit and delete options to instructor if his posting is announcement', () => {
         metisServiceUserIsAtLeastInstructorStub.mockReturnValue(true);
+        metisServiceUserIsAuthorOfPostingStub.mockReturnValue(true);
         component.posting = metisAnnouncement;
         component.ngOnInit();
         fixture.detectChanges();
@@ -214,14 +255,13 @@ describe('PostReactionsBarComponent', () => {
         expect(getDeleteButton()).not.toBeNull();
     });
 
-    it('should display edit and delete options to instructor if posting is in course-wide channel from a student', () => {
+    it('should display the delete option to instructor if posting is in course-wide channel from a student', () => {
         metisServiceUserIsAtLeastInstructorStub.mockReturnValue(true);
         metisServiceUserIsAuthorOfPostingStub.mockReturnValue(false);
         component.posting = { ...metisPostInChannel };
         component.posting.authorRole = UserRole.USER;
         component.ngOnInit();
         fixture.detectChanges();
-        expect(getEditButton()).not.toBeNull();
         expect(getDeleteButton()).not.toBeNull();
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [X] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [X] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As agreed, the "edit message" option should only be enabled for users if they are the author of the post. However, instructors currently have the ability to edit messages posted by other users.


### Description
<!-- Describe your changes in detail -->
The "edit message" option is only visible if the logged-in user is the author of the post.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Course with Communication enabled

1. Log in to Artemis as a student.
2. Navigate to the Communication section of a course.
3. Send some messages to a channel and add some replies to those messages.
4. Verify that you can edit your own posts/replies by clicking the "edit message" option, either from the hover bar or the dropdown menu that appears when you right-click.
5. Log in to Artemis as an instructor and navigate to the same channel in the Communication section.
6. Attempt to edit the messages sent by the previous user and verify that the "edit message" option is now disabled if the user is not the author of the post, even if s/he is an instructor.



### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [X] Code Review 1
- [X] Code Review 2
#### Manual Tests
- [X] Test 1
- [X] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| answer-post.component.ts | 94.23% | ✅ ❌ |
| post.component.ts | 95.23% | ✅ ❌ |
| answer-post-reactions-bar.component.ts | 90.69% | ✅ ❌ |
| post-reactions-bar.component.ts | 93.1% | ✅ ❌ |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced user permissions handling for editing and deleting posts with clearer distinctions in the UI.
	- Added confirmation tooltip for delete actions.
  
- **Bug Fixes**
	- Improved conditional rendering for edit and delete buttons based on user permissions.

- **Tests**
	- Refined test cases to accurately reflect user permissions for editing and deleting posts.
	- Added new tests to ensure correct visibility of options based on user roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->