### PR TITLE
`Development`: Fix execution of exercise template integration tests on Linux systems

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTemplateIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTemplateIntegrationTest.java
@@ -2,7 +2,7 @@ package de.tum.cit.aet.artemis.programming;
 
 import static de.tum.cit.aet.artemis.core.util.TestConstants.COMMIT_HASH_OBJECT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 
@@ -83,13 +83,11 @@ class ProgrammingExerciseTemplateIntegrationTest extends AbstractProgrammingInte
     @BeforeAll
     static void detectMavenHome() {
         /*
-         * Maven invoker only looks for those two values and ignores maven, even if it is available over PATH. Because Maven reports the path when "-version" is used, we use that
-         * to auto-detect the maven home and store it in the system properties.
+         * Maven invoker only looks for system properties and ignores maven, even if it is available over PATH.
+         * Because Maven reports the path when "-version" is used, we use that to auto-detect the maven home and store it in the system properties.
          */
-        String m2Home = System.getenv("M2_HOME");
-        String mavenHome = System.getProperty("maven.home");
 
-        if (m2Home != null || mavenHome != null) {
+        if (isMavenHomeSet()) {
             return;
         }
 
@@ -98,57 +96,68 @@ class ProgrammingExerciseTemplateIntegrationTest extends AbstractProgrammingInte
             var lines = runProcess(new ProcessBuilder(mvnExecutable, "-version"));
             String prefix = "maven home:";
             Optional<String> home = lines.stream().filter(line -> line.toLowerCase().startsWith(prefix)).findFirst();
-            if (home.isPresent()) {
-                System.setProperty("maven.home", home.get().substring(prefix.length()).strip());
-            }
-            else {
-                fail("maven home not found, unexpected '-version' format");
-            }
+            home.ifPresent(homeLocation -> System.setProperty("maven.home", homeLocation.substring(prefix.length()).strip()));
         }
         catch (Exception e) {
-            fail("maven home not found", e);
+            log.debug("maven home not found", e);
         }
+    }
+
+    private static boolean isMavenHomeSet() {
+        String m2Home = System.getenv("M2_HOME");
+        String mavenHome = System.getProperty("maven.home");
+
+        return m2Home != null || mavenHome != null;
     }
 
     @BeforeAll
     static void findAndSetJava17Home() throws Exception {
         if (Os.isFamily(Os.FAMILY_UNIX) || Os.isFamily(Os.FAMILY_MAC)) {
-            // Use which to find all java installations on Linux
-            var javaInstallations = runProcess(new ProcessBuilder("which", "-a", "java"));
-            for (String path : javaInstallations) {
-                File binFolder = new File(path).getParentFile();
-                if (checkJavaVersion(binFolder, "./java", "-version")) {
-                    return;
-                }
-            }
-
-            var alternativeInstallations = runProcess(new ProcessBuilder("/usr/libexec/java_home", "-v", "17"));
-            for (String path : alternativeInstallations) {
-                File binFolder = new File(path).getParentFile();
-                binFolder = new File(binFolder, "Home/bin");
-                if (checkJavaVersion(binFolder, "./java", "-version")) {
-                    return;
-                }
-            }
+            findAndSetJava17UnixSystems();
         }
         else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            // Use PATH to find all java installations on windows
-            String[] path = System.getenv("PATH").split(";");
-            var java17 = Arrays.stream(path).map(Path::of).filter(p -> p.endsWith("bin")).filter(Files::isDirectory).filter(binDir -> Files.exists(binDir.resolve("java.exe")))
-                    .filter(binDir -> {
-                        try {
-                            return checkJavaVersion(binDir.toFile(), "cmd", "/c", "java.exe", "-version");
-                        }
-                        catch (Exception e) {
-                            return false;
-                        }
-                    }).findFirst();
+            findAndSetJava17Windows();
+        }
+    }
 
-            if (java17.isPresent()) {
+    private static void findAndSetJava17UnixSystems() throws Exception {
+        // Use which to find all java installations on Linux
+        var javaInstallations = runProcess(new ProcessBuilder("which", "-a", "java"));
+        for (String path : javaInstallations) {
+            File binFolder = new File(path).getParentFile();
+            if (checkJavaVersion(binFolder, "./java", "-version")) {
                 return;
             }
         }
-        fail("Java 17 not found");
+
+        // Mac systems have additional locations where Java could potentially be
+        if (Os.isFamily(Os.FAMILY_MAC)) {
+            findAndSetJava17Mac();
+        }
+    }
+
+    private static void findAndSetJava17Mac() throws Exception {
+        var alternativeInstallations = runProcess(new ProcessBuilder("/usr/libexec/java_home", "-v", "17"));
+        for (String path : alternativeInstallations) {
+            File binFolder = new File(path).getParentFile();
+            binFolder = new File(binFolder, "Home/bin");
+            if (checkJavaVersion(binFolder, "./java", "-version")) {
+                return;
+            }
+        }
+    }
+
+    private static void findAndSetJava17Windows() {
+        // Use PATH to find all java installations on windows
+        String[] path = System.getenv("PATH").split(";");
+        Arrays.stream(path).map(Path::of).filter(p -> p.endsWith("bin")).filter(Files::isDirectory).filter(binDir -> Files.exists(binDir.resolve("java.exe"))).forEach(binDir -> {
+            try {
+                checkJavaVersion(binDir.toFile(), "cmd", "/c", "java.exe", "-version");
+            }
+            catch (Exception e) {
+                // ignore: we still continue to find another Java installation
+            }
+        });
     }
 
     private static boolean checkJavaVersion(File binFolder, String... command) throws Exception {
@@ -248,6 +257,7 @@ class ProgrammingExerciseTemplateIntegrationTest extends AbstractProgrammingInte
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     @MethodSource("languageTypeBuilder")
     void testTemplateExercise(ProgrammingLanguage language, ProjectType projectType, boolean testwiseCoverageAnalysis) throws Exception {
+        checkPreconditionsForJavaTemplateExecution(projectType);
         runTests(language, projectType, exerciseRepo, TestResult.FAILED, testwiseCoverageAnalysis);
     }
 
@@ -255,7 +265,15 @@ class ProgrammingExerciseTemplateIntegrationTest extends AbstractProgrammingInte
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     @MethodSource("languageTypeBuilder")
     void testTemplateSolution(ProgrammingLanguage language, ProjectType projectType, boolean testwiseCoverageAnalysis) throws Exception {
+        checkPreconditionsForJavaTemplateExecution(projectType);
         runTests(language, projectType, solutionRepo, TestResult.SUCCESSFUL, testwiseCoverageAnalysis);
+    }
+
+    private void checkPreconditionsForJavaTemplateExecution(final ProjectType projectType) {
+        if (projectType == null || projectType.isMaven()) {
+            assumeTrue(isMavenHomeSet(), "Could not find Maven. Skipping execution of template tests.");
+        }
+        assumeTrue(java17Home != null, "Could not find Java 17. Skipping execution of template tests.");
     }
 
     private void runTests(ProgrammingLanguage language, ProjectType projectType, LocalRepository repository, TestResult testResult, boolean testwiseCoverageAnalysis)


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The tests require an installation of Maven and Java 17 to run. On Linux systems, one approach to find Java 17 was using `/usr/libexec/java_home`. However, this tool is specific to Mac systems, thus resulting in always failing tests.

### Description
<!-- Describe your changes in detail -->
- Only calls `/usr/libexec/java_home` on Mac systems.
- Instead of failing the tests if Maven or Java 17 cannot be found, skip them. This is achieved by using JUnit assumptions. Gradle tests can still be executed in case Maven could not be found but Java 17 was found.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- local development setup

1. Run the tests in `ProgrammingExerciseTemplateIntegrationTest`. If either Maven or Java 17 cannot be found, they are skipped instead of failing. If both Maven and Java 17 can be found, they are executed (like e.g. in the CI pipeline on Bamboo or GitHub Actions).

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
unchanged

---

@coderabbitai ignore
