### PR TITLE
`Communication`: Fix an issue with list formatting in Markdown

### DIFF
--- a/src/main/webapp/app/shared/metis/posting-content/posting-content-part/posting-content-part.components.ts
+++ b/src/main/webapp/app/shared/metis/posting-content/posting-content-part/posting-content-part.components.ts
@@ -76,15 +76,21 @@ export class PostingContentPartComponent implements OnInit {
     processContent() {
         if (this.postingContentPart.contentBeforeReference) {
             this.processedContentBeforeReference = this.escapeNumberedList(this.postingContentPart.contentBeforeReference);
+            this.processedContentBeforeReference = this.escapeUnorderedList(this.processedContentBeforeReference);
         }
 
         if (this.postingContentPart.contentAfterReference) {
             this.processedContentAfterReference = this.escapeNumberedList(this.postingContentPart.contentAfterReference);
+            this.processedContentAfterReference = this.escapeUnorderedList(this.processedContentAfterReference);
         }
     }
 
     escapeNumberedList(content: string): string {
-        return content.replace(/^(\s*\d+)\. /gm, '$1\\. ');
+        return content.replace(/^(\s*\d+)\. /gm, '$1\\.  ');
+    }
+
+    escapeUnorderedList(content: string): string {
+        return content.replace(/^(- )/gm, '\\$1');
     }
 
     /**

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
@@ -126,7 +126,7 @@ export class PostingMarkdownEditorComponent implements OnInit, ControlValueAcces
 
         const editor = this.markdownEditor.monacoEditor;
         if (editor) {
-            editor.onDidChangeModelContent((event: { changes: string | any[] }) => {
+            editor.onDidChangeModelContent((event: monaco.editor.IModelContentChangedEvent) => {
                 const position = editor.getPosition();
                 if (!position) {
                     return;

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
@@ -15,6 +15,7 @@ import {
     inject,
     input,
 } from '@angular/core';
+import monaco from 'monaco-editor';
 import { ViewContainerRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MetisService } from 'app/shared/metis/metis.service';
@@ -122,6 +123,43 @@ export class PostingMarkdownEditorComponent implements OnInit, ControlValueAcces
 
     ngAfterViewInit(): void {
         this.markdownEditor.enableTextFieldMode();
+
+        const editor = this.markdownEditor.monacoEditor;
+        if (editor) {
+            if (editor) {
+                editor.onDidChangeModelContent((event: { changes: string | any[] }) => {
+                    const position = editor.getPosition();
+                    if (!position) {
+                        return;
+                    }
+
+                    const model = editor.getModel();
+                    if (!model) {
+                        return;
+                    }
+
+                    const lineContent = model.getLineContent(position.lineNumber).trimStart();
+                    const hasPrefix = lineContent.startsWith('- ') || /^\s*1\. /.test(lineContent);
+                    if (hasPrefix && event.changes.length === 1 && (event.changes[0].text.startsWith('- ') || event.changes[0].text.startsWith('1. '))) {
+                        return;
+                    }
+
+                    if (hasPrefix) {
+                        this.handleKeyDown(model, position.lineNumber);
+                    }
+                });
+            }
+        }
+    }
+
+    private handleKeyDown(model: monaco.editor.ITextModel, lineNumber: number): void {
+        const lineContent = model.getLineContent(lineNumber).trimStart();
+
+        if (lineContent.startsWith('- ')) {
+            this.markdownEditor.handleActionClick(new MouseEvent('click'), this.defaultActions.find((action) => action instanceof BulletedListAction)!);
+        } else if (/^\d+\. /.test(lineContent)) {
+            this.markdownEditor.handleActionClick(new MouseEvent('click'), this.defaultActions.find((action) => action instanceof OrderedListAction)!);
+        }
     }
 
     /**

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
@@ -126,29 +126,27 @@ export class PostingMarkdownEditorComponent implements OnInit, ControlValueAcces
 
         const editor = this.markdownEditor.monacoEditor;
         if (editor) {
-            if (editor) {
-                editor.onDidChangeModelContent((event: { changes: string | any[] }) => {
-                    const position = editor.getPosition();
-                    if (!position) {
-                        return;
-                    }
+            editor.onDidChangeModelContent((event: { changes: string | any[] }) => {
+                const position = editor.getPosition();
+                if (!position) {
+                    return;
+                }
 
-                    const model = editor.getModel();
-                    if (!model) {
-                        return;
-                    }
+                const model = editor.getModel();
+                if (!model) {
+                    return;
+                }
 
-                    const lineContent = model.getLineContent(position.lineNumber).trimStart();
-                    const hasPrefix = lineContent.startsWith('- ') || /^\s*1\. /.test(lineContent);
-                    if (hasPrefix && event.changes.length === 1 && (event.changes[0].text.startsWith('- ') || event.changes[0].text.startsWith('1. '))) {
-                        return;
-                    }
+                const lineContent = model.getLineContent(position.lineNumber).trimStart();
+                const hasPrefix = lineContent.startsWith('- ') || /^\s*1\. /.test(lineContent);
+                if (hasPrefix && event.changes.length === 1 && (event.changes[0].text.startsWith('- ') || event.changes[0].text.startsWith('1. '))) {
+                    return;
+                }
 
-                    if (hasPrefix) {
-                        this.handleKeyDown(model, position.lineNumber);
-                    }
-                });
-            }
+                if (hasPrefix) {
+                    this.handleKeyDown(model, position.lineNumber);
+                }
+            });
         }
     }
 

--- a/src/main/webapp/app/shared/monaco-editor/model/actions/bulleted-list.action.ts
+++ b/src/main/webapp/app/shared/monaco-editor/model/actions/bulleted-list.action.ts
@@ -1,7 +1,7 @@
 import { faListUl } from '@fortawesome/free-solid-svg-icons';
 import { ListAction } from './list.action';
 
-const BULLET_PREFIX = '•  ';
+const BULLET_PREFIX = '- ';
 
 /**
  * Action used to add or modify a bullet-point list in the text editor.

--- a/src/main/webapp/app/shared/monaco-editor/model/actions/list.action.ts
+++ b/src/main/webapp/app/shared/monaco-editor/model/actions/list.action.ts
@@ -37,7 +37,7 @@ export abstract class ListAction extends TextEditorAction {
      */
     protected stripAnyListPrefix(line: string): string {
         const numberedListRegex = /^\s*\d+\.\s+/;
-        const bulletListRegex = /^\s*[-*+•]\s+/;
+        const bulletListRegex = /^\s*[-*+]\s+/;
 
         if (numberedListRegex.test(line)) {
             return line.replace(numberedListRegex, '');
@@ -91,10 +91,13 @@ export abstract class ListAction extends TextEditorAction {
             }
 
             if (position.getColumn() === currentLineText.length + 1) {
-                const lineWithoutPrefix = this.stripAnyListPrefix(currentLineText);
                 const newPrefix = this.getPrefix(1);
 
-                const updatedLine = currentLineText.startsWith(newPrefix) ? lineWithoutPrefix : newPrefix + lineWithoutPrefix;
+                if (currentLineText.startsWith(newPrefix)) {
+                    return;
+                }
+
+                const updatedLine = newPrefix + currentLineText;
 
                 editor.replaceTextAtRange(
                     new TextEditorRange(new TextEditorPosition(position.getLineNumber(), 1), new TextEditorPosition(position.getLineNumber(), currentLineText.length + 1)),
@@ -110,7 +113,7 @@ export abstract class ListAction extends TextEditorAction {
 
         // Determine if all lines have the current prefix
         let allLinesHaveCurrentPrefix;
-        if (this.getPrefix(1) != '•  ') {
+        if (this.getPrefix(1) != '- ') {
             const numberedListRegex = /^\s*\d+\.\s+/;
             allLinesHaveCurrentPrefix = lines.every((line) => numberedListRegex.test(line));
         } else {
@@ -124,7 +127,7 @@ export abstract class ListAction extends TextEditorAction {
             const linesWithoutPrefix = lines.map((line) => this.stripAnyListPrefix(line));
 
             updatedLines = linesWithoutPrefix.map((line, index) => {
-                const prefix = this.getPrefix(index) != '•  ' ? this.getPrefix(index + 1) : this.getPrefix(startLineNumber + index);
+                const prefix = this.getPrefix(index) != '- ' ? this.getPrefix(index + 1) : this.getPrefix(startLineNumber + index);
                 return prefix + line;
             });
         }
@@ -141,7 +144,7 @@ export abstract class ListAction extends TextEditorAction {
      */
     protected hasPrefix(line: string): boolean {
         const numberedListRegex = /^\s*\d+\.\s+/;
-        const bulletListRegex = /^\s*[•\-*+]\s+/;
+        const bulletListRegex = /^\s*[-\-*+]\s+/;
         return numberedListRegex.test(line) || bulletListRegex.test(line);
     }
 
@@ -162,9 +165,9 @@ export abstract class ListAction extends TextEditorAction {
                 if (isNumbered) {
                     const match = currentLineText.match(/^\s*(\d+)\.\s+/);
                     const currentNumber = match ? parseInt(match[1], 10) : 0;
-                    nextLinePrefix = `${currentNumber + 1}.  `;
+                    nextLinePrefix = `${currentNumber + 1}. `;
                 } else {
-                    nextLinePrefix = '•  ';
+                    nextLinePrefix = '- ';
                 }
             }
 
@@ -187,7 +190,7 @@ export abstract class ListAction extends TextEditorAction {
         if (position) {
             const lineNumber = position.getLineNumber();
             const lineContent = editor.getLineText(lineNumber);
-            const linePrefixMatch = lineContent.match(/^\s*(\d+\.\s+|[-*+•]\s+)/);
+            const linePrefixMatch = lineContent.match(/^\s*(\d+\.\s+|[-*+]\s+)/);
 
             if (linePrefixMatch) {
                 const prefixLength = linePrefixMatch[0].length;

--- a/src/main/webapp/app/shared/monaco-editor/model/actions/ordered-list.action.ts
+++ b/src/main/webapp/app/shared/monaco-editor/model/actions/ordered-list.action.ts
@@ -12,7 +12,7 @@ export class OrderedListAction extends ListAction {
     }
 
     public getPrefix(lineNumber: number): string {
-        const space = lineNumber >= 10 ? ' ' : '  ';
+        const space = ' ';
         return `${lineNumber}.${space}`;
     }
 

--- a/src/main/webapp/app/shared/monaco-editor/monaco-editor.component.ts
+++ b/src/main/webapp/app/shared/monaco-editor/monaco-editor.component.ts
@@ -118,6 +118,19 @@ export class MonacoEditorComponent implements OnInit, OnDestroy {
         return convertedWords.join(' ');
     }
 
+    public onDidChangeModelContent(listener: (event: monaco.editor.IModelContentChangedEvent) => void): monaco.IDisposable {
+        return this._editor.onDidChangeModelContent(listener);
+    }
+
+    public getModel() {
+        return this._editor.getModel();
+    }
+
+    public getLineContent(lineNumber: number): string {
+        const model = this._editor.getModel();
+        return model ? model.getLineContent(lineNumber) : '';
+    }
+
     ngOnInit(): void {
         const resizeObserver = new ResizeObserver(() => {
             this._editor.layout();

--- a/src/test/javascript/spec/component/shared/metis/posting-content/posting-content-part.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/posting-content/posting-content-part.component.spec.ts
@@ -270,4 +270,50 @@ describe('PostingContentPartComponent', () => {
             expect(outputEmitter).not.toHaveBeenCalled();
         });
     });
+
+    describe('Content processing', () => {
+        it('should process content before and after reference with escaped numbered and unordered lists', () => {
+            const contentBefore = '1. This is a numbered list\n2. Another item\n- This is an unordered list';
+            const contentAfter = '1. Numbered again\n- Unordered again';
+            component.postingContentPart = {
+                contentBeforeReference: contentBefore,
+                contentAfterReference: contentAfter,
+                linkToReference: undefined,
+                queryParams: undefined,
+                referenceStr: undefined,
+            } as PostingContentPart;
+            fixture.detectChanges();
+
+            component.processContent();
+
+            expect(component.processedContentBeforeReference).toBe('1\\.  This is a numbered list\n2\\.  Another item\n\\- This is an unordered list');
+            expect(component.processedContentAfterReference).toBe('1\\.  Numbered again\n\\- Unordered again');
+        });
+
+        it('should escape numbered lists correctly', () => {
+            const content = '1. First item\n2. Second item\n3. Third item';
+            const escapedContent = component.escapeNumberedList(content);
+            expect(escapedContent).toBe('1\\.  First item\n2\\.  Second item\n3\\.  Third item');
+        });
+
+        it('should escape unordered lists correctly', () => {
+            const content = '- First item\n- Second item\n- Third item';
+            const escapedContent = component.escapeUnorderedList(content);
+            expect(escapedContent).toBe('\\- First item\n\\- Second item\n\\- Third item');
+        });
+
+        it('should not escape text without numbered or unordered lists', () => {
+            const content = 'This is just a paragraph.\nAnother paragraph.';
+            const escapedNumbered = component.escapeNumberedList(content);
+            const escapedUnordered = component.escapeUnorderedList(content);
+            expect(escapedNumbered).toBe(content);
+            expect(escapedUnordered).toBe(content);
+        });
+
+        it('should handle mixed numbered and unordered lists in content', () => {
+            const content = '1. Numbered item\n- Unordered item\n2. Another numbered item\n- Another unordered item';
+            const escapedContent = component.escapeNumberedList(component.escapeUnorderedList(content));
+            expect(escapedContent).toBe('1\\.  Numbered item\n\\- Unordered item\n2\\.  Another numbered item\n\\- Another unordered item');
+        });
+    });
 });

--- a/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
@@ -37,6 +37,7 @@ import { TextEditorPosition } from 'app/shared/monaco-editor/model/actions/adapt
 import { BulletedListAction } from 'app/shared/monaco-editor/model/actions/bulleted-list.action';
 import { OrderedListAction } from 'app/shared/monaco-editor/model/actions/ordered-list.action';
 import { ListAction } from '../../../../../../../main/webapp/app/shared/monaco-editor/model/actions/list.action';
+import monaco from 'monaco-editor';
 
 describe('PostingsMarkdownEditor', () => {
     let component: PostingMarkdownEditorComponent;
@@ -124,6 +125,7 @@ describe('PostingsMarkdownEditor', () => {
                 MockProvider(ChannelService),
                 { provide: Overlay, useValue: mockOverlay },
                 { provide: OverlayPositionBuilder, useValue: overlayPositionBuilderMock },
+                { provide: MarkdownEditorMonacoComponent, useValue: mockMarkdownEditorComponent },
             ],
             declarations: [PostingMarkdownEditorComponent, MockComponent(MarkdownEditorMonacoComponent)],
         })
@@ -140,6 +142,8 @@ describe('PostingsMarkdownEditor', () => {
                 findLectureWithDetailsSpy.mockReturnValue(returnValue);
                 fixture.autoDetectChanges();
                 mockMarkdownEditorComponent = fixture.debugElement.query(By.directive(MarkdownEditorMonacoComponent)).componentInstance;
+                mockMarkdownEditorComponent.monacoEditor.getPosition = jest.fn();
+                mockMarkdownEditorComponent.monacoEditor.getModel = jest.fn();
                 component.ngOnInit();
                 component.content = metisPostExerciseUser1.content;
 
@@ -361,15 +365,15 @@ describe('PostingsMarkdownEditor', () => {
             getLineNumber: () => 1,
             getColumn: () => 6,
         } as TextEditorPosition);
-        mockEditor.getLineText.mockReturnValue('•  First line');
+        mockEditor.getLineText.mockReturnValue('- First line');
 
         bulletedListAction.run(mockEditor);
 
         const { preventDefaultSpy } = simulateKeydownEvent(mockEditor, 'Enter', { shiftKey: true });
 
         expect(preventDefaultSpy).toHaveBeenCalled();
-        expect(mockEditor.replaceTextAtRange).toHaveBeenCalledWith(expect.any(TextEditorRange), '\n•  ');
-        expect(mockEditor.setPosition).toHaveBeenCalledWith(new TextEditorPosition(2, 4));
+        expect(mockEditor.replaceTextAtRange).toHaveBeenCalledWith(expect.any(TextEditorRange), '\n- ');
+        expect(mockEditor.setPosition).toHaveBeenCalledWith(new TextEditorPosition(2, 3));
     });
 
     it('should handle Cmd+Enter correctly without inserting double line breaks', () => {
@@ -379,7 +383,7 @@ describe('PostingsMarkdownEditor', () => {
             getLineNumber: () => 1,
             getColumn: () => 6,
         } as TextEditorPosition);
-        mockEditor.getLineText.mockReturnValue('•  First line');
+        mockEditor.getLineText.mockReturnValue('- First line');
 
         bulletedListAction.run(mockEditor);
 
@@ -387,8 +391,8 @@ describe('PostingsMarkdownEditor', () => {
 
         expect(preventDefaultSpy).toHaveBeenCalled();
         expect(stopPropagationSpy).toHaveBeenCalled();
-        expect(mockEditor.replaceTextAtRange).toHaveBeenCalledWith(expect.any(TextEditorRange), '\n•  ');
-        expect(mockEditor.setPosition).toHaveBeenCalledWith(new TextEditorPosition(2, 4));
+        expect(mockEditor.replaceTextAtRange).toHaveBeenCalledWith(expect.any(TextEditorRange), '\n- ');
+        expect(mockEditor.setPosition).toHaveBeenCalledWith(new TextEditorPosition(2, 3));
     });
 
     const simulateListAction = (action: TextEditorAction, selectedText: string, expectedText: string, startLineNumber: number = 1) => {
@@ -437,14 +441,14 @@ describe('PostingsMarkdownEditor', () => {
     it('should add bulleted list prefixes correctly', () => {
         const bulletedListAction = component.defaultActions.find((action: any) => action instanceof BulletedListAction) as BulletedListAction;
         const selectedText = `First line\nSecond line\nThird line`;
-        const expectedText = `•  First line\n•  Second line\n•  Third line`;
+        const expectedText = `- First line\n- Second line\n- Third line`;
 
         simulateListAction(bulletedListAction, selectedText, expectedText);
     });
 
     it('should remove bulleted list prefixes correctly when toggled', () => {
         const bulletedListAction = component.defaultActions.find((action: any) => action instanceof BulletedListAction) as BulletedListAction;
-        const selectedText = `•  First line\n•  Second line\n•  Third line`;
+        const selectedText = `- First line\n- Second line\n- Third line`;
         const expectedText = `First line\nSecond line\nThird line`;
 
         simulateListAction(bulletedListAction, selectedText, expectedText);
@@ -453,7 +457,7 @@ describe('PostingsMarkdownEditor', () => {
     it('should add ordered list prefixes correctly starting from 1', () => {
         const orderedListAction = component.defaultActions.find((action: any) => action instanceof OrderedListAction) as OrderedListAction;
         const selectedText = `First line\nSecond line\nThird line`;
-        const expectedText = `1.  First line\n2.  Second line\n3.  Third line`;
+        const expectedText = `1. First line\n2. Second line\n3. Third line`;
 
         simulateListAction(orderedListAction, selectedText, expectedText);
     });
@@ -469,8 +473,8 @@ describe('PostingsMarkdownEditor', () => {
     it('should switch from bulleted list to ordered list correctly', () => {
         const bulletedListAction = component.defaultActions.find((action: any) => action instanceof BulletedListAction) as BulletedListAction;
         const orderedListAction = component.defaultActions.find((action: any) => action instanceof OrderedListAction) as OrderedListAction;
-        const bulletedText = `•  First line\n•  Second line\n•  Third line`;
-        const expectedOrderedText = `1.  First line\n2.  Second line\n3.  Third line`;
+        const bulletedText = `- First line\n- Second line\n- Third line`;
+        const expectedOrderedText = `1. First line\n2. Second line\n3. Third line`;
 
         simulateListAction(bulletedListAction, bulletedText, `First line\nSecond line\nThird line`);
 
@@ -482,7 +486,7 @@ describe('PostingsMarkdownEditor', () => {
         const orderedListAction = component.defaultActions.find((action: any) => action instanceof OrderedListAction) as OrderedListAction;
         const bulletedListAction = component.defaultActions.find((action: any) => action instanceof BulletedListAction) as BulletedListAction;
         const orderedText = `1.  First line\n2.  Second line\n3.  Third line`;
-        const expectedBulletedText = `•  First line\n•  Second line\n•  Third line`;
+        const expectedBulletedText = `- First line\n- Second line\n- Third line`;
 
         simulateListAction(orderedListAction, orderedText, `First line\nSecond line\nThird line`);
 
@@ -493,7 +497,7 @@ describe('PostingsMarkdownEditor', () => {
     it('should start ordered list numbering from 1 regardless of an inline list', () => {
         const orderedListAction = component.defaultActions.find((action: any) => action instanceof OrderedListAction) as OrderedListAction;
         const selectedText = `Some previous text\n1.  First line\n2.  Second line\n3.  Third line`;
-        const expectedText = `1.  Some previous text\n2.  First line\n3.  Second line\n4.  Third line`;
+        const expectedText = `1. Some previous text\n2. First line\n3. Second line\n4. Third line`;
 
         simulateListAction(orderedListAction, selectedText, expectedText);
     });
@@ -502,8 +506,8 @@ describe('PostingsMarkdownEditor', () => {
         const bulletedListAction = component.defaultActions.find((action: any) => action instanceof BulletedListAction) as BulletedListAction;
         const orderedListAction = component.defaultActions.find((action: any) => action instanceof OrderedListAction) as OrderedListAction;
 
-        const bulletedText = `•  First line\n•  Second line\n•  Third line`;
-        const expectedOrderedText = `1.  First line\n2.  Second line\n3.  Third line`;
+        const bulletedText = `- First line\n- Second line\n- Third line`;
+        const expectedOrderedText = `1. First line\n2. Second line\n3. Third line`;
 
         simulateListAction(bulletedListAction, `First line\nSecond line\nThird line`, bulletedText);
 
@@ -517,13 +521,13 @@ describe('PostingsMarkdownEditor', () => {
 
         const initialText = `First line\nSecond line\nThird line`;
 
-        const bulletedText = `•  First line\n•  Second line\n•  Third line`;
+        const bulletedText = `- First line\n- Second line\n- Third line`;
         simulateListAction(bulletedListAction, initialText, bulletedText);
 
         mockEditor.replaceTextAtRange.mockClear();
         simulateListAction(bulletedListAction, bulletedText, initialText);
 
-        const orderedText = `1.  First line\n2.  Second line\n3.  Third line`;
+        const orderedText = `1. First line\n2. Second line\n3. Third line`;
         mockEditor.replaceTextAtRange.mockClear();
         simulateListAction(orderedListAction, initialText, orderedText);
 
@@ -537,14 +541,31 @@ describe('PostingsMarkdownEditor', () => {
 
         const initialText = `First line\nSecond line\nThird line`;
 
-        const bulletedText = `•  First line\n•  Second line\n•  Third line`;
+        const bulletedText = `- First line\n- Second line\n- Third line`;
         simulateListAction(bulletedListAction, initialText, bulletedText);
 
-        const orderedText = `1.  First line\n2.  Second line\n3.  Third line`;
+        const orderedText = `1. First line\n2. Second line\n3. Third line`;
         mockEditor.replaceTextAtRange.mockClear();
         simulateListAction(orderedListAction, bulletedText, orderedText);
 
         mockEditor.replaceTextAtRange.mockClear();
         simulateListAction(bulletedListAction, orderedText, bulletedText);
+    });
+
+    it('should handle key down event and invoke the correct action', () => {
+        const bulletedListAction = new BulletedListAction();
+
+        component.defaultActions = [bulletedListAction];
+
+        const handleActionClickSpy = jest.spyOn(component.markdownEditor, 'handleActionClick');
+
+        const mockModel = {
+            getLineContent: jest.fn().mockReturnValue('- List item'),
+        } as unknown as monaco.editor.ITextModel;
+        const mockPosition = { lineNumber: 1 } as monaco.Position;
+
+        (component as any).handleKeyDown(mockModel, mockPosition.lineNumber);
+
+        expect(handleActionClickSpy).toHaveBeenCalledWith(expect.any(MouseEvent), bulletedListAction);
     });
 });

--- a/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
@@ -566,4 +566,15 @@ describe('PostingsMarkdownEditor', () => {
 
         expect(handleActionClickSpy).toHaveBeenCalledWith(expect.any(MouseEvent), bulletedListAction);
     });
+
+    it('should handle invalid line content gracefully', () => {
+        const mockModel = {
+            getLineContent: jest.fn().mockReturnValue(''),
+        } as unknown as monaco.editor.ITextModel;
+        const mockPosition = { lineNumber: 1 } as monaco.Position;
+        const handleActionClickSpy = jest.spyOn(component.markdownEditor, 'handleActionClick');
+
+        (component as any).handleKeyDown(mockModel, mockPosition.lineNumber);
+        expect(handleActionClickSpy).not.toHaveBeenCalled();
+    });
 });

--- a/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
@@ -142,8 +142,6 @@ describe('PostingsMarkdownEditor', () => {
                 findLectureWithDetailsSpy.mockReturnValue(returnValue);
                 fixture.autoDetectChanges();
                 mockMarkdownEditorComponent = fixture.debugElement.query(By.directive(MarkdownEditorMonacoComponent)).componentInstance;
-                mockMarkdownEditorComponent.monacoEditor.getPosition = jest.fn();
-                mockMarkdownEditorComponent.monacoEditor.getModel = jest.fn();
                 component.ngOnInit();
                 component.content = metisPostExerciseUser1.content;
 

--- a/src/test/javascript/spec/component/shared/monaco-editor/monaco-editor-action.integration.spec.ts
+++ b/src/test/javascript/spec/component/shared/monaco-editor/monaco-editor-action.integration.spec.ts
@@ -138,7 +138,7 @@ describe('MonacoEditorActionIntegration', () => {
         const action = new OrderedListAction();
         comp.registerAction(action);
         action.executeInCurrentEditor();
-        expect(comp.getText()).toBe('1.  ');
+        expect(comp.getText()).toBe('1. ');
     });
 
     it.each([1, 2, 3])('Should toggle heading %i on selected line', (headingLevel) => {

--- a/src/test/javascript/spec/component/shared/monaco-editor/monaco-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/monaco-editor/monaco-editor.component.spec.ts
@@ -313,4 +313,18 @@ describe('MonacoEditorComponent', () => {
         const lineContent = comp.getLineContent(2);
         expect(lineContent).toBe('static void main() {');
     });
+
+    it('should handle invalid line numbers in getLineContent', () => {
+        fixture.detectChanges();
+        comp.setText(multiLineText);
+
+        // Invalid line numbers
+        expect(() => comp.getLineContent(0)).toThrow();
+        expect(() => comp.getLineContent(-1)).toThrow();
+        expect(() => comp.getLineContent(999)).toThrow();
+
+        // Empty line
+        comp.setText('line1\n\nline3');
+        expect(comp.getLineContent(2)).toBe('');
+    });
 });

--- a/src/test/javascript/spec/component/shared/monaco-editor/monaco-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/monaco-editor/monaco-editor.component.spec.ts
@@ -289,4 +289,28 @@ describe('MonacoEditorComponent', () => {
         comp.setText(originalText);
         expect(comp.getText()).toBe(originalText);
     });
+
+    it('should register a listener for model content changes', () => {
+        const listenerStub = jest.fn();
+        fixture.detectChanges();
+        const disposable = comp.onDidChangeModelContent(listenerStub);
+        comp.setText(singleLineText);
+        expect(listenerStub).toHaveBeenCalled();
+        disposable.dispose();
+    });
+
+    it('should retrieve the editor model', () => {
+        fixture.detectChanges();
+        comp.setText(singleLineText);
+        const model = comp.getModel();
+        expect(model).not.toBeNull();
+        expect(model?.getValue()).toBe(singleLineText);
+    });
+
+    it('should get the content of a specific line', () => {
+        fixture.detectChanges();
+        comp.setText(multiLineText);
+        const lineContent = comp.getLineContent(2);
+        expect(lineContent).toBe('static void main() {');
+    });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [X] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [X] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Previously, the editor automatically added list prefixes (e.g., -, 1.) after selecting the list option. However, it did not automatically add a prefix when the previous line already contained one unless the user had pressed the list option button once before starting the list, unlike the behavior in Slack.
- The unordered list prefix character is incompatible with the iOS app, it needs to be changed from "• " to "- ". 
(Closes #9881)


### Description
<!-- Describe your changes in detail -->
- This change implements auto-prefixing for list creation. If the previous line contains a list prefix (e.g., -, 1.), the editor now automatically adds the same prefix to the next line, without requiring the user to manually select the list option. 
- The unordered list prefix character has been changed from "• " to "- ". 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor/Student
- 1 Course with Communication enabled

1. Log in to Artemis.
2. Navigate to the Communication section of a course.
3. Without selecting any list option, type something that starts with a list prefix, such as "- list item" or "1. list item."
4. Press Shift/Cmd + Enter to move to a new line and notice that the prefix is added automatically.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [X] Code Review 1
- [X] Code Review 2
#### Manual Tests
- [X] Test 1
- [X] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| posting-content-part.components.ts | 94.11% | ✅ ❌ |
| posting-markdown-editor.component.ts | 82.5% | ✅ ❌ |
| bulleted-list.action.ts | 100% | ✅ |
| list.action.ts | 76.92% | ✅ ❌ |
| ordered-list.action.ts | 100% | ✅ |
| monaco-editor.component.ts | 94.8% | ✅ ❌ |





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced content processing to support unordered lists in the editor.
  - Improved markdown editor functionality for dynamic list formatting based on user input.
  - New methods added to the Monaco editor component for better content management.

- **Bug Fixes**
  - Adjusted list prefix handling to ensure consistent representation in the text editor.

- **Tests**
  - Expanded test coverage for content processing, markdown editing, and Monaco editor interactions to ensure robustness and accuracy.
  - Added tests for handling model content changes and retrieving line content in the Monaco editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->