### PR TITLE
`Integrated code lifecycle`: Limit build logs size

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/dto/BuildLogDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/dto/BuildLogDTO.java
@@ -1,0 +1,13 @@
+package de.tum.cit.aet.artemis.buildagent.dto;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record BuildLogDTO(@NotNull ZonedDateTime time, @NotNull String log) implements Serializable {
+
+}

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/dto/BuildResult.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/dto/BuildResult.java
@@ -27,6 +27,7 @@ import de.tum.cit.aet.artemis.programming.service.ci.notification.dto.TestwiseCo
 // in the future are migrated or cleared. Changes should be communicated in release notes as potentially breaking changes.
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+// TODO: this should be a record in the future
 public class BuildResult extends AbstractBuildResultNotificationDTO implements Serializable {
 
     private final String assignmentRepoBranchName;
@@ -41,7 +42,7 @@ public class BuildResult extends AbstractBuildResultNotificationDTO implements S
 
     private final List<LocalCIJobDTO> jobs;
 
-    private List<BuildLogEntry> buildLogEntries = new ArrayList<>();
+    private List<BuildLogDTO> buildLogEntries = new ArrayList<>();
 
     private final List<StaticCodeAnalysisReportDTO> staticCodeAnalysisReports;
 
@@ -123,7 +124,8 @@ public class BuildResult extends AbstractBuildResultNotificationDTO implements S
 
     @Override
     public List<BuildLogEntry> extractBuildLogs() {
-        return buildLogEntries;
+        // convert the buildLogEntry DTOs to BuildLogEntry objects
+        return buildLogEntries.stream().map(log -> new BuildLogEntry(log.time(), log.log())).toList();
     }
 
     /**
@@ -131,7 +133,7 @@ public class BuildResult extends AbstractBuildResultNotificationDTO implements S
      *
      * @param buildLogEntries the buildLogEntries to be set
      */
-    public void setBuildLogEntries(List<BuildLogEntry> buildLogEntries) {
+    public void setBuildLogEntries(List<BuildLogDTO> buildLogEntries) {
         this.buildLogEntries = buildLogEntries;
         hasLogs = true;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/dto/ResultQueueItem.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/dto/ResultQueueItem.java
@@ -5,11 +5,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.programming.domain.build.BuildLogEntry;
-
 // NOTE: this data structure is used in shared code between core and build agent nodes. Changing it requires that the shared data structures in Hazelcast (or potentially Redis)
 // in the future are migrated or cleared. Changes should be communicated in release notes as potentially breaking changes.
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-// TODO: this data structure should not use BuildLogEntry because it's an entity class (and not a DTO)
-public record ResultQueueItem(BuildResult buildResult, BuildJobQueueItem buildJobQueueItem, List<BuildLogEntry> buildLogs, Throwable exception) implements Serializable {
+public record ResultQueueItem(BuildResult buildResult, BuildJobQueueItem buildJobQueueItem, List<BuildLogDTO> buildLogs, Throwable exception) implements Serializable {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
@@ -180,16 +180,14 @@ public class BuildAgentDockerService {
         @Override
         public void onNext(PullResponseItem item) {
             String msg = "~~~~~~~~~~~~~~~~~~~~ Pull image progress: " + item.getStatus() + " ~~~~~~~~~~~~~~~~~~~~";
-            log.info(msg);
-            buildLogsMap.appendBuildLogEntry(buildJobId, msg);
+            log.debug(msg);
             super.onNext(item);
         }
 
         @Override
         public void onComplete() {
             String msg = "~~~~~~~~~~~~~~~~~~~~ Pull image complete ~~~~~~~~~~~~~~~~~~~~";
-            log.info(msg);
-            buildLogsMap.appendBuildLogEntry(buildJobId, msg);
+            log.debug(msg);
             super.onComplete();
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -43,9 +43,9 @@ import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.HostConfig;
 
+import de.tum.cit.aet.artemis.buildagent.dto.BuildLogDTO;
 import de.tum.cit.aet.artemis.core.exception.LocalCIException;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage;
-import de.tum.cit.aet.artemis.programming.domain.build.BuildLogEntry;
 import de.tum.cit.aet.artemis.programming.service.ci.ContinuousIntegrationService.RepositoryCheckoutPath;
 
 /**
@@ -414,7 +414,7 @@ public class BuildJobContainerService {
                 @Override
                 public void onNext(Frame item) {
                     String text = new String(item.getPayload());
-                    BuildLogEntry buildLogEntry = new BuildLogEntry(ZonedDateTime.now(), text);
+                    var buildLogEntry = new BuildLogDTO(ZonedDateTime.now(), text);
                     if (buildJobId != null) {
                         buildLogsMap.appendBuildLogEntry(buildJobId, buildLogEntry);
                     }

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -414,7 +414,7 @@ public class BuildJobContainerService {
                 @Override
                 public void onNext(Frame item) {
                     String text = new String(item.getPayload());
-                    var buildLogEntry = new BuildLogDTO(ZonedDateTime.now(), text);
+                    BuildLogDTO buildLogEntry = new BuildLogDTO(ZonedDateTime.now(), text);
                     if (buildJobId != null) {
                         buildLogsMap.appendBuildLogEntry(buildJobId, buildLogEntry);
                     }

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobExecutionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobExecutionService.java
@@ -345,7 +345,7 @@ public class BuildJobExecutionService {
         try {
             buildResult = parseTestResults(testResultsTarInputStream, buildJob.buildConfig().branch(), assignmentRepoCommitHash, testRepoCommitHash, buildCompletedDate,
                     buildJob.id());
-            buildResult.setBuildLogEntries(buildLogsMap.getBuildLogs(buildJob.id()));
+            buildResult.setBuildLogEntries(buildLogsMap.getAndTruncateBuildLogs(buildJob.id()));
         }
         catch (IOException | IllegalStateException e) {
             msg = "Error while parsing test results";

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobManagementService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobManagementService.java
@@ -32,9 +32,9 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.topic.ITopic;
 
 import de.tum.cit.aet.artemis.buildagent.dto.BuildJobQueueItem;
+import de.tum.cit.aet.artemis.buildagent.dto.BuildLogDTO;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildResult;
 import de.tum.cit.aet.artemis.core.exception.LocalCIException;
-import de.tum.cit.aet.artemis.programming.domain.build.BuildLogEntry;
 
 /**
  * This service is responsible for adding build jobs to the Integrated Code Lifecycle executor service.
@@ -171,7 +171,7 @@ public class BuildJobManagementService {
                     finishCancelledBuildJob(buildJobItem.repositoryInfo().assignmentRepositoryUri(), buildJobItem.id(), containerName);
                     String msg = "Build job with id " + buildJobItem.id() + " was cancelled.";
                     String stackTrace = stackTraceToString(e);
-                    buildLogsMap.appendBuildLogEntry(buildJobItem.id(), new BuildLogEntry(ZonedDateTime.now(), msg + "\n" + stackTrace));
+                    buildLogsMap.appendBuildLogEntry(buildJobItem.id(), new BuildLogDTO(ZonedDateTime.now(), msg + "\n" + stackTrace));
                     throw new CompletionException(msg, e);
                 }
                 else {
@@ -232,7 +232,7 @@ public class BuildJobManagementService {
     private void finishBuildJobExceptionally(String buildJobId, String containerName, Exception exception) {
         String msg = "Error while executing build job " + buildJobId + ": " + exception.getMessage();
         String stackTrace = stackTraceToString(exception);
-        buildLogsMap.appendBuildLogEntry(buildJobId, new BuildLogEntry(ZonedDateTime.now(), msg + "\n" + stackTrace));
+        buildLogsMap.appendBuildLogEntry(buildJobId, new BuildLogDTO(ZonedDateTime.now(), msg + "\n" + stackTrace));
         log.error(msg);
 
         log.info("Getting ID of running container {}", containerName);

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildLogsMap.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildLogsMap.java
@@ -42,6 +42,12 @@ public class BuildLogsMap {
         buildLogsMap.remove(buildLogId);
     }
 
+    /**
+     * Retrieves and truncates the build logs for the specified build log ID.
+     *
+     * @param buildLogId the ID of the build log to retrieve and truncate
+     * @return a list of truncated build log entries, or null if no logs are found for the specified ID
+     */
     public List<BuildLogEntry> getAndTruncateBuildLogs(String buildLogId) {
         List<BuildLogEntry> buildLogs = buildLogsMap.get(buildLogId);
 

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildLogsMap.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildLogsMap.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,12 @@ import de.tum.cit.aet.artemis.programming.domain.build.BuildLogEntry;
 @Profile(PROFILE_BUILDAGENT)
 @Component
 public class BuildLogsMap {
+
+    @Value("${artemis.continuous-integration.build-logs.max-lines-per-job:10000}")
+    private int maxLogLinesPerBuildJob;
+
+    @Value("${artemis.continuous-integration.build-logs.max-chars-per-line:1024}")
+    private int maxCharsPerLine;
 
     private final ConcurrentMap<String, List<BuildLogEntry>> buildLogsMap = new ConcurrentHashMap<>();
 
@@ -33,5 +40,32 @@ public class BuildLogsMap {
 
     public void removeBuildLogs(String buildLogId) {
         buildLogsMap.remove(buildLogId);
+    }
+
+    public List<BuildLogEntry> getAndTruncateBuildLogs(String buildLogId) {
+        List<BuildLogEntry> buildLogs = buildLogsMap.get(buildLogId);
+
+        if (buildLogs == null) {
+            return null;
+        }
+
+        // Truncate the build logs to maxLogLinesPerBuildJob
+        if (buildLogs.size() > maxLogLinesPerBuildJob) {
+            List<BuildLogEntry> truncatedBuildLogs = new ArrayList<>(buildLogs.subList(0, maxLogLinesPerBuildJob));
+            truncatedBuildLogs.add(new BuildLogEntry(ZonedDateTime.now(), "Truncated build logs...\n"));
+            buildLogs = truncatedBuildLogs;
+        }
+
+        // Truncate each line to maxCharsPerLine
+        for (int i = 0; i < buildLogs.size(); i++) {
+            BuildLogEntry buildLog = buildLogs.get(i);
+            String log = buildLog.getLog();
+            if (log.length() > maxCharsPerLine) {
+                String truncatedLog = log.substring(0, maxCharsPerLine) + "\n";
+                buildLogs.set(i, new BuildLogEntry(buildLog.getTime(), truncatedLog));
+            }
+        }
+
+        return buildLogs;
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildLogsMap.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildLogsMap.java
@@ -46,7 +46,7 @@ public class BuildLogsMap {
      * @param buildLog   the build log entry to append to the build log
      */
     public void appendBuildLogEntry(String buildJobId, BuildLogDTO buildLog) {
-        var buildLogs = buildLogsMap.computeIfAbsent(buildJobId, k -> new ArrayList<>());
+        List<BuildLogDTO> buildLogs = buildLogsMap.computeIfAbsent(buildJobId, k -> new ArrayList<>());
         if (buildLogs.size() < maxLogLinesPerBuildJob) {
             if (buildLog.log() != null && buildLog.log().length() > maxCharsPerLine) {
                 buildLog = new BuildLogDTO(buildLog.time(), buildLog.log().substring(0, maxCharsPerLine) + "\n");

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
@@ -397,7 +397,7 @@ public class SharedQueueProcessingService {
                     buildJob.exerciseId(), buildJob.retryCount(), buildJob.priority(), BuildStatus.SUCCESSFUL, buildJob.repositoryInfo(), jobTimingInfo, buildJob.buildConfig(),
                     null);
 
-            List<BuildLogEntry> buildLogs = buildLogsMap.getBuildLogs(buildJob.id());
+            List<BuildLogEntry> buildLogs = buildLogsMap.getAndTruncateBuildLogs(buildJob.id());
             buildLogsMap.removeBuildLogs(buildJob.id());
 
             ResultQueueItem resultQueueItem = new ResultQueueItem(buildResult, finishedJob, buildLogs, null);
@@ -435,7 +435,7 @@ public class SharedQueueProcessingService {
 
             job = new BuildJobQueueItem(buildJob, completionDate, status);
 
-            List<BuildLogEntry> buildLogs = buildLogsMap.getBuildLogs(buildJob.id());
+            List<BuildLogEntry> buildLogs = buildLogsMap.getAndTruncateBuildLogs(buildJob.id());
             buildLogsMap.removeBuildLogs(buildJob.id());
 
             BuildResult failedResult = new BuildResult(buildJob.buildConfig().branch(), buildJob.buildConfig().assignmentCommitHash(), buildJob.buildConfig().testCommitHash(),

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
@@ -49,11 +49,11 @@ import com.hazelcast.topic.ITopic;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildAgentDTO;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildAgentInformation;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildJobQueueItem;
+import de.tum.cit.aet.artemis.buildagent.dto.BuildLogDTO;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildResult;
 import de.tum.cit.aet.artemis.buildagent.dto.JobTimingInfo;
 import de.tum.cit.aet.artemis.buildagent.dto.ResultQueueItem;
 import de.tum.cit.aet.artemis.core.security.SecurityUtils;
-import de.tum.cit.aet.artemis.programming.domain.build.BuildLogEntry;
 import de.tum.cit.aet.artemis.programming.domain.build.BuildStatus;
 
 /**
@@ -397,7 +397,7 @@ public class SharedQueueProcessingService {
                     buildJob.exerciseId(), buildJob.retryCount(), buildJob.priority(), BuildStatus.SUCCESSFUL, buildJob.repositoryInfo(), jobTimingInfo, buildJob.buildConfig(),
                     null);
 
-            List<BuildLogEntry> buildLogs = buildLogsMap.getAndTruncateBuildLogs(buildJob.id());
+            List<BuildLogDTO> buildLogs = buildLogsMap.getAndTruncateBuildLogs(buildJob.id());
             buildLogsMap.removeBuildLogs(buildJob.id());
 
             ResultQueueItem resultQueueItem = new ResultQueueItem(buildResult, finishedJob, buildLogs, null);
@@ -435,7 +435,7 @@ public class SharedQueueProcessingService {
 
             job = new BuildJobQueueItem(buildJob, completionDate, status);
 
-            List<BuildLogEntry> buildLogs = buildLogsMap.getAndTruncateBuildLogs(buildJob.id());
+            List<BuildLogDTO> buildLogs = buildLogsMap.getAndTruncateBuildLogs(buildJob.id());
             buildLogsMap.removeBuildLogs(buildJob.id());
 
             BuildResult failedResult = new BuildResult(buildJob.buildConfig().branch(), buildJob.buildConfig().assignmentCommitHash(), buildJob.buildConfig().testCommitHash(),

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/BuildLogEntryService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/BuildLogEntryService.java
@@ -23,6 +23,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import de.tum.cit.aet.artemis.buildagent.dto.BuildLogDTO;
 import de.tum.cit.aet.artemis.core.service.ProfileService;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage;
@@ -300,14 +301,14 @@ public class BuildLogEntryService {
      * and the build job ID. If the directory structure for the logs does not already exist, it is created.
      * Each log entry is written to the log file in the format of "time\tlog message".
      *
-     * @param buildLogEntries     A list of {@link BuildLogEntry} objects containing the build log information to be saved.
+     * @param buildLogEntries     A list of {@link BuildLogDTO} objects containing the build log information to be saved.
      * @param buildJobId          The unique identifier of the build job whose logs are being saved.
      * @param programmingExercise The programming exercise associated with the build job, used to
      *                                retrieve the course and exercise short names.
      * @throws IllegalStateException If the directory for storing the logs could not be created.
      * @throws RuntimeException      If an I/O error occurs while writing the log file.
      */
-    public void saveBuildLogsToFile(List<BuildLogEntry> buildLogEntries, String buildJobId, ProgrammingExercise programmingExercise) {
+    public void saveBuildLogsToFile(List<BuildLogDTO> buildLogEntries, String buildJobId, ProgrammingExercise programmingExercise) {
         String courseShortName = programmingExercise.getCourseViaExerciseGroupOrCourseMember().getShortName();
         String exerciseShortName = programmingExercise.getShortName();
         Path exerciseLogsPath = buildLogsPath.resolve(courseShortName).resolve(exerciseShortName);
@@ -323,8 +324,8 @@ public class BuildLogEntryService {
         Path logPath = exerciseLogsPath.resolve(buildJobId + ".log");
 
         StringBuilder logsStringBuilder = new StringBuilder();
-        for (BuildLogEntry buildLogEntry : buildLogEntries) {
-            logsStringBuilder.append(buildLogEntry.getTime()).append("\t").append(buildLogEntry.getLog());
+        for (var buildLogEntry : buildLogEntries) {
+            logsStringBuilder.append(buildLogEntry.time()).append("\t").append(buildLogEntry.log());
         }
 
         try {

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/BuildLogEntryService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/BuildLogEntryService.java
@@ -324,7 +324,7 @@ public class BuildLogEntryService {
         Path logPath = exerciseLogsPath.resolve(buildJobId + ".log");
 
         StringBuilder logsStringBuilder = new StringBuilder();
-        for (var buildLogEntry : buildLogEntries) {
+        for (BuildLogDTO buildLogEntry : buildLogEntries) {
             logsStringBuilder.append(buildLogEntry.time()).append("\t").append(buildLogEntry.log());
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/localci/LocalCIResultProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/localci/LocalCIResultProcessingService.java
@@ -27,6 +27,7 @@ import com.hazelcast.map.IMap;
 import de.tum.cit.aet.artemis.assessment.domain.Result;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildAgentInformation;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildJobQueueItem;
+import de.tum.cit.aet.artemis.buildagent.dto.BuildLogDTO;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildResult;
 import de.tum.cit.aet.artemis.buildagent.dto.ResultQueueItem;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
@@ -37,7 +38,6 @@ import de.tum.cit.aet.artemis.exercise.repository.ParticipationRepository;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseParticipation;
 import de.tum.cit.aet.artemis.programming.domain.RepositoryType;
 import de.tum.cit.aet.artemis.programming.domain.build.BuildJob;
-import de.tum.cit.aet.artemis.programming.domain.build.BuildLogEntry;
 import de.tum.cit.aet.artemis.programming.domain.build.BuildStatus;
 import de.tum.cit.aet.artemis.programming.dto.ResultDTO;
 import de.tum.cit.aet.artemis.programming.exception.BuildTriggerWebsocketError;
@@ -133,7 +133,7 @@ public class LocalCIResultProcessingService {
 
         BuildJobQueueItem buildJob = resultQueueItem.buildJobQueueItem();
         BuildResult buildResult = resultQueueItem.buildResult();
-        List<BuildLogEntry> buildLogs = resultQueueItem.buildLogs();
+        List<BuildLogDTO> buildLogs = resultQueueItem.buildLogs();
         Throwable ex = resultQueueItem.exception();
 
         BuildJob savedBuildJob;

--- a/src/main/resources/config/application-buildagent.yml
+++ b/src/main/resources/config/application-buildagent.yml
@@ -34,9 +34,12 @@ artemis:
             cleanup-schedule-minutes: 60
         pause-grace-period-seconds: 60
         build-timeout-seconds:
-          min: 10
-          default: 120
-          max: 240
+            min: 10
+            default: 120
+            max: 240
+        build-logs:
+            max-lines-per-job: 10000
+            max-chars-per-line: 1024
     git:
         name: Artemis
         email: artemis@xcit.tum.de

--- a/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalCIResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalCIResourceIntegrationTest.java
@@ -29,6 +29,7 @@ import de.tum.cit.aet.artemis.buildagent.dto.BuildAgentInformation;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildConfig;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildJobQueueItem;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildJobsStatisticsDTO;
+import de.tum.cit.aet.artemis.buildagent.dto.BuildLogDTO;
 import de.tum.cit.aet.artemis.buildagent.dto.FinishedBuildJobDTO;
 import de.tum.cit.aet.artemis.buildagent.dto.JobTimingInfo;
 import de.tum.cit.aet.artemis.buildagent.dto.RepositoryInfo;
@@ -37,7 +38,6 @@ import de.tum.cit.aet.artemis.core.dto.pageablesearch.PageableSearchDTO;
 import de.tum.cit.aet.artemis.programming.AbstractProgrammingIntegrationLocalCILocalVCTestBase;
 import de.tum.cit.aet.artemis.programming.domain.RepositoryType;
 import de.tum.cit.aet.artemis.programming.domain.build.BuildJob;
-import de.tum.cit.aet.artemis.programming.domain.build.BuildLogEntry;
 import de.tum.cit.aet.artemis.programming.domain.build.BuildStatus;
 
 class LocalCIResourceIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalVCTestBase {
@@ -332,7 +332,7 @@ class LocalCIResourceIntegrationTest extends AbstractProgrammingIntegrationLocal
     void testGetBuildLogsForResult() throws Exception {
         try {
             buildJobRepository.save(finishedJobForLogs);
-            BuildLogEntry buildLogEntry = new BuildLogEntry(ZonedDateTime.now(), "Dummy log");
+            BuildLogDTO buildLogEntry = new BuildLogDTO(ZonedDateTime.now(), "Dummy log");
             buildLogEntryService.saveBuildLogsToFile(List.of(buildLogEntry), "6", programmingExercise);
             var response = request.get("/api/build-log/6", HttpStatus.OK, String.class);
             assertThat(response).contains("Dummy log");


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There is an issue where an exercise can generate huge build logs, which when transferred over hazelcast, could crash the system with out of memory errors. This PR limits the build logs size to max 10.000 logs and max 1.024 chars per log.

### Description
<!-- Describe your changes in detail -->

Before sending the buildlogs over hazelcast, we truncate them to max 10.000 logs and 1.024 chars per log. Numbers are configurable via application properties (yml settings of the build agents)

**Please note that a log can consist of multiple lines. So it's normal if the lines per log file exceed 10000. But each log should not have more than 1024 chars. The number of logs can be counted by counting the timestamps (Ctrl+F `[Europe/Berlin]`)**

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Submit a few times as a student
2. As instructor, navigate to the build logs (/course-management/{courseId}/build-queue)
3. Make sure that you can view the build logs. Make sure that each build job has max 10000 logs (the number of logs is equal to the number of timestamps, you can figure out how logs there are by Ctrl+F `[Europe/Berlin]` and view count)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Performance Tests
- [x] Test 1
- [x] Test 2




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced configurable limits on the number of log entries and the length of each log entry for better log management.
	- Added a new `BuildLogDTO` class to improve the structure of log entries.

- **Bug Fixes**
	- Enhanced logging behavior during build job execution, ensuring logs are conditionally added based on new constraints.

- **Refactor**
	- Updated logging methods across multiple services to streamline log entry management and improve readability, transitioning from `BuildLogEntry` to `BuildLogDTO`.
	- Improved handling of build logs in various services to ensure consistency and efficiency in log management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->