### PR TITLE
`General`: Fix header position in exercise and course summaries

### DIFF
--- a/src/main/webapp/app/forms/form-status-bar/form-status-bar.component.scss
+++ b/src/main/webapp/app/forms/form-status-bar/form-status-bar.component.scss
@@ -1,6 +1,6 @@
 .form-status-bar-container {
     position: sticky;
-    top: var(--header-height);
+    top: 0;
     z-index: 7;
     background-color: var(--bs-card-bg);
 }

--- a/src/main/webapp/app/shared/detail-overview-navigation-bar/detail-overview-navigation-bar.scss
+++ b/src/main/webapp/app/shared/detail-overview-navigation-bar/detail-overview-navigation-bar.scss
@@ -1,6 +1,6 @@
 nav {
     position: sticky;
-    top: var(--header-height);
+    top: 0;
     z-index: 2;
     padding: 1rem 0;
     background: var(--bs-card-bg);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently there is an issue with the header in exercise and course detail views, which makes the position look off when scrolling:

<img width="1631" alt="Bildschirmfoto 2024-12-10 um 23 46 11" src="https://github.com/user-attachments/assets/885042b2-6a77-4bb4-82a9-46a3bb741b66">

Also in the programming exercises:

<img width="951" alt="Bildschirmfoto 2024-12-11 um 00 02 32" src="https://github.com/user-attachments/assets/0ed0d9cd-1d82-4b04-8a46-d902517f0666">

### Description
<!-- Describe your changes in detail -->
I set the sticky position to 0, so that the navbar is correctly positioned.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Scroll down and see if the navbar for the detail component properly attaches to the top
4. Go to a Manage Exercises
5. Edit a programming exercise
6. Check if the header is correctly positioned when scrolling down

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1632" alt="Bildschirmfoto 2024-12-10 um 23 59 26" src="https://github.com/user-attachments/assets/9d760510-0ce6-46fa-ba95-e5cdce354607">

<img width="956" alt="Bildschirmfoto 2024-12-11 um 00 02 47" src="https://github.com/user-attachments/assets/f43f254c-5d6d-42e9-bc23-3eccbbe7225b">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the vertical positioning of the form status bar to stick to the top with a fixed value.
	- Adjusted the navigation bar's vertical positioning to stick to the top with a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->