### PR TITLE
`Communication`: Improve design of hover area on messages

### DIFF
--- a/src/main/webapp/app/shared/metis/answer-post/answer-post.component.html
+++ b/src/main/webapp/app/shared/metis/answer-post/answer-post.component.html
@@ -1,11 +1,20 @@
-<div [id]="'item-' + posting.id" class="answer-post" [ngClass]="{ 'module-bg mt-2 rounded-2': isCommunicationPage, 'is-saved': !isConsecutive() && posting.isSaved }">
+<div
+    [id]="'item-' + posting.id"
+    class="answer-post hover-container"
+    [ngClass]="{ 'module-bg rounded-2': isCommunicationPage, 'is-saved': !isConsecutive() && posting.isSaved, 'non-consecutive': !isConsecutive() }"
+>
     @if (posting.isSaved) {
-        <div class="post-is-saved-message answer-post-content-margin fs-xx-small py-1" [ngClass]="{ 'is-saved': isConsecutive() && posting.isSaved }">
+        <div class="post-is-saved-message post-content-padding fs-xx-small py-1" [ngClass]="{ 'is-saved': isConsecutive() && posting.isSaved }">
             <div class="post-is-saved-message-content">
                 <fa-icon [icon]="faBookmark"></fa-icon>
                 <span class="text-secondary" jhiTranslate="artemisApp.metis.post.saved"></span>
             </div>
         </div>
+    }
+    @if (isConsecutive()) {
+        <span class="post-time fs-small" ngbTooltip="{{ posting.creationDate | artemisDate: 'time' }}">
+            {{ posting.creationDate | artemisDate: 'time' }}
+        </span>
     }
     @if (!isConsecutive()) {
         <div class="ps-3">
@@ -19,7 +28,7 @@
         </div>
     }
     @if (!createAnswerPostModal.isInputOpen) {
-        <div class="answer-post-content-margin message-container" [ngClass]="{ 'is-saved': isConsecutive() && posting.isSaved }" (contextmenu)="onRightClick($event)">
+        <div class="message-container post-content-padding" [ngClass]="{ 'is-saved': isConsecutive() && posting.isSaved }" (contextmenu)="onRightClick($event)">
             <div class="message-content" [class.force-hover]="showDropdown">
                 <jhi-posting-content
                     [content]="posting.content"
@@ -33,7 +42,7 @@
                     (userReferenceClicked)="userReferenceClicked.emit($event)"
                     (channelReferenceClicked)="channelReferenceClicked.emit($event)"
                 />
-                <div class="answer-post-content-margin hover-actions">
+                <div class="post-content-padding hover-actions">
                     <jhi-answer-post-reactions-bar
                         [isReadOnlyMode]="isReadOnlyMode"
                         [posting]="posting"
@@ -50,11 +59,11 @@
             </div>
         </div>
     }
-    <div class="answer-post-content-margin">
+    <div class="post-content-padding">
         <ng-container #createEditAnswerPostContainer />
     </div>
     @if (!isDeleted) {
-        <div class="answer-post-content-margin post-reactions-bar" [ngClass]="{ 'is-saved': posting.isSaved && isConsecutive() }" @fade>
+        <div class="post-content-padding post-reactions-bar" [ngClass]="{ 'is-saved': posting.isSaved && isConsecutive() }" @fade>
             <jhi-answer-post-reactions-bar
                 [isReadOnlyMode]="isReadOnlyMode"
                 [posting]="posting"

--- a/src/main/webapp/app/shared/metis/answer-post/answer-post.component.scss
+++ b/src/main/webapp/app/shared/metis/answer-post/answer-post.component.scss
@@ -54,7 +54,7 @@
 }
 
 .non-consecutive .hover-actions {
-    top: -3.5rem;
+    top: -2rem;
 }
 
 .hover-container {

--- a/src/main/webapp/app/shared/metis/answer-post/answer-post.component.scss
+++ b/src/main/webapp/app/shared/metis/answer-post/answer-post.component.scss
@@ -8,10 +8,6 @@
     border-radius: 7px;
 }
 
-.answer-post-content-margin {
-    padding-left: 3.42rem;
-}
-
 @include media-breakpoint-down(sm) {
     .answer-post-content-margin {
         padding-left: 0.5rem;
@@ -25,6 +21,7 @@
     display: flex;
     gap: 10px;
     visibility: hidden;
+    max-height: 2.2rem;
     transition:
         opacity 0.2s ease-in-out,
         visibility 0.2s ease-in-out;
@@ -56,15 +53,22 @@
     padding-left: 0.25rem;
 }
 
-.message-content {
-    &.force-hover {
-        background: var(--metis-selection-option-hover-background);
+.non-consecutive .hover-actions {
+    top: -3.5rem;
+}
 
-        .hover-actions {
-            opacity: 1;
-            visibility: visible;
-        }
-    }
+.hover-container {
+    position: relative;
+}
+
+.hover-container:hover {
+    background: var(--metis-selection-option-hover-background);
+    transition: background-color 0.2s ease-in-out;
+}
+
+.hover-container:hover .hover-actions {
+    visibility: visible;
+    opacity: 1;
 }
 
 .message-content:hover {
@@ -84,4 +88,23 @@
     width: 20px;
     height: 20px;
     margin-right: 0.2rem;
+}
+
+.post-time {
+    position: absolute;
+    top: 5%;
+    left: 0.5rem;
+    margin-left: 0.7rem;
+    visibility: hidden;
+    opacity: 0;
+    transition:
+        visibility 0.2s ease-in-out,
+        opacity 0.2s ease-in-out;
+    font-size: 0.75rem;
+    color: var(--metis-gray-dark);
+}
+
+.hover-container:hover .post-time {
+    visibility: visible;
+    opacity: 1;
 }

--- a/src/main/webapp/app/shared/metis/post/post.component.html
+++ b/src/main/webapp/app/shared/metis/post/post.component.html
@@ -1,4 +1,7 @@
-<div class="post" [ngClass]="{ 'mx-0': !isThreadSidebar, 'pinned-message': isPinned(), 'is-saved': !isConsecutive() && posting.isSaved }">
+<div
+    class="post hover-container"
+    [ngClass]="{ 'mx-0': !isThreadSidebar, 'pinned-message': isPinned(), 'is-saved': !isConsecutive() && posting.isSaved, 'non-consecutive': !isConsecutive() }"
+>
     @if (posting.isSaved) {
         <div class="post-is-saved-message post-content-padding fs-xx-small py-1" [ngClass]="{ 'is-saved': isConsecutive() && posting.isSaved }">
             <div class="post-is-saved-message-content">
@@ -6,6 +9,11 @@
                 <span class="text-secondary" jhiTranslate="artemisApp.metis.post.saved"></span>
             </div>
         </div>
+    }
+    @if (isConsecutive()) {
+        <span class="post-time fs-small" ngbTooltip="{{ posting.creationDate | artemisDate: 'time' }}">
+            {{ posting.creationDate | artemisDate: 'time' }}
+        </span>
     }
     @if (!isConsecutive()) {
         <div class="ps-3">

--- a/src/main/webapp/app/shared/metis/post/post.component.scss
+++ b/src/main/webapp/app/shared/metis/post/post.component.scss
@@ -33,7 +33,7 @@
 }
 
 .non-consecutive .hover-actions {
-    top: -3.5rem;
+    top: -2rem;
 }
 
 .hover-container:hover {

--- a/src/main/webapp/app/shared/metis/post/post.component.scss
+++ b/src/main/webapp/app/shared/metis/post/post.component.scss
@@ -32,17 +32,22 @@
     border: 0.01rem solid var(--metis-gray);
 }
 
+.non-consecutive .hover-actions {
+    top: -3.5rem;
+}
+
+.hover-container:hover {
+    background: var(--metis-selection-option-hover-background);
+    transition: background-color 0.2s ease-in-out;
+}
+
+.hover-container:hover .hover-actions {
+    visibility: visible;
+    opacity: 1;
+}
+
 .message-container {
     position: relative;
-
-    &.force-hover {
-        background: var(--metis-selection-option-hover-background);
-
-        .hover-actions {
-            opacity: 1;
-            visibility: visible;
-        }
-    }
 }
 
 .post-is-saved-message,
@@ -64,15 +69,6 @@
     padding-left: 0.25rem;
 }
 
-.message-content:hover {
-    background: var(--metis-selection-option-hover-background);
-}
-
-.message-container:hover .hover-actions {
-    opacity: 1;
-    visibility: visible;
-}
-
 .clickable {
     cursor: pointer;
 }
@@ -85,4 +81,27 @@
 
 .pinned-message {
     background-color: var(--artemis-alert-warning-background);
+}
+
+.hover-container {
+    position: relative;
+}
+
+.post-time {
+    position: absolute;
+    top: 5%;
+    left: 0.5rem;
+    margin-left: 0.7rem;
+    visibility: hidden;
+    opacity: 0;
+    transition:
+        visibility 0.2s ease-in-out,
+        opacity 0.2s ease-in-out;
+    font-size: 0.75rem;
+    color: var(--metis-gray-dark);
+}
+
+.hover-container:hover .post-time {
+    visibility: visible;
+    opacity: 1;
 }

--- a/src/main/webapp/app/shared/metis/post/post.component.scss
+++ b/src/main/webapp/app/shared/metis/post/post.component.scss
@@ -32,6 +32,10 @@
     border: 0.01rem solid var(--metis-gray);
 }
 
+.hover-container {
+    position: relative;
+}
+
 .non-consecutive .hover-actions {
     top: -2rem;
 }
@@ -81,10 +85,6 @@
 
 .pinned-message {
     background-color: var(--artemis-alert-warning-background);
-}
-
-.hover-container {
-    position: relative;
 }
 
 .post-time {

--- a/src/main/webapp/app/shared/metis/posting-footer/post-footer/post-footer.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-footer/post-footer/post-footer.component.ts
@@ -137,7 +137,7 @@ export class PostFooterComponent extends PostingFooterDirective<Post> implements
                 timeDiff = currentDate.diff(lastDate, 'minute');
             }
 
-            if (currentPost.author?.id === currentGroup.author?.id && timeDiff < 1 && timeDiff >= 0) {
+            if (currentPost.author?.id === currentGroup.author?.id && timeDiff < 5 && timeDiff >= 0) {
                 currentGroup.posts.push({ ...currentPost, isConsecutive: true }); // consecutive post
             } else {
                 groups.push(currentGroup);

--- a/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.html
+++ b/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.html
@@ -31,7 +31,11 @@
                 <span [jhiTranslate]="todayFlag ?? ''" id="today-flag" class="fs-small"></span>,
             }
             <span class="post-header-date fs-small" [disableTooltip]="postingIsOfToday" ngbTooltip="{{ posting.creationDate | artemisDate: 'time' }}">
-                {{ postingIsOfToday ? (posting.creationDate | artemisDate: 'time') : (posting.creationDate | artemisDate: 'short-date') }}
+                {{
+                    postingIsOfToday
+                        ? (posting.creationDate | artemisDate: 'time')
+                        : (posting.creationDate | artemisDate: 'short-date') + ' - ' + (posting.creationDate | artemisDate: 'time')
+                }}
             </span>
         </span>
         @if (!!isCommunicationPage && (!lastReadDate || (lastReadDate && posting.creationDate && posting.creationDate.isAfter(lastReadDate))) && !isAuthorOfPosting) {

--- a/src/main/webapp/app/shared/metis/posting-header/post-header/post-header.component.html
+++ b/src/main/webapp/app/shared/metis/posting-header/post-header/post-header.component.html
@@ -31,7 +31,11 @@
                 <span [jhiTranslate]="todayFlag ?? ''" id="today-flag" class="fs-small"></span>,
             }
             <span class="fs-small" [disableTooltip]="postingIsOfToday" ngbTooltip="{{ posting.creationDate | artemisDate: 'time' }}">
-                {{ postingIsOfToday ? (posting.creationDate | artemisDate: 'time') : (posting.creationDate | artemisDate: 'short-date') }}
+                {{
+                    postingIsOfToday
+                        ? (posting.creationDate | artemisDate: 'time')
+                        : (posting.creationDate | artemisDate: 'short-date') + ' - ' + (posting.creationDate | artemisDate: 'time')
+                }}
             </span>
         </span>
         @if (posting.resolved) {

--- a/src/test/javascript/spec/component/shared/metis/answer-post/answer-post.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/answer-post/answer-post.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AnswerPostComponent } from 'app/shared/metis/answer-post/answer-post.component';
 import { DebugElement, input, runInInjectionContext } from '@angular/core';
-import { MockComponent, MockModule, MockPipe, ngMocks } from 'ng-mocks';
+import { MockComponent, MockDirective, MockModule, MockPipe, ngMocks } from 'ng-mocks';
 import { HtmlForMarkdownPipe } from 'app/shared/pipes/html-for-markdown.pipe';
 import { By } from '@angular/platform-browser';
 import { AnswerPostHeaderComponent } from 'app/shared/metis/posting-header/answer-post-header/answer-post-header.component';
 import { AnswerPostReactionsBarComponent } from 'app/shared/metis/posting-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component';
 import { PostingContentComponent } from 'app/shared/metis/posting-content/posting-content.components';
-import { metisResolvingAnswerPostUser1 } from '../../../../helpers/sample/metis-sample-data';
+import { metisPostExerciseUser1, metisResolvingAnswerPostUser1 } from '../../../../helpers/sample/metis-sample-data';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { AnswerPostCreateEditModalComponent } from 'app/shared/metis/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component';
 import { DOCUMENT } from '@angular/common';
@@ -17,6 +17,13 @@ import { MetisService } from 'app/shared/metis/metis.service';
 import { MockMetisService } from '../../../../helpers/mocks/service/mock-metis-service.service';
 import { Posting, PostingType } from 'app/entities/metis/posting.model';
 import { AnswerPost } from 'app/entities/metis/answer-post.model';
+import dayjs from 'dayjs/esm';
+import { ArtemisDatePipe } from '../../../../../../../main/webapp/app/shared/pipes/artemis-date.pipe';
+import { ArtemisTranslatePipe } from '../../../../../../../main/webapp/app/shared/pipes/artemis-translate.pipe';
+import { TranslateDirective } from '../../../../../../../main/webapp/app/shared/language/translate.directive';
+import { MockTranslateService } from '../../../../helpers/mocks/service/mock-translate.service';
+import { TranslateService } from '@ngx-translate/core';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 
 describe('AnswerPostComponent', () => {
     let component: AnswerPostComponent;
@@ -30,7 +37,7 @@ describe('AnswerPostComponent', () => {
         document.body.appendChild(mainContainer);
 
         return TestBed.configureTestingModule({
-            imports: [OverlayModule, MockModule(BrowserAnimationsModule)],
+            imports: [OverlayModule, MockModule(BrowserAnimationsModule), MockDirective(NgbTooltip)],
             declarations: [
                 AnswerPostComponent,
                 MockPipe(HtmlForMarkdownPipe),
@@ -38,10 +45,14 @@ describe('AnswerPostComponent', () => {
                 MockComponent(PostingContentComponent),
                 MockComponent(AnswerPostCreateEditModalComponent),
                 MockComponent(AnswerPostReactionsBarComponent),
+                ArtemisDatePipe,
+                ArtemisTranslatePipe,
+                MockDirective(TranslateDirective),
             ],
             providers: [
                 { provide: DOCUMENT, useValue: document },
                 { provide: MetisService, useClass: MockMetisService },
+                { provide: TranslateService, useClass: MockTranslateService },
             ],
         })
             .compileComponents()
@@ -236,5 +247,32 @@ describe('AnswerPostComponent', () => {
 
         expect(component.posting).toBeInstanceOf(AnswerPost);
         expect(spy).toHaveBeenCalled();
+    });
+
+    it('should display post-time span when isConsecutive() returns true', () => {
+        const fixedDate = dayjs('2024-12-06T23:39:27.080Z');
+        component.posting = { ...metisPostExerciseUser1, creationDate: fixedDate };
+
+        jest.spyOn(component, 'isConsecutive').mockReturnValue(true);
+        fixture.detectChanges();
+
+        const postTimeDebugElement = debugElement.query(By.css('span.post-time'));
+        const postTimeElement = postTimeDebugElement.nativeElement as HTMLElement;
+
+        expect(postTimeDebugElement).toBeTruthy();
+
+        const expectedTime = dayjs(fixedDate).format('HH:mm');
+        expect(postTimeElement.textContent?.trim()).toBe(expectedTime);
+    });
+
+    it('should not display post-time span when isConsecutive() returns false', () => {
+        const fixedDate = dayjs('2024-12-06T23:39:27.080Z');
+        component.posting = { ...metisPostExerciseUser1, creationDate: fixedDate };
+
+        jest.spyOn(component, 'isConsecutive').mockReturnValue(false);
+        fixture.detectChanges();
+
+        const postTimeElement = debugElement.query(By.css('span.post-time'));
+        expect(postTimeElement).toBeFalsy();
     });
 });

--- a/src/test/javascript/spec/component/shared/metis/post/post.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/post/post.component.spec.ts
@@ -11,7 +11,7 @@ import { MockMetisService } from '../../../../helpers/mocks/service/mock-metis-s
 import { MetisService } from 'app/shared/metis/metis.service';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { DisplayPriority, PageType } from 'app/shared/metis/metis.util';
-import { TranslatePipeMock } from '../../../../helpers/mocks/service/mock-translate.service';
+import { MockTranslateService, TranslatePipeMock } from '../../../../helpers/mocks/service/mock-translate.service';
 import { OverlayModule } from '@angular/cdk/overlay';
 import {
     metisChannel,
@@ -38,6 +38,12 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DOCUMENT } from '@angular/common';
 import { Posting, PostingType } from 'app/entities/metis/posting.model';
 import { Post } from 'app/entities/metis/post.model';
+import { ArtemisTranslatePipe } from '../../../../../../../main/webapp/app/shared/pipes/artemis-translate.pipe';
+import { ArtemisDatePipe } from '../../../../../../../main/webapp/app/shared/pipes/artemis-date.pipe';
+import { TranslateDirective } from '../../../../../../../main/webapp/app/shared/language/translate.directive';
+import { TranslateService } from '@ngx-translate/core';
+import { By } from '@angular/platform-browser';
+import dayjs from 'dayjs/esm';
 
 describe('PostComponent', () => {
     let component: PostComponent;
@@ -64,6 +70,7 @@ describe('PostComponent', () => {
                 { provide: DOCUMENT, useValue: document },
                 MockProvider(MetisConversationService),
                 MockProvider(OneToOneChatService),
+                { provide: TranslateService, useClass: MockTranslateService },
             ],
             declarations: [
                 PostComponent,
@@ -77,6 +84,9 @@ describe('PostComponent', () => {
                 MockRouterLinkDirective,
                 MockQueryParamsDirective,
                 TranslatePipeMock,
+                ArtemisDatePipe,
+                ArtemisTranslatePipe,
+                MockDirective(TranslateDirective),
             ],
         })
             .compileComponents()
@@ -379,5 +389,32 @@ describe('PostComponent', () => {
 
         expect(component.posting).toBeInstanceOf(Post);
         expect(spy).toHaveBeenCalled();
+    });
+
+    it('should display post-time span when isConsecutive() returns true', () => {
+        const fixedDate = dayjs('2024-12-06T23:39:27.080Z');
+        component.posting = { ...metisPostExerciseUser1, creationDate: fixedDate };
+
+        jest.spyOn(component, 'isConsecutive').mockReturnValue(true);
+        fixture.detectChanges();
+
+        const postTimeDebugElement = debugElement.query(By.css('span.post-time'));
+        const postTimeElement = postTimeDebugElement.nativeElement as HTMLElement;
+
+        expect(postTimeDebugElement).toBeTruthy();
+
+        const expectedTime = dayjs(fixedDate).format('HH:mm');
+        expect(postTimeElement.textContent?.trim()).toBe(expectedTime);
+    });
+
+    it('should not display post-time span when isConsecutive() returns false', () => {
+        const fixedDate = dayjs('2024-12-06T23:39:27.080Z');
+        component.posting = { ...metisPostExerciseUser1, creationDate: fixedDate };
+
+        jest.spyOn(component, 'isConsecutive').mockReturnValue(false);
+        fixture.detectChanges();
+
+        const postTimeElement = debugElement.query(By.css('span.post-time'));
+        expect(postTimeElement).toBeFalsy();
     });
 });

--- a/src/test/javascript/spec/component/shared/metis/postings-footer/post-footer/post-footer.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-footer/post-footer/post-footer.component.spec.ts
@@ -17,6 +17,7 @@ import { MockMetisService } from '../../../../../helpers/mocks/service/mock-meti
 import { metisPostExerciseUser1, post, unsortedAnswerArray } from '../../../../../helpers/sample/metis-sample-data';
 import { AnswerPost } from 'app/entities/metis/answer-post.model';
 import { User } from 'app/core/user/user.model';
+import dayjs from 'dayjs/esm';
 
 interface PostGroup {
     author: User | undefined;
@@ -72,8 +73,8 @@ describe('PostFooterComponent', () => {
     it('should group answer posts correctly', () => {
         component.sortedAnswerPosts = unsortedAnswerArray;
         component.groupAnswerPosts();
-        expect(component.groupedAnswerPosts.length).toBeGreaterThan(0); // Ensure groups are created
-        expect(component.groupedAnswerPosts[0].posts.length).toBeGreaterThan(0); // Ensure posts exist in groups
+        expect(component.groupedAnswerPosts.length).toBeGreaterThan(0);
+        expect(component.groupedAnswerPosts[0].posts.length).toBeGreaterThan(0);
     });
 
     it('should group answer posts and detect changes on changes to sortedAnswerPosts input', () => {
@@ -159,5 +160,40 @@ describe('PostFooterComponent', () => {
         const createAnswerPostModalClose = jest.spyOn(component.createAnswerPostModalComponent, 'close');
         component.closeCreateAnswerPostModal();
         expect(createAnswerPostModalClose).toHaveBeenCalledOnce();
+    });
+
+    it('should group answer posts correctly based on author and time difference', () => {
+        const authorA: User = { id: 1, login: 'authorA' } as User;
+        const authorB: User = { id: 2, login: 'authorB' } as User;
+
+        const baseTime = dayjs();
+
+        const post1: AnswerPost = { id: 1, author: authorA, creationDate: baseTime.toDate() } as unknown as AnswerPost;
+        const post2: AnswerPost = { id: 2, author: authorA, creationDate: baseTime.add(3, 'minute').toDate() } as unknown as AnswerPost;
+        const post3: AnswerPost = { id: 3, author: authorA, creationDate: baseTime.add(10, 'minute').toDate() } as unknown as AnswerPost;
+        const post4: AnswerPost = { id: 4, author: authorB, creationDate: baseTime.add(12, 'minute').toDate() } as unknown as AnswerPost;
+        const post5: AnswerPost = { id: 5, author: authorB, creationDate: baseTime.add(14, 'minute').toDate() } as unknown as AnswerPost;
+
+        component.sortedAnswerPosts = [post3, post1, post5, post2, post4];
+
+        component.groupAnswerPosts();
+        expect(component.groupedAnswerPosts).toHaveLength(3);
+
+        const group1 = component.groupedAnswerPosts[0];
+        expect(group1.author).toEqual(authorA);
+        expect(group1.posts).toHaveLength(2);
+        expect(group1.posts).toContainEqual(expect.objectContaining({ id: post1.id }));
+        expect(group1.posts).toContainEqual(expect.objectContaining({ id: post2.id }));
+
+        const group2 = component.groupedAnswerPosts[1];
+        expect(group2.author).toEqual(authorA);
+        expect(group2.posts).toHaveLength(1);
+        expect(group2.posts).toContainEqual(expect.objectContaining({ id: post3.id }));
+
+        const group3 = component.groupedAnswerPosts[2];
+        expect(group3.author).toEqual(authorB);
+        expect(group3.posts).toHaveLength(2);
+        expect(group3.posts).toContainEqual(expect.objectContaining({ id: post4.id }));
+        expect(group3.posts).toContainEqual(expect.objectContaining({ id: post5.id }));
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



#### Client
- [X] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [X] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [X] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- The hover area for messages was not completely aligned with Slack's behavior. Instead of covering the entire message container, it only covered the content, reducing the interactive area for users. (Closes #9734)
- When messages were hovered over, the time of the message was not displayed, unlike in Slack.
- For messages sent on days other than the current day, the exact time was not displayed.
- In the `AnswerPost` component, there was an additional spacing issue between consecutive messages compared to the `Post` component. 
- The timeframe for grouping consecutive messages in the `AnswerPost` component was 1 minute, whereas in the `Post` component, it was 5 minutes. 




### Description
<!-- Describe your changes in detail -->
- The hover area now covers the entire message container instead of just the content. 
- The sent time of the message is now displayed when hovering over messages, aligning with Slack's functionality.
- For messages sent on days other than the current day, the sent time is now displayed on the message header.
- The additional spacing between consecutive messages in the `AnswerPost` component has been removed.
- The timeframe for grouping consecutive messages in the `AnswerPost` component has been updated from 1 minute to 5 minutes, making it consistent with the `Post` component.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 User
- 1 Course with Communication enabled

1. Log in to Artemis.
2. Navigate to the Communication section of a course.
3. Send some consecutive messages to a channel and notice that when the consecutive messages are hovered, the exact time is displayed on the left of the message content.
4. Send some consecutive replies to a message and notice the same hovering behavior.
5. Verify that the spacing between consecutive replies and posts is consistent.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [X] Code Review 1
- [X] Code Review 2
#### Manual Tests
- [X] Test 1
- [X] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| post-footer.component.ts | 98.57% | ✅ ❌ |


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
**hovered message with expanded hover area and sent time on header**
![image](https://github.com/user-attachments/assets/33c15b95-6415-4768-9b7b-d06a41fbb26a)

**hovered consecutive message with sent time**
![image](https://github.com/user-attachments/assets/521bd8d0-563a-4ccc-8997-372f64d0eef7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced visual feedback for posts with new hover effects and conditional display of posting creation date.
  - Improved grouping logic for consecutive posts, now considering a 5-minute threshold.

- **Bug Fixes**
  - Adjusted rendering logic to ensure accurate display of post timing and saved messages.

- **Style**
  - Updated styles for hover interactions and layout adjustments to improve user experience.

- **Tests**
  - Expanded test coverage for post timing and grouping functionalities, ensuring accurate behavior across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->