### PR TITLE
`Iris`: Allow team repository access for Iris

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisExerciseChatSessionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisExerciseChatSessionService.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.iris.service.session;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_IRIS;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -27,6 +28,7 @@ import de.tum.cit.aet.artemis.iris.service.pyris.PyrisPipelineService;
 import de.tum.cit.aet.artemis.iris.service.settings.IrisSettingsService;
 import de.tum.cit.aet.artemis.iris.service.websocket.IrisChatWebsocketService;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParticipation;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseStudentParticipationRepository;
@@ -144,7 +146,14 @@ public class IrisExerciseChatSessionService extends AbstractIrisChatSessionServi
     }
 
     private Optional<ProgrammingSubmission> getLatestSubmissionIfExists(ProgrammingExercise exercise, User user) {
-        var participations = programmingExerciseStudentParticipationRepository.findAllWithSubmissionsByExerciseIdAndStudentLogin(exercise.getId(), user.getLogin());
+        List<ProgrammingExerciseStudentParticipation> participations;
+        if (exercise.isTeamMode()) {
+            participations = programmingExerciseStudentParticipationRepository.findAllWithSubmissionByExerciseIdAndStudentLoginInTeam(exercise.getId(), user.getLogin());
+        }
+        else {
+            participations = programmingExerciseStudentParticipationRepository.findAllWithSubmissionsByExerciseIdAndStudentLogin(exercise.getId(), user.getLogin());
+        }
+
         if (participations.isEmpty()) {
             return Optional.empty();
         }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseStudentParticipationRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseStudentParticipationRepository.java
@@ -195,6 +195,18 @@ public interface ProgrammingExerciseStudentParticipationRepository extends Artem
             """)
     List<ProgrammingExerciseStudentParticipation> findAllWithSubmissionsByExerciseIdAndStudentLogin(@Param("exerciseId") long exerciseId, @Param("username") String username);
 
+    @Query("""
+            SELECT participation
+            FROM ProgrammingExerciseStudentParticipation participation
+                LEFT JOIN FETCH participation.team team
+                LEFT JOIN FETCH team.students student
+                LEFT JOIN FETCH participation.submissions
+            WHERE participation.exercise.id = :exerciseId
+                AND student.login = :username
+            ORDER BY participation.testRun ASC
+            """)
+    List<ProgrammingExerciseStudentParticipation> findAllWithSubmissionByExerciseIdAndStudentLoginInTeam(@Param("exerciseId") long exerciseId, @Param("username") String username);
+
     @EntityGraph(type = LOAD, attributePaths = "team.students")
     Optional<ProgrammingExerciseStudentParticipation> findWithTeamStudentsById(long participationId);
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/connector/IrisRequestMockProvider.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/connector/IrisRequestMockProvider.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.core.connector;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_IRIS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withRawStatus;
@@ -109,18 +110,19 @@ public class IrisRequestMockProvider {
                 var mockRequest = (MockClientHttpRequest) request;
                 var jsonNode = mapper.readTree(mockRequest.getBodyAsString());
 
-                if (!jsonNode.has("submission") || !jsonNode.get("submission").isObject()) {
-                    throw new AssertionError("Field 'submission' is missing or not an object");
-                }
-
-                if (!jsonNode.get("submission").has("id")) {
-                    throw new AssertionError("Field 'id' is missing in 'submission'");
-                }
-
-                long id = jsonNode.get("submission").get("id").asLong();
-                if (id != submissionId) {
-                    throw new AssertionError("Field 'id' in 'submission' is not equal to " + submissionId);
-                }
+                assertThat(jsonNode.has("submission"))
+                    .withFailMessage("Request body must contain a 'submission' field")
+                    .isTrue();
+                assertThat(jsonNode.get("submission").isObject())
+                    .withFailMessage("The 'submission' field must be an object")
+                    .isTrue();
+                assertThat(jsonNode.get("submission").has("id"))
+                    .withFailMessage("The 'submission' object must contain an 'id' field")
+                    .isTrue();
+                assertThat(jsonNode.get("submission").get("id").asLong())
+                    .withFailMessage("Submission ID in request (%d) does not match expected ID (%d)",
+                        jsonNode.get("submission").get("id").asLong(), submissionId)
+                    .isEqualTo(submissionId);
             })
             .andRespond(request -> {
                 var mockRequest = (MockClientHttpRequest) request;

--- a/src/test/java/de/tum/cit/aet/artemis/core/connector/IrisRequestMockProvider.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/connector/IrisRequestMockProvider.java
@@ -107,8 +107,7 @@ public class IrisRequestMockProvider {
             .andExpect(method(HttpMethod.POST))
             .andExpect(request -> {
                 var mockRequest = (MockClientHttpRequest) request;
-                var objectMapper = new ObjectMapper();
-                var jsonNode = objectMapper.readTree(mockRequest.getBodyAsString());
+                var jsonNode = mapper.readTree(mockRequest.getBodyAsString());
 
                 if (!jsonNode.has("submission") || !jsonNode.get("submission").isObject()) {
                     throw new AssertionError("Field 'submission' is missing or not an object");

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/util/ExerciseUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/util/ExerciseUtilService.java
@@ -159,7 +159,7 @@ public class ExerciseUtilService {
     }
 
     /**
-     * Accesses the first found exercise of a course with the passed type. The course stores exercises in a set, therefore any
+     * Accesses the first found non-team exercise of a course with the passed type. The course stores exercises in a set, therefore any
      * exercise with the corresponding type could be accessed.
      *
      * @param course The course which should be searched for the exercise.
@@ -167,7 +167,20 @@ public class ExerciseUtilService {
      * @return The first exercise which was found in the course and is of the expected type.
      */
     public <T extends Exercise> T getFirstExerciseWithType(Course course, Class<T> clazz) {
-        var exercise = course.getExercises().stream().filter(ex -> ex.getClass().equals(clazz)).findFirst().orElseThrow();
+        var exercise = course.getExercises().stream().filter(ex -> !ex.isTeamMode() && ex.getClass().equals(clazz)).findFirst().orElseThrow();
+        return (T) exercise;
+    }
+
+    /**
+     * Accesses the first found team exercise of a course with the passed type. The course stores exercises in a set, therefore any
+     * exercise with the corresponding type could be accessed.
+     *
+     * @param course The course which should be searched for the exercise.
+     * @param clazz  The class (type) of the exercise to look for.
+     * @return The first exercise which was found in the course and is of the expected type.
+     */
+    public <T extends Exercise> T getFirstTeamExerciseWithType(Course course, Class<T> clazz) {
+        var exercise = course.getExercises().stream().filter(ex -> ex.isTeamMode() && ex.getClass().equals(clazz)).findFirst().orElseThrow();
         return (T) exercise;
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatMessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatMessageIntegrationTest.java
@@ -17,8 +17,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +33,12 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.cit.aet.artemis.core.domain.Course;
+import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
+import de.tum.cit.aet.artemis.exercise.domain.Team;
+import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
+import de.tum.cit.aet.artemis.exercise.repository.TeamRepository;
 import de.tum.cit.aet.artemis.iris.domain.message.IrisMessage;
 import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageContent;
 import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender;
@@ -68,72 +75,130 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     private IrisMessageRepository irisMessageRepository;
 
     @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
     private ParticipationUtilService participationUtilService;
 
-    private ProgrammingExercise exercise;
+    private ProgrammingExercise soloExercise;
+
+    private ProgrammingExerciseStudentParticipation soloParticipation;
+
+    private ProgrammingExercise teamExercise;
+
+    private ProgrammingExerciseStudentParticipation teamParticipation;
 
     private AtomicBoolean pipelineDone;
 
     @BeforeEach
     void initTestCase() throws GitAPIException, IOException, URISyntaxException {
-        userUtilService.addUsers(TEST_PREFIX, 2, 0, 0, 0);
+        List<User> users = userUtilService.addUsers(TEST_PREFIX, 3, 0, 0, 0);
 
         final Course course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
-        exercise = exerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
-        String projectKey = exercise.getProjectKey();
-        exercise.setProjectType(ProjectType.PLAIN_GRADLE);
-        exercise.setTestRepositoryUri(localVCBaseUrl + "/git/" + projectKey + "/" + projectKey.toLowerCase() + "-tests.git");
-        programmingExerciseBuildConfigRepository.save(exercise.getBuildConfig());
-        programmingExerciseRepository.save(exercise);
-        exercise = programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(exercise.getId()).orElseThrow();
-
-        // Set the correct repository URIs for the template and the solution participation.
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
-        TemplateProgrammingExerciseParticipation templateParticipation = exercise.getTemplateParticipation();
-        templateParticipation.setRepositoryUri(localVCBaseUrl + "/git/" + projectKey + "/" + templateRepositorySlug + ".git");
-        templateProgrammingExerciseParticipationRepository.save(templateParticipation);
-        String solutionRepositorySlug = projectKey.toLowerCase() + "-solution";
-        SolutionProgrammingExerciseParticipation solutionParticipation = exercise.getSolutionParticipation();
-        solutionParticipation.setRepositoryUri(localVCBaseUrl + "/git/" + projectKey + "/" + solutionRepositorySlug + ".git");
-        solutionProgrammingExerciseParticipationRepository.save(solutionParticipation);
-
-        String assignmentRepositorySlug = projectKey.toLowerCase() + "-" + TEST_PREFIX + "student1";
-
-        // Add a participation for student1.
-        ProgrammingExerciseStudentParticipation studentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
-        studentParticipation.setRepositoryUri(String.format(localVCBaseUrl + "/git/%s/%s.git", projectKey, assignmentRepositorySlug));
-        studentParticipation.setBranch(defaultBranch);
-        programmingExerciseStudentParticipationRepository.save(studentParticipation);
-
-        // Prepare the repositories.
-        localVCLocalCITestService.createAndConfigureLocalRepository(projectKey, templateRepositorySlug);
-        localVCLocalCITestService.createAndConfigureLocalRepository(projectKey, projectKey.toLowerCase() + "-tests");
-        localVCLocalCITestService.createAndConfigureLocalRepository(projectKey, solutionRepositorySlug);
-        localVCLocalCITestService.createAndConfigureLocalRepository(projectKey, assignmentRepositorySlug);
-
-        // Check that the repository folders were created in the file system for all base repositories.
-        localVCLocalCITestService.verifyRepositoryFoldersExist(exercise, localVCBasePath);
 
         activateIrisGlobally();
         activateIrisFor(course);
-        activateIrisFor(exercise);
+
+        soloExercise = exerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
+        teamExercise = programmingExerciseUtilService.addProgrammingExerciseToCourse(course);
+        teamExercise.setMode(ExerciseMode.TEAM);
+        programmingExerciseRepository.save(teamExercise);
+
+        Team team = new Team();
+        team.setName("Team 1");
+        team.setShortName("team1");
+        team.setExercise(teamExercise);
+        team.setStudents(Set.of(users.get(1), users.get(2)));
+        team.setOwner(users.get(1));
+        final var savedTeam = teamRepository.save(team);
+
+        Stream.of(soloExercise, teamExercise).forEach(exercise -> {
+            String projectKey = exercise.getProjectKey();
+            exercise.setProjectType(ProjectType.PLAIN_GRADLE);
+            exercise.setTestRepositoryUri(localVCBaseUrl + "/git/" + projectKey + "/" + projectKey.toLowerCase() + "-tests.git");
+            programmingExerciseBuildConfigRepository.save(exercise.getBuildConfig());
+            programmingExerciseRepository.save(exercise);
+            exercise = programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(exercise.getId()).orElseThrow();
+
+            // Set the correct repository URIs for the template and the solution participation.
+            String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
+            TemplateProgrammingExerciseParticipation templateParticipation = exercise.getTemplateParticipation();
+            templateParticipation.setRepositoryUri(localVCBaseUrl + "/git/" + projectKey + "/" + templateRepositorySlug + ".git");
+            templateProgrammingExerciseParticipationRepository.save(templateParticipation);
+            String solutionRepositorySlug = projectKey.toLowerCase() + "-solution";
+            SolutionProgrammingExerciseParticipation solutionParticipation = exercise.getSolutionParticipation();
+            solutionParticipation.setRepositoryUri(localVCBaseUrl + "/git/" + projectKey + "/" + solutionRepositorySlug + ".git");
+            solutionProgrammingExerciseParticipationRepository.save(solutionParticipation);
+
+            String assignmentRepositorySlug = projectKey.toLowerCase() + "-" + TEST_PREFIX + (exercise.isTeamMode() ? "team1" : "student1");
+
+            // Add a participation
+            ProgrammingExerciseStudentParticipation studentParticipation;
+            if (exercise.isTeamMode()) {
+                studentParticipation = participationUtilService.addTeamParticipationForProgrammingExercise(exercise, savedTeam);
+            }
+            else {
+                studentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
+            }
+
+            var submission = ParticipationFactory.generateProgrammingSubmission(true);
+            participationUtilService.addSubmission(studentParticipation, submission);
+
+            studentParticipation.setRepositoryUri(String.format(localVCBaseUrl + "/git/%s/%s.git", projectKey, assignmentRepositorySlug));
+            studentParticipation.setBranch(defaultBranch);
+            programmingExerciseStudentParticipationRepository.save(studentParticipation);
+
+            if (exercise.isTeamMode()) {
+                teamParticipation = studentParticipation;
+            }
+            else {
+                soloParticipation = studentParticipation;
+            }
+
+            // Prepare the repositories.
+            try {
+                localVCLocalCITestService.createAndConfigureLocalRepository(projectKey, templateRepositorySlug);
+                localVCLocalCITestService.createAndConfigureLocalRepository(projectKey, projectKey.toLowerCase() + "-tests");
+                localVCLocalCITestService.createAndConfigureLocalRepository(projectKey, solutionRepositorySlug);
+                localVCLocalCITestService.createAndConfigureLocalRepository(projectKey, assignmentRepositorySlug);
+            }
+            catch (GitAPIException | IOException | URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+
+            // Check that the repository folders were created in the file system for all base repositories.
+            localVCLocalCITestService.verifyRepositoryFoldersExist(exercise, localVCBasePath);
+
+            activateIrisFor(exercise);
+        });
+
         pipelineDone = new AtomicBoolean(false);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void sendOneMessage() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+    public void sendOneMessageNormalExercise() throws Exception {
+        sendOneMessage(soloExercise, "student1", soloParticipation.getSubmissions().iterator().next().getId());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student2", roles = "USER")
+    public void sendOneMessageTeamExercise() throws Exception {
+        sendOneMessage(teamExercise, "student2", teamParticipation.getSubmissions().iterator().next().getId());
+    }
+
+    private void sendOneMessage(ProgrammingExercise exercise, String studentLogin, long submissionId) throws Exception {
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + studentLogin));
         var messageToSend = createDefaultMockMessage(irisSession);
         messageToSend.setMessageDifferentiator(1453);
 
-        irisRequestMockProvider.mockProgrammingExerciseChatResponse(dto -> {
+        irisRequestMockProvider.mockProgrammingExerciseChatResponseExpectingSubmissionId(dto -> {
             assertThat(dto.settings().authenticationToken()).isNotNull();
 
             assertThatNoException().isThrownBy(() -> sendStatus(dto.settings().authenticationToken(), "Hello World", dto.initialStages(), null));
 
             pipelineDone.set(true);
-        });
+        }, submissionId);
 
         request.postWithoutResponseBody("/api/iris/sessions/" + irisSession.getId() + "/messages", messageToSend, HttpStatus.CREATED);
 
@@ -146,7 +211,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void sendSuggestions() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         var messageToSend = createDefaultMockMessage(irisSession);
         messageToSend.setMessageDifferentiator(1454);
 
@@ -171,8 +236,8 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void sendOneMessageToWrongSession() throws Exception {
-        irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student2"));
+        irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student2"));
         IrisMessage messageToSend = createDefaultMockMessage(irisSession);
         request.postWithoutResponseBody("/api/iris/sessions/" + irisSession.getId() + "/messages", messageToSend, HttpStatus.FORBIDDEN);
     }
@@ -180,7 +245,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void sendMessageWithoutContent() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         var messageToSend = irisSession.newMessage();
         request.postWithoutResponseBody("/api/iris/sessions/" + irisSession.getId() + "/messages", messageToSend, HttpStatus.BAD_REQUEST);
     }
@@ -188,7 +253,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void sendTwoMessages() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         IrisMessage messageToSend1 = createDefaultMockMessage(irisSession);
 
         irisRequestMockProvider.mockProgrammingExerciseChatResponse(dto -> {
@@ -221,7 +286,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void getMessages() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
 
         IrisMessage message1 = irisMessageService.saveMessage(createDefaultMockMessage(irisSession), irisSession, IrisMessageSender.USER);
         IrisMessage message2 = irisMessageService.saveMessage(createDefaultMockMessage(irisSession), irisSession, IrisMessageSender.LLM);
@@ -235,7 +300,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void rateMessageHelpfulTrue() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         var message = irisSession.newMessage();
         message.addContent(createMockTextContent());
         var irisMessage = irisMessageService.saveMessage(message, irisSession, IrisMessageSender.LLM);
@@ -247,7 +312,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void rateMessageHelpfulFalse() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         var message = irisSession.newMessage();
         message.addContent(createMockTextContent());
         var irisMessage = irisMessageService.saveMessage(message, irisSession, IrisMessageSender.LLM);
@@ -259,7 +324,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void rateMessageHelpfulNull() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         var message = irisSession.newMessage();
         message.addContent(createMockTextContent());
         var irisMessage = irisMessageService.saveMessage(message, irisSession, IrisMessageSender.LLM);
@@ -271,7 +336,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void rateMessageWrongSender() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         var message = irisSession.newMessage();
         message.addContent(createMockTextContent());
         var irisMessage = irisMessageService.saveMessage(message, irisSession, IrisMessageSender.USER);
@@ -281,8 +346,8 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void rateMessageWrongSession() throws Exception {
-        var irisSession1 = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
-        var irisSession2 = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student2"));
+        var irisSession1 = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession2 = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student2"));
         var message = irisSession1.newMessage();
         message.addContent(createMockTextContent());
         var irisMessage = irisMessageService.saveMessage(message, irisSession1, IrisMessageSender.USER);
@@ -292,7 +357,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void resendMessage() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         var messageToSend = createDefaultMockMessage(irisSession);
 
         irisRequestMockProvider.mockProgrammingExerciseChatResponse(dto -> {
@@ -312,9 +377,9 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
 
     // User needs to be Admin to change settings
     @Test
-    @WithMockUser(username = TEST_PREFIX + "student2", roles = "ADMIN")
+    @WithMockUser(username = TEST_PREFIX + "student3", roles = "ADMIN")
     void sendMessageRateLimitReached() throws Exception {
-        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "student2"));
+        var irisSession = irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student3"));
         var messageToSend1 = createDefaultMockMessage(irisSession);
         var messageToSend2 = createDefaultMockMessage(irisSession);
 

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatMessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatMessageIntegrationTest.java
@@ -177,13 +177,13 @@ class IrisChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    public void sendOneMessageNormalExercise() throws Exception {
+    void sendOneMessageNormalExercise() throws Exception {
         sendOneMessage(soloExercise, "student1", soloParticipation.getSubmissions().iterator().next().getId());
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student2", roles = "USER")
-    public void sendOneMessageTeamExercise() throws Exception {
+    void sendOneMessageTeamExercise() throws Exception {
         sendOneMessage(teamExercise, "student2", teamParticipation.getSubmissions().iterator().next().getId());
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Iris should be able to help on all programming exericses; however, it currently can't see the code of submissions in team exercises.

### Description
<!-- Describe your changes in detail -->

Added compatibility with team exercises by checking wether the exercise is a team exercise, then altering the retrieval logic accordingly.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Team Programming Exercise
- 2 Students in a team within that exercise

1. Submit something to the programming exercise
2. Talk to your submitted code with Iris using both students accounts
3. Verify that the student who did not submit can also talk to Iris about the code submitted by student 1

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| IrisExerciseChatSessionService.java | 93% | ✅                           |
| ProgrammingExerciseStudentParticipationRepository.java | 80% | ✅              |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced retrieval of student participations for team exercises.
	- Added a method to fetch participations based on team and exercise ID.
	- New functionality to mock HTTP requests for programming exercise chat responses.
	- Introduced a method to get the first team exercise of a specified type.

- **Bug Fixes**
	- Improved error handling and structure in integration tests for solo and team exercises.

- **Tests**
	- Refactored integration tests to differentiate between solo and team exercises, enhancing clarity and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->