### PR TITLE
`Programming exercises`: Add MATLAB programming exercise template

### DIFF
--- a/docs/user/exercises/programming-exercise-features.inc
+++ b/docs/user/exercises/programming-exercise-features.inc
@@ -45,6 +45,8 @@ Instructors can still use those templates to generate programming exercises and 
   +----------------------+----------+---------+
   | C#                   | yes      | yes     |
   +----------------------+----------+---------+
+  | MATLAB               | yes      | no      |
+  +----------------------+----------+---------+
 
 - Not all ``templates`` support the same feature set and supported features can also change depending on the continuous integration system setup.
   Depending on the feature set, some options might not be available during the creation of the programming exercise.
@@ -86,6 +88,8 @@ Instructors can still use those templates to generate programming exercises and 
   | TypeScript           | no                   | no                   | yes                 | no           | n/a                                      | no                           | no                         | L: yes, J: no          |
   +----------------------+----------------------+----------------------+---------------------+--------------+------------------------------------------+------------------------------+----------------------------+------------------------+
   | C#                   | no                   | no                   | yes                 | no           | n/a                                      | no                           | no                         | L: yes, J: no          |
+  +----------------------+----------------------+----------------------+---------------------+--------------+------------------------------------------+------------------------------+----------------------------+------------------------+
+  | MATLAB               | no                   | no                   | no                  | no           | n/a                                      | no                           | no                         | L: yes, J: no          |
   +----------------------+----------------------+----------------------+---------------------+--------------+------------------------------------------+------------------------------+----------------------------+------------------------+
 
   - *Sequential Test Runs*: ``Artemis`` can generate a build plan which first executes structural and then behavioral tests. This feature can help students to better concentrate on the immediate challenge at hand.

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -107,7 +107,7 @@ public class BuildJobContainerService {
                 // container from exiting until it finishes.
                 // It waits until the script that is running the tests (see below execCreateCmdResponse) is completed, and until the result files are extracted which is indicated
                 // by the creation of a file "stop_container.txt" in the container's root directory.
-                .withCmd("sh", "-c", "while [ ! -f " + LOCALCI_WORKING_DIRECTORY + "/stop_container.txt ]; do sleep 0.5; done")
+                .withEntrypoint().withCmd("sh", "-c", "while [ ! -f " + LOCALCI_WORKING_DIRECTORY + "/stop_container.txt ]; do sleep 0.5; done")
                 // .withCmd("tail", "-f", "/dev/null") // Activate for debugging purposes instead of the above command to get a running container that you can peek into using
                 // "docker exec -it <container-id> /bin/bash".
                 .exec();

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingLanguage.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingLanguage.java
@@ -46,6 +46,7 @@ public enum ProgrammingLanguage {
         JAVA,
         JAVASCRIPT,
         KOTLIN,
+        MATLAB,
         OCAML,
         PYTHON,
         R,

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/TemplateUpgradePolicyService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/TemplateUpgradePolicyService.java
@@ -32,8 +32,8 @@ public class TemplateUpgradePolicyService {
     public TemplateUpgradeService getUpgradeService(ProgrammingLanguage programmingLanguage) {
         return switch (programmingLanguage) {
             case JAVA -> javaRepositoryUpgradeService;
-            case KOTLIN, PYTHON, C, HASKELL, VHDL, ASSEMBLER, SWIFT, OCAML, EMPTY, RUST, JAVASCRIPT, R, C_PLUS_PLUS, TYPESCRIPT, C_SHARP -> defaultRepositoryUpgradeService;
-            case SQL, GO, MATLAB, BASH, RUBY, POWERSHELL, ADA, DART, PHP -> throw new UnsupportedOperationException("Unsupported programming language: " + programmingLanguage);
+            case KOTLIN, PYTHON, C, HASKELL, VHDL, ASSEMBLER, SWIFT, OCAML, EMPTY, RUST, JAVASCRIPT, R, C_PLUS_PLUS, TYPESCRIPT, C_SHARP, MATLAB -> defaultRepositoryUpgradeService;
+            case SQL, GO, BASH, RUBY, POWERSHELL, ADA, DART, PHP -> throw new UnsupportedOperationException("Unsupported programming language: " + programmingLanguage);
         };
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ci/ContinuousIntegrationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ci/ContinuousIntegrationService.java
@@ -219,8 +219,8 @@ public interface ContinuousIntegrationService {
             @Override
             public String forProgrammingLanguage(ProgrammingLanguage language) {
                 return switch (language) {
-                    case JAVA, PYTHON, C, HASKELL, KOTLIN, VHDL, ASSEMBLER, SWIFT, OCAML, EMPTY, RUST, JAVASCRIPT, R, C_PLUS_PLUS, TYPESCRIPT, C_SHARP -> "assignment";
-                    case SQL, GO, MATLAB, BASH, RUBY, POWERSHELL, ADA, DART, PHP -> throw new UnsupportedOperationException("Unsupported programming language: " + language);
+                    case JAVA, PYTHON, C, HASKELL, KOTLIN, VHDL, ASSEMBLER, SWIFT, OCAML, EMPTY, RUST, JAVASCRIPT, R, C_PLUS_PLUS, TYPESCRIPT, C_SHARP, MATLAB -> "assignment";
+                    case SQL, GO, BASH, RUBY, POWERSHELL, ADA, DART, PHP -> throw new UnsupportedOperationException("Unsupported programming language: " + language);
                 };
             }
         },
@@ -230,8 +230,8 @@ public interface ContinuousIntegrationService {
             public String forProgrammingLanguage(ProgrammingLanguage language) {
                 return switch (language) {
                     case JAVA, PYTHON, HASKELL, KOTLIN, SWIFT, EMPTY, RUST, JAVASCRIPT, R, C_PLUS_PLUS, TYPESCRIPT -> "";
-                    case C, VHDL, ASSEMBLER, OCAML, C_SHARP -> "tests";
-                    case SQL, GO, MATLAB, BASH, RUBY, POWERSHELL, ADA, DART, PHP -> throw new UnsupportedOperationException("Unsupported programming language: " + language);
+                    case C, VHDL, ASSEMBLER, OCAML, C_SHARP, MATLAB -> "tests";
+                    case SQL, GO, BASH, RUBY, POWERSHELL, ADA, DART, PHP -> throw new UnsupportedOperationException("Unsupported programming language: " + language);
                 };
             }
         },

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/localci/LocalCIProgrammingLanguageFeatureService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/localci/LocalCIProgrammingLanguageFeatureService.java
@@ -10,6 +10,7 @@ import static de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage.HASK
 import static de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage.JAVA;
 import static de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage.JAVASCRIPT;
 import static de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage.KOTLIN;
+import static de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage.MATLAB;
 import static de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage.OCAML;
 import static de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage.PYTHON;
 import static de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage.R;
@@ -52,6 +53,7 @@ public class LocalCIProgrammingLanguageFeatureService extends ProgrammingLanguag
                 new ProgrammingLanguageFeature(JAVA, true, true, true, true, false, List.of(PLAIN_GRADLE, GRADLE_GRADLE, PLAIN_MAVEN, MAVEN_MAVEN), false, true));
         programmingLanguageFeatures.put(JAVASCRIPT, new ProgrammingLanguageFeature(JAVASCRIPT, false, false, true, false, false, List.of(), false, true));
         programmingLanguageFeatures.put(KOTLIN, new ProgrammingLanguageFeature(KOTLIN, false, false, true, true, false, List.of(), false, true));
+        programmingLanguageFeatures.put(MATLAB, new ProgrammingLanguageFeature(MATLAB, false, false, false, false, false, List.of(), false, true));
         programmingLanguageFeatures.put(OCAML, new ProgrammingLanguageFeature(OCAML, false, false, false, false, true, List.of(), false, true));
         programmingLanguageFeatures.put(PYTHON, new ProgrammingLanguageFeature(PYTHON, false, false, true, false, false, List.of(), false, true));
         programmingLanguageFeatures.put(R, new ProgrammingLanguageFeature(R, false, false, true, false, false, List.of(), false, true));

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -99,6 +99,8 @@ artemis:
                     default: "ghcr.io/ls1intum/artemis-csharp-docker:v1.0.0"
                 typescript:
                     default: "ghcr.io/ls1intum/artemis-javascript-docker:v1.0.0"
+                matlab:
+                    default: "mathworks/matlab:r2024b"
 
         # The following properties are used to configure the Artemis build agent.
         # The build agent is responsible for executing the buildJob to test student submissions.

--- a/src/main/resources/templates/aeolus/matlab/default.sh
+++ b/src/main/resources/templates/aeolus/matlab/default.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+test () {
+  echo '⚙️ executing test'
+  cd "${testWorkingDirectory}"
+
+  sudo mkdir test-results
+  sudo chown matlab:matlab test-results
+  sudo rm /etc/sudoers.d/matlab
+
+  matlab -batch testRunner
+
+}
+
+main () {
+  test
+}
+
+main "${@}"

--- a/src/main/resources/templates/aeolus/matlab/default.yaml
+++ b/src/main/resources/templates/aeolus/matlab/default.yaml
@@ -1,0 +1,18 @@
+api: v0.0.1
+metadata:
+  name: "MATLAB"
+  id: matlab
+actions:
+  - name: test
+    script: |
+      cd "${testWorkingDirectory}"
+
+      sudo mkdir test-results
+      sudo chown matlab:matlab test-results
+      sudo rm /etc/sudoers.d/matlab
+
+      matlab -batch testRunner
+    results:
+      - name: Test Results
+        path: "${testWorkingDirectory}/test-results/results.xml"
+        type: junit

--- a/src/main/resources/templates/matlab/exercise/square.m
+++ b/src/main/resources/templates/matlab/exercise/square.m
@@ -1,0 +1,3 @@
+function sq = square(x)
+    % TODO: implement function
+end

--- a/src/main/resources/templates/matlab/solution/square.m
+++ b/src/main/resources/templates/matlab/solution/square.m
@@ -1,0 +1,3 @@
+function sq = square(x)
+    sq = x^2;
+end

--- a/src/main/resources/templates/matlab/test/.gitattributes
+++ b/src/main/resources/templates/matlab/test/.gitattributes
@@ -1,0 +1,28 @@
+* text=auto
+
+*.fig binary
+*.mat binary
+*.mdl binary diff merge=mlAutoMerge
+*.mdlp binary
+*.mex* binary
+*.mlapp binary
+*.mldatx binary
+*.mlproj binary
+*.mlx binary
+*.p binary
+*.sfx binary
+*.sldd binary
+*.slreqx binary merge=mlAutoMerge
+*.slmx binary merge=mlAutoMerge
+*.sltx binary
+*.slxc binary
+*.slx binary merge=mlAutoMerge
+*.slxp binary
+
+## Other common binary file types
+*.docx binary
+*.exe binary
+*.jpg binary
+*.pdf binary
+*.png binary
+*.xlsx binary

--- a/src/main/resources/templates/matlab/test/.gitignore
+++ b/src/main/resources/templates/matlab/test/.gitignore
@@ -1,0 +1,39 @@
+# Test results
+results.xml
+
+# Autosave files
+*.asv
+*.m~
+*.autosave
+*.slx.r*
+*.mdl.r*
+
+# Derived content-obscured files
+*.p
+
+# Compiled MEX files
+*.mex*
+
+# Packaged app and toolbox files
+*.mlappinstall
+*.mltbx
+
+# Deployable archives
+*.ctf
+
+# Generated helpsearch folders
+helpsearch*/
+
+# Code generation folders
+slprj/
+sccprj/
+codegen/
+
+# Cache files
+*.slxc
+
+# Cloud based storage dotfile
+.MATLABDriveTag
+
+# buildtool cache folder
+.buildtool/

--- a/src/main/resources/templates/matlab/test/testRunner.m
+++ b/src/main/resources/templates/matlab/test/testRunner.m
@@ -1,0 +1,12 @@
+import matlab.unittest.plugins.XMLPlugin
+
+addpath("../${studentParentWorkingDirectoryName}")
+
+runner = testrunner;
+
+plugin = XMLPlugin.producingJUnitFormat("test-results/results.xml");
+addPlugin(runner,plugin);
+
+suite = testsuite("tests");
+
+run(runner,suite);

--- a/src/main/resources/templates/matlab/test/tests/MathTest.m
+++ b/src/main/resources/templates/matlab/test/tests/MathTest.m
@@ -1,0 +1,21 @@
+classdef MathTest < matlab.unittest.TestCase
+
+    methods (TestClassSetup)
+        % Shared setup for the entire test class
+    end
+
+    methods (TestMethodSetup)
+        % Setup for each test
+    end
+
+    methods (Test)
+        % Test methods
+
+        function testSquare(testCase)
+            actual = square(3);
+            expected = 9;
+            testCase.assertEqual(actual,expected,"square(3) should be 9")
+        end
+    end
+
+end

--- a/src/main/webapp/app/entities/programming/programming-exercise.model.ts
+++ b/src/main/webapp/app/entities/programming/programming-exercise.model.ts
@@ -22,6 +22,7 @@ export enum ProgrammingLanguage {
     JAVA = 'JAVA',
     JAVASCRIPT = 'JAVASCRIPT',
     KOTLIN = 'KOTLIN',
+    MATLAB = 'MATLAB',
     OCAML = 'OCAML',
     PYTHON = 'PYTHON',
     R = 'R',

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -78,6 +78,8 @@ artemis:
                     default: "~~invalid~~"
                 typescript:
                     default: "~~invalid~~"
+                matlab:
+                    default: "~~invalid~~"
         build-agent:
             short-name: "artemis-build-agent-test"
     telemetry:


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [ ] I **strictly** followed the principle of **data economy** for all database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **Gitlab** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


### Description
<!-- Describe your changes in detail -->


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
