### PR TITLE
`Development`: Fix a flaky e2e test where the instructor edits a channel

### DIFF
--- a/src/test/playwright/e2e/course/CourseMessages.spec.ts
+++ b/src/test/playwright/e2e/course/CourseMessages.spec.ts
@@ -148,6 +148,7 @@ test.describe('Course messages', { tag: '@fast' }, () => {
                 await courseMessages.editDescription('New Description');
                 await courseMessages.closeEditPanel();
                 await page.reload();
+                await page.locator('jhi-conversation-header').waitFor({ state: 'visible', timeout: 10000 });
                 await expect(courseMessages.getName()).toContainText(newName);
                 await expect(courseMessages.getTopic()).toContainText(topic);
             });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
"Instructor should be able to edit a channel" test is flaky and sometimes fails on [multi-node build plan](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AEPAEPTMLM). The reason is the header of conversation page sometimes loading longer than expected.

### Description
This PR adds a waiting for the header of conversation page with additional timeout - 10 seconds (instead of default 5 seconds) and starts asserting its elements only after it's loaded and visible to user.

### Steps for Testing
- **Code Review**: Ensure that test passes for valid reasons and improvements make sense.
- **CI testing**: Check that all tests pass on both [single-node](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AEPTMA1213) and [multi-node](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AEPAEPTMLM) Artemis Bamboo builds.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of channel editing tests by adding a wait condition for the visibility of the conversation header, addressing potential timing issues.

- **Tests**
	- Enhanced the robustness of the test suite without altering existing test logic or flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->