### PR TITLE
`Development`: Fix LTI content selection table not loading

### DIFF
--- a/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
+++ b/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
@@ -114,11 +114,6 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
         this.storeLtiSessionData(ltiIdToken, clientRegistrationId);
 
         if (targetLinkUri) {
-            /*
-            if (targetLinkUri === '/lti/select-course') {
-                this.replaceWindowLocationWrapper(window.location.origin + targetLinkUri);
-            }
-            */
             this.replaceWindowLocationWrapper(targetLinkUri);
         } else {
             this.isLaunching = false;

--- a/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
+++ b/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
@@ -114,7 +114,13 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
         this.storeLtiSessionData(ltiIdToken, clientRegistrationId);
 
         if (targetLinkUri) {
-            this.replaceWindowLocationWrapper(targetLinkUri);
+            try {
+                new URL(targetLinkUri);
+                this.replaceWindowLocationWrapper(targetLinkUri);
+            } catch (e) {
+                console.error('Invalid targetLinkUri received:', targetLinkUri);
+                this.isLaunching = false;
+            }
         } else {
             this.isLaunching = false;
             console.error('No LTI targetLinkUri received for a successful launch');

--- a/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
+++ b/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
@@ -114,9 +114,11 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
         this.storeLtiSessionData(ltiIdToken, clientRegistrationId);
 
         if (targetLinkUri) {
+            /*
             if (targetLinkUri === '/lti/select-course') {
                 this.replaceWindowLocationWrapper(window.location.origin + targetLinkUri);
             }
+            */
             this.replaceWindowLocationWrapper(targetLinkUri);
         } else {
             this.isLaunching = false;
@@ -151,7 +153,9 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
     replaceWindowLocationWrapper(url: string): void {
         this.ltiService.setShownViaLti(true);
         this.themeService.applyThemePreference(Theme.LIGHT);
+        console.log(url);
         const path = new URL(url).pathname;
+        console.log(path);
 
         this.router.navigate([path], { replaceUrl: true });
     }

--- a/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
+++ b/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
@@ -115,10 +115,10 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
 
         if (targetLinkUri) {
             try {
-                const absoluteUrl = new URL(targetLinkUri, window.location.origin);
-                this.replaceWindowLocationWrapper(absoluteUrl.toString());
+                this.replaceWindowLocationWrapper(targetLinkUri);
             } catch (e) {
                 console.error('Invalid targetLinkUri received:', targetLinkUri);
+                console.log(window.location.origin);
                 this.isLaunching = false;
             }
         } else {

--- a/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
+++ b/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
@@ -153,9 +153,12 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
     replaceWindowLocationWrapper(url: string): void {
         this.ltiService.setShownViaLti(true);
         this.themeService.applyThemePreference(Theme.LIGHT);
-        console.log(url);
-        const path = new URL(url).pathname;
-        console.log(path);
+        let path;
+        if (url === '/lti/select-course') {
+            path = url;
+        } else {
+            path = new URL(url).pathname;
+        }
 
         this.router.navigate([path], { replaceUrl: true });
     }

--- a/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
+++ b/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
@@ -115,10 +115,13 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
 
         if (targetLinkUri) {
             try {
-                this.replaceWindowLocationWrapper(targetLinkUri);
+                const url = window.location.origin + targetLinkUri;
+                this.replaceWindowLocationWrapper(url);
             } catch (e) {
                 console.error('Invalid targetLinkUri received:', targetLinkUri);
                 console.log(window.location.origin);
+                console.log(window.location);
+                console.log(targetLinkUri);
                 this.isLaunching = false;
             }
         } else {

--- a/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
+++ b/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
@@ -115,8 +115,8 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
 
         if (targetLinkUri) {
             try {
-                new URL(targetLinkUri);
-                this.replaceWindowLocationWrapper(targetLinkUri);
+                const absoluteUrl = new URL(targetLinkUri, window.location.origin);
+                this.replaceWindowLocationWrapper(absoluteUrl.toString());
             } catch (e) {
                 console.error('Invalid targetLinkUri received:', targetLinkUri);
                 this.isLaunching = false;

--- a/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
+++ b/src/main/webapp/app/lti/lti13-exercise-launch.component.ts
@@ -114,16 +114,10 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
         this.storeLtiSessionData(ltiIdToken, clientRegistrationId);
 
         if (targetLinkUri) {
-            try {
-                const url = window.location.origin + targetLinkUri;
-                this.replaceWindowLocationWrapper(url);
-            } catch (e) {
-                console.error('Invalid targetLinkUri received:', targetLinkUri);
-                console.log(window.location.origin);
-                console.log(window.location);
-                console.log(targetLinkUri);
-                this.isLaunching = false;
+            if (targetLinkUri === '/lti/select-course') {
+                this.replaceWindowLocationWrapper(window.location.origin + targetLinkUri);
             }
+            this.replaceWindowLocationWrapper(targetLinkUri);
         } else {
             this.isLaunching = false;
             console.error('No LTI targetLinkUri received for a successful launch');


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Content selection table for creating lti learning activities was not loading correctly


### Description
<!-- Describe your changes in detail -->
Change the launch method to take the url path and not a full URL in case of table because of different parameter format given by the table.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Access to Moodle
- Testserver 1

1. Make sure you are logged in to Artemis with a Test User 16)
2. Navigate to [Moodle](https://moodle.ase.in.tum.de) and login with the same test user (Test User 16}, same PW as for the Artemis Test Server)
3. Go to My Courses and open the lti test course
4. Activate Edit mode in top right corner
5. Add a learning activity somewhere by clicking on the blue + 
![image](https://github.com/user-attachments/assets/7db604f2-16f8-4808-b8f8-54d3037a91c5)

6. Select TS1
![image](https://github.com/user-attachments/assets/f7a57d31-98f2-4610-be74-cd8e00cd9f9d)

7. Click on "Select content"
![image](https://github.com/user-attachments/assets/9c6a81ce-ada8-4444-ab81-afe863779964)

8. A modal should appear with either a course or a message that there are no lti courses for your user.
![image](https://github.com/user-attachments/assets/138222fb-51fe-4dd9-b724-3946441b3ef8)

(As long as the table does not display a "Am Starten..." or "Starting" message, everything works as expected)




### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation handling for the specific URL `'/lti/select-course'`.

- **Bug Fixes**
	- Improved control flow for determining navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->