### PR TITLE
`Development`: Remove race condition in faky playwright test

### DIFF
--- a/src/test/playwright/e2e/course/CourseMessages.spec.ts
+++ b/src/test/playwright/e2e/course/CourseMessages.spec.ts
@@ -142,17 +142,15 @@ test.describe('Course messages', { tag: '@fast' }, () => {
                 await login(instructor, `/courses/${course.id}/communication?conversationId=${channel.id}`);
                 const newName = 'new-test-name';
                 const topic = 'test-topic';
-                await courseMessages.getName().click();
+
+                // each edit action triggers an update to the server, on multinode this can lead to a race condition
                 await courseMessages.editName(newName);
                 await courseMessages.editTopic(topic);
                 await courseMessages.editDescription('New Description');
-                await courseMessages.closeEditPanel();
+
                 await page.reload();
                 await page.locator('jhi-conversation-header').waitFor({ state: 'visible', timeout: 10000 });
                 await expect(courseMessages.getName()).toContainText(newName);
-                await courseMessages.getName().click();
-                await courseMessages.checkTopic(topic);
-                await courseMessages.closeEditPanel();
                 await expect(courseMessages.getTopic()).toContainText(topic);
             });
         });

--- a/src/test/playwright/e2e/course/CourseMessages.spec.ts
+++ b/src/test/playwright/e2e/course/CourseMessages.spec.ts
@@ -150,6 +150,9 @@ test.describe('Course messages', { tag: '@fast' }, () => {
                 await page.reload();
                 await page.locator('jhi-conversation-header').waitFor({ state: 'visible', timeout: 10000 });
                 await expect(courseMessages.getName()).toContainText(newName);
+                await courseMessages.getName().click();
+                await courseMessages.checkTopic(topic);
+                await courseMessages.closeEditPanel();
                 await expect(courseMessages.getTopic()).toContainText(topic);
             });
         });

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -192,6 +192,14 @@ export class CourseMessagesPage {
     }
 
     /**
+     * Edits the topic of the conversation to a new topic.
+     * @param newTopic - The new topic for the conversation.
+     */
+    async checkTopic(newTopic: string) {
+        await expect(this.page.locator('#topic-section textarea')).toHaveValue(newTopic);
+    }
+
+    /**
      * Edits the description of the conversation to a new description.
      * @param newDescription - The new description for the conversation.
      */

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -170,12 +170,15 @@ export class CourseMessagesPage {
      * @param newName - The new name for the conversation.
      */
     async editName(newName: string) {
+        await this.getName().click();
         await this.page.locator('#name-section .action-button').click();
         const nameField = this.page.locator('.channels-overview #name');
         await nameField.clear();
         await nameField.fill(newName);
         await this.page.locator('#submitButton').click();
         await expect(this.page.locator('#name-section textarea')).toHaveValue(newName);
+        await this.closeEditPanel();
+        await this.page.waitForTimeout(200);
     }
 
     /**
@@ -183,20 +186,15 @@ export class CourseMessagesPage {
      * @param newTopic - The new topic for the conversation.
      */
     async editTopic(newTopic: string) {
+        await this.getName().click();
         await this.page.locator('#topic-section .action-button').click();
         const topicField = this.page.locator('.channels-overview #topic');
         await topicField.clear();
         await topicField.fill(newTopic);
         await this.page.locator('#submitButton').click();
         await expect(this.page.locator('#topic-section textarea')).toHaveValue(newTopic);
-    }
-
-    /**
-     * Edits the topic of the conversation to a new topic.
-     * @param newTopic - The new topic for the conversation.
-     */
-    async checkTopic(newTopic: string) {
-        await expect(this.page.locator('#topic-section textarea')).toHaveValue(newTopic);
+        await this.closeEditPanel();
+        await this.page.waitForTimeout(200);
     }
 
     /**
@@ -204,12 +202,15 @@ export class CourseMessagesPage {
      * @param newDescription - The new description for the conversation.
      */
     async editDescription(newDescription: string) {
+        await this.getName().click();
         await this.page.locator('#description-section .action-button').click();
         const descriptionField = this.page.locator('.channels-overview #description');
         await descriptionField.clear();
         await descriptionField.fill(newDescription);
         await this.page.locator('#submitButton').click();
         await expect(this.page.locator('#description-section textarea')).toHaveValue(newDescription);
+        await this.closeEditPanel();
+        await this.page.waitForTimeout(200);
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -175,6 +175,7 @@ export class CourseMessagesPage {
         await nameField.clear();
         await nameField.fill(newName);
         await this.page.locator('#submitButton').click();
+        await expect(this.page.locator('#name-section textarea')).toHaveValue(newName);
     }
 
     /**
@@ -187,6 +188,7 @@ export class CourseMessagesPage {
         await topicField.clear();
         await topicField.fill(newTopic);
         await this.page.locator('#submitButton').click();
+        await expect(this.page.locator('#topic-section textarea')).toHaveValue(newTopic);
     }
 
     /**
@@ -199,6 +201,7 @@ export class CourseMessagesPage {
         await descriptionField.clear();
         await descriptionField.fill(newDescription);
         await this.page.locator('#submitButton').click();
+        await expect(this.page.locator('#description-section textarea')).toHaveValue(newDescription);
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The `instructor should be able to edit a channel: Test case result` test is flaky on multi node: https://bamboo.ase.in.tum.de/browse/ARTEMIS-AEPAEPTMLM-DA-512/test/case/757931218

### Description
<!-- Describe your changes in detail -->
Most likely cause: race condition when updating the channel. 
Before the response to the playwright's request to change the topic playwright already sends the next request to change the description. In that request the topic is not updated yet, and since the channel is updated as a whole, the change to the topic gets overwritten.

This PR makes sure, to wait for the server response, and waits for the UI to be updated.

Before the change:
![image](https://github.com/user-attachments/assets/2dfadf65-fddc-458d-80ec-95fc8bd7f09e)

After the change (only update description when changing the topic has completed):
![image](https://github.com/user-attachments/assets/da4e4f9d-afc7-449f-a231-0a7841d296ab)


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

1. Make sure the e2e tests pass

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced validation for editing operations on course messages, ensuring that the UI correctly reflects updated values after changes are submitted.
	- Improved test coverage for channel editing functionality, verifying that both the name and topic are accurately updated after edits.
	- Addressed potential synchronization issues during channel edits to ensure updated information is accurately reflected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->