### PR TITLE
`Lectures`: Disable submit button on invalid form and add tooltip

### DIFF
--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
@@ -63,7 +63,6 @@
                 @if (isFileTooBig()) {
                     <div class="alert alert-danger">
                         {{ 'artemisApp.attachmentUnit.createAttachmentUnit.fileTooBig' | artemisTranslate }}
-                        {{ 'artemisApp.attachmentUnit.createAttachmentUnit.fileLimitation' | artemisTranslate }}
                     </div>
                 }
                 @if (!fileName() && fileInputTouched) {

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
@@ -104,7 +104,7 @@
             </div>
             <div class="row">
                 <div class="col-12">
-                    <span [ngbTooltip]="tooltipText" container="body" class="d-inline-block">
+                    <span [ngbTooltip]="tooltipText()" container="body" class="d-inline-block">
                         <button id="submitButton" class="btn btn-primary" type="submit" [disabled]="!isFormValid()">
                             <span jhiTranslate="entity.action.submit"></span>
                         </button>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
@@ -2,7 +2,7 @@
     <div class="col-12">
         <form [formGroup]="form" (ngSubmit)="submitForm()">
             <div class="form-group">
-                <label for="name">{{ 'artemisApp.attachmentUnit.createAttachmentUnit.name' | artemisTranslate }} *</label>
+                <label for="name">{{ 'artemisApp.attachmentUnit.createAttachmentUnit.name' | artemisTranslate }}*</label>
                 <input
                     type="text"
                     class="form-control"
@@ -105,14 +105,29 @@
             </div>
             <div class="row">
                 <div class="col-12">
-                    <button id="submitButton" class="btn btn-primary" type="submit" [disabled]="!isFormValid()">
-                        <span jhiTranslate="entity.action.submit"></span>
-                    </button>
-                    @if (hasCancelButton()) {
-                        <button type="button" (click)="cancelForm()" class="btn btn-default">
-                            <fa-icon [icon]="faTimes" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
+                    <span
+                        [ngbTooltip]="
+                            !fileInputTouched && nameControl?.invalid
+                                ? ('artemisApp.attachmentUnit.createAttachmentUnit.nameRequiredValidationError' | artemisTranslate) +
+                                  ' ' +
+                                  ('artemisApp.attachmentUnit.createAttachmentUnit.fileRequiredValidationError' | artemisTranslate)
+                                : !fileInputTouched
+                                  ? ('artemisApp.attachmentUnit.createAttachmentUnit.fileRequiredValidationError' | artemisTranslate)
+                                  : nameControl?.invalid
+                                    ? ('artemisApp.attachmentUnit.createAttachmentUnit.nameRequiredValidationError' | artemisTranslate)
+                                    : null
+                        "
+                        container="body"
+                    >
+                        <button id="submitButton" class="btn btn-primary" type="submit" [disabled]="!isFormValid()">
+                            <span jhiTranslate="entity.action.submit"></span>
                         </button>
-                    }
+                        @if (hasCancelButton()) {
+                            <button type="button" (click)="cancelForm()" class="btn btn-default">
+                                <fa-icon [icon]="faTimes" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
+                            </button>
+                        }
+                    </span>
                 </div>
             </div>
         </form>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
@@ -105,20 +105,7 @@
             </div>
             <div class="row">
                 <div class="col-12">
-                    <span
-                        [ngbTooltip]="
-                            !fileInputTouched && nameControl?.invalid
-                                ? ('artemisApp.attachmentUnit.createAttachmentUnit.nameRequiredValidationError' | artemisTranslate) +
-                                  ' ' +
-                                  ('artemisApp.attachmentUnit.createAttachmentUnit.fileRequiredValidationError' | artemisTranslate)
-                                : !fileInputTouched
-                                  ? ('artemisApp.attachmentUnit.createAttachmentUnit.fileRequiredValidationError' | artemisTranslate)
-                                  : nameControl?.invalid
-                                    ? ('artemisApp.attachmentUnit.createAttachmentUnit.nameRequiredValidationError' | artemisTranslate)
-                                    : null
-                        "
-                        container="body"
-                    >
+                    <span [ngbTooltip]="tooltipText" container="body">
                         <button id="submitButton" class="btn btn-primary" type="submit" [disabled]="!isFormValid()">
                             <span jhiTranslate="entity.action.submit"></span>
                         </button>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
@@ -105,7 +105,7 @@
             </div>
             <div class="row">
                 <div class="col-12">
-                    <span [ngbTooltip]="tooltipText" container="body">
+                    <span [ngbTooltip]="tooltipText" container="body" class="d-inline-block">
                         <button id="submitButton" class="btn btn-primary" type="submit" [disabled]="!isFormValid()">
                             <span jhiTranslate="entity.action.submit"></span>
                         </button>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
@@ -73,7 +73,7 @@ export class AttachmentUnitFormComponent implements OnChanges {
     private readonly statusChanges = toSignal(this.form.statusChanges ?? 'INVALID');
 
     isFormValid = computed(() => {
-        return this.statusChanges() === 'VALID' && !this.isFileTooBig() && this.nameControl?.value != '' && this.fileName();
+        return this.statusChanges() === 'VALID' && !this.isFileTooBig() && this.nameControl?.value !== '' && this.fileName();
     });
 
     ngOnChanges(): void {

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
@@ -51,7 +51,7 @@ export class AttachmentUnitFormComponent implements OnChanges {
 
     datePickerComponent = viewChild(FormDateTimePickerComponent);
 
-    // have to handle the file input as a special case at is not part of the reactive form
+    // have to handle the file input as a special case, as it is not part of the reactive form
     @ViewChild('fileInput', { static: false })
     fileInput: ElementRef;
     file: File;

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
@@ -6,7 +6,7 @@ import { ACCEPTED_FILE_EXTENSIONS_FILE_BROWSER, ALLOWED_FILE_EXTENSIONS_HUMAN_RE
 import { CompetencyLectureUnitLink } from 'app/entities/competency.model';
 import { MAX_FILE_SIZE } from 'app/shared/constants/input.constants';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { of } from 'rxjs';
+import { map, of } from 'rxjs';
 import { FormDateTimePickerComponent } from 'app/shared/date-time-picker/date-time-picker.component';
 import { TranslateService } from '@ngx-translate/core';
 
@@ -83,6 +83,8 @@ export class AttachmentUnitFormComponent implements OnChanges {
         }
     }
 
+    private readonly currentLanguage = toSignal(this.translateService.onLangChange.pipe(map((event) => event.lang)));
+
     onFileChange(event: Event): void {
         const input = event.target as HTMLInputElement;
         if (!input.files?.length) {
@@ -101,6 +103,7 @@ export class AttachmentUnitFormComponent implements OnChanges {
     }
 
     tooltipText = computed(() => {
+        this.currentLanguage();
         if (!this.fileName() && !this.name()) {
             return this.translateService.instant('artemisApp.attachmentUnit.createAttachmentUnit.nameAndFileRequiredValidationError');
         }

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
@@ -7,6 +7,7 @@ import { CompetencyLectureUnitLink } from 'app/entities/competency.model';
 import { MAX_FILE_SIZE } from 'app/shared/constants/input.constants';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormDateTimePickerComponent } from 'app/shared/date-time-picker/date-time-picker.component';
+import { TranslateService } from '@ngx-translate/core';
 
 export interface AttachmentUnitFormData {
     formProperties: FormProperties;
@@ -59,6 +60,7 @@ export class AttachmentUnitFormComponent implements OnChanges {
     fileName = signal<string | undefined>(undefined);
     isFileTooBig = signal<boolean>(false);
 
+    private readonly translateService = inject(TranslateService);
     private readonly formBuilder = inject(FormBuilder);
     form: FormGroup = this.formBuilder.group({
         name: [undefined as string | undefined, [Validators.required, Validators.maxLength(255)]],
@@ -71,7 +73,7 @@ export class AttachmentUnitFormComponent implements OnChanges {
     private readonly statusChanges = toSignal(this.form.statusChanges ?? 'INVALID');
 
     isFormValid = computed(() => {
-        return (this.statusChanges() === 'VALID' || this.fileName()) && !this.isFileTooBig() && this.datePickerComponent()?.isValid();
+        return this.statusChanges() === 'VALID' && !this.isFileTooBig() && this.nameControl?.value != '' && this.fileName();
     });
 
     ngOnChanges(): void {
@@ -95,6 +97,23 @@ export class AttachmentUnitFormComponent implements OnChanges {
             });
         }
         this.isFileTooBig.set(this.file.size > MAX_FILE_SIZE);
+    }
+
+    get tooltipText(): string | null {
+        if (!this.fileInputTouched && this.nameControl?.invalid) {
+            return (
+                this.translateService.instant('artemisApp.attachmentUnit.createAttachmentUnit.nameRequiredValidationError') +
+                ' ' +
+                this.translateService.instant('artemisApp.attachmentUnit.createAttachmentUnit.fileRequiredValidationError')
+            );
+        }
+        if (!this.fileInputTouched) {
+            return this.translateService.instant('artemisApp.attachmentUnit.createAttachmentUnit.fileRequiredValidationError');
+        }
+        if (this.nameControl?.invalid) {
+            return this.translateService.instant('artemisApp.attachmentUnit.createAttachmentUnit.nameRequiredValidationError');
+        }
+        return null;
     }
 
     get nameControl() {

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
@@ -100,16 +100,15 @@ export class AttachmentUnitFormComponent implements OnChanges {
     }
 
     get tooltipText(): string | null {
+        // Both name and file are invalid
         if (!this.fileInputTouched && this.nameControl?.invalid) {
-            return (
-                this.translateService.instant('artemisApp.attachmentUnit.createAttachmentUnit.nameRequiredValidationError') +
-                ' ' +
-                this.translateService.instant('artemisApp.attachmentUnit.createAttachmentUnit.fileRequiredValidationError')
-            );
+            return this.translateService.instant('artemisApp.attachmentUnit.createAttachmentUnit.nameAndFileRequiredValidationError');
         }
+        // Only file is invalid
         if (!this.fileInputTouched) {
             return this.translateService.instant('artemisApp.attachmentUnit.createAttachmentUnit.fileRequiredValidationError');
         }
+        // Only name is invalid
         if (this.nameControl?.invalid) {
             return this.translateService.instant('artemisApp.attachmentUnit.createAttachmentUnit.nameRequiredValidationError');
         }

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
@@ -65,6 +65,7 @@ export class AttachmentUnitFormComponent implements OnChanges {
     private readonly formBuilder = inject(FormBuilder);
     form: FormGroup = this.formBuilder.group({
         name: [undefined as string | undefined, [Validators.required, Validators.maxLength(255)]],
+        fileName: [undefined as string | undefined, [Validators.required]],
         description: [undefined as string | undefined, [Validators.maxLength(1000)]],
         releaseDate: [undefined as dayjs.Dayjs | undefined],
         version: [{ value: 1, disabled: true }],
@@ -74,7 +75,7 @@ export class AttachmentUnitFormComponent implements OnChanges {
     private readonly statusChanges = toSignal(this.form.statusChanges ?? 'INVALID');
     private readonly name = toSignal(this.nameControl?.valueChanges ?? of(''));
     isFormValid = computed(() => {
-        return this.statusChanges() === 'VALID' && !this.isFileTooBig() && this.name() && this.fileName();
+        return this.statusChanges() === 'VALID' && !this.isFileTooBig();
     });
 
     ngOnChanges(): void {
@@ -92,6 +93,9 @@ export class AttachmentUnitFormComponent implements OnChanges {
         }
         this.file = input.files[0];
         this.fileName.set(this.file.name);
+        this.form.patchValue({
+            fileName: this.file.name,
+        });
         // automatically set the name in case it is not yet specified
         if (this.form && !this.name()) {
             this.form.patchValue({
@@ -159,6 +163,9 @@ export class AttachmentUnitFormComponent implements OnChanges {
         }
         if (formData?.fileProperties?.fileName) {
             this.fileName.set(formData?.fileProperties?.fileName);
+            this.form.patchValue({
+                fileName: formData?.fileProperties?.fileName,
+            });
         }
     }
 

--- a/src/main/webapp/i18n/de/lectureUnit.json
+++ b/src/main/webapp/i18n/de/lectureUnit.json
@@ -173,6 +173,7 @@
                 "file": "Datei",
                 "version": "Version",
                 "fileRequiredValidationError": "Du musst eine Datei zum Uploaden auswählen.",
+                "nameAndFileRequiredValidationError": "Der Name ist ein Pflichtfeld. Du musst eine Datei zum Uploaden auswählen.",
                 "chooseFile": "Datei auswählen",
                 "fileTooBig": "Die Datei ist zu groß! Die maximale Dateigröße beträgt 20 MB.",
                 "fileLimitation": "(max. Größe 20 MB)",

--- a/src/main/webapp/i18n/en/lectureUnit.json
+++ b/src/main/webapp/i18n/en/lectureUnit.json
@@ -173,6 +173,7 @@
                 "file": "File",
                 "version": "Version",
                 "fileRequiredValidationError": "You must select a file to upload.",
+                "nameAndFileRequiredValidationError": "Name is required. You must select a file to upload.",
                 "chooseFile": "Choose File",
                 "fileTooBig": "File is too big! The maximum file size is 20 MB.",
                 "fileLimitation": "(max. size 20 MB)",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #9829. The submit button did not indicate that a mandatory field was still missing and could be clicked.
This led to confusion among users.
The error message for files that were too large also had an redundant sentence.


### Description
<!-- Describe your changes in detail -->
I have updated/changed the conditions in isValidForm to recognize empty string names and uploaded files.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Course
- 1 Lecture

1. Log in to Artemis
2. Navigate the Course
3. Create a new `Lecture`
4. Click on `Units` -> `File`
5. Take a look at tooltip and unclickable submit button


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://github.com/user-attachments/assets/e24f4f10-cf52-4686-a81e-a8f375c67b2d)

https://github.com/user-attachments/assets/39e42cf4-e1c9-4c27-a0ba-11a8737dd9f1




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced validation for the attachment unit form, ensuring both name and file are required before submission.
  - Added tooltips for improved user guidance on form validation errors.

- **Bug Fixes**
  - Removed redundant error messages for file size limitations.
  
- **Localization**
  - Introduced new validation error messages in both English and German to clarify requirements for name and file uploads during attachment creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->