### PR TITLE
`Communication`: Fix visibility of create channel option for students

### DIFF
--- a/src/main/webapp/app/overview/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/course-conversations.component.ts
@@ -40,6 +40,7 @@ import { CourseSidebarService } from 'app/overview/course-sidebar.service';
 import { LayoutService } from 'app/shared/breakpoints/layout.service';
 import { CustomBreakpointNames } from 'app/shared/breakpoints/breakpoints.service';
 import { Posting, PostingType, SavedPostStatus, SavedPostStatusMap } from 'app/entities/metis/posting.model';
+import { canCreateChannel } from 'app/shared/metis/conversations/conversation-permissions.utils';
 
 const DEFAULT_CHANNEL_GROUPS: AccordionGroups = {
     favoriteChannels: { entityData: [] },
@@ -424,6 +425,7 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
             ungroupedData: this.sidebarConversations,
             showAccordionLeadingIcon: true,
             messagingEnabled: isMessagingEnabled(this.course),
+            canCreateChannel: canCreateChannel(this.course!),
         };
     }
 

--- a/src/main/webapp/app/shared/sidebar/sidebar.component.html
+++ b/src/main/webapp/app/shared/sidebar/sidebar.component.html
@@ -35,10 +35,12 @@
                                             <span jhiTranslate="artemisApp.courseOverview.sidebar.createGroupChat"></span>
                                         </button>
                                     }
-                                    <button (click)="createNewChannel()" class="p-2" ngbDropdownItem>
-                                        <fa-icon [icon]="faHashtag" class="item-icon"></fa-icon>
-                                        <span jhiTranslate="artemisApp.courseOverview.sidebar.createChannel"></span>
-                                    </button>
+                                    @if (sidebarData?.canCreateChannel) {
+                                        <button (click)="createNewChannel()" class="p-2 createChannel" ngbDropdownItem>
+                                            <fa-icon [icon]="faHashtag" class="item-icon"></fa-icon>
+                                            <span jhiTranslate="artemisApp.courseOverview.sidebar.createChannel"></span>
+                                        </button>
+                                    }
                                     <button (click)="browseChannels()" class="p-2" ngbDropdownItem>
                                         <fa-icon [icon]="faSearch" class="item-icon"></fa-icon>
                                         <span jhiTranslate="artemisApp.courseOverview.sidebar.browseChannels"></span>

--- a/src/main/webapp/app/types/sidebar.ts
+++ b/src/main/webapp/app/types/sidebar.ts
@@ -41,6 +41,7 @@ export interface SidebarData {
     storageId?: string;
     showAccordionLeadingIcon?: boolean;
     messagingEnabled?: boolean;
+    canCreateChannel?: boolean;
 }
 
 export interface SidebarCardElement {

--- a/src/test/javascript/spec/component/shared/sidebar/sidebar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/sidebar/sidebar.component.spec.ts
@@ -17,7 +17,7 @@ import { SidebarCardElement, SidebarData } from 'app/types/sidebar';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { ExerciseFilterModalComponent } from 'app/shared/exercise-filter/exercise-filter-modal.component';
 import { ExerciseFilterResults } from 'app/types/exercise-filter';
-import { EventEmitter } from '@angular/core';
+import { EventEmitter, input, runInInjectionContext } from '@angular/core';
 import { ExerciseCategory } from 'app/entities/exercise-category.model';
 import { ExerciseType } from 'app/entities/exercise.model';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
@@ -49,9 +49,7 @@ describe('SidebarComponent', () => {
             ],
             providers: [MockProvider(NgbModal)],
         }).compileComponents();
-    });
 
-    beforeEach(() => {
         fixture = TestBed.createComponent(SidebarComponent);
         component = fixture.componentInstance;
         modalService = TestBed.inject(NgbModal);
@@ -287,6 +285,28 @@ describe('SidebarComponent', () => {
             expect(component.sidebarData).toEqual(mockFilterResults.filteredSidebarData);
             expect(component.exerciseFilters).toEqual(mockFilterResults.appliedExerciseFilters);
             expect(component.isFilterActive).toBeTrue();
+        });
+
+        it('should show "Create Channel" button when canCreateChannel is true', () => {
+            runInInjectionContext(fixture.debugElement.injector, () => {
+                component.inCommunication = input<boolean>(true);
+                component.ngOnInit();
+                component.sidebarData.canCreateChannel = true;
+                fixture.detectChanges();
+                const createChannelButton = fixture.debugElement.query(By.css('.createChannel'));
+                expect(createChannelButton).toBeTruthy();
+            });
+        });
+
+        it('should not show "Create Channel" button when canCreateChannel is false', () => {
+            runInInjectionContext(fixture.debugElement.injector, () => {
+                component.inCommunication = input<boolean>(true);
+                component.ngOnInit();
+                component.sidebarData.canCreateChannel = false;
+                fixture.detectChanges();
+                const createChannelButton = fixture.debugElement.query(By.css('.createChannel'));
+                expect(createChannelButton).toBeFalsy();
+            });
         });
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).





#### Client
- [X] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [X] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Students currently see the "Create Channel" button despite lacking the permission to create channel, leading to confusion and errors. (Closes [#9969](https://github.com/ls1intum/Artemis/issues/9969))

### Description
<!-- Describe your changes in detail -->
The visibility of the "Create Channel" button was fixed using the `canCreateChannel` variable to ensure it only appears for users with the necessary permissions.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Course with Communication enabled

1. Log in to Artemis (as an Instructor)
2. Navigate to Communication section of a course
3. As an Instructor, click on the "+" button in the sidebar and verify that the "Create Channel" option is visible.
4. Log out and log in as a Student.
5. Click on the "+" button in the sidebar and verify that the "Create Channel" option is not visible.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [X] Code Review 1
- [X] Code Review 2
#### Manual Tests
- [X] Test 1
- [X] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| course-conversations.component.ts | 90.76% | ✅ ❌ |
| sidebar.ts | not found (modified) | ❌ |





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to determine if users can create a channel, enhancing sidebar data.
	- Conditional rendering for the "Create Channel" button based on user permissions.
  
- **Bug Fixes**
	- Updated tests to verify the visibility of the "Create Channel" button according to permissions.

- **Documentation**
	- Updated the `SidebarData` interface to include a new optional property for channel creation permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->