### PR TITLE
`Programming exercises`: Fix inconsistencies between diff viewer and diff line stats

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/CommitHistoryService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/CommitHistoryService.java
@@ -107,7 +107,7 @@ public class CommitHistoryService {
 
             diffs.append(out.toString(StandardCharsets.UTF_8));
         }
-        var programmingExerciseGitDiffEntries = gitDiffReportParserService.extractDiffEntries(diffs.toString(), false);
+        var programmingExerciseGitDiffEntries = gitDiffReportParserService.extractDiffEntries(diffs.toString(), false, false);
         var report = new ProgrammingExerciseGitDiffReport();
         for (ProgrammingExerciseGitDiffEntry gitDiffEntry : programmingExerciseGitDiffEntries) {
             gitDiffEntry.setGitDiffReport(report);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/GitDiffReportParserService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/GitDiffReportParserService.java
@@ -175,8 +175,8 @@ public class GitDiffReportParserService {
         }
 
         for (int i = 0; i < addedLines.size(); i++) {
-            String added = addedLines.get(i).replaceAll("\\s+", "");
-            String removed = removedLines.get(i).replaceAll("\\s+", "");
+            String added = addedLines.get(i).trim();
+            String removed = removedLines.get(i).trim();
             if (!added.equals(removed)) {
                 return false;
             }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/GitDiffReportParserService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/GitDiffReportParserService.java
@@ -30,6 +30,7 @@ public class GitDiffReportParserService {
      *
      * @param diff                 The raw git-diff output
      * @param useAbsoluteLineCount Whether to use absolute line count or previous line count
+     * @param ignoreWhitespace     Whether to ignore entries where only leading and trailing whitespace differ
      * @return The extracted ProgrammingExerciseGitDiffEntries
      */
     public List<ProgrammingExerciseGitDiffEntry> extractDiffEntries(String diff, boolean useAbsoluteLineCount, boolean ignoreWhitespace) {

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/GitDiffReportParserService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/GitDiffReportParserService.java
@@ -23,7 +23,7 @@ public class GitDiffReportParserService {
 
     private static final String PREFIX_RENAME_TO = "rename to ";
 
-    private final Pattern gitDiffLinePattern = Pattern.compile("@@ -(?<previousLine>\\d+)(,(?<previousLineCount>\\d+))? \\+(?<newLine>\\d+)(,(?<newLineCount>\\d+))? @@");
+    private final Pattern gitDiffLinePattern = Pattern.compile("@@ -(?<previousLine>\\d+)(,(?<previousLineCount>\\d+))? \\+(?<newLine>\\d+)(,(?<newLineCount>\\d+))? @@.*");
 
     /**
      * Extracts the ProgrammingExerciseGitDiffEntry from the raw git-diff output

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/UnionFindTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/UnionFindTest.java
@@ -1,4 +1,4 @@
-package de.tum.cit.aet.artemis;
+package de.tum.cit.aet.artemis.atlas;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
@@ -70,7 +70,9 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractProgrammin
         exercise = hestiaUtilTestService.setupTemplate(FILE_NAME, "TEST", exercise, templateRepo);
         exercise = hestiaUtilTestService.setupSolution(FILE_NAME, "TEST", exercise, solutionRepo);
         reportService.updateReport(exercise);
-        request.get("/api/programming-exercises/" + exercise.getId() + "/diff-report", HttpStatus.OK, ProgrammingExerciseGitDiffReport.class);
+        var report = request.get("/api/programming-exercises/" + exercise.getId() + "/diff-report", HttpStatus.OK, ProgrammingExerciseGitDiffReport.class);
+        assertThat(report).isNotNull();
+        assertThat(report.getEntries()).isNull();
     }
 
     @Test
@@ -79,7 +81,9 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractProgrammin
         exercise = hestiaUtilTestService.setupTemplate(FILE_NAME, "TEST", exercise, templateRepo);
         exercise = hestiaUtilTestService.setupSolution(FILE_NAME, "TEST", exercise, solutionRepo);
         reportService.updateReport(exercise);
-        request.get("/api/programming-exercises/" + exercise.getId() + "/diff-report", HttpStatus.OK, ProgrammingExerciseGitDiffReport.class);
+        var report = request.get("/api/programming-exercises/" + exercise.getId() + "/diff-report", HttpStatus.OK, ProgrammingExerciseGitDiffReport.class);
+        assertThat(report).isNotNull();
+        assertThat(report.getEntries()).isNull();
     }
 
     @Test
@@ -88,7 +92,9 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractProgrammin
         exercise = hestiaUtilTestService.setupTemplate(FILE_NAME, "TEST", exercise, templateRepo);
         exercise = hestiaUtilTestService.setupSolution(FILE_NAME, "TEST", exercise, solutionRepo);
         reportService.updateReport(exercise);
-        request.get("/api/programming-exercises/" + exercise.getId() + "/diff-report", HttpStatus.OK, ProgrammingExerciseGitDiffReport.class);
+        var report = request.get("/api/programming-exercises/" + exercise.getId() + "/diff-report", HttpStatus.OK, ProgrammingExerciseGitDiffReport.class);
+        assertThat(report).isNotNull();
+        assertThat(report.getEntries()).isNull();
     }
 
     @Test
@@ -98,8 +104,10 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractProgrammin
         participationRepo.configureRepos("participationLocalRepo", "participationOriginRepo");
         var studentLogin = TEST_PREFIX + "student1";
         var submission = hestiaUtilTestService.setupSubmission(FILE_NAME, "TEST", exercise, participationRepo, studentLogin);
-        request.get("/api/programming-exercises/" + exercise.getId() + "/submissions/" + submission.getId() + "/diff-report-with-template", HttpStatus.OK,
+        var report = request.get("/api/programming-exercises/" + exercise.getId() + "/submissions/" + submission.getId() + "/diff-report-with-template", HttpStatus.OK,
                 ProgrammingExerciseGitDiffReport.class);
+        assertThat(report).isNotNull();
+        assertThat(report.getEntries()).isNull();
     }
 
     @Test
@@ -121,8 +129,11 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractProgrammin
         var studentLogin = TEST_PREFIX + "student1";
         var submission = hestiaUtilTestService.setupSubmission(FILE_NAME, "TEST", exercise, participationRepo, studentLogin);
         var submission2 = hestiaUtilTestService.setupSubmission(FILE_NAME, "TEST2", exercise, participationRepo, studentLogin);
-        request.get("/api/programming-exercises/" + exercise.getId() + "/commits/" + submission.getCommitHash() + "/diff-report/" + submission2.getCommitHash()
+        var report = request.get("/api/programming-exercises/" + exercise.getId() + "/commits/" + submission.getCommitHash() + "/diff-report/" + submission2.getCommitHash()
                 + "?participationId=" + submission.getParticipation().getId(), HttpStatus.OK, ProgrammingExerciseGitDiffReport.class);
+        assertThat(report).isNotNull();
+        assertThat(report.getEntries()).hasSize(1);
+        // TODO: add more assertions
     }
 
     @Test
@@ -179,8 +190,11 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractProgrammin
         var studentLogin = TEST_PREFIX + "student1";
         var submission = hestiaUtilTestService.setupSubmission(FILE_NAME, "TEST", exercise, participationRepo, studentLogin);
         var submission2 = hestiaUtilTestService.setupSubmission(FILE_NAME, "TEST2", exercise, participationRepo, studentLogin);
-        request.get("/api/programming-exercises/" + exercise.getId() + "/submissions/" + submission.getId() + "/diff-report/" + submission2.getId(), HttpStatus.OK,
+        var report = request.get("/api/programming-exercises/" + exercise.getId() + "/submissions/" + submission.getId() + "/diff-report/" + submission2.getId(), HttpStatus.OK,
                 ProgrammingExerciseGitDiffReport.class);
+        assertThat(report).isNotNull();
+        assertThat(report.getEntries()).hasSize(1);
+        // TODO: add more assertions
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/programming/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
@@ -38,7 +38,7 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractProgrammin
     private ProgrammingExercise exercise;
 
     @BeforeEach
-    void initTestCase() throws Exception {
+    void initTestCase() {
         Course course = courseUtilService.addEmptyCourse();
         userUtilService.addUsers(TEST_PREFIX, 1, 1, 1, 1);
         exercise = ProgrammingExerciseFactory.generateProgrammingExercise(ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(7), course);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
@@ -133,7 +133,13 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractProgrammin
                 + "?participationId=" + submission.getParticipation().getId(), HttpStatus.OK, ProgrammingExerciseGitDiffReport.class);
         assertThat(report).isNotNull();
         assertThat(report.getEntries()).hasSize(1);
-        // TODO: add more assertions
+        var entry = report.getEntries().stream().findAny().orElseThrow();
+        assertThat(entry.getPreviousFilePath()).isEqualTo(FILE_NAME);
+        assertThat(entry.getPreviousStartLine()).isEqualTo(1);
+        assertThat(entry.getPreviousLineCount()).isEqualTo(1);
+        assertThat(entry.getFilePath()).isEqualTo(FILE_NAME);
+        assertThat(entry.getStartLine()).isEqualTo(1);
+        assertThat(entry.getLineCount()).isEqualTo(1);
     }
 
     @Test
@@ -194,7 +200,13 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractProgrammin
                 ProgrammingExerciseGitDiffReport.class);
         assertThat(report).isNotNull();
         assertThat(report.getEntries()).hasSize(1);
-        // TODO: add more assertions
+        var entry = report.getEntries().stream().findAny().orElseThrow();
+        assertThat(entry.getPreviousFilePath()).isEqualTo(FILE_NAME);
+        assertThat(entry.getPreviousStartLine()).isEqualTo(1);
+        assertThat(entry.getPreviousLineCount()).isEqualTo(1);
+        assertThat(entry.getFilePath()).isEqualTo(FILE_NAME);
+        assertThat(entry.getStartLine()).isEqualTo(1);
+        assertThat(entry.getLineCount()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/programming/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
@@ -138,6 +138,15 @@ class ProgrammingExerciseGitDiffReportServiceTest extends AbstractProgrammingInt
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void gitDiffWhitespace() throws Exception {
+        exercise = hestiaUtilTestService.setupTemplate(FILE_NAME, "   ", exercise, templateRepo);
+        exercise = hestiaUtilTestService.setupSolution(FILE_NAME, "\t", exercise, solutionRepo);
+        var report = reportService.updateReport(exercise);
+        assertThat(report.getEntries()).hasSize(0);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void updateGitDiffReuseExisting() throws Exception {
         exercise = hestiaUtilTestService.setupTemplate(FILE_NAME, "Line 1\nLine 2", exercise, templateRepo);
         exercise = hestiaUtilTestService.setupSolution(FILE_NAME, "Line 1\nLine 2\nLine 3\n", exercise, solutionRepo);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Monaco Editor ignores leading and trailing whitespace while computing the diff (see [ignoreTrimWhitespace](https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor.IStandaloneDiffEditorConstructionOptions.html#ignoreTrimWhitespace)).
The displayed counts of added and removed lines are provided by the server.
The server-side diff does not ignore whitespace like the Monaco Editor.

The git-diff output allows its hunk headers to be annotated with the containing function if the `diff` attribute is set accordingly (see [custom hunk headers](https://git-scm.com/docs/gitattributes#_defining_a_custom_hunk_header)).
Such blocks are not handled correctly by the server parser and are ignored.

### Description
<!-- Describe your changes in detail -->
The GitDiffReportParserService is modified to optionally ignore diffs where the lines only differ in leading and trailing whitespace.
This option to ignore whitespace is enabled where the diff is used together with the diff viewer.
Hunk headers are handled correctly.

Closes #9928.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

1. Create a Java programming exercise
2. Upload files to the template and solution repositories where the only differences in indentation
3. Upload files with the appropriate file extensions to the template and solution repositories where the only difference is a line 10 lines below the start of its containing function
4. Wait until the builds finish
5. Click on "Review Changes"
6. Verify that the indentation differences are not shown
7. Verify that the shown differences are consistent with the displayed line counts
8. Verify that the change deep within the function is shown

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Server

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| CommitHistoryService.java | 85% | ✅ |
| ProgrammingExerciseGitDiffReportService.java | 81% | ✅ |
| GitDiffReportParserService.java | 88% | ✅ |



### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced git diff processing to include whitespace changes.
	- New test method added to validate report handling for whitespace-only differences.

- **Bug Fixes**
	- Improved assertions in integration tests to validate report properties and entries.

- **Refactor**
	- Method signatures updated for clarity and consistency across services.

- **Chores**
	- Organizational change for test class package structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->