### PR TITLE
`Integrated code lifecycle`: Allow admins to pause all build agents

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/web/admin/AdminBuildJobQueueResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/admin/AdminBuildJobQueueResource.java
@@ -195,7 +195,7 @@ public class AdminBuildJobQueueResource {
     }
 
     /**
-     * {@code PUT /api/admin/agent/{agentName}/pause} : Pause the specified build agent.
+     * {@code PUT /api/admin/agents/{agentName}/pause} : Pause the specified build agent.
      * This endpoint allows administrators to pause a specific build agent by its name.
      * Pausing a build agent will prevent it from picking up any new build jobs until it is resumed.
      *
@@ -207,7 +207,7 @@ public class AdminBuildJobQueueResource {
      * @return {@link ResponseEntity} with status code 204 (No Content) if the agent was successfully paused
      *         or an appropriate error response if something went wrong
      */
-    @PutMapping("agent/{agentName}/pause")
+    @PutMapping("agents/{agentName}/pause")
     public ResponseEntity<Void> pauseBuildAgent(@PathVariable String agentName) {
         log.debug("REST request to pause agent {}", agentName);
         localCIBuildJobQueueService.pauseBuildAgent(agentName);
@@ -215,7 +215,26 @@ public class AdminBuildJobQueueResource {
     }
 
     /**
-     * {@code PUT /api/admin/agent/{agentName}/resume} : Resume the specified build agent.
+     * {@code PUT /api/admin/agents/pause-all} : Pause all build agents.
+     * This endpoint allows administrators to pause all build agents.
+     * Pausing all build agents will prevent them from picking up any new build jobs until they are resumed.
+     *
+     * <p>
+     * <strong>Authorization:</strong> This operation requires admin privileges, enforced by {@code @EnforceAdmin}.
+     * </p>
+     *
+     * @return {@link ResponseEntity} with status code 204 (No Content) if all agents were successfully paused
+     *         or an appropriate error response if something went wrong
+     */
+    @PutMapping("agents/pause-all")
+    public ResponseEntity<Void> pauseAllBuildAgents() {
+        log.debug("REST request to pause all agents");
+        localCIBuildJobQueueService.pauseAllBuildAgents();
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * {@code PUT /api/admin/agents/{agentName}/resume} : Resume the specified build agent.
      * This endpoint allows administrators to resume a specific build agent by its name.
      * Resuming a build agent will allow it to pick up new build jobs again.
      *
@@ -227,10 +246,29 @@ public class AdminBuildJobQueueResource {
      * @return {@link ResponseEntity} with status code 204 (No Content) if the agent was successfully resumed
      *         or an appropriate error response if something went wrong
      */
-    @PutMapping("agent/{agentName}/resume")
+    @PutMapping("agents/{agentName}/resume")
     public ResponseEntity<Void> resumeBuildAgent(@PathVariable String agentName) {
         log.debug("REST request to resume agent {}", agentName);
         localCIBuildJobQueueService.resumeBuildAgent(agentName);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * {@code PUT /api/admin/agents/resume-all} : Resume all build agents.
+     * This endpoint allows administrators to resume all build agents.
+     * Resuming all build agents will allow them to pick up new build jobs again.
+     *
+     * <p>
+     * <strong>Authorization:</strong> This operation requires admin privileges, enforced by {@code @EnforceAdmin}.
+     * </p>
+     *
+     * @return {@link ResponseEntity} with status code 204 (No Content) if all agents were successfully resumed
+     *         or an appropriate error response if something went wrong
+     */
+    @PutMapping("agents/resume-all")
+    public ResponseEntity<Void> resumeAllBuildAgents() {
+        log.debug("REST request to resume all agents");
+        localCIBuildJobQueueService.resumeAllBuildAgents();
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/localci/SharedQueueManagementService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/localci/SharedQueueManagementService.java
@@ -154,8 +154,16 @@ public class SharedQueueManagementService {
         pauseBuildAgentTopic.publish(agent);
     }
 
+    public void pauseAllBuildAgents() {
+        getBuildAgentInformation().forEach(agent -> pauseBuildAgent(agent.buildAgent().name()));
+    }
+
     public void resumeBuildAgent(String agent) {
         resumeBuildAgentTopic.publish(agent);
+    }
+
+    public void resumeAllBuildAgents() {
+        getBuildAgentInformation().forEach(agent -> resumeBuildAgent(agent.buildAgent().name()));
     }
 
     /**

--- a/src/main/webapp/app/localci/build-agents/build-agent-summary/build-agent-summary.component.html
+++ b/src/main/webapp/app/localci/build-agents/build-agent-summary/build-agent-summary.component.html
@@ -1,11 +1,24 @@
 <div style="padding-bottom: 60px">
-    <h3 id="build-agents-heading" jhiTranslate="artemisApp.buildAgents.summary"></h3>
     @if (buildAgents) {
-        <p>
-            {{ buildAgents.length }} <span jhiTranslate="artemisApp.buildAgents.onlineAgents"></span>: {{ currentBuilds }} <span jhiTranslate="artemisApp.buildAgents.of"></span>
-            {{ buildCapacity }} <span jhiTranslate="artemisApp.buildAgents.buildJobsRunning"></span>
-        </p>
-        <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-3"></div>
+        <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-3">
+            <div>
+                <h3 id="build-agents-heading" jhiTranslate="artemisApp.buildAgents.summary"></h3>
+                <p>
+                    {{ buildAgents.length }} <span jhiTranslate="artemisApp.buildAgents.onlineAgents"></span>: {{ currentBuilds }}
+                    <span jhiTranslate="artemisApp.buildAgents.of"></span> {{ buildCapacity }} <span jhiTranslate="artemisApp.buildAgents.buildJobsRunning"></span>
+                </p>
+            </div>
+            <div>
+                <button class="btn btn-success" (click)="resumeAllBuildAgents()">
+                    <fa-icon [icon]="faPlay" />
+                    <span jhiTranslate="artemisApp.buildAgents.resumeAll"></span>
+                </button>
+                <button class="btn btn-danger" (click)="displayPauseBuildAgentModal(content)">
+                    <fa-icon [icon]="faPause" />
+                    <span jhiTranslate="artemisApp.buildAgents.pauseAll"></span>
+                </button>
+            </div>
+        </div>
         <jhi-data-table [showPageSizeDropdown]="false" [showSearchField]="false" entityType="buildAgent" [allEntities]="buildAgents!">
             <ng-template let-settings="settings" let-controls="controls">
                 <ngx-datatable
@@ -115,3 +128,28 @@
         </jhi-data-table>
     }
 </div>
+
+<!-- Modal -->
+<ng-template #content let-modal>
+    <div class="modal-header">
+        <h5 class="modal-title">
+            <span jhiTranslate="artemisApp.buildAgents.pauseAll"></span>
+        </h5>
+        <button type="button" class="btn-close" aria-label="Close" (click)="modal.close()"></button>
+    </div>
+    <div class="modal-body">
+        <div>
+            <span jhiTranslate="artemisApp.buildAgents.pauseAllWarning"></span>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" (click)="modal.close()">
+            <fa-icon [icon]="faTimes" />
+            <span jhiTranslate="artemisApp.buildQueue.filter.close"></span>
+        </button>
+        <button type="button" class="btn btn-danger" (click)="pauseAllBuildAgents(modal)">
+            <fa-icon [icon]="faPause" />
+            <span jhiTranslate="artemisApp.buildAgents.pauseAll"></span>
+        </button>
+    </div>
+</ng-template>

--- a/src/main/webapp/app/localci/build-agents/build-agent-summary/build-agent-summary.component.ts
+++ b/src/main/webapp/app/localci/build-agents/build-agent-summary/build-agent-summary.component.ts
@@ -1,12 +1,14 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { BuildAgentInformation } from 'app/entities/programming/build-agent-information.model';
+import { BuildAgentInformation, BuildAgentStatus } from 'app/entities/programming/build-agent-information.model';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
 import { BuildAgentsService } from 'app/localci/build-agents/build-agents.service';
 import { Subscription } from 'rxjs';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faPause, faPlay, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { BuildQueueService } from 'app/localci/build-queue/build-queue.service';
 import { Router } from '@angular/router';
 import { BuildAgent } from 'app/entities/programming/build-agent.model';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { AlertService, AlertType } from 'app/core/util/alert.service';
 
 @Component({
     selector: 'jhi-build-agents',
@@ -23,13 +25,17 @@ export class BuildAgentSummaryComponent implements OnInit, OnDestroy {
     routerLink: string;
 
     //icons
-    faTimes = faTimes;
+    protected readonly faTimes = faTimes;
+    protected readonly faPause = faPause;
+    protected readonly faPlay = faPlay;
 
     constructor(
         private websocketService: JhiWebsocketService,
         private buildAgentsService: BuildAgentsService,
         private buildQueueService: BuildQueueService,
         private router: Router,
+        private modalService: NgbModal,
+        private alertService: AlertService,
     ) {}
 
     ngOnInit() {
@@ -59,7 +65,9 @@ export class BuildAgentSummaryComponent implements OnInit, OnDestroy {
 
     private updateBuildAgents(buildAgents: BuildAgentInformation[]) {
         this.buildAgents = buildAgents;
-        this.buildCapacity = this.buildAgents.reduce((sum, agent) => sum + (agent.maxNumberOfConcurrentBuildJobs || 0), 0);
+        this.buildCapacity = this.buildAgents
+            .filter((agent) => agent.status !== BuildAgentStatus.PAUSED)
+            .reduce((sum, agent) => sum + (agent.maxNumberOfConcurrentBuildJobs || 0), 0);
         this.currentBuilds = this.buildAgents.reduce((sum, agent) => sum + (agent.numberOfCurrentBuildJobs || 0), 0);
     }
 
@@ -85,5 +93,48 @@ export class BuildAgentSummaryComponent implements OnInit, OnDestroy {
         if (buildAgentToCancel?.buildAgent?.name) {
             this.buildQueueService.cancelAllRunningBuildJobsForAgent(buildAgentToCancel.buildAgent?.name).subscribe();
         }
+    }
+
+    displayPauseBuildAgentModal(modal: any) {
+        this.modalService.open(modal);
+    }
+
+    pauseAllBuildAgents(modal?: any) {
+        this.buildAgentsService.pauseAllBuildAgents().subscribe({
+            next: () => {
+                this.load();
+                this.alertService.addAlert({
+                    type: AlertType.SUCCESS,
+                    message: 'artemisApp.buildAgents.alerts.buildAgentsPaused',
+                });
+            },
+            error: () => {
+                this.alertService.addAlert({
+                    type: AlertType.DANGER,
+                    message: 'artemisApp.buildAgents.alerts.buildAgentPauseFailed',
+                });
+            },
+        });
+        if (modal) {
+            modal.close();
+        }
+    }
+
+    resumeAllBuildAgents() {
+        this.buildAgentsService.resumeAllBuildAgents().subscribe({
+            next: () => {
+                this.load();
+                this.alertService.addAlert({
+                    type: AlertType.SUCCESS,
+                    message: 'artemisApp.buildAgents.alerts.buildAgentsResumed',
+                });
+            },
+            error: () => {
+                this.alertService.addAlert({
+                    type: AlertType.DANGER,
+                    message: 'artemisApp.buildAgents.alerts.buildAgentResumeFailed',
+                });
+            },
+        });
     }
 }

--- a/src/main/webapp/app/localci/build-agents/build-agents.service.ts
+++ b/src/main/webapp/app/localci/build-agents/build-agents.service.ts
@@ -33,9 +33,20 @@ export class BuildAgentsService {
      */
     pauseBuildAgent(agentName: string): Observable<void> {
         const encodedAgentName = encodeURIComponent(agentName);
-        return this.http.put<void>(`${this.adminResourceUrl}/agent/${encodedAgentName}/pause`, null).pipe(
+        return this.http.put<void>(`${this.adminResourceUrl}/agents/${encodedAgentName}/pause`, null).pipe(
             catchError((err) => {
                 return throwError(() => new Error(`Failed to pause build agent ${agentName}\n${err.message}`));
+            }),
+        );
+    }
+
+    /**
+     * Pause All Build Agents
+     */
+    pauseAllBuildAgents(): Observable<void> {
+        return this.http.put<void>(`${this.adminResourceUrl}/agents/pause-all`, null).pipe(
+            catchError((err) => {
+                return throwError(() => new Error(`Failed to pause build agents\n${err.message}`));
             }),
         );
     }
@@ -45,9 +56,20 @@ export class BuildAgentsService {
      */
     resumeBuildAgent(agentName: string): Observable<void> {
         const encodedAgentName = encodeURIComponent(agentName);
-        return this.http.put<void>(`${this.adminResourceUrl}/agent/${encodedAgentName}/resume`, null).pipe(
+        return this.http.put<void>(`${this.adminResourceUrl}/agents/${encodedAgentName}/resume`, null).pipe(
             catchError((err) => {
                 return throwError(() => new Error(`Failed to resume build agent ${agentName}\n${err.message}`));
+            }),
+        );
+    }
+
+    /**
+     * Resume all Build Agents
+     */
+    resumeAllBuildAgents(): Observable<void> {
+        return this.http.put<void>(`${this.adminResourceUrl}/agents/resume-all`, null).pipe(
+            catchError((err) => {
+                return throwError(() => new Error(`Failed to resume build agents\n${err.message}`));
             }),
         );
     }

--- a/src/main/webapp/i18n/de/buildAgents.json
+++ b/src/main/webapp/i18n/de/buildAgents.json
@@ -22,10 +22,15 @@
                 "buildAgentResumed": "Anfrage zum Fortsetzen des BuildJobs erfolgreich gesendet. Der Agent wird wieder neue BuildJobs annehmen.",
                 "buildAgentPauseFailed": "Anhalten des Build-Agenten fehlgeschlagen.",
                 "buildAgentResumeFailed": "Fortsetzen des Build-Agenten fehlgeschlagen.",
-                "buildAgentWithoutName": "Der Name des Build-Agenten ist erforderlich."
+                "buildAgentWithoutName": "Der Name des Build-Agenten ist erforderlich.",
+                "buildAgentsPaused": "Anfrage zum Anhalten aller Build-Agenten erfolgreich gesendet. Die Agenten akzeptieren keine neuen Build-Jobs und werden die aktuellen Build-Jobs entweder ordnungsgemäß beenden oder nach einer konfigurierbaren Anzahl von Sekunden abbrechen.",
+                "buildAgentsResumed": "Anfrage zum Fortsetzen aller Build-Agenten erfolgreich gesendet. Die Agenten werden wieder neue Build-Jobs annehmen."
             },
             "pause": "Anhalten",
-            "resume": "Fortsetzen"
+            "resume": "Fortsetzen",
+            "pauseAll": "Alle Agenten Anhalten",
+            "resumeAll": "Alle Agenten fortsetzen",
+            "pauseAllWarning": "Du bist dabei, alle Build-Agenten anzuhalten. Dies wird verhindern, dass sie neue Build-Jobs verarbeiten.\nBist du sicher, dass du fortfahren möchtest?"
         }
     }
 }

--- a/src/main/webapp/i18n/en/buildAgents.json
+++ b/src/main/webapp/i18n/en/buildAgents.json
@@ -20,12 +20,17 @@
             "alerts": {
                 "buildAgentPaused": "Build agent pause request sent successfully. The agent will not accept new build jobs and will gracefully finish the current build jobs or will cancel them after a configurable seconds.",
                 "buildAgentResumed": "Build agent resume request sent successfully. The agent will start accepting new build jobs.",
-                "buildAgentPauseFailed": "Failed to pause the build agent.",
-                "buildAgentResumeFailed": "Failed to resume the build agent.",
-                "buildAgentWithoutName": "Build agent name is required."
+                "buildAgentPauseFailed": "Failed to pause build agent.",
+                "buildAgentResumeFailed": "Failed to resume build agent.",
+                "buildAgentWithoutName": "Build agent name is required.",
+                "buildAgentsPaused": "Pause request sent to all build agents. The agents will not accept new build jobs and will gracefully finish the current build jobs or will cancel them after a configurable seconds.",
+                "buildAgentsResumed": "Resume request sent to all build agents. The agents will start accepting new build jobs."
             },
             "pause": "Pause",
-            "resume": "Resume"
+            "resume": "Resume",
+            "pauseAll": "Pause All Agents",
+            "resumeAll": "Resume All Agents",
+            "pauseAllWarning": "You are about to pause all build agents. This will prevent them from processing any new build jobs.\nAre you sure you want to proceed?"
         }
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalCIResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalCIResourceIntegrationTest.java
@@ -364,10 +364,29 @@ class LocalCIResourceIntegrationTest extends AbstractProgrammingIntegrationLocal
         // We need to clear the processing jobs to avoid the agent being set to ACTIVE again
         processingJobs.clear();
 
-        request.put("/api/admin/agent/" + URLEncoder.encode(agent1.buildAgent().name(), StandardCharsets.UTF_8) + "/pause", null, HttpStatus.NO_CONTENT);
+        request.put("/api/admin/agents/" + URLEncoder.encode(agent1.buildAgent().name(), StandardCharsets.UTF_8) + "/pause", null, HttpStatus.NO_CONTENT);
         await().until(() -> buildAgentInformation.get(agent1.buildAgent().memberAddress()).status() == BuildAgentInformation.BuildAgentStatus.PAUSED);
 
-        request.put("/api/admin/agent/" + URLEncoder.encode(agent1.buildAgent().name(), StandardCharsets.UTF_8) + "/resume", null, HttpStatus.NO_CONTENT);
+        request.put("/api/admin/agents/" + URLEncoder.encode(agent1.buildAgent().name(), StandardCharsets.UTF_8) + "/resume", null, HttpStatus.NO_CONTENT);
         await().until(() -> buildAgentInformation.get(agent1.buildAgent().memberAddress()).status() == BuildAgentInformation.BuildAgentStatus.IDLE);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
+    void testPauseAllBuildAgents() throws Exception {
+        // We need to clear the processing jobs to avoid the agent being set to ACTIVE again
+        processingJobs.clear();
+
+        request.put("/api/admin/agents/pause-all", null, HttpStatus.NO_CONTENT);
+        await().until(() -> {
+            var agents = buildAgentInformation.values();
+            return agents.stream().allMatch(agent -> agent.status() == BuildAgentInformation.BuildAgentStatus.PAUSED);
+        });
+
+        request.put("/api/admin/agents/resume-all", null, HttpStatus.NO_CONTENT);
+        await().until(() -> {
+            var agents = buildAgentInformation.values();
+            return agents.stream().allMatch(agent -> agent.status() == BuildAgentInformation.BuildAgentStatus.IDLE);
+        });
     }
 }

--- a/src/test/javascript/spec/component/localci/build-agents/build-agents.service.spec.ts
+++ b/src/test/javascript/spec/component/localci/build-agents/build-agents.service.spec.ts
@@ -134,7 +134,7 @@ describe('BuildAgentsService', () => {
     it('should pause build agent', () => {
         service.pauseBuildAgent('buildAgent1').subscribe();
 
-        const req = httpMock.expectOne(`${service.adminResourceUrl}/agent/buildAgent1/pause`);
+        const req = httpMock.expectOne(`${service.adminResourceUrl}/agents/buildAgent1/pause`);
         expect(req.request.method).toBe('PUT');
         req.flush({});
     });
@@ -142,7 +142,23 @@ describe('BuildAgentsService', () => {
     it('should resume build agent', () => {
         service.resumeBuildAgent('buildAgent1').subscribe();
 
-        const req = httpMock.expectOne(`${service.adminResourceUrl}/agent/buildAgent1/resume`);
+        const req = httpMock.expectOne(`${service.adminResourceUrl}/agents/buildAgent1/resume`);
+        expect(req.request.method).toBe('PUT');
+        req.flush({});
+    });
+
+    it('should pause all build agents', () => {
+        service.pauseAllBuildAgents().subscribe();
+
+        const req = httpMock.expectOne(`${service.adminResourceUrl}/agents/pause-all`);
+        expect(req.request.method).toBe('PUT');
+        req.flush({});
+    });
+
+    it('should resume all build agents', () => {
+        service.resumeAllBuildAgents().subscribe();
+
+        const req = httpMock.expectOne(`${service.adminResourceUrl}/agents/resume-all`);
         expect(req.request.method).toBe('PUT');
         req.flush({});
     });
@@ -152,7 +168,7 @@ describe('BuildAgentsService', () => {
 
         const observable = lastValueFrom(service.pauseBuildAgent('buildAgent1'));
 
-        const req = httpMock.expectOne(`${service.adminResourceUrl}/agent/buildAgent1/pause`);
+        const req = httpMock.expectOne(`${service.adminResourceUrl}/agents/buildAgent1/pause`);
         expect(req.request.method).toBe('PUT');
         req.flush({ message: errorMessage }, { status: 500, statusText: 'Internal Server Error' });
 
@@ -170,7 +186,42 @@ describe('BuildAgentsService', () => {
         const observable = lastValueFrom(service.resumeBuildAgent('buildAgent1'));
 
         // Set up the expected HTTP request and flush the response with an error.
-        const req = httpMock.expectOne(`${service.adminResourceUrl}/agent/buildAgent1/resume`);
+        const req = httpMock.expectOne(`${service.adminResourceUrl}/agents/buildAgent1/resume`);
+        expect(req.request.method).toBe('PUT');
+        req.flush({ message: errorMessage }, { status: 500, statusText: 'Internal Server Error' });
+
+        try {
+            await observable;
+            throw new Error('expected an error, but got a success');
+        } catch (error) {
+            expect(error.message).toContain(errorMessage);
+        }
+    });
+
+    it('should handle pause all build agents error', async () => {
+        const errorMessage = 'Failed to pause build agents';
+
+        const observable = lastValueFrom(service.pauseAllBuildAgents());
+
+        const req = httpMock.expectOne(`${service.adminResourceUrl}/agents/pause-all`);
+        expect(req.request.method).toBe('PUT');
+        req.flush({ message: errorMessage }, { status: 500, statusText: 'Internal Server Error' });
+
+        try {
+            await observable;
+            throw new Error('expected an error, but got a success');
+        } catch (error) {
+            expect(error.message).toContain(errorMessage);
+        }
+    });
+
+    it('should handle resume all build agents error', async () => {
+        const errorMessage = 'Failed to resume build agents';
+
+        const observable = lastValueFrom(service.resumeAllBuildAgents());
+
+        // Set up the expected HTTP request and flush the response with an error.
+        const req = httpMock.expectOne(`${service.adminResourceUrl}/agents/resume-all`);
         expect(req.request.method).toBe('PUT');
         req.flush({ message: errorMessage }, { status: 500, statusText: 'Internal Server Error' });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


We want to give admins the possibility to pause all agents with a simple click


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Admin
- Test server 3

1. Navigate to build agents.
2. Try to pause and resume build agents.
3. Try to pause individual agents and then resume all agents.
4. Try to mess around with pause, resume individual/all build agents

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- The line coverage must be above 90% for changes files and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Use the table below and confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate one from the corresponding Bamboo build plan artefacts. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/user-attachments/assets/a6bfdae6-6df4-4b01-bf66-4e5c744966f7)

![image](https://github.com/user-attachments/assets/e9b59b1d-9c41-41d3-89a8-6226de4748e1)

![image](https://github.com/user-attachments/assets/f1fe61d0-6cdf-4fe6-8369-8133d38510c6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced endpoints for pausing and resuming all build agents.
  - Added buttons for pausing and resuming all agents with confirmation modals in the UI.
  - Enhanced localization with new alert messages for bulk operations.
  - Implemented user feedback alerts for success and error scenarios when managing build agents.

- **Bug Fixes**
  - Updated URL paths for pausing and resuming individual agents to ensure consistency.

- **Documentation**
  - Improved user interface text for clarity regarding build agent management actions.

- **Tests**
  - Expanded test coverage for new features, including success and error scenarios for pausing and resuming all agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->