### PR TITLE
`Programming Exercises`: Align title and buttons for participation page

### DIFF
--- a/src/main/webapp/app/exercises/shared/participation/participation.component.html
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.html
@@ -1,64 +1,55 @@
 <div>
-    <div class="d-flex flex-wrap">
-        <div class="mr-auto flex-fill">
-            <h2>
-                <span>{{ exercise?.title }} - </span>{{ filteredParticipationsSize }} <span jhiTranslate="artemisApp.participation.home.title"></span>
-            </h2>
-            <div class="d-flex align-items-center mt-2">
-                <label class="radio-inline mb-0 d-flex align-items-center">
-                    <input type="radio" [ngModel]="participationCriteria.filterProp" (click)="updateParticipationFilter(FilterProp.ALL)" [value]="FilterProp.ALL" />
-                    <span class="ms-1" jhiTranslate="artemisApp.exercise.showAll"></span>
-                </label>
-                <label class="radio-inline ms-2 mb-0 d-flex align-items-center">
-                    <input type="radio" [ngModel]="participationCriteria.filterProp" (click)="updateParticipationFilter(FilterProp.FAILED)" [value]="FilterProp.FAILED" />
-                    <span class="ms-1" jhiTranslate="artemisApp.exercise.showFailed"></span>
-                </label>
-                <label class="radio-inline ms-2 mb-0 d-flex align-items-center">
-                    <input
-                        type="radio"
-                        [ngModel]="participationCriteria.filterProp"
-                        (click)="updateParticipationFilter(FilterProp.NO_SUBMISSIONS)"
-                        [value]="FilterProp.NO_SUBMISSIONS"
-                    />
-                    <span class="ms-1" jhiTranslate="artemisApp.exercise.showNoSubmissions"></span>
-                </label>
-                @if (exercise.type === ExerciseType.PROGRAMMING && afterDueDate) {
-                    <label class="radio-inline ms-2 mb-0 d-flex align-items-center">
-                        <input
-                            type="radio"
-                            [ngModel]="participationCriteria.filterProp"
-                            (click)="updateParticipationFilter(FilterProp.NO_PRACTICE)"
-                            [value]="FilterProp.NO_PRACTICE"
-                        />
-                        <span class="ms-1" jhiTranslate="artemisApp.exercise.showNoPracticeMode"></span>
-                    </label>
+    <div class="d-flex flex-wrap align-items-center justify-content-between">
+        <h2 class="mb-0">
+            <span>{{ exercise?.title }} - </span>{{ filteredParticipationsSize }} <span jhiTranslate="artemisApp.participation.home.title"></span>
+        </h2>
+        <div class="d-flex">
+            @if (exercise?.type !== ExerciseType.QUIZ && exercise?.isAtLeastInstructor) {
+                <div class="p-2">
+                    <button
+                        class="btn btn-success"
+                        [disabled]="isSaving || participationsChangedDueDate.size === 0"
+                        (click)="saveChangedDueDates()"
+                        jhiTranslate="entity.action.save"
+                    ></button>
+                </div>
+            }
+            @if (exercise?.isAtLeastInstructor && exercise?.type === ExerciseType.PROGRAMMING) {
+                <jhi-programming-exercise-instructor-submission-state class="p-2" [exercise]="exercise" />
+            }
+            <div class="p-2">
+                @if (exercise?.isAtLeastTutor) {
+                    <a class="btn btn-info" [routerLink]="getScoresRoute(exercise)">
+                        <div>
+                            <fa-icon [icon]="faTable" />
+                            <span class="d-md-inline" jhiTranslate="entity.action.scores"></span>
+                        </div>
+                    </a>
                 }
             </div>
         </div>
-        @if (exercise?.type !== ExerciseType.QUIZ && exercise?.isAtLeastInstructor) {
-            <div class="p-2">
-                <button
-                    class="btn btn-success"
-                    [disabled]="isSaving || participationsChangedDueDate.size === 0"
-                    (click)="saveChangedDueDates()"
-                    jhiTranslate="entity.action.save"
-                ></button>
-            </div>
-        }
-        @if (exercise?.isAtLeastInstructor && exercise?.type === ExerciseType.PROGRAMMING) {
-            <jhi-programming-exercise-instructor-submission-state class="p-2" [exercise]="exercise" />
-        }
-        <div class="p-2">
-            @if (exercise?.isAtLeastTutor) {
-                <a class="btn btn-info" [routerLink]="getScoresRoute(exercise)">
-                    <div>
-                        <fa-icon [icon]="faTable" />
-                        <span class="d-md-inline" jhiTranslate="entity.action.scores"></span>
-                    </div>
-                </a>
-            }
-        </div>
     </div>
+    <div class="d-flex align-items-center mt-2">
+        <label class="radio-inline mb-0 d-flex align-items-center">
+            <input type="radio" [ngModel]="participationCriteria.filterProp" (click)="updateParticipationFilter(FilterProp.ALL)" [value]="FilterProp.ALL" />
+            <span class="ms-1" jhiTranslate="artemisApp.exercise.showAll"></span>
+        </label>
+        <label class="radio-inline ms-2 mb-0 d-flex align-items-center">
+            <input type="radio" [ngModel]="participationCriteria.filterProp" (click)="updateParticipationFilter(FilterProp.FAILED)" [value]="FilterProp.FAILED" />
+            <span class="ms-1" jhiTranslate="artemisApp.exercise.showFailed"></span>
+        </label>
+        <label class="radio-inline ms-2 mb-0 d-flex align-items-center">
+            <input type="radio" [ngModel]="participationCriteria.filterProp" (click)="updateParticipationFilter(FilterProp.NO_SUBMISSIONS)" [value]="FilterProp.NO_SUBMISSIONS" />
+            <span class="ms-1" jhiTranslate="artemisApp.exercise.showNoSubmissions"></span>
+        </label>
+        @if (exercise.type === ExerciseType.PROGRAMMING && afterDueDate) {
+            <label class="radio-inline ms-2 mb-0 d-flex align-items-center">
+                <input type="radio" [ngModel]="participationCriteria.filterProp" (click)="updateParticipationFilter(FilterProp.NO_PRACTICE)" [value]="FilterProp.NO_PRACTICE" />
+                <span class="ms-1" jhiTranslate="artemisApp.exercise.showNoPracticeMode"></span>
+            </label>
+        }
+    </div>
+
     <jhi-data-table
         [isLoading]="isLoading"
         entityType="participation"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Very optional changes, but it was a little offputting that the buttons weren't actually centered with anything.
(_Another solution could be to center them with the original div structure to place them in the middle of the title and filters._)
Closes #9967.

### Description
<!-- Describe your changes in detail -->
- Adjusted div structure (swapped buttons and filters) and classes to achieve centering of buttons
- Ensured filters remain in a separate row below the title and buttons
- Refactored layout with no impact on functionality

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Exercise

1. Go to an exercise as an instructor
2. Click on `Instructor actions` -> `Participations`
3. Take a look at the title and buttons centered

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
**Before:**
![image](https://github.com/user-attachments/assets/36885896-597e-4d58-b9e5-baac03cca485)

**After:**
![image](https://github.com/user-attachments/assets/fcb7a8d3-1280-446e-994c-d80cb05bd1c2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced layout and alignment of elements in the participation component.
	- Conditional rendering of buttons based on user roles and exercise types.

- **Bug Fixes**
	- Improved organization of radio button filters for better usability.

- **Refactor**
	- Streamlined code by consolidating redundant conditional checks.
	- Simplified overall structure for better readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->