### PR TITLE
`Development`: Migrate text exercises module to standalone on client

### DIFF
--- a/src/main/webapp/app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component.ts
@@ -4,10 +4,14 @@ import { TextSubmission } from 'app/entities/text/text-submission.model';
 import { TextBlock } from 'app/entities/text/text-block.model';
 import { GradingCriterion } from 'app/exercises/shared/structured-grading-criterion/grading-criterion.model';
 import { wordSelection } from 'app/exercises/text/shared/manual-text-selection/manual-text-selection.component';
+import { TextblockAssessmentCardComponent } from 'app/exercises/text/assess/textblock-assessment-card/textblock-assessment-card.component';
+import { ManualTextSelectionComponent } from 'app/exercises/text/shared/manual-text-selection/manual-text-selection.component';
 
 @Component({
     selector: 'jhi-manual-textblock-selection',
     templateUrl: './manual-textblock-selection.component.html',
+    standalone: true,
+    imports: [TextblockAssessmentCardComponent, ManualTextSelectionComponent],
 })
 export class ManualTextblockSelectionComponent {
     @Input() set textBlockRefs(textBlockRefs: TextBlockRef[]) {

--- a/src/main/webapp/app/exercises/text/assess/text-assessment-area/text-assessment-area.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment-area/text-assessment-area.component.ts
@@ -3,6 +3,9 @@ import { TextSubmission } from 'app/entities/text/text-submission.model';
 import { TextBlockRef } from 'app/entities/text/text-block-ref.model';
 import { StringCountService } from 'app/exercises/text/participate/string-count.service';
 import { GradingCriterion } from 'app/exercises/shared/structured-grading-criterion/grading-criterion.model';
+import { TextblockAssessmentCardComponent } from 'app/exercises/text/assess/textblock-assessment-card/textblock-assessment-card.component';
+import { ManualTextblockSelectionComponent } from 'app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
 
 @Component({
     selector: 'jhi-text-assessment-area',
@@ -14,6 +17,8 @@ import { GradingCriterion } from 'app/exercises/shared/structured-grading-criter
             }
         `,
     ],
+    standalone: true,
+    imports: [TextblockAssessmentCardComponent, ManualTextblockSelectionComponent, TranslateDirective],
 })
 export class TextAssessmentAreaComponent implements OnChanges {
     private stringCountService = inject(StringCountService);

--- a/src/main/webapp/app/exercises/text/assess/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-submission-assessment.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { Location } from '@angular/common';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import dayjs from 'dayjs/esm';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { TextSubmission } from 'app/entities/text/text-submission.model';
@@ -35,11 +35,19 @@ import { TextBlockRef } from 'app/entities/text/text-block-ref.model';
 import { AthenaService } from 'app/assessment/athena.service';
 import { TextBlock } from 'app/entities/text/text-block.model';
 import { Subscription } from 'rxjs';
+import { ArtemisAssessmentSharedModule } from '../../../assessment/assessment-shared.module';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
+import { TextAssessmentAreaComponent } from './text-assessment-area/text-assessment-area.component';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { TranslateDirective } from '../../../shared/language/translate.directive';
+import { AssessmentInstructionsModule } from '../../../assessment/assessment-instructions/assessment-instructions.module';
 
 @Component({
     selector: 'jhi-text-submission-assessment',
     templateUrl: './text-submission-assessment.component.html',
     styleUrls: ['./text-submission-assessment.component.scss'],
+    standalone: true,
+    imports: [ArtemisAssessmentSharedModule, ArtemisSharedModule, TextAssessmentAreaComponent, FaIconComponent, TranslateDirective, AssessmentInstructionsModule, RouterLink],
 })
 export class TextSubmissionAssessmentComponent extends TextAssessmentBaseComponent implements OnInit, OnDestroy {
     private activatedRoute = inject(ActivatedRoute);

--- a/src/main/webapp/app/exercises/text/assess/text-submission-assessment.module.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-submission-assessment.module.ts
@@ -40,8 +40,6 @@ const ENTITY_STATES = [...textSubmissionAssessmentRoutes];
         SubmissionResultStatusModule,
         ArtemisAssessmentProgressLabelModule,
         ArtemisFeedbackModule,
-    ],
-    declarations: [
         TextSubmissionAssessmentComponent,
         TextAssessmentAreaComponent,
         TextblockAssessmentCardComponent,

--- a/src/main/webapp/app/exercises/text/assess/textblock-assessment-card/textblock-assessment-card.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/textblock-assessment-card/textblock-assessment-card.component.ts
@@ -8,6 +8,7 @@ import { TextBlockType } from 'app/entities/text/text-block.model';
 import { TextAssessmentAnalytics } from 'app/exercises/text/assess/analytics/text-assesment-analytics.service';
 import { ActivatedRoute } from '@angular/router';
 import { GradingCriterion } from 'app/exercises/shared/structured-grading-criterion/grading-criterion.model';
+import { TextblockFeedbackEditorComponent as TextblockFeedbackEditorComponent_1 } from 'app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component';
 
 type OptionalTextBlockRef = TextBlockRef | undefined;
 
@@ -15,6 +16,8 @@ type OptionalTextBlockRef = TextBlockRef | undefined;
     selector: 'jhi-textblock-assessment-card',
     templateUrl: './textblock-assessment-card.component.html',
     styleUrls: ['./textblock-assessment-card.component.scss'],
+    standalone: true,
+    imports: [TextblockFeedbackEditorComponent_1],
 })
 export class TextblockAssessmentCardComponent {
     protected route = inject(ActivatedRoute);

--- a/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/dropdown/textblock-feedback-dropdown.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/dropdown/textblock-feedback-dropdown.component.ts
@@ -2,11 +2,14 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Feedback } from 'app/entities/feedback.model';
 import { GradingCriterion } from 'app/exercises/shared/structured-grading-criterion/grading-criterion.model';
 import { GradingInstruction } from 'app/exercises/shared/structured-grading-criterion/grading-instruction.model';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
 
 @Component({
     selector: 'jhi-textblock-feedback-dropdown',
     templateUrl: './textblock-feedback-dropdown.component.html',
     styleUrls: ['./textblock-feedback-dropdown.component.scss'],
+    standalone: true,
+    imports: [ArtemisSharedComponentModule],
 })
 export class TextblockFeedbackDropdownComponent {
     @Output() didChange = new EventEmitter();

--- a/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.ts
@@ -3,17 +3,42 @@ import { TextBlock } from 'app/entities/text/text-block.model';
 import { Feedback, FeedbackType } from 'app/entities/feedback.model';
 import { ConfirmIconComponent } from 'app/shared/confirm-icon/confirm-icon.component';
 import { StructuredGradingCriterionService } from 'app/exercises/shared/structured-grading-criterion/structured-grading-criterion.service';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDropdown, NgbDropdownMenu, NgbDropdownToggle, NgbModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { ActivatedRoute } from '@angular/router';
 import { TextAssessmentEventType } from 'app/entities/text/text-assesment-event.model';
 import { TextAssessmentAnalytics } from 'app/exercises/text/assess/analytics/text-assesment-analytics.service';
 import { faAngleRight, faEdit, faExclamationTriangle, faQuestionCircle, faTimes, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { GradingCriterion } from 'app/exercises/shared/structured-grading-criterion/grading-criterion.model';
+import { ArtemisFeedbackModule } from 'app/exercises/shared/feedback/feedback.module';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { ArtemisConfirmIconModule } from 'app/shared/confirm-icon/confirm-icon.module';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { ArtemisGradingInstructionLinkIconModule } from 'app/shared/grading-instruction-link-icon/grading-instruction-link-icon.module';
+import { TextblockFeedbackDropdownComponent } from './dropdown/textblock-feedback-dropdown.component';
+import { FormsModule } from '@angular/forms';
+import { ArtemisAssessmentSharedModule } from 'app/assessment/assessment-shared.module';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
 
 @Component({
     selector: 'jhi-textblock-feedback-editor',
     templateUrl: './textblock-feedback-editor.component.html',
     styleUrls: ['./textblock-feedback-editor.component.scss'],
+    standalone: true,
+    imports: [
+        ArtemisFeedbackModule,
+        FaIconComponent,
+        NgbTooltip,
+        ArtemisConfirmIconModule,
+        TranslateDirective,
+        ArtemisGradingInstructionLinkIconModule,
+        NgbDropdown,
+        NgbDropdownToggle,
+        NgbDropdownMenu,
+        TextblockFeedbackDropdownComponent,
+        FormsModule,
+        ArtemisAssessmentSharedModule,
+        ArtemisSharedCommonModule,
+    ],
 })
 export class TextblockFeedbackEditorComponent implements AfterViewInit {
     protected route = inject(ActivatedRoute);

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
@@ -23,6 +23,15 @@ import { faEdit, faSave } from '@fortawesome/free-solid-svg-icons';
 import { faListAlt } from '@fortawesome/free-regular-svg-icons';
 import { Observable, of } from 'rxjs';
 import { ArtemisNavigationUtilService } from 'app/utils/navigation.utils';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
+import { FormsModule } from '@angular/forms';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
+import { ArtemisAssessmentSharedModule } from 'app/assessment/assessment-shared.module';
+import { TextAssessmentAreaComponent } from 'app/exercises/text/assess/text-assessment-area/text-assessment-area.component';
+import { AssessmentInstructionsModule } from 'app/assessment/assessment-instructions/assessment-instructions.module';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
 
 type ExampleSubmissionResponseType = EntityResponseType;
 
@@ -30,6 +39,18 @@ type ExampleSubmissionResponseType = EntityResponseType;
     selector: 'jhi-example-text-submission',
     templateUrl: './example-text-submission.component.html',
     styleUrls: ['./example-text-submission.component.scss'],
+    standalone: true,
+    imports: [
+        TranslateDirective,
+        ArtemisSharedComponentModule,
+        FormsModule,
+        FaIconComponent,
+        ArtemisSharedModule,
+        ArtemisAssessmentSharedModule,
+        TextAssessmentAreaComponent,
+        AssessmentInstructionsModule,
+        ArtemisSharedCommonModule,
+    ],
 })
 export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent implements OnInit, Context, FeedbackMarker {
     private route = inject(ActivatedRoute);

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.module.ts
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.module.ts
@@ -23,7 +23,8 @@ const ENTITY_STATES = [...exampleTextSubmissionRoute];
         AssessmentInstructionsModule,
         ArtemisMarkdownModule,
         ArtemisSharedComponentModule,
+        ExampleTextSubmissionComponent,
+        ResizableInstructionsComponent,
     ],
-    declarations: [ExampleTextSubmissionComponent, ResizableInstructionsComponent],
 })
 export class ArtemisExampleTextSubmissionModule {}

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/resizable-instructions/resizable-instructions.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/resizable-instructions/resizable-instructions.component.ts
@@ -2,11 +2,17 @@ import { Component, Input } from '@angular/core';
 import { faListAlt } from '@fortawesome/free-regular-svg-icons';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { GradingCriterion } from 'app/exercises/shared/structured-grading-criterion/grading-criterion.model';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { AssessmentInstructionsModule } from 'app/assessment/assessment-instructions/assessment-instructions.module';
+import { ArtemisMarkdownModule } from 'app/shared/markdown.module';
 
 @Component({
     selector: 'jhi-resizable-instructions',
     templateUrl: './resizable-instructions.component.html',
     styleUrls: ['./resizable-instructions.component.scss'],
+    standalone: true,
+    imports: [FaIconComponent, TranslateDirective, AssessmentInstructionsModule, ArtemisMarkdownModule],
 })
 export class ResizableInstructionsComponent {
     @Input() public criteria: GradingCriterion[];

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts
@@ -23,10 +23,17 @@ import {
     getExerciseModeDetailSection,
     getExerciseProblemDetailSection,
 } from 'app/exercises/shared/utils';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
+import { NonProgrammingExerciseDetailCommonActionsModule } from 'app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.module';
+import { ArtemisExerciseModule } from 'app/exercises/shared/exercise/exercise.module';
+import { DetailModule } from 'app/detail-overview-list/detail.module';
 
 @Component({
     selector: 'jhi-text-exercise-detail',
     templateUrl: './text-exercise-detail.component.html',
+    standalone: true,
+    imports: [TranslateDirective, ArtemisSharedComponentModule, NonProgrammingExerciseDetailCommonActionsModule, ArtemisExerciseModule, DetailModule],
 })
 export class TextExerciseDetailComponent implements OnInit, OnDestroy {
     private route = inject(ActivatedRoute);

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-row-buttons.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-row-buttons.component.ts
@@ -6,10 +6,16 @@ import { TextExercise } from 'app/entities/text/text-exercise.model';
 import { EventManager } from 'app/core/util/event-manager.service';
 import { faBook, faTable, faTrash, faUsers, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { faListAlt } from '@fortawesome/free-regular-svg-icons';
+import { RouterLink } from '@angular/router';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
 
 @Component({
     selector: 'jhi-text-exercise-row-buttons',
     templateUrl: './text-exercise-row-buttons.component.html',
+    standalone: true,
+    imports: [RouterLink, FaIconComponent, TranslateDirective, ArtemisSharedModule],
 })
 export class TextExerciseRowButtonsComponent {
     private eventManager = inject(EventManager);

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
@@ -9,7 +9,7 @@ import { AssessmentType } from 'app/entities/assessment-type.model';
 import { ExerciseMode, IncludedInOverallScore, resetForImport } from 'app/entities/exercise.model';
 import { switchMap, tap } from 'rxjs/operators';
 import { ExerciseGroupService } from 'app/exam/manage/exercise-groups/exercise-group.service';
-import { NgForm, NgModel } from '@angular/forms';
+import { FormsModule, NgForm, NgModel } from '@angular/forms';
 import { ArtemisNavigationUtilService } from 'app/utils/navigation.utils';
 import { ExerciseCategory } from 'app/entities/exercise-category.model';
 import { cloneDeep } from 'lodash-es';
@@ -30,11 +30,45 @@ import { ExerciseUpdatePlagiarismComponent } from 'app/exercises/shared/plagiari
 import { TeamConfigFormGroupComponent } from 'app/exercises/shared/team-config-form-group/team-config-form-group.component';
 import { FormDateTimePickerComponent } from 'app/shared/date-time-picker/date-time-picker.component';
 import { FormulaAction } from 'app/shared/monaco-editor/model/actions/formula.action';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
+import { ExerciseTitleChannelNameModule } from 'app/exercises/shared/exercise-title-channel-name/exercise-title-channel-name.module';
+import { ArtemisCategorySelectorModule } from 'app/shared/category-selector/category-selector.module';
+import { ArtemisDifficultyPickerModule } from 'app/exercises/shared/difficulty-picker/difficulty-picker.module';
+import { ArtemisTeamConfigFormGroupModule } from 'app/exercises/shared/team-config-form-group/team-config-form-group.module';
+import { ArtemisMarkdownEditorModule } from 'app/shared/markdown-editor/markdown-editor.module';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
+import { FormDateTimePickerModule } from 'app/shared/date-time-picker/date-time-picker.module';
+import { ArtemisIncludedInOverallScorePickerModule } from 'app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.module';
+import { ExerciseFeedbackSuggestionOptionsModule } from 'app/exercises/shared/feedback-suggestion/exercise-feedback-suggestion-options.module';
+import { ExerciseUpdatePlagiarismModule } from 'app/exercises/shared/plagiarism/exercise-update-plagiarism/exercise-update-plagiarism.module';
+import { ArtemisPresentationScoreModule } from 'app/exercises/shared/presentation-score/presentation-score.module';
+import { StructuredGradingCriterionModule } from 'app/exercises/shared/structured-grading-criterion/structured-grading-criterion.module';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
 
 @Component({
     selector: 'jhi-text-exercise-update',
     templateUrl: './text-exercise-update.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
+    standalone: true,
+    imports: [
+        FormsModule,
+        TranslateDirective,
+        ArtemisSharedComponentModule,
+        ExerciseTitleChannelNameModule,
+        ArtemisCategorySelectorModule,
+        ArtemisDifficultyPickerModule,
+        ArtemisTeamConfigFormGroupModule,
+        ArtemisMarkdownEditorModule,
+        ArtemisSharedModule,
+        FormDateTimePickerModule,
+        ArtemisIncludedInOverallScorePickerModule,
+        ExerciseFeedbackSuggestionOptionsModule,
+        ExerciseUpdatePlagiarismModule,
+        ArtemisPresentationScoreModule,
+        StructuredGradingCriterionModule,
+        ArtemisSharedCommonModule,
+    ],
 })
 export class TextExerciseUpdateComponent implements OnInit, OnDestroy, AfterViewInit {
     private activatedRoute = inject(ActivatedRoute);

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
@@ -9,7 +9,7 @@ import { AssessmentType } from 'app/entities/assessment-type.model';
 import { ExerciseMode, IncludedInOverallScore, resetForImport } from 'app/entities/exercise.model';
 import { switchMap, tap } from 'rxjs/operators';
 import { ExerciseGroupService } from 'app/exam/manage/exercise-groups/exercise-group.service';
-import { FormsModule, NgForm, NgModel } from '@angular/forms';
+import { NgForm, NgModel } from '@angular/forms';
 import { ArtemisNavigationUtilService } from 'app/utils/navigation.utils';
 import { ExerciseCategory } from 'app/entities/exercise-category.model';
 import { cloneDeep } from 'lodash-es';
@@ -45,6 +45,7 @@ import { ExerciseUpdatePlagiarismModule } from 'app/exercises/shared/plagiarism/
 import { ArtemisPresentationScoreModule } from 'app/exercises/shared/presentation-score/presentation-score.module';
 import { StructuredGradingCriterionModule } from 'app/exercises/shared/structured-grading-criterion/structured-grading-criterion.module';
 import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
+import { FormsModule } from 'app/forms/forms.module';
 
 @Component({
     selector: 'jhi-text-exercise-update',

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.ts
@@ -4,7 +4,7 @@ import { ExerciseType } from 'app/entities/exercise.model';
 import { TextExercise } from 'app/entities/text/text-exercise.model';
 import { TextExerciseService } from './text-exercise.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { ExerciseComponent } from 'app/exercises/shared/exercise/exercise.component';
 import { onError } from 'app/shared/util/global.utils';
 import { AccountService } from 'app/core/auth/account.service';
@@ -14,10 +14,28 @@ import { AlertService } from 'app/core/util/alert.service';
 import { faPlus, faSort, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { CourseExerciseService } from 'app/exercises/shared/course-exercises/course-exercise.service';
 import { ExerciseImportWrapperComponent } from 'app/exercises/shared/import/exercise-import-wrapper/exercise-import-wrapper.component';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
+import { FormsModule } from '@angular/forms';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { ExerciseCategoriesModule } from 'app/shared/exercise-categories/exercise-categories.module';
+import { TextExerciseRowButtonsComponent } from 'app/exercises/text/manage/text-exercise/text-exercise-row-buttons.component';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
 
 @Component({
     selector: 'jhi-text-exercise',
     templateUrl: './text-exercise.component.html',
+    standalone: true,
+    imports: [
+        ArtemisSharedCommonModule,
+        FormsModule,
+        TranslateDirective,
+        FaIconComponent,
+        RouterLink,
+        ExerciseCategoriesModule,
+        TextExerciseRowButtonsComponent,
+        ArtemisSharedModule,
+    ],
 })
 export class TextExerciseComponent extends ExerciseComponent {
     protected exerciseService = inject(ExerciseService);

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.module.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.module.ts
@@ -60,8 +60,11 @@ const ENTITY_STATES = [...textExerciseRoute];
         ExerciseFeedbackSuggestionOptionsModule,
         DetailModule,
         FormsModule,
+        TextExerciseComponent,
+        TextExerciseDetailComponent,
+        TextExerciseUpdateComponent,
+        TextExerciseRowButtonsComponent,
     ],
-    declarations: [TextExerciseComponent, TextExerciseDetailComponent, TextExerciseUpdateComponent, TextExerciseRowButtonsComponent],
     exports: [TextExerciseComponent],
 })
 export class ArtemisTextExerciseModule {}

--- a/src/main/webapp/app/exercises/text/manage/tutor-effort/tutor-effort-statistics.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/tutor-effort/tutor-effort-statistics.component.ts
@@ -9,6 +9,11 @@ import { TranslateService } from '@ngx-translate/core';
 import { median } from 'simple-statistics';
 import { GraphColors } from 'app/entities/statistics.model';
 import { round } from 'app/shared/util/utils';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
+import { BarChartModule } from '@swimlane/ngx-charts';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
 
 interface TutorEffortRange {
     minimumTimeSpent: number;
@@ -19,6 +24,8 @@ interface TutorEffortRange {
     selector: 'jhi-text-exercise-tutor-effort-statistics',
     templateUrl: './tutor-effort-statistics.component.html',
     styleUrls: ['./tutor-effort-statistics.component.scss'],
+    standalone: true,
+    imports: [TranslateDirective, FaIconComponent, ArtemisSharedComponentModule, BarChartModule, ArtemisSharedCommonModule],
 })
 export class TutorEffortStatisticsComponent extends PlagiarismAndTutorEffortDirective implements OnInit {
     private route = inject(ActivatedRoute);

--- a/src/main/webapp/app/exercises/text/manage/tutor-effort/tutor-effort-statistics.module.ts
+++ b/src/main/webapp/app/exercises/text/manage/tutor-effort/tutor-effort-statistics.module.ts
@@ -8,7 +8,6 @@ import { ArtemisSharedComponentModule } from 'app/shared/components/shared-compo
 
 const ENTITY_STATES = [...tutorEffortStatisticsRoute];
 @NgModule({
-    imports: [ArtemisSharedModule, RouterModule.forChild(ENTITY_STATES), BarChartModule, ArtemisSharedComponentModule],
-    declarations: [TutorEffortStatisticsComponent],
+    imports: [ArtemisSharedModule, RouterModule.forChild(ENTITY_STATES), BarChartModule, ArtemisSharedComponentModule, TutorEffortStatisticsComponent],
 })
 export class ArtemisTutorEffortStatisticsModule {}

--- a/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit, inject } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AlertService } from 'app/core/util/alert.service';
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
@@ -33,12 +33,50 @@ import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { PROFILE_IRIS } from 'app/app.constants';
 import { IrisSettingsService } from 'app/iris/settings/shared/iris-settings.service';
 import { AssessmentType } from 'app/entities/assessment-type.model';
+import { ArtemisHeaderExercisePageWithDetailsModule } from 'app/exercises/shared/exercise-headers/exercise-headers.module';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
+import { RequestFeedbackButtonComponent } from 'app/overview/exercise-details/request-feedback-button/request-feedback-button.component';
+import { ArtemisResultModule } from 'app/exercises/shared/result/result.module';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
+import { ArtemisTeamParticipeModule } from 'app/exercises/shared/team/team-participate/team-participate.module';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { FormsModule } from '@angular/forms';
+import { ArtemisTeamSubmissionSyncModule } from 'app/exercises/shared/team-submission-sync/team-submission-sync.module';
+import { TextResultComponent } from 'app/exercises/text/participate/text-result/text-result.component';
+import { RatingModule } from 'app/exercises/shared/rating/rating.module';
+import { ArtemisComplaintsModule } from 'app/complaints/complaints.module';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { IrisModule } from 'app/iris/iris.module';
+import { UpperCasePipe } from '@angular/common';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
+import { ArtemisMarkdownModule } from 'app/shared/markdown.module';
 
 @Component({
     selector: 'jhi-text-editor',
     templateUrl: './text-editor.component.html',
     providers: [ParticipationService],
     styleUrls: ['./text-editor.component.scss'],
+    standalone: true,
+    imports: [
+        ArtemisHeaderExercisePageWithDetailsModule,
+        ArtemisSharedComponentModule,
+        RouterLink,
+        RequestFeedbackButtonComponent,
+        ArtemisResultModule,
+        ArtemisSharedModule,
+        ArtemisTeamParticipeModule,
+        TranslateDirective,
+        FormsModule,
+        ArtemisTeamSubmissionSyncModule,
+        TextResultComponent,
+        RatingModule,
+        ArtemisComplaintsModule,
+        FaIconComponent,
+        IrisModule,
+        UpperCasePipe,
+        ArtemisSharedCommonModule,
+        ArtemisMarkdownModule,
+    ],
 })
 export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeactivate {
     private route = inject(ActivatedRoute);

--- a/src/main/webapp/app/exercises/text/participate/text-participation.module.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-participation.module.ts
@@ -31,8 +31,9 @@ import { ArtemisExerciseButtonsModule } from 'app/overview/exercise-details/exer
         IrisModule,
         RequestFeedbackButtonComponent,
         ArtemisExerciseButtonsModule,
+        TextEditorComponent,
+        TextResultComponent,
     ],
-    declarations: [TextEditorComponent, TextResultComponent],
     exports: [TextEditorComponent],
 })
 export class ArtemisTextParticipationModule {}

--- a/src/main/webapp/app/exercises/text/participate/text-result/text-result.component.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-result/text-result.component.ts
@@ -8,11 +8,17 @@ import { TextBlock } from 'app/entities/text/text-block.model';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { LocaleConversionService } from 'app/shared/service/locale-conversion.service';
 import { Course } from 'app/entities/course.model';
+import { NgClass } from '@angular/common';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
 
 @Component({
     selector: 'jhi-text-result',
     templateUrl: './text-result.component.html',
     styleUrls: ['./text-result.component.scss'],
+    standalone: true,
+    imports: [NgClass, FaIconComponent, NgbTooltip, ArtemisSharedCommonModule],
 })
 export class TextResultComponent {
     private translateService = inject(TranslateService);

--- a/src/main/webapp/app/exercises/text/shared/manual-text-selection/manual-text-selection.component.ts
+++ b/src/main/webapp/app/exercises/text/shared/manual-text-selection/manual-text-selection.component.ts
@@ -19,6 +19,7 @@ const SPACE = ' ';
     selector: 'jhi-manual-text-selection',
     templateUrl: './manual-text-selection.component.html',
     styleUrls: ['./manual-text-selection.component.scss'],
+    standalone: true,
 })
 export class ManualTextSelectionComponent {
     protected route = inject(ActivatedRoute);

--- a/src/main/webapp/app/exercises/text/shared/text-select.directive.ts
+++ b/src/main/webapp/app/exercises/text/shared/text-select.directive.ts
@@ -30,6 +30,7 @@ enum EventType {
 
 @Directive({
     selector: '[jhiTextSelect]',
+    standalone: true,
 })
 export class TextSelectDirective implements OnInit, OnDestroy {
     private elementRef = inject(ElementRef);

--- a/src/main/webapp/app/exercises/text/shared/text-shared.module.ts
+++ b/src/main/webapp/app/exercises/text/shared/text-shared.module.ts
@@ -5,8 +5,7 @@ import { TextSelectDirective } from './text-select.directive';
 import { ManualTextSelectionComponent } from './manual-text-selection/manual-text-selection.component';
 
 @NgModule({
-    imports: [CommonModule, ArtemisSharedLibsModule],
-    declarations: [TextSelectDirective, ManualTextSelectionComponent],
+    imports: [CommonModule, ArtemisSharedLibsModule, TextSelectDirective, ManualTextSelectionComponent],
     exports: [TextSelectDirective, ManualTextSelectionComponent],
 })
 export class TextSharedModule {}

--- a/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
@@ -10,7 +10,7 @@ import { TextEditorService } from 'app/exercises/text/participate/text-editor.se
 import { BehaviorSubject } from 'rxjs';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
-import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
+import { MockComponent, MockDirective, MockModule, MockPipe } from 'ng-mocks';
 import { TextResultComponent } from 'app/exercises/text/participate/text-result/text-result.component';
 import { SubmissionResultStatusComponent } from 'app/overview/submission-result-status.component';
 import { TextEditorComponent } from 'app/exercises/text/participate/text-editor.component';
@@ -36,7 +36,7 @@ import { TeamParticipateInfoBoxComponent } from 'app/exercises/shared/team/team-
 import { TeamSubmissionSyncComponent } from 'app/exercises/shared/team-submission-sync/team-submission-sync.component';
 import { AdditionalFeedbackComponent } from 'app/shared/additional-feedback/additional-feedback.component';
 import { RatingComponent } from 'app/exercises/shared/rating/rating.component';
-import { NgModel } from '@angular/forms';
+import { FormsModule, NgModel } from '@angular/forms';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { ComplaintsStudentViewComponent } from 'app/complaints/complaints-for-students/complaints-student-view.component';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
@@ -54,6 +54,8 @@ import { RatingModule } from 'app/exercises/shared/rating/rating.module';
 import { ArtemisComplaintsModule } from 'app/complaints/complaints.module';
 import { IrisModule } from 'app/iris/iris.module';
 import { ArtemisMarkdownModule } from 'app/shared/markdown.module';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { UpperCasePipe } from '@angular/common';
 
 describe('TextEditorComponent', () => {
     let comp: TextEditorComponent;

--- a/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
@@ -42,6 +42,18 @@ import { ComplaintsStudentViewComponent } from 'app/complaints/complaints-for-st
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { By } from '@angular/platform-browser';
 import { AssessmentType } from 'app/entities/assessment-type.model';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
+import { ArtemisHeaderExercisePageWithDetailsModule } from 'app/exercises/shared/exercise-headers/exercise-headers.module';
+import { RequestFeedbackButtonComponent } from 'app/overview/exercise-details/request-feedback-button/request-feedback-button.component';
+import { ArtemisResultModule } from 'app/exercises/shared/result/result.module';
+import { ArtemisTeamParticipeModule } from 'app/exercises/shared/team/team-participate/team-participate.module';
+import { ArtemisTeamSubmissionSyncModule } from 'app/exercises/shared/team-submission-sync/team-submission-sync.module';
+import { RatingModule } from 'app/exercises/shared/rating/rating.module';
+import { ArtemisComplaintsModule } from 'app/complaints/complaints.module';
+import { IrisModule } from 'app/iris/iris.module';
+import { ArtemisMarkdownModule } from 'app/shared/markdown.module';
 
 describe('TextEditorComponent', () => {
     let comp: TextEditorComponent;
@@ -67,7 +79,6 @@ describe('TextEditorComponent', () => {
         return TestBed.configureTestingModule({
             imports: [ArtemisTestModule, RouterModule.forRoot([textEditorRoute[0]])],
             declarations: [
-                TextEditorComponent,
                 MockComponent(SubmissionResultStatusComponent),
                 MockComponent(ButtonComponent),
                 MockComponent(TextResultComponent),
@@ -94,6 +105,50 @@ describe('TextEditorComponent', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         })
+            .overrideComponent(TextEditorComponent, {
+                remove: {
+                    imports: [
+                        ArtemisHeaderExercisePageWithDetailsModule,
+                        ArtemisSharedComponentModule,
+                        RequestFeedbackButtonComponent,
+                        ArtemisResultModule,
+                        ArtemisSharedModule,
+                        ArtemisTeamParticipeModule,
+                        TranslateDirective,
+                        FormsModule,
+                        ArtemisTeamSubmissionSyncModule,
+                        TextResultComponent,
+                        RatingModule,
+                        ArtemisComplaintsModule,
+                        FaIconComponent,
+                        IrisModule,
+                        UpperCasePipe,
+                        ArtemisSharedCommonModule,
+                        ArtemisMarkdownModule,
+                    ],
+                },
+                add: {
+                    imports: [
+                        MockPipe(UpperCasePipe),
+                        MockModule(ArtemisHeaderExercisePageWithDetailsModule),
+                        MockModule(ArtemisSharedComponentModule),
+                        MockModule(ArtemisResultModule),
+                        MockModule(ArtemisSharedModule),
+                        MockModule(ArtemisTeamParticipeModule),
+                        MockModule(FormsModule),
+                        MockModule(ArtemisTeamSubmissionSyncModule),
+                        MockModule(RatingModule),
+                        MockModule(ArtemisComplaintsModule),
+                        MockModule(IrisModule),
+                        MockModule(ArtemisSharedCommonModule),
+                        MockModule(ArtemisMarkdownModule),
+                        MockComponent(RequestFeedbackButtonComponent),
+                        MockComponent(TextResultComponent),
+                        MockComponent(FaIconComponent),
+                        MockDirective(TranslateDirective),
+                    ],
+                },
+            })
             .compileComponents()
             .then(() => {
                 fixture = TestBed.createComponent(TextEditorComponent);

--- a/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
@@ -39,6 +39,7 @@ import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
 import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
 import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { AssessmentInstructionsModule } from 'app/assessment/assessment-instructions/assessment-instructions.module';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
 describe('ExampleTextSubmissionComponent', () => {
     let fixture: ComponentFixture<ExampleTextSubmissionComponent>;
@@ -68,7 +69,6 @@ describe('ExampleTextSubmissionComponent', () => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, FormsModule],
             declarations: [
-                ExampleTextSubmissionComponent,
                 MockComponent(ConfirmAutofocusModalComponent),
                 MockComponent(ResizeableContainerComponent),
                 MockComponent(ScoreDisplayComponent),
@@ -96,6 +96,7 @@ describe('ExampleTextSubmissionComponent', () => {
                         TranslateDirective,
                         ArtemisSharedComponentModule,
                         FormsModule,
+                        FaIconComponent,
                         ArtemisSharedModule,
                         ArtemisAssessmentSharedModule,
                         TextAssessmentAreaComponent,
@@ -112,6 +113,7 @@ describe('ExampleTextSubmissionComponent', () => {
                         MockModule(AssessmentInstructionsModule),
                         MockModule(ArtemisSharedCommonModule),
                         MockComponent(TextAssessmentAreaComponent),
+                        MockComponent(FaIconComponent),
                         MockDirective(TranslateDirective),
                     ],
                 },

--- a/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
@@ -22,7 +22,7 @@ import { HelpIconComponent } from 'app/shared/components/help-icon.component';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ResizeableContainerComponent } from 'app/shared/resizeable-container/resizeable-container.component';
 import { ScoreDisplayComponent } from 'app/shared/score-display/score-display.component';
-import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
+import { MockComponent, MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { of, throwError } from 'rxjs';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
@@ -33,6 +33,12 @@ import { AlertService } from 'app/core/util/alert.service';
 import { DebugElement } from '@angular/core';
 import { ConfirmAutofocusModalComponent } from 'app/shared/components/confirm-autofocus-modal.component';
 import { ConfirmAutofocusButtonComponent } from 'app/shared/components/confirm-autofocus-button.component';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { ArtemisAssessmentSharedModule } from 'app/assessment/assessment-shared.module';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
+import { AssessmentInstructionsModule } from 'app/assessment/assessment-instructions/assessment-instructions.module';
 
 describe('ExampleTextSubmissionComponent', () => {
     let fixture: ComponentFixture<ExampleTextSubmissionComponent>;
@@ -83,7 +89,34 @@ describe('ExampleTextSubmissionComponent', () => {
                 MockProvider(TranslateService),
                 MockProvider(AlertService),
             ],
-        }).compileComponents();
+        })
+            .overrideComponent(ExampleTextSubmissionComponent, {
+                remove: {
+                    imports: [
+                        TranslateDirective,
+                        ArtemisSharedComponentModule,
+                        FormsModule,
+                        ArtemisSharedModule,
+                        ArtemisAssessmentSharedModule,
+                        TextAssessmentAreaComponent,
+                        AssessmentInstructionsModule,
+                        ArtemisSharedCommonModule,
+                    ],
+                },
+                add: {
+                    imports: [
+                        MockModule(ArtemisSharedComponentModule),
+                        MockModule(FormsModule),
+                        MockModule(ArtemisAssessmentSharedModule),
+                        MockModule(ArtemisSharedModule),
+                        MockModule(AssessmentInstructionsModule),
+                        MockModule(ArtemisSharedCommonModule),
+                        MockComponent(TextAssessmentAreaComponent),
+                        MockDirective(TranslateDirective),
+                    ],
+                },
+            })
+            .compileComponents();
 
         fixture = TestBed.createComponent(ExampleTextSubmissionComponent);
         comp = fixture.componentInstance;

--- a/src/test/javascript/spec/component/text-exercise/text-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/text-exercise-detail.component.spec.ts
@@ -10,15 +10,14 @@ import { TextExercise } from 'app/entities/text/text-exercise.model';
 import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import { MockActivatedRoute } from '../../helpers/mocks/activated-route/mock-activated-route';
 import { TranslateService } from '@ngx-translate/core';
-import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
-import { NonProgrammingExerciseDetailCommonActionsComponent } from 'app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component';
+import { MockDirective, MockModule, MockProvider } from 'ng-mocks';
 import { StatisticsService } from 'app/shared/statistics-graph/statistics.service';
 import { ExerciseManagementStatisticsDto } from 'app/exercises/shared/statistics/exercise-management-statistics-dto';
 import { MockRouterLinkDirective } from '../../helpers/mocks/directive/mock-router-link.directive';
-import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
-import { ExerciseDetailStatisticsComponent } from 'app/exercises/shared/statistics/exercise-detail-statistics.component';
-import { DocumentationButtonComponent } from 'app/shared/components/documentation-button/documentation-button.component';
-import { DetailOverviewListComponent } from 'app/detail-overview-list/detail-overview-list.component';
+import { NonProgrammingExerciseDetailCommonActionsModule } from 'app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.module';
+import { ArtemisExerciseModule } from 'app/exercises/shared/exercise/exercise.module';
+import { DetailModule } from 'app/detail-overview-list/detail.module';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
 
 describe('TextExercise Management Detail Component', () => {
     let comp: TextExerciseDetailComponent;
@@ -43,17 +42,23 @@ describe('TextExercise Management Detail Component', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
-            declarations: [
-                TextExerciseDetailComponent,
-                MockComponent(NonProgrammingExerciseDetailCommonActionsComponent),
-                MockComponent(ExerciseDetailStatisticsComponent),
-                MockComponent(DetailOverviewListComponent),
-                MockComponent(DocumentationButtonComponent),
-                MockRouterLinkDirective,
-                MockPipe(ArtemisTranslatePipe),
-            ],
+            declarations: [MockRouterLinkDirective],
             providers: [{ provide: ActivatedRoute, useValue: new MockActivatedRoute() }, MockProvider(TranslateService)],
-        }).compileComponents();
+        })
+            .overrideComponent(TextExerciseDetailComponent, {
+                remove: {
+                    imports: [NonProgrammingExerciseDetailCommonActionsModule, ArtemisExerciseModule, DetailModule, TranslateDirective],
+                },
+                add: {
+                    imports: [
+                        MockModule(NonProgrammingExerciseDetailCommonActionsModule),
+                        MockModule(DetailModule),
+                        MockModule(ArtemisExerciseModule),
+                        MockDirective(TranslateDirective),
+                    ],
+                },
+            })
+            .compileComponents();
         fixture = TestBed.createComponent(TextExerciseDetailComponent);
         comp = fixture.componentInstance;
         exerciseService = fixture.debugElement.injector.get(TextExerciseService);

--- a/src/test/javascript/spec/component/text-exercise/text-exercise-row-buttons.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/text-exercise-row-buttons.component.spec.ts
@@ -18,7 +18,7 @@ describe('TextExercise Row Buttons Component', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
-            declarations: [TextExerciseRowButtonsComponent],
+            declarations: [],
             providers: [
                 { provide: TextExerciseService, useValue: { delete: jest.fn() } },
                 { provide: EventManager, useValue: { broadcast: jest.fn() } },

--- a/src/test/javascript/spec/component/text-exercise/text-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/text-exercise-update.component.spec.ts
@@ -40,7 +40,7 @@ describe('TextExercise Management Update Component', () => {
                 { provide: NgbModal, useClass: MockNgbModalService },
                 MockProvider(TranslateService),
             ],
-            declarations: [TextExerciseUpdateComponent],
+            declarations: [],
         })
             .overrideTemplate(TextExerciseUpdateComponent, '')
             .compileComponents();

--- a/src/test/javascript/spec/component/text-exercise/text-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/text-exercise.component.spec.ts
@@ -30,7 +30,7 @@ describe('TextExercise Management Component', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
-            declarations: [TextExerciseComponent],
+            declarations: [],
             providers: [
                 { provide: ActivatedRoute, useValue: route },
                 { provide: LocalStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/text-exercise/tutor-effort-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/tutor-effort-statistics.component.spec.ts
@@ -51,7 +51,7 @@ describe('TutorEffortStatisticsComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, MockModule(BarChartModule)],
-            declarations: [TutorEffortStatisticsComponent, MockPipe(ArtemisTranslatePipe), MockDirective(MockHasAnyAuthorityDirective), MockComponent(HelpIconComponent)],
+            declarations: [MockPipe(ArtemisTranslatePipe), MockDirective(MockHasAnyAuthorityDirective), MockComponent(HelpIconComponent)],
             providers: [
                 provideHttpClient(),
                 provideHttpClientTesting(),

--- a/src/test/javascript/spec/component/text-result/text-result.component.spec.ts
+++ b/src/test/javascript/spec/component/text-result/text-result.component.spec.ts
@@ -44,7 +44,7 @@ describe('TextResultComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
-            declarations: [TextResultComponent, MockDirective(MockHasAnyAuthorityDirective), MockPipe(ArtemisTranslatePipe)],
+            declarations: [MockDirective(MockHasAnyAuthorityDirective), MockPipe(ArtemisTranslatePipe)],
             providers: [
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -27,6 +27,8 @@ import { Feedback, FeedbackType } from 'app/entities/feedback.model';
 import { ComplaintResponse } from 'app/entities/complaint-response.model';
 import { AlertService } from 'app/core/util/alert.service';
 import { SubmissionService } from 'app/exercises/shared/submission/submission.service';
+import { ComplaintService } from 'app/complaints/complaint.service';
+import { MockComplaintService } from '../../helpers/mocks/service/mock-complaint.service';
 import { GradingInstructionLinkIconComponent } from 'app/shared/grading-instruction-link-icon/grading-instruction-link-icon.component';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
@@ -147,7 +149,6 @@ describe('TextSubmissionAssessmentComponent', () => {
                 studentParticipation: participation,
             }),
         } as unknown as ActivatedRoute;
-        jest.spyOn(component, 'getComplaint').mockImplementation(() => {});
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [
@@ -172,6 +173,7 @@ describe('TextSubmissionAssessmentComponent', () => {
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: AthenaService, useClass: MockAthenaService },
+                { provide: ComplaintService, useClass: MockComplaintService },
                 MockProvider(Router),
             ],
         })

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -147,7 +147,7 @@ describe('TextSubmissionAssessmentComponent', () => {
                 studentParticipation: participation,
             }),
         } as unknown as ActivatedRoute;
-
+        jest.spyOn(YourComponent.prototype, 'getComplaint').mockImplementation(() => {});
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -5,7 +5,7 @@ import { By } from '@angular/platform-browser';
 import { of, throwError } from 'rxjs';
 import { AssessmentLayoutComponent } from 'app/assessment/assessment-layout/assessment-layout.component';
 import { TextAssessmentAreaComponent } from 'app/exercises/text/assess/text-assessment-area/text-assessment-area.component';
-import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
+import { MockComponent, MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { TextblockAssessmentCardComponent } from 'app/exercises/text/assess/textblock-assessment-card/textblock-assessment-card.component';
 import { TextblockFeedbackEditorComponent } from 'app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component';
 import { ExerciseType } from 'app/entities/exercise.model';
@@ -46,6 +46,7 @@ import { AthenaService } from 'app/assessment/athena.service';
 import { MockAthenaService } from '../../helpers/mocks/service/mock-athena-service';
 import { TextBlockRef } from 'app/entities/text/text-block-ref.model';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { AssessmentInstructionsModule } from 'app/assessment/assessment-instructions/assessment-instructions.module';
 
 describe('TextSubmissionAssessmentComponent', () => {
     let component: TextSubmissionAssessmentComponent;
@@ -171,7 +172,16 @@ describe('TextSubmissionAssessmentComponent', () => {
                 { provide: AthenaService, useClass: MockAthenaService },
                 MockProvider(Router),
             ],
-        }).compileComponents();
+        })
+            .overrideComponent(TextSubmissionAssessmentComponent, {
+                remove: {
+                    imports: [TextAssessmentAreaComponent, TranslateDirective, AssessmentInstructionsModule],
+                },
+                add: {
+                    imports: [MockModule(AssessmentInstructionsModule), MockComponent(TextAssessmentAreaComponent), MockDirective(TranslateDirective)],
+                },
+            })
+            .compileComponents();
     });
 
     beforeEach(() => {

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -47,6 +47,9 @@ import { MockAthenaService } from '../../helpers/mocks/service/mock-athena-servi
 import { TextBlockRef } from 'app/entities/text/text-block-ref.model';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { AssessmentInstructionsModule } from 'app/assessment/assessment-instructions/assessment-instructions.module';
+import { ArtemisAssessmentSharedModule } from 'app/assessment/assessment-shared.module';
+import { ArtemisSharedModule } from 'app/shared/shared.module';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
 describe('TextSubmissionAssessmentComponent', () => {
     let component: TextSubmissionAssessmentComponent;
@@ -148,7 +151,6 @@ describe('TextSubmissionAssessmentComponent', () => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [
-                TextSubmissionAssessmentComponent,
                 TextAssessmentAreaComponent,
                 MockComponent(TextblockAssessmentCardComponent),
                 MockComponent(TextblockFeedbackEditorComponent),
@@ -175,10 +177,17 @@ describe('TextSubmissionAssessmentComponent', () => {
         })
             .overrideComponent(TextSubmissionAssessmentComponent, {
                 remove: {
-                    imports: [TextAssessmentAreaComponent, TranslateDirective, AssessmentInstructionsModule],
+                    imports: [ArtemisAssessmentSharedModule, ArtemisSharedModule, TextAssessmentAreaComponent, FaIconComponent, TranslateDirective, AssessmentInstructionsModule],
                 },
                 add: {
-                    imports: [MockModule(AssessmentInstructionsModule), MockComponent(TextAssessmentAreaComponent), MockDirective(TranslateDirective)],
+                    imports: [
+                        MockModule(AssessmentInstructionsModule),
+                        MockModule(ArtemisAssessmentSharedModule),
+                        MockModule(ArtemisSharedModule),
+                        MockComponent(TextAssessmentAreaComponent),
+                        MockComponent(FaIconComponent),
+                        MockDirective(TranslateDirective),
+                    ],
                 },
             })
             .compileComponents();

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -147,7 +147,7 @@ describe('TextSubmissionAssessmentComponent', () => {
                 studentParticipation: participation,
             }),
         } as unknown as ActivatedRoute;
-        jest.spyOn(YourComponent.prototype, 'getComplaint').mockImplementation(() => {});
+        jest.spyOn(component, 'getComplaint').mockImplementation(() => {});
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [

--- a/src/test/javascript/spec/component/text-submission-assessment/textblock-assessment-card.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/textblock-assessment-card.component.spec.ts
@@ -30,8 +30,6 @@ describe('TextblockAssessmentCardComponent', () => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, MockDirective(NgbTooltip)],
             declarations: [
-                TextblockAssessmentCardComponent,
-                TextblockFeedbackEditorComponent,
                 TranslatePipeMock,
                 MockDirective(TranslateDirective),
                 MockDirective(NgModel),

--- a/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-dropdown.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-dropdown.component.spec.ts
@@ -25,7 +25,7 @@ describe('TextblockFeedbackDropdownComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
-            declarations: [TextblockFeedbackDropdownComponent, MockComponent(HelpIconComponent)],
+            declarations: [MockComponent(HelpIconComponent)],
         })
             .compileComponents()
             .then(() => {

--- a/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-editor.component.spec.ts
@@ -6,7 +6,7 @@ import { TextBlock, TextBlockType } from 'app/entities/text/text-block.model';
 import { ConfirmIconComponent } from 'app/shared/confirm-icon/confirm-icon.component';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { NgbModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
-import { MockComponent, MockDirective, MockProvider } from 'ng-mocks';
+import { MockComponent, MockDirective, MockModule, MockProvider } from 'ng-mocks';
 import { FaLayersComponent } from '@fortawesome/angular-fontawesome';
 import { GradingInstruction } from 'app/exercises/shared/structured-grading-criterion/grading-instruction.model';
 import { AssessmentCorrectionRoundBadgeComponent } from 'app/assessment/unreferenced-feedback-detail/assessment-correction-round-badge/assessment-correction-round-badge.component';
@@ -20,6 +20,11 @@ import { TextAssessmentEventType } from 'app/entities/text/text-assesment-event.
 import { NgModel } from '@angular/forms';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { TextblockFeedbackDropdownComponent } from 'app/exercises/text/assess/textblock-feedback-editor/dropdown/textblock-feedback-dropdown.component';
+import { ArtemisFeedbackModule } from 'app/exercises/shared/feedback/feedback.module';
+import { ArtemisConfirmIconModule } from 'app/shared/confirm-icon/confirm-icon.module';
+import { ArtemisGradingInstructionLinkIconModule } from 'app/shared/grading-instruction-link-icon/grading-instruction-link-icon.module';
+import { ArtemisAssessmentSharedModule } from 'app/assessment/assessment-shared.module';
+import { ArtemisSharedCommonModule } from 'app/shared/shared-common.module';
 
 describe('TextblockFeedbackEditorComponent', () => {
     let component: TextblockFeedbackEditorComponent;
@@ -32,7 +37,6 @@ describe('TextblockFeedbackEditorComponent', () => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, TranslateModule.forRoot(), TranslateTestingModule, MockDirective(NgbTooltip)],
             declarations: [
-                TextblockFeedbackEditorComponent,
                 AssessmentCorrectionRoundBadgeComponent,
                 MockComponent(TextblockFeedbackDropdownComponent),
                 MockComponent(ConfirmIconComponent),
@@ -48,7 +52,32 @@ describe('TextblockFeedbackEditorComponent', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
             ],
-        }).compileComponents();
+        })
+            .overrideComponent(TextblockFeedbackEditorComponent, {
+                remove: {
+                    imports: [
+                        ArtemisFeedbackModule,
+                        ArtemisConfirmIconModule,
+                        TranslateDirective,
+                        ArtemisGradingInstructionLinkIconModule,
+                        TextblockFeedbackDropdownComponent,
+                        ArtemisAssessmentSharedModule,
+                        ArtemisSharedCommonModule,
+                    ],
+                },
+                add: {
+                    imports: [
+                        MockModule(ArtemisFeedbackModule),
+                        MockModule(ArtemisConfirmIconModule),
+                        MockModule(ArtemisGradingInstructionLinkIconModule),
+                        MockModule(ArtemisAssessmentSharedModule),
+                        MockModule(ArtemisSharedCommonModule),
+                        MockComponent(TextblockFeedbackDropdownComponent),
+                        MockDirective(TranslateDirective),
+                    ],
+                },
+            })
+            .compileComponents();
     });
 
     beforeEach(() => {

--- a/src/test/javascript/spec/component/text/manual-text-selection.component.spec.ts
+++ b/src/test/javascript/spec/component/text/manual-text-selection.component.spec.ts
@@ -37,7 +37,7 @@ describe('ManualTextSelectionComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
-            declarations: [ManualTextSelectionComponent],
+            declarations: [],
             providers: [MockProvider(TextAssessmentAnalytics), MockProvider(ActivatedRoute)],
         })
             .compileComponents()


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ ] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [ ] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

https://angular.dev/reference/migrations/standalone

### Description
<!-- Describe your changes in detail -->

Migrates all components and directives of the text exercises module on the client side to use the new standalone mode.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Students
- 1 Text exercise

Just check if you notice something strange at each step and check if everything works as expected

1. Log in to Artemis as Instructor
2. Navigate to Course Management 
3. -> Select any course
4. -> Select "Exercises"
5. "Press Create Text Exercise"
6. Create a text exercise
7. Participate in the text exercise
8. Set due date to be over
9. Assess the participation 
10. -> Click "Assessment Dashboard" on the exercise detail as instructor
11. -> Confirm that you understood the instructions
12. -> Open assessment
13. -> Give feedback
14. -> Submit feedback
15. -> Click "Use as Example Submission"
16. Go to Assessment Dashboard
17. Click "Start reading example submissions"
18. Click "I have read and understood the example"
19. Go to student view
20. Click "View submission"

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
Unchanged

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Unchanged
