### PR TITLE
`Communication`: Fix padding issues in channel search and post components

### DIFF
--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.html
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.html
@@ -1,7 +1,7 @@
 @if (course) {
     <div class="py-3 pt-0 justify-content-center conversation-messages">
         <div class="justify-content-center">
-            <div class="row justify-content-center p-0">
+            <div class="justify-content-center px-3 py-0">
                 <!-- search bar -->
                 @if (!searchbarCollapsed) {
                     <div class="input-group ps-0" [class.search-active]="!!searchText">

--- a/src/main/webapp/app/shared/metis/post/post.component.html
+++ b/src/main/webapp/app/shared/metis/post/post.component.html
@@ -21,23 +21,23 @@
         </div>
     }
     <div class="align-items-center">
-        <div class="col">
-            <div>
+        <div>
+            <div class="post-context-information-wrap post-content-padding" [ngClass]="{ 'is-saved': isConsecutive() && posting.isSaved }">
                 @if (showAnnouncementIcon) {
                     <fa-icon
                         [icon]="faBullhorn"
                         iconSize="xs"
-                        class="col-auto pe-0 announcement-icon"
+                        class="pe-0 ms-1 announcement-icon"
                         [ngbTooltip]="'artemisApp.metis.post.postMarkedAsAnnouncementTooltip' | artemisTranslate"
                     />
                 }
                 <!-- in the course all-messages as well as in the preview mode during similarity check, the context (lecture, exercise, course-wide topic) is shown -->
                 <!-- not shown in course messages page -->
                 @if (showChannelReference && (pageType === PageType.OVERVIEW || previewMode)) {
-                    <span class="col-auto">
+                    <span>
                         @if (contextInformation.routerLinkComponents) {
                             <a
-                                class="linked-context-information post-content-padding ms-1"
+                                class="linked-context-information ms-1"
                                 [routerLink]="contextInformation.routerLinkComponents"
                                 [queryParams]="contextInformation.queryParams"
                                 (click)="onNavigateToContext($event)"
@@ -46,15 +46,15 @@
                             >
                         }
                         @if (!contextInformation.routerLinkComponents) {
-                            <span class="context-information post-content-padding ms-1">{{ contextInformation.displayName }}:</span>
+                            <span class="context-information ms-1">{{ contextInformation.displayName }}:</span>
                         }
                     </span>
                 }
                 <!-- post title not shown for plagiarism cases -->
                 @if (pageType !== PageType.PLAGIARISM_CASE_INSTRUCTOR && pageType !== PageType.PLAGIARISM_CASE_STUDENT) {
-                    <span class="col-auto">
+                    <span>
                         @if (posting.title?.length) {
-                            <span class="post-title post-content-padding ms-1">{{ posting.title }}</span>
+                            <span class="post-title ms-1">{{ posting.title }}</span>
                         }
                     </span>
                 }

--- a/src/main/webapp/app/shared/metis/post/post.component.scss
+++ b/src/main/webapp/app/shared/metis/post/post.component.scss
@@ -48,6 +48,7 @@
 .post-is-saved-message,
 .message-container,
 .post-reactions-bar,
+.post-context-information-wrap,
 .post {
     background-color: transparent;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, there are some padding issues when searching for announcement posts. This makes the search result look buggy:
<img width="454" alt="390392304-e2ae9c08-6eea-4a4b-aa26-7aebe9e88511" src="https://github.com/user-attachments/assets/9859fa4e-ac95-471b-bfb2-0717be36bfb1">

This was accompanied by another issue that consecutive announcements that were saved did not color the title accordingly:
<img width="944" alt="Bildschirmfoto 2024-12-02 um 09 47 35" src="https://github.com/user-attachments/assets/fbcfe10a-4fb0-4721-9e51-7713d9eaa524">

Lastly, also the channel internal search had some missing padding, making it look out-of-line with the other components:
![image](https://github.com/user-attachments/assets/226e0674-fad1-4ddd-9e18-eab0eeb90db2)


### Description
<!-- Describe your changes in detail -->
I added some padding to the search component and removed the padding at the announcement channel title and added the coloring to the background if saved.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 User
- 1 Course with communication enabled

1. Log into Artemis
2. Go to course
3. Go to the communication tab
4. Open a channel
5. Click on the channel-search button
6. Check if the search input is aligned with the other components
7. Search for a keyword within a announcement
8. Check if the channel title in the result is aligned with the message

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Announcement Title:
<img width="955" alt="Bildschirmfoto 2024-12-02 um 09 57 49" src="https://github.com/user-attachments/assets/03b73a8e-7c32-4055-9e43-3b52407ea95c">
Search input:
<img width="972" alt="Bildschirmfoto 2024-12-02 um 09 58 57" src="https://github.com/user-attachments/assets/c0e6d2d8-674d-4d5b-ac29-e77a2beb6eee">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced layout for the conversation messages and post components, improving user experience.
	- Introduced a new class for styling context information in posts.

- **Bug Fixes**
	- Adjusted padding and layout for the search bar section to ensure better visibility and usability.

- **Documentation**
	- Improved HTML structure for better readability and maintainability without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->