### PR TITLE
`Development`: Ignore build directory in Jest's module path

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -128,7 +128,7 @@ module.exports = {
             },
         ],
     },
-    modulePathIgnorePatterns: ['<rootDir>/src/main/resources/templates/'],
+    modulePathIgnorePatterns: ['<rootDir>/src/main/resources/templates/', '<rootDir>/build/'],
     testTimeout: 3000,
     testMatch: [
         '<rootDir>/src/test/javascript/spec/component/**/*.spec.ts',


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, client tests always start with this message:
```
jest-haste-map: Haste module naming collision: artemis-exercise
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/build/resources/main/templates/javascript/exercise/package.json
    * <rootDir>/build/resources/main/templates/javascript/solution/package.json

jest-haste-map: Haste module naming collision: artemis-test
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/build/resources/main/templates/javascript/test/package.json
    * <rootDir>/build/resources/main/templates/typescript/test/package.json
```
Jest detects the package.json files in the build directory and tries to add them as modules.

### Description
<!-- Describe your changes in detail -->
The `modulePathIgnorePatterns` option of Jest is used to ignore the build directory, like it's already done with the template resources.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Jest configuration to expand ignored module paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->