### PR TITLE
`Adaptive learning`: Improve competency student view

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CourseCompetencyRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CourseCompetencyRepository.java
@@ -300,6 +300,7 @@ public interface CourseCompetencyRepository extends ArtemisJpaRepository<CourseC
             FROM CourseCompetency c
             WHERE c.course.id = :courseId
                 AND (SIZE(c.lectureUnitLinks) > 0 OR SIZE(c.exerciseLinks) > 0)
+            ORDER BY c.id
             """)
     List<CourseCompetency> findByCourseIdAndLinkedToLearningObjectOrderById(@Param("courseId") long courseId);
 

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CourseCompetencyRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CourseCompetencyRepository.java
@@ -295,5 +295,13 @@ public interface CourseCompetencyRepository extends ArtemisJpaRepository<CourseC
 
     List<CourseCompetency> findByCourseIdOrderById(long courseId);
 
+    @Query("""
+            SELECT c
+            FROM CourseCompetency c
+            WHERE c.course.id = :courseId
+                AND (SIZE(c.lectureUnitLinks) > 0 OR SIZE(c.exerciseLinks) > 0)
+            """)
+    List<CourseCompetency> findByCourseIdAndLinkedToLearningObjectOrderById(@Param("courseId") long courseId);
+
     boolean existsByIdAndCourseId(long competencyId, long courseId);
 }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CourseCompetencyService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CourseCompetencyService.java
@@ -124,10 +124,17 @@ public class CourseCompetencyService {
      *
      * @param courseId The id of the course for which to fetch the competencies
      * @param userId   The id of the user for which to fetch the progress
+     * @param filter   Whether to filter out competencies that are not linked to any learning objects
      * @return The found competency
      */
-    public List<CourseCompetency> findCourseCompetenciesWithProgressForUserByCourseId(Long courseId, Long userId) {
-        List<CourseCompetency> competencies = courseCompetencyRepository.findByCourseIdOrderById(courseId);
+    public List<CourseCompetency> findCourseCompetenciesWithProgressForUserByCourseId(long courseId, long userId, boolean filter) {
+        List<CourseCompetency> competencies;
+        if (filter) {
+            competencies = courseCompetencyRepository.findByCourseIdAndLinkedToLearningObjectOrderById(courseId);
+        }
+        else {
+            competencies = courseCompetencyRepository.findByCourseIdOrderById(courseId);
+        }
         return findProgressForCompetenciesAndUser(competencies, userId);
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/web/CourseCompetencyResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/web/CourseCompetencyResource.java
@@ -167,10 +167,10 @@ public class CourseCompetencyResource {
      */
     @GetMapping("courses/{courseId}/course-competencies")
     @EnforceAtLeastStudentInCourse
-    public ResponseEntity<List<CourseCompetency>> getCourseCompetenciesWithProgress(@PathVariable long courseId) {
+    public ResponseEntity<List<CourseCompetency>> getCourseCompetenciesWithProgress(@PathVariable long courseId, @RequestParam(defaultValue = "false") boolean filter) {
         log.debug("REST request to get competencies for course with id: {}", courseId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
-        final var competencies = courseCompetencyService.findCourseCompetenciesWithProgressForUserByCourseId(courseId, user.getId());
+        final var competencies = courseCompetencyService.findCourseCompetenciesWithProgressForUserByCourseId(courseId, user.getId(), filter);
         return ResponseEntity.ok(competencies);
     }
 

--- a/src/main/webapp/app/course/competencies/course-competency.service.ts
+++ b/src/main/webapp/app/course/competencies/course-competency.service.ts
@@ -74,11 +74,13 @@ export class CourseCompetencyService {
             .set('semester', pageable.semester);
     }
 
-    getAllForCourse(courseId: number): Observable<EntityArrayResponseType> {
-        return this.httpClient.get<CourseCompetency[]>(`${this.resourceURL}/courses/${courseId}/course-competencies?filter=true`, { observe: 'response' }).pipe(
-            map((res: EntityArrayResponseType) => this.convertArrayResponseDatesFromServer(res)),
-            tap((res: EntityArrayResponseType) => res?.body?.forEach(this.sendTitlesToEntityTitleService.bind(this))),
-        );
+    getAllForCourse(courseId: number, filtered = false): Observable<EntityArrayResponseType> {
+        return this.httpClient
+            .get<CourseCompetency[]>(`${this.resourceURL}/courses/${courseId}/course-competencies${filtered ? '?filter=true' : ''}`, { observe: 'response' })
+            .pipe(
+                map((res: EntityArrayResponseType) => this.convertArrayResponseDatesFromServer(res)),
+                tap((res: EntityArrayResponseType) => res?.body?.forEach(this.sendTitlesToEntityTitleService.bind(this))),
+            );
     }
 
     getProgress(competencyId: number, courseId: number, refresh = false) {

--- a/src/main/webapp/app/course/competencies/course-competency.service.ts
+++ b/src/main/webapp/app/course/competencies/course-competency.service.ts
@@ -75,7 +75,7 @@ export class CourseCompetencyService {
     }
 
     getAllForCourse(courseId: number): Observable<EntityArrayResponseType> {
-        return this.httpClient.get<CourseCompetency[]>(`${this.resourceURL}/courses/${courseId}/course-competencies`, { observe: 'response' }).pipe(
+        return this.httpClient.get<CourseCompetency[]>(`${this.resourceURL}/courses/${courseId}/course-competencies?filter=true`, { observe: 'response' }).pipe(
             map((res: EntityArrayResponseType) => this.convertArrayResponseDatesFromServer(res)),
             tap((res: EntityArrayResponseType) => res?.body?.forEach(this.sendTitlesToEntityTitleService.bind(this))),
         );

--- a/src/main/webapp/app/entities/competency.model.ts
+++ b/src/main/webapp/app/entities/competency.model.ts
@@ -287,3 +287,24 @@ export function getMastery(competencyProgress: CompetencyProgress | undefined): 
     // clamp the value between 0 and 100
     return Math.min(100, Math.max(0, Math.round(getProgress(competencyProgress) * getConfidence(competencyProgress))));
 }
+
+/**
+ * Simple comparator for sorting competencies by their soft due date
+ * @param a The first competency
+ * @param b The second competency
+ */
+export function compareSoftDueDate(a: CourseCompetency, b: CourseCompetency): number {
+    if (a.softDueDate) {
+        if (b.softDueDate) {
+            if (a.softDueDate.isSame(b.softDueDate)) {
+                return 0;
+            }
+            return a.softDueDate.isBefore(b.softDueDate) ? -1 : 1;
+        }
+        return -1;
+    }
+    if (b.softDueDate) {
+        return 1;
+    }
+    return 0;
+}

--- a/src/main/webapp/app/overview/course-competencies/course-competencies.component.ts
+++ b/src/main/webapp/app/overview/course-competencies/course-competencies.component.ts
@@ -86,7 +86,7 @@ export class CourseCompetenciesComponent implements OnInit, OnDestroy {
     loadData() {
         this.isLoading = true;
 
-        const courseCompetencyObservable = this.courseCompetencyService.getAllForCourse(this.courseId);
+        const courseCompetencyObservable = this.courseCompetencyService.getAllForCourse(this.courseId, true);
         const competencyJolObservable = this.judgementOfLearningEnabled ? this.courseCompetencyService.getJoLAllForCourse(this.courseId) : of(undefined);
 
         forkJoin([courseCompetencyObservable, competencyJolObservable]).subscribe({

--- a/src/main/webapp/app/overview/course-competencies/course-competencies.component.ts
+++ b/src/main/webapp/app/overview/course-competencies/course-competencies.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { AlertService } from 'app/core/util/alert.service';
 import { onError } from 'app/shared/util/global.utils';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Competency, CompetencyJol, CourseCompetencyType, getMastery } from 'app/entities/competency.model';
+import { Competency, CompetencyJol, CourseCompetencyType, compareSoftDueDate, getMastery } from 'app/entities/competency.model';
 import { Subscription, forkJoin, of } from 'rxjs';
 import { Course } from 'app/entities/course.model';
 import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
@@ -92,7 +92,7 @@ export class CourseCompetenciesComponent implements OnInit, OnDestroy {
         forkJoin([courseCompetencyObservable, competencyJolObservable]).subscribe({
             next: ([courseCompetencies, judgementOfLearningMap]) => {
                 const courseCompetenciesResponse = courseCompetencies.body ?? [];
-                this.competencies = courseCompetenciesResponse.filter((competency) => competency.type === CourseCompetencyType.COMPETENCY);
+                this.competencies = courseCompetenciesResponse.filter((competency) => competency.type === CourseCompetencyType.COMPETENCY).sort(compareSoftDueDate);
                 this.prerequisites = courseCompetenciesResponse.filter((competency) => competency.type === CourseCompetencyType.PREREQUISITE);
 
                 if (judgementOfLearningMap !== undefined) {

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/competency/AbstractCompetencyPrerequisiteIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/competency/AbstractCompetencyPrerequisiteIntegrationTest.java
@@ -225,6 +225,20 @@ abstract class AbstractCompetencyPrerequisiteIntegrationTest extends AbstractAtl
         assertThat(competenciesOfCourse.stream().filter(l -> l.getId().equals(newCompetency.getId())).findFirst().orElseThrow().getLectureUnitLinks()).isEmpty();
     }
 
+    abstract List<? extends CourseCompetency> getAllFilteredCall(long courseId, HttpStatus expectedStatus) throws Exception;
+
+    // Test
+    void shouldReturnCompetenciesForCourseFiltered(CourseCompetency newCompetency) throws Exception {
+        newCompetency.setTitle("Title");
+        newCompetency.setDescription("Description");
+        newCompetency.setCourse(course);
+        courseCompetencyRepository.save(newCompetency);
+
+        List<? extends CourseCompetency> competenciesOfCourse = getAllFilteredCall(course.getId(), HttpStatus.OK);
+
+        assertThat(competenciesOfCourse).noneMatch(c -> c.getId().equals(courseCompetency.getId()));
+    }
+
     // Test
     void testShouldReturnForbiddenForStudentNotInCourse() throws Exception {
         getAllCall(course.getId(), HttpStatus.FORBIDDEN);

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/competency/AbstractCompetencyPrerequisiteIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/competency/AbstractCompetencyPrerequisiteIntegrationTest.java
@@ -236,7 +236,7 @@ abstract class AbstractCompetencyPrerequisiteIntegrationTest extends AbstractAtl
 
         List<? extends CourseCompetency> competenciesOfCourse = getAllFilteredCall(course.getId(), HttpStatus.OK);
 
-        assertThat(competenciesOfCourse).noneMatch(c -> c.getId().equals(courseCompetency.getId()));
+        assertThat(competenciesOfCourse).noneMatch(c -> c.getId().equals(newCompetency.getId()));
     }
 
     // Test

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/competency/CompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/competency/CompetencyIntegrationTest.java
@@ -109,6 +109,11 @@ class CompetencyIntegrationTest extends AbstractCompetencyPrerequisiteIntegratio
         super.shouldReturnCompetenciesForCourse(new Competency());
     }
 
+    @Override
+    List<? extends CourseCompetency> getAllFilteredCall(long courseId, HttpStatus expectedStatus) throws Exception {
+        throw new UnsupportedOperationException("Not implemented for competencies");
+    }
+
     @Test
     @WithMockUser(username = TEST_PREFIX + "student42", roles = "USER")
     void testShouldReturnForbiddenForStudentNotInCourse() throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/competency/CourseCompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/competency/CourseCompetencyIntegrationTest.java
@@ -152,6 +152,17 @@ class CourseCompetencyIntegrationTest extends AbstractCompetencyPrerequisiteInte
         super.shouldReturnCompetenciesForCourse(new Competency());
     }
 
+    @Override
+    List<? extends CourseCompetency> getAllFilteredCall(long courseId, HttpStatus expectedStatus) throws Exception {
+        return request.getList("/api/courses/" + courseId + "/course-competencies?filtered=true", expectedStatus, CourseCompetency.class);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void shouldReturnCompetenciesForStudentOfCourseFiltered() throws Exception {
+        super.shouldReturnCompetenciesForCourseFiltered(new Competency());
+    }
+
     @Test
     @WithMockUser(username = TEST_PREFIX + "student42", roles = "USER")
     void testShouldReturnForbiddenForStudentNotInCourse() throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/competency/CourseCompetencyIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/competency/CourseCompetencyIntegrationTest.java
@@ -154,7 +154,7 @@ class CourseCompetencyIntegrationTest extends AbstractCompetencyPrerequisiteInte
 
     @Override
     List<? extends CourseCompetency> getAllFilteredCall(long courseId, HttpStatus expectedStatus) throws Exception {
-        return request.getList("/api/courses/" + courseId + "/course-competencies?filtered=true", expectedStatus, CourseCompetency.class);
+        return request.getList("/api/courses/" + courseId + "/course-competencies?filter=true", expectedStatus, CourseCompetency.class);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/competency/PrerequisiteIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/competency/PrerequisiteIntegrationTest.java
@@ -109,6 +109,11 @@ class PrerequisiteIntegrationTest extends AbstractCompetencyPrerequisiteIntegrat
         super.shouldReturnCompetenciesForCourse(new Prerequisite());
     }
 
+    @Override
+    List<? extends CourseCompetency> getAllFilteredCall(long courseId, HttpStatus expectedStatus) throws Exception {
+        throw new UnsupportedOperationException("Not implemented for prerequisites");
+    }
+
     @Test
     @WithMockUser(username = TEST_PREFIX + "student42", roles = "USER")
     void shouldReturnCompetenciesForStudentNotInCourse() throws Exception {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The student view of competencies shows competencies that are not linked to any resources. Furthermore the order of the competencies might be confusing.

### Description
<!-- Describe your changes in detail -->
- Adjusted endpoint to support request param to filter out competencies without existing exercise or lecture unit links
- Client: Sort list of competency in student view by due date

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Students
- at least one exercise / lecture unit
- at least 4 competencies
1. Competency *without* due date but linked to exercise / lecture unit
2. Competency with due date and linked to exercise / lecture unit
3. Competency with due date and linked to exercise / lecture unit
4. Competency that is not linked to any exercise / lecture unit

1. Log in to Artemis
2. Navigate to Course Competencies
3. You should *not* see the Competency that isn't linked to any exercise / lecture unit
4. You should see all the other competencies ordered by the due date (earliest first, no due date last)

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to filter course competencies based on their linkage to learning objects.
	- Added functionality to retrieve filtered course competencies in the user interface.
	- Implemented sorting of competencies by their due dates.
	- Enhanced the ability to retrieve competencies with additional filtering options.

- **Bug Fixes**
	- Enhanced filtering logic to ensure accurate retrieval of competencies.

- **Tests**
	- Expanded test coverage for filtered competency retrieval scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->