### PR TITLE
`Development`: Add module/Java API for text exercises

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ExampleSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ExampleSubmissionService.java
@@ -15,6 +15,7 @@ import de.tum.cit.aet.artemis.assessment.domain.GradingInstruction;
 import de.tum.cit.aet.artemis.assessment.repository.ExampleSubmissionRepository;
 import de.tum.cit.aet.artemis.assessment.repository.GradingCriterionRepository;
 import de.tum.cit.aet.artemis.assessment.repository.TutorParticipationRepository;
+import de.tum.cit.aet.artemis.core.exception.ApiNotPresentException;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
@@ -23,6 +24,7 @@ import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
 import de.tum.cit.aet.artemis.modeling.service.ModelingExerciseImportService;
+import de.tum.cit.aet.artemis.text.api.TextExerciseSubmissionApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 import de.tum.cit.aet.artemis.text.repository.TextSubmissionRepository;
@@ -44,6 +46,8 @@ public class ExampleSubmissionService {
 
     private final ModelingExerciseImportService modelingExerciseImportService;
 
+    private final Optional<TextExerciseSubmissionApi> textExerciseSubmissionApi;
+
     private final TextSubmissionRepository textSubmissionRepository;
 
     private final GradingCriterionRepository gradingCriterionRepository;
@@ -51,13 +55,15 @@ public class ExampleSubmissionService {
     private final TutorParticipationRepository tutorParticipationRepository;
 
     public ExampleSubmissionService(ExampleSubmissionRepository exampleSubmissionRepository, SubmissionRepository submissionRepository, ExerciseRepository exerciseRepository,
-            TextExerciseImportService textExerciseImportService, ModelingExerciseImportService modelingExerciseImportService, TextSubmissionRepository textSubmissionRepository,
-            GradingCriterionRepository gradingCriterionRepository, TutorParticipationRepository tutorParticipationRepository) {
+            TextExerciseImportService textExerciseImportService, ModelingExerciseImportService modelingExerciseImportService,
+            Optional<TextExerciseSubmissionApi> textExerciseSubmissionApi, TextSubmissionRepository textSubmissionRepository, GradingCriterionRepository gradingCriterionRepository,
+            TutorParticipationRepository tutorParticipationRepository) {
         this.exampleSubmissionRepository = exampleSubmissionRepository;
         this.submissionRepository = submissionRepository;
         this.exerciseRepository = exerciseRepository;
         this.modelingExerciseImportService = modelingExerciseImportService;
         this.textExerciseImportService = textExerciseImportService;
+        this.textExerciseSubmissionApi = textExerciseSubmissionApi;
         this.textSubmissionRepository = textSubmissionRepository;
         this.gradingCriterionRepository = gradingCriterionRepository;
         this.tutorParticipationRepository = tutorParticipationRepository;
@@ -136,11 +142,9 @@ public class ExampleSubmissionService {
             newExampleSubmission.setSubmission(modelingExerciseImportService.copySubmission(modelingSubmission, gradingInstructionCopyTracker));
         }
         if (exercise instanceof TextExercise) {
-            TextSubmission textSubmission = textSubmissionRepository.findByIdWithEagerResultsAndFeedbackAndTextBlocksElseThrow(submissionId);
-            checkGivenExerciseIdSameForSubmissionParticipation(exercise.getId(), textSubmission.getParticipation().getExercise().getId());
-            // example submission does not need participation
-            textSubmission.setParticipation(null);
-            newExampleSubmission.setSubmission(textExerciseImportService.copySubmission(textSubmission, gradingInstructionCopyTracker));
+            var api = textExerciseSubmissionApi.orElseThrow(() -> new ApiNotPresentException(TextExerciseSubmissionApi.class, PROFILE_CORE));
+            TextSubmission textSubmission = api.importStudentSubmission(submissionId, exercise.getId(), gradingInstructionCopyTracker);
+            newExampleSubmission.setSubmission(textSubmission);
         }
         return exampleSubmissionRepository.save(newExampleSubmission);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ExampleSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ExampleSubmissionService.java
@@ -24,11 +24,9 @@ import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
 import de.tum.cit.aet.artemis.modeling.service.ModelingExerciseImportService;
-import de.tum.cit.aet.artemis.text.api.TextExerciseSubmissionApi;
+import de.tum.cit.aet.artemis.text.api.TextSubmissionApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
-import de.tum.cit.aet.artemis.text.repository.TextSubmissionRepository;
-import de.tum.cit.aet.artemis.text.service.TextExerciseImportService;
 
 @Profile(PROFILE_CORE)
 @Service
@@ -42,29 +40,22 @@ public class ExampleSubmissionService {
 
     private final ExerciseRepository exerciseRepository;
 
-    private final TextExerciseImportService textExerciseImportService;
-
     private final ModelingExerciseImportService modelingExerciseImportService;
 
-    private final Optional<TextExerciseSubmissionApi> textExerciseSubmissionApi;
-
-    private final TextSubmissionRepository textSubmissionRepository;
+    private final Optional<TextSubmissionApi> textSubmissionApi;
 
     private final GradingCriterionRepository gradingCriterionRepository;
 
     private final TutorParticipationRepository tutorParticipationRepository;
 
     public ExampleSubmissionService(ExampleSubmissionRepository exampleSubmissionRepository, SubmissionRepository submissionRepository, ExerciseRepository exerciseRepository,
-            TextExerciseImportService textExerciseImportService, ModelingExerciseImportService modelingExerciseImportService,
-            Optional<TextExerciseSubmissionApi> textExerciseSubmissionApi, TextSubmissionRepository textSubmissionRepository, GradingCriterionRepository gradingCriterionRepository,
+            ModelingExerciseImportService modelingExerciseImportService, Optional<TextSubmissionApi> textSubmissionApi, GradingCriterionRepository gradingCriterionRepository,
             TutorParticipationRepository tutorParticipationRepository) {
         this.exampleSubmissionRepository = exampleSubmissionRepository;
         this.submissionRepository = submissionRepository;
         this.exerciseRepository = exerciseRepository;
         this.modelingExerciseImportService = modelingExerciseImportService;
-        this.textExerciseImportService = textExerciseImportService;
-        this.textExerciseSubmissionApi = textExerciseSubmissionApi;
-        this.textSubmissionRepository = textSubmissionRepository;
+        this.textSubmissionApi = textSubmissionApi;
         this.gradingCriterionRepository = gradingCriterionRepository;
         this.tutorParticipationRepository = tutorParticipationRepository;
     }
@@ -142,7 +133,7 @@ public class ExampleSubmissionService {
             newExampleSubmission.setSubmission(modelingExerciseImportService.copySubmission(modelingSubmission, gradingInstructionCopyTracker));
         }
         if (exercise instanceof TextExercise) {
-            var api = textExerciseSubmissionApi.orElseThrow(() -> new ApiNotPresentException(TextExerciseSubmissionApi.class, PROFILE_CORE));
+            var api = textSubmissionApi.orElseThrow(() -> new ApiNotPresentException(TextSubmissionApi.class, PROFILE_CORE));
             TextSubmission textSubmission = api.importStudentSubmission(submissionId, exercise.getId(), gradingInstructionCopyTracker);
             newExampleSubmission.setSubmission(textSubmission);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ExampleSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ExampleSubmissionService.java
@@ -25,6 +25,7 @@ import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
 import de.tum.cit.aet.artemis.modeling.service.ModelingExerciseImportService;
 import de.tum.cit.aet.artemis.text.api.TextSubmissionApi;
+import de.tum.cit.aet.artemis.text.api.TextSubmissionImportApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 
@@ -42,20 +43,20 @@ public class ExampleSubmissionService {
 
     private final ModelingExerciseImportService modelingExerciseImportService;
 
-    private final Optional<TextSubmissionApi> textSubmissionApi;
+    private final Optional<TextSubmissionImportApi> textSubmissionImportApi;
 
     private final GradingCriterionRepository gradingCriterionRepository;
 
     private final TutorParticipationRepository tutorParticipationRepository;
 
     public ExampleSubmissionService(ExampleSubmissionRepository exampleSubmissionRepository, SubmissionRepository submissionRepository, ExerciseRepository exerciseRepository,
-            ModelingExerciseImportService modelingExerciseImportService, Optional<TextSubmissionApi> textSubmissionApi, GradingCriterionRepository gradingCriterionRepository,
-            TutorParticipationRepository tutorParticipationRepository) {
+            ModelingExerciseImportService modelingExerciseImportService, Optional<TextSubmissionImportApi> textSubmissionImportApi,
+            GradingCriterionRepository gradingCriterionRepository, TutorParticipationRepository tutorParticipationRepository) {
         this.exampleSubmissionRepository = exampleSubmissionRepository;
         this.submissionRepository = submissionRepository;
         this.exerciseRepository = exerciseRepository;
         this.modelingExerciseImportService = modelingExerciseImportService;
-        this.textSubmissionApi = textSubmissionApi;
+        this.textSubmissionImportApi = textSubmissionImportApi;
         this.gradingCriterionRepository = gradingCriterionRepository;
         this.tutorParticipationRepository = tutorParticipationRepository;
     }
@@ -133,7 +134,7 @@ public class ExampleSubmissionService {
             newExampleSubmission.setSubmission(modelingExerciseImportService.copySubmission(modelingSubmission, gradingInstructionCopyTracker));
         }
         if (exercise instanceof TextExercise) {
-            var api = textSubmissionApi.orElseThrow(() -> new ApiNotPresentException(TextSubmissionApi.class, PROFILE_CORE));
+            var api = textSubmissionImportApi.orElseThrow(() -> new ApiNotPresentException(TextSubmissionApi.class, PROFILE_CORE));
             TextSubmission textSubmission = api.importStudentSubmission(submissionId, exercise.getId(), gradingInstructionCopyTracker);
             newExampleSubmission.setSubmission(textSubmission);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaDTOConverterService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaDTOConverterService.java
@@ -1,6 +1,9 @@
 package de.tum.cit.aet.artemis.athena.service;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_ATHENA;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -8,7 +11,6 @@ import org.springframework.stereotype.Service;
 
 import de.tum.cit.aet.artemis.assessment.domain.Feedback;
 import de.tum.cit.aet.artemis.assessment.repository.GradingCriterionRepository;
-import de.tum.cit.aet.artemis.assessment.repository.TextBlockRepository;
 import de.tum.cit.aet.artemis.athena.dto.ExerciseBaseDTO;
 import de.tum.cit.aet.artemis.athena.dto.FeedbackBaseDTO;
 import de.tum.cit.aet.artemis.athena.dto.ModelingExerciseDTO;
@@ -21,15 +23,16 @@ import de.tum.cit.aet.artemis.athena.dto.SubmissionBaseDTO;
 import de.tum.cit.aet.artemis.athena.dto.TextExerciseDTO;
 import de.tum.cit.aet.artemis.athena.dto.TextFeedbackDTO;
 import de.tum.cit.aet.artemis.athena.dto.TextSubmissionDTO;
+import de.tum.cit.aet.artemis.core.exception.ApiNotPresentException;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
+import de.tum.cit.aet.artemis.text.api.TextApi;
 import de.tum.cit.aet.artemis.text.domain.TextBlock;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
-import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
 
 /**
  * Service to convert exercises, submissions and feedback to DTOs for Athena.
@@ -41,18 +44,15 @@ public class AthenaDTOConverterService {
     @Value("${server.url}")
     private String artemisServerUrl;
 
-    private final TextBlockRepository textBlockRepository;
-
-    private final TextExerciseRepository textExerciseRepository;
+    private final Optional<TextApi> textApi;
 
     private final ProgrammingExerciseRepository programmingExerciseRepository;
 
     private final GradingCriterionRepository gradingCriterionRepository;
 
-    public AthenaDTOConverterService(TextBlockRepository textBlockRepository, TextExerciseRepository textExerciseRepository,
-            ProgrammingExerciseRepository programmingExerciseRepository, GradingCriterionRepository gradingCriterionRepository) {
-        this.textBlockRepository = textBlockRepository;
-        this.textExerciseRepository = textExerciseRepository;
+    public AthenaDTOConverterService(Optional<TextApi> textApi, ProgrammingExerciseRepository programmingExerciseRepository,
+            GradingCriterionRepository gradingCriterionRepository) {
+        this.textApi = textApi;
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.gradingCriterionRepository = gradingCriterionRepository;
     }
@@ -67,7 +67,7 @@ public class AthenaDTOConverterService {
         switch (exercise.getExerciseType()) {
             case TEXT -> {
                 // Fetch text exercise with grade criteria
-                var textExercise = textExerciseRepository.findWithGradingCriteriaByIdElseThrow(exercise.getId());
+                var textExercise = textApi.orElseThrow(() -> new ApiNotPresentException(TextApi.class, PROFILE_CORE)).findWithGradingCriteriaByIdElseThrow(exercise.getId());
                 return TextExerciseDTO.of(textExercise);
             }
             case PROGRAMMING -> {
@@ -117,8 +117,8 @@ public class AthenaDTOConverterService {
         switch (exercise.getExerciseType()) {
             case TEXT -> {
                 TextBlock feedbackTextBlock = null;
-                if (feedback.getReference() != null) {
-                    feedbackTextBlock = textBlockRepository.findById(feedback.getReference()).orElse(null);
+                if (feedback.getReference() != null && textApi.isPresent()) {
+                    feedbackTextBlock = textApi.get().findById(feedback.getReference());
                 }
                 return TextFeedbackDTO.of(exercise.getId(), submissionId, feedback, feedbackTextBlock);
             }

--- a/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaDTOConverterService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaDTOConverterService.java
@@ -118,7 +118,7 @@ public class AthenaDTOConverterService {
             case TEXT -> {
                 TextBlock feedbackTextBlock = null;
                 if (feedback.getReference() != null && textApi.isPresent()) {
-                    feedbackTextBlock = textApi.get().findById(feedback.getReference());
+                    feedbackTextBlock = textApi.get().findById(feedback.getReference()).orElse(null);
                 }
                 return TextFeedbackDTO.of(exercise.getId(), submissionId, feedback, feedbackTextBlock);
             }

--- a/src/main/java/de/tum/cit/aet/artemis/athena/web/AthenaResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/athena/web/AthenaResource.java
@@ -1,9 +1,11 @@
 package de.tum.cit.aet.artemis.athena.web;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_ATHENA;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -27,6 +29,7 @@ import de.tum.cit.aet.artemis.athena.service.AthenaModuleService;
 import de.tum.cit.aet.artemis.athena.service.AthenaRepositoryExportService;
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
+import de.tum.cit.aet.artemis.core.exception.ApiNotPresentException;
 import de.tum.cit.aet.artemis.core.exception.InternalServerErrorException;
 import de.tum.cit.aet.artemis.core.exception.NetworkingException;
 import de.tum.cit.aet.artemis.core.repository.CourseRepository;
@@ -45,8 +48,8 @@ import de.tum.cit.aet.artemis.modeling.repository.ModelingSubmissionRepository;
 import de.tum.cit.aet.artemis.programming.domain.RepositoryType;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingSubmissionRepository;
-import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
-import de.tum.cit.aet.artemis.text.repository.TextSubmissionRepository;
+import de.tum.cit.aet.artemis.text.api.TextApi;
+import de.tum.cit.aet.artemis.text.api.TextSubmissionApi;
 
 /**
  * REST controller for Athena feedback suggestions.
@@ -63,9 +66,9 @@ public class AthenaResource {
 
     private final CourseRepository courseRepository;
 
-    private final TextExerciseRepository textExerciseRepository;
+    private final Optional<TextApi> textApi;
 
-    private final TextSubmissionRepository textSubmissionRepository;
+    private final Optional<TextSubmissionApi> textSubmissionApi;
 
     private final ProgrammingExerciseRepository programmingExerciseRepository;
 
@@ -86,14 +89,14 @@ public class AthenaResource {
     /**
      * The AthenaResource provides an endpoint for the client to fetch feedback suggestions from Athena.
      */
-    public AthenaResource(CourseRepository courseRepository, TextExerciseRepository textExerciseRepository, TextSubmissionRepository textSubmissionRepository,
+    public AthenaResource(CourseRepository courseRepository, Optional<TextApi> textApi, Optional<TextSubmissionApi> textSubmissionApi,
             ProgrammingExerciseRepository programmingExerciseRepository, ProgrammingSubmissionRepository programmingSubmissionRepository,
             ModelingExerciseRepository modelingExerciseRepository, ModelingSubmissionRepository modelingSubmissionRepository, AuthorizationCheckService authCheckService,
             AthenaFeedbackSuggestionsService athenaFeedbackSuggestionsService, AthenaRepositoryExportService athenaRepositoryExportService,
             AthenaModuleService athenaModuleService) {
         this.courseRepository = courseRepository;
-        this.textExerciseRepository = textExerciseRepository;
-        this.textSubmissionRepository = textSubmissionRepository;
+        this.textSubmissionApi = textSubmissionApi;
+        this.textApi = textApi;
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.programmingSubmissionRepository = programmingSubmissionRepository;
         this.modelingExerciseRepository = modelingExerciseRepository;
@@ -162,7 +165,10 @@ public class AthenaResource {
     @GetMapping("athena/text-exercises/{exerciseId}/submissions/{submissionId}/feedback-suggestions")
     @EnforceAtLeastTutor
     public ResponseEntity<List<TextFeedbackDTO>> getTextFeedbackSuggestions(@PathVariable long exerciseId, @PathVariable long submissionId) {
-        return getFeedbackSuggestions(exerciseId, submissionId, textExerciseRepository::findByIdElseThrow, textSubmissionRepository::findByIdElseThrow,
+        var api = textApi.orElseThrow(() -> new ApiNotPresentException(TextApi.class, PROFILE_CORE));
+        var submissionApi = textSubmissionApi.orElseThrow(() -> new ApiNotPresentException(TextSubmissionApi.class, PROFILE_CORE));
+
+        return getFeedbackSuggestions(exerciseId, submissionId, api::findByIdElseThrow, submissionApi::findByIdElseThrow,
                 athenaFeedbackSuggestionsService::getTextFeedbackSuggestions);
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/export/CourseExamExportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/export/CourseExamExportService.java
@@ -48,8 +48,8 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.service.ProgrammingExerciseExportService;
 import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
 import de.tum.cit.aet.artemis.quiz.service.QuizExerciseWithSubmissionsExportService;
+import de.tum.cit.aet.artemis.text.api.TextSubmissionExportApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
-import de.tum.cit.aet.artemis.text.service.TextExerciseWithSubmissionsExportService;
 
 /**
  * Service Implementation for exporting courses and exams.
@@ -67,7 +67,7 @@ public class CourseExamExportService {
 
     private final ZipFileService zipFileService;
 
-    private final TextExerciseWithSubmissionsExportService textExerciseWithSubmissionsExportService;
+    private final Optional<TextSubmissionExportApi> textSubmissionExportApi;
 
     private final FileUploadExerciseWithSubmissionsExportService fileUploadExerciseWithSubmissionsExportService;
 
@@ -81,15 +81,16 @@ public class CourseExamExportService {
 
     private final WebsocketMessagingService websocketMessagingService;
 
-    public CourseExamExportService(ProgrammingExerciseExportService programmingExerciseExportService, ZipFileService zipFileService, FileService fileService,
-            TextExerciseWithSubmissionsExportService textExerciseWithSubmissionsExportService,
+    public CourseExamExportService(ProgrammingExerciseExportService programmingExerciseExportService, ZipFileService zipFileService,
+            Optional<TextSubmissionExportApi> textSubmissionExportApi, FileService fileService,
+
             FileUploadExerciseWithSubmissionsExportService fileUploadExerciseWithSubmissionsExportService,
             ModelingExerciseWithSubmissionsExportService modelingExerciseWithSubmissionsExportService,
             QuizExerciseWithSubmissionsExportService quizExerciseWithSubmissionsExportService, WebsocketMessagingService websocketMessagingService, ExamRepository examRepository) {
         this.programmingExerciseExportService = programmingExerciseExportService;
         this.zipFileService = zipFileService;
+        this.textSubmissionExportApi = textSubmissionExportApi;
         this.fileService = fileService;
-        this.textExerciseWithSubmissionsExportService = textExerciseWithSubmissionsExportService;
         this.fileUploadExerciseWithSubmissionsExportService = fileUploadExerciseWithSubmissionsExportService;
         this.modelingExerciseWithSubmissionsExportService = modelingExerciseWithSubmissionsExportService;
         this.quizExerciseWithSubmissionsExportService = quizExerciseWithSubmissionsExportService;
@@ -423,8 +424,8 @@ public class CourseExamExportService {
                                 .ifPresent(exportedExercises::add);
                     case FileUploadExercise fileUploadExercise -> exportedExercises.add(fileUploadExerciseWithSubmissionsExportService
                             .exportFileUploadExerciseWithSubmissions(fileUploadExercise, submissionsExportOptions, exerciseExportDir, exportErrors, reportData));
-                    case TextExercise textExercise -> exportedExercises.add(textExerciseWithSubmissionsExportService.exportTextExerciseWithSubmissions(textExercise,
-                            submissionsExportOptions, exerciseExportDir, exportErrors, reportData));
+                    case TextExercise textExercise -> textSubmissionExportApi.ifPresent(api -> exportedExercises
+                            .add(api.exportTextExerciseWithSubmissions(textExercise, submissionsExportOptions, exerciseExportDir, exportErrors, reportData)));
                     case ModelingExercise modelingExercise -> exportedExercises.add(modelingExerciseWithSubmissionsExportService
                             .exportModelingExerciseWithSubmissions(modelingExercise, submissionsExportOptions, exerciseExportDir, exportErrors, reportData));
                     case QuizExercise quizExercise ->

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamService.java
@@ -73,7 +73,7 @@ import de.tum.cit.aet.artemis.quiz.domain.compare.SAMapping;
 import de.tum.cit.aet.artemis.quiz.repository.QuizSubmissionRepository;
 import de.tum.cit.aet.artemis.quiz.repository.SubmittedAnswerRepository;
 import de.tum.cit.aet.artemis.quiz.service.QuizPoolService;
-import de.tum.cit.aet.artemis.text.api.TextExerciseSubmissionApi;
+import de.tum.cit.aet.artemis.text.api.TextSubmissionApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 
@@ -110,7 +110,7 @@ public class StudentExamService {
 
     private final SubmittedAnswerRepository submittedAnswerRepository;
 
-    private final Optional<TextExerciseSubmissionApi> textExerciseSubmissionApi;
+    private final Optional<TextSubmissionApi> textSubmissionApi;
 
     private final ModelingSubmissionRepository modelingSubmissionRepository;
 
@@ -130,8 +130,8 @@ public class StudentExamService {
             QuizSubmissionRepository quizSubmissionRepository, SubmittedAnswerRepository submittedAnswerRepository, ModelingSubmissionRepository modelingSubmissionRepository,
             SubmissionVersionService submissionVersionService, ProgrammingExerciseParticipationService programmingExerciseParticipationService, SubmissionService submissionService,
             StudentParticipationRepository studentParticipationRepository, ExamQuizService examQuizService, ProgrammingExerciseRepository programmingExerciseRepository,
-            ProgrammingTriggerService programmingTriggerService, Optional<TextExerciseSubmissionApi> textExerciseSubmissionApi, ExamRepository examRepository,
-            CacheManager cacheManager, WebsocketMessagingService websocketMessagingService, @Qualifier("taskScheduler") TaskScheduler scheduler, QuizPoolService quizPoolService) {
+            ProgrammingTriggerService programmingTriggerService, Optional<TextSubmissionApi> textSubmissionApi, ExamRepository examRepository, CacheManager cacheManager,
+            WebsocketMessagingService websocketMessagingService, @Qualifier("taskScheduler") TaskScheduler scheduler, QuizPoolService quizPoolService) {
         this.participationService = participationService;
         this.studentExamRepository = studentExamRepository;
         this.userRepository = userRepository;
@@ -145,7 +145,7 @@ public class StudentExamService {
         this.submissionService = submissionService;
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.programmingTriggerService = programmingTriggerService;
-        this.textExerciseSubmissionApi = textExerciseSubmissionApi;
+        this.textSubmissionApi = textSubmissionApi;
         this.examRepository = examRepository;
         this.cacheManager = cacheManager;
         this.websocketMessagingService = websocketMessagingService;
@@ -314,7 +314,7 @@ public class StudentExamService {
                         TextSubmission existingSubmissionInDatabase = (TextSubmission) existingParticipationInDatabase.findLatestSubmission().orElse(null);
                         TextSubmission textSubmissionFromClient = (TextSubmission) submissionFromClient;
                         if (!isContentEqualTo(existingSubmissionInDatabase, textSubmissionFromClient)) {
-                            textExerciseSubmissionApi.orElseThrow(() -> new ApiNotPresentException(TextExerciseSubmissionApi.class, PROFILE_CORE));
+                            textSubmissionApi.orElseThrow(() -> new ApiNotPresentException(TextSubmissionApi.class, PROFILE_CORE));
                             saveSubmissionVersion(currentUser, submissionFromClient);
                         }
                     }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseDeletionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseDeletionService.java
@@ -38,8 +38,8 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParti
 import de.tum.cit.aet.artemis.programming.service.ProgrammingExerciseService;
 import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
 import de.tum.cit.aet.artemis.quiz.service.QuizExerciseService;
+import de.tum.cit.aet.artemis.text.api.TextApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
-import de.tum.cit.aet.artemis.text.service.TextExerciseService;
 
 /**
  * Service Implementation for managing Exercise.
@@ -72,7 +72,7 @@ public class ExerciseDeletionService {
 
     private final PlagiarismResultRepository plagiarismResultRepository;
 
-    private final TextExerciseService textExerciseService;
+    private final Optional<TextApi> textApi;
 
     private final ChannelRepository channelRepository;
 
@@ -85,9 +85,8 @@ public class ExerciseDeletionService {
     public ExerciseDeletionService(ExerciseRepository exerciseRepository, ExerciseUnitRepository exerciseUnitRepository, ParticipationService participationService,
             ProgrammingExerciseService programmingExerciseService, ModelingExerciseService modelingExerciseService, QuizExerciseService quizExerciseService,
             TutorParticipationRepository tutorParticipationRepository, ExampleSubmissionService exampleSubmissionService, StudentExamRepository studentExamRepository,
-            LectureUnitService lectureUnitService, PlagiarismResultRepository plagiarismResultRepository, TextExerciseService textExerciseService,
-            ChannelRepository channelRepository, ChannelService channelService, Optional<CompetencyProgressApi> competencyProgressApi,
-            Optional<IrisSettingsService> irisSettingsService) {
+            LectureUnitService lectureUnitService, PlagiarismResultRepository plagiarismResultRepository, Optional<TextApi> textApi, ChannelRepository channelRepository,
+            ChannelService channelService, Optional<CompetencyProgressApi> competencyProgressApi, Optional<IrisSettingsService> irisSettingsService) {
         this.exerciseRepository = exerciseRepository;
         this.participationService = participationService;
         this.programmingExerciseService = programmingExerciseService;
@@ -99,7 +98,7 @@ public class ExerciseDeletionService {
         this.exerciseUnitRepository = exerciseUnitRepository;
         this.lectureUnitService = lectureUnitService;
         this.plagiarismResultRepository = plagiarismResultRepository;
-        this.textExerciseService = textExerciseService;
+        this.textApi = textApi;
         this.channelRepository = channelRepository;
         this.channelService = channelService;
         this.competencyProgressApi = competencyProgressApi;
@@ -167,7 +166,7 @@ public class ExerciseDeletionService {
 
         if (exercise instanceof TextExercise) {
             log.info("Cancel scheduled operations of exercise {}", exercise.getId());
-            textExerciseService.cancelScheduledOperations(exerciseId);
+            textApi.ifPresent(api -> api.cancelScheduledOperations(exerciseId));
         }
 
         // delete all exercise units linking to the exercise

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationResource.java
@@ -97,8 +97,8 @@ import de.tum.cit.aet.artemis.quiz.repository.QuizExerciseRepository;
 import de.tum.cit.aet.artemis.quiz.repository.SubmittedAnswerRepository;
 import de.tum.cit.aet.artemis.quiz.service.QuizBatchService;
 import de.tum.cit.aet.artemis.quiz.service.QuizSubmissionService;
+import de.tum.cit.aet.artemis.text.api.TextFeedbackApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
-import de.tum.cit.aet.artemis.text.service.TextExerciseFeedbackService;
 
 /**
  * REST controller for managing Participation.
@@ -165,7 +165,7 @@ public class ParticipationResource {
 
     private final ProgrammingExerciseCodeReviewFeedbackService programmingExerciseCodeReviewFeedbackService;
 
-    private final TextExerciseFeedbackService textExerciseFeedbackService;
+    private final Optional<TextFeedbackApi> textFeedbackApi;
 
     private final ModelingExerciseFeedbackService modelingExerciseFeedbackService;
 
@@ -178,7 +178,7 @@ public class ParticipationResource {
             ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository, SubmissionRepository submissionRepository,
             ResultRepository resultRepository, ExerciseDateService exerciseDateService, InstanceMessageSendService instanceMessageSendService, QuizBatchService quizBatchService,
             SubmittedAnswerRepository submittedAnswerRepository, QuizSubmissionService quizSubmissionService, GradingScaleService gradingScaleService,
-            ProgrammingExerciseCodeReviewFeedbackService programmingExerciseCodeReviewFeedbackService, TextExerciseFeedbackService textExerciseFeedbackService,
+            ProgrammingExerciseCodeReviewFeedbackService programmingExerciseCodeReviewFeedbackService, Optional<TextFeedbackApi> textFeedbackApi,
             ModelingExerciseFeedbackService modelingExerciseFeedbackService) {
         this.participationService = participationService;
         this.programmingExerciseParticipationService = programmingExerciseParticipationService;
@@ -205,7 +205,7 @@ public class ParticipationResource {
         this.quizSubmissionService = quizSubmissionService;
         this.gradingScaleService = gradingScaleService;
         this.programmingExerciseCodeReviewFeedbackService = programmingExerciseCodeReviewFeedbackService;
-        this.textExerciseFeedbackService = textExerciseFeedbackService;
+        this.textFeedbackApi = textFeedbackApi;
         this.modelingExerciseFeedbackService = modelingExerciseFeedbackService;
     }
 
@@ -417,7 +417,8 @@ public class ParticipationResource {
         // Process feedback request
         StudentParticipation updatedParticipation;
         if (exercise instanceof TextExercise) {
-            updatedParticipation = textExerciseFeedbackService.handleNonGradedFeedbackRequest(participation, (TextExercise) exercise);
+            StudentParticipation finalParticipation = participation;
+            updatedParticipation = textFeedbackApi.map(a -> a.handleNonGradedFeedbackRequest(finalParticipation, (TextExercise) exercise)).orElse(participation);
         }
         else if (exercise instanceof ModelingExercise) {
             updatedParticipation = modelingExerciseFeedbackService.handleNonGradedFeedbackRequest(participation, (ModelingExercise) exercise);

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationTeamWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationTeamWebsocketService.java
@@ -34,6 +34,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 
 import de.tum.cit.aet.artemis.communication.service.WebsocketMessagingService;
 import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.core.exception.ApiNotPresentException;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.security.SecurityUtils;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
@@ -48,9 +49,9 @@ import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
 import de.tum.cit.aet.artemis.modeling.service.ModelingSubmissionService;
 import de.tum.cit.aet.artemis.programming.dto.OnlineTeamStudentDTO;
+import de.tum.cit.aet.artemis.text.api.TextSubmissionApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
-import de.tum.cit.aet.artemis.text.service.TextSubmissionService;
 
 @Controller
 @Profile(PROFILE_CORE)
@@ -68,7 +69,7 @@ public class ParticipationTeamWebsocketService {
 
     private final ExerciseRepository exerciseRepository;
 
-    private final TextSubmissionService textSubmissionService;
+    private final Optional<TextSubmissionApi> textSubmissionApi;
 
     private final ModelingSubmissionService modelingSubmissionService;
 
@@ -81,14 +82,14 @@ public class ParticipationTeamWebsocketService {
     private Map<String, Instant> lastActionTracker;
 
     public ParticipationTeamWebsocketService(WebsocketMessagingService websocketMessagingService, SimpUserRegistry simpUserRegistry, UserRepository userRepository,
-            StudentParticipationRepository studentParticipationRepository, ExerciseRepository exerciseRepository, TextSubmissionService textSubmissionService,
+            StudentParticipationRepository studentParticipationRepository, ExerciseRepository exerciseRepository, Optional<TextSubmissionApi> textSubmissionApi,
             ModelingSubmissionService modelingSubmissionService, @Qualifier("hazelcastInstance") HazelcastInstance hazelcastInstance) {
         this.websocketMessagingService = websocketMessagingService;
         this.simpUserRegistry = simpUserRegistry;
         this.userRepository = userRepository;
         this.studentParticipationRepository = studentParticipationRepository;
         this.exerciseRepository = exerciseRepository;
-        this.textSubmissionService = textSubmissionService;
+        this.textSubmissionApi = textSubmissionApi;
         this.modelingSubmissionService = modelingSubmissionService;
         this.hazelcastInstance = hazelcastInstance;
     }
@@ -215,8 +216,8 @@ public class ParticipationTeamWebsocketService {
             modelingSubmissionService.hideDetails(submission, user);
         }
         else if (submission instanceof TextSubmission textSubmission && exercise instanceof TextExercise textExercise) {
-            submission = textSubmissionService.handleTextSubmission(textSubmission, textExercise, user);
-            textSubmissionService.hideDetails(submission, user);
+            submission = textSubmissionApi.orElseThrow(() -> new ApiNotPresentException(TextSubmissionApi.class, PROFILE_CORE)).handleTextSubmission(textSubmission, textExercise,
+                    user);
         }
         else {
             throw new IllegalArgumentException("Submission type '" + submission.getType() + "' not allowed.");

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisTextExerciseChatSessionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisTextExerciseChatSessionService.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.iris.service.session;
 
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
 import java.util.Comparator;
 import java.util.Optional;
 
@@ -8,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
+import de.tum.cit.aet.artemis.core.exception.ApiNotPresentException;
 import de.tum.cit.aet.artemis.core.exception.ConflictException;
 import de.tum.cit.aet.artemis.core.security.Role;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
@@ -30,8 +33,8 @@ import de.tum.cit.aet.artemis.iris.service.pyris.dto.data.PyrisTextExerciseDTO;
 import de.tum.cit.aet.artemis.iris.service.pyris.job.TextExerciseChatJob;
 import de.tum.cit.aet.artemis.iris.service.settings.IrisSettingsService;
 import de.tum.cit.aet.artemis.iris.service.websocket.IrisChatWebsocketService;
+import de.tum.cit.aet.artemis.text.api.TextApi;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
-import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
 
 @Service
 @Profile("iris")
@@ -45,7 +48,7 @@ public class IrisTextExerciseChatSessionService implements IrisChatBasedFeatureI
 
     private final IrisMessageService irisMessageService;
 
-    private final TextExerciseRepository textExerciseRepository;
+    private final Optional<TextApi> textApi;
 
     private final StudentParticipationRepository studentParticipationRepository;
 
@@ -58,14 +61,14 @@ public class IrisTextExerciseChatSessionService implements IrisChatBasedFeatureI
     private final AuthorizationCheckService authCheckService;
 
     public IrisTextExerciseChatSessionService(IrisSettingsService irisSettingsService, IrisSessionRepository irisSessionRepository, IrisRateLimitService rateLimitService,
-            IrisMessageService irisMessageService, TextExerciseRepository textExerciseRepository, StudentParticipationRepository studentParticipationRepository,
+            IrisMessageService irisMessageService, Optional<TextApi> textApi, StudentParticipationRepository studentParticipationRepository,
             PyrisPipelineService pyrisPipelineService, PyrisJobService pyrisJobService, IrisChatWebsocketService irisChatWebsocketService,
             AuthorizationCheckService authCheckService) {
         this.irisSettingsService = irisSettingsService;
         this.irisSessionRepository = irisSessionRepository;
         this.rateLimitService = rateLimitService;
         this.irisMessageService = irisMessageService;
-        this.textExerciseRepository = textExerciseRepository;
+        this.textApi = textApi;
         this.studentParticipationRepository = studentParticipationRepository;
         this.pyrisPipelineService = pyrisPipelineService;
         this.pyrisJobService = pyrisJobService;
@@ -84,7 +87,7 @@ public class IrisTextExerciseChatSessionService implements IrisChatBasedFeatureI
         if (session.getExercise().isExamExercise()) {
             throw new ConflictException("Iris is not supported for exam exercises", "Iris", "irisExamExercise");
         }
-        var exercise = textExerciseRepository.findByIdElseThrow(session.getExercise().getId());
+        var exercise = textApi.orElseThrow(() -> new ApiNotPresentException(TextApi.class, PROFILE_CORE)).findByIdElseThrow(session.getExercise().getId());
         if (!irisSettingsService.isEnabledFor(IrisSubSettingsType.TEXT_EXERCISE_CHAT, exercise)) {
             throw new ConflictException("Iris is not enabled for this exercise", "Iris", "irisDisabled");
         }

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/settings/IrisSettingsService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/settings/IrisSettingsService.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -46,8 +47,8 @@ import de.tum.cit.aet.artemis.iris.dto.IrisCombinedSettingsDTO;
 import de.tum.cit.aet.artemis.iris.repository.IrisSettingsRepository;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
+import de.tum.cit.aet.artemis.text.api.TextApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
-import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
 
 /**
  * Service for managing {@link IrisSettings}.
@@ -70,16 +71,16 @@ public class IrisSettingsService {
 
     private final ObjectMapper objectMapper;
 
-    private final TextExerciseRepository textExerciseRepository;
+    private final Optional<TextApi> textApi;
 
     public IrisSettingsService(IrisSettingsRepository irisSettingsRepository, IrisSubSettingsService irisSubSettingsService, AuthorizationCheckService authCheckService,
-            ProgrammingExerciseRepository programmingExerciseRepository, ObjectMapper objectMapper, TextExerciseRepository textExerciseRepository) {
+            ProgrammingExerciseRepository programmingExerciseRepository, ObjectMapper objectMapper, Optional<TextApi> textApi) {
         this.irisSettingsRepository = irisSettingsRepository;
         this.irisSubSettingsService = irisSubSettingsService;
         this.authCheckService = authCheckService;
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.objectMapper = objectMapper;
-        this.textExerciseRepository = textExerciseRepository;
+        this.textApi = textApi;
     }
 
     /**
@@ -329,8 +330,8 @@ public class IrisSettingsService {
         var newEnabledForCategoriesTextExerciseChat = existingSettings.getIrisTextExerciseChatSettings() == null ? new TreeSet<String>()
                 : existingSettings.getIrisTextExerciseChatSettings().getEnabledForCategories();
         if (!Objects.equals(oldEnabledForCategoriesTextExerciseChat, newEnabledForCategoriesTextExerciseChat)) {
-            textExerciseRepository.findAllWithCategoriesByCourseId(existingSettings.getCourse().getId())
-                    .forEach(exercise -> setEnabledForExerciseByCategories(exercise, oldEnabledForCategoriesTextExerciseChat, newEnabledForCategoriesTextExerciseChat));
+            textApi.ifPresent(api -> api.findAllWithCategoriesByCourseId(existingSettings.getCourse().getId())
+                    .forEach(exercise -> setEnabledForExerciseByCategories(exercise, oldEnabledForCategoriesTextExerciseChat, newEnabledForCategoriesTextExerciseChat)));
         }
 
         return irisSettingsRepository.save(existingSettings);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/web/IrisTextExerciseChatSessionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/web/IrisTextExerciseChatSessionResource.java
@@ -1,8 +1,11 @@
 package de.tum.cit.aet.artemis.iris.web;
 
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import de.tum.cit.aet.artemis.core.exception.ApiNotPresentException;
 import de.tum.cit.aet.artemis.core.exception.ConflictException;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInExercise.EnforceAtLeastStudentInExercise;
@@ -22,8 +26,8 @@ import de.tum.cit.aet.artemis.iris.repository.IrisTextExerciseChatSessionReposit
 import de.tum.cit.aet.artemis.iris.service.IrisSessionService;
 import de.tum.cit.aet.artemis.iris.service.session.IrisTextExerciseChatSessionService;
 import de.tum.cit.aet.artemis.iris.service.settings.IrisSettingsService;
+import de.tum.cit.aet.artemis.text.api.TextApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
-import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
 
 /**
  * REST controller for managing {@link IrisTextExerciseChatSession}.
@@ -39,20 +43,20 @@ public class IrisTextExerciseChatSessionResource {
 
     private final IrisSettingsService irisSettingsService;
 
-    private final TextExerciseRepository textExerciseRepository;
+    private final Optional<TextApi> textApi;
 
     private final IrisTextExerciseChatSessionService irisTextExerciseChatSessionService;
 
     private final IrisTextExerciseChatSessionRepository irisTextExerciseChatSessionRepository;
 
     protected IrisTextExerciseChatSessionResource(IrisTextExerciseChatSessionRepository irisTextExerciseChatSessionRepository, UserRepository userRepository,
-            TextExerciseRepository textExerciseRepository, IrisSessionService irisSessionService, IrisSettingsService irisSettingsService,
+            IrisSessionService irisSessionService, IrisSettingsService irisSettingsService, Optional<TextApi> textApi,
             IrisTextExerciseChatSessionService irisTextExerciseChatSessionService) {
         this.irisTextExerciseChatSessionRepository = irisTextExerciseChatSessionRepository;
         this.userRepository = userRepository;
         this.irisSessionService = irisSessionService;
         this.irisSettingsService = irisSettingsService;
-        this.textExerciseRepository = textExerciseRepository;
+        this.textApi = textApi;
         this.irisTextExerciseChatSessionService = irisTextExerciseChatSessionService;
     }
 
@@ -65,7 +69,7 @@ public class IrisTextExerciseChatSessionResource {
     @PostMapping("{exerciseId}/sessions/current")
     @EnforceAtLeastStudentInExercise
     public ResponseEntity<IrisTextExerciseChatSession> getCurrentSessionOrCreateIfNotExists(@PathVariable Long exerciseId) throws URISyntaxException {
-        var exercise = textExerciseRepository.findByIdElseThrow(exerciseId);
+        var exercise = textApi.orElseThrow(() -> new ApiNotPresentException(TextApi.class, PROFILE_CORE)).findByIdElseThrow(exerciseId);
         validateExercise(exercise);
 
         irisSettingsService.isEnabledForElseThrow(IrisSubSettingsType.TEXT_EXERCISE_CHAT, exercise);
@@ -93,7 +97,7 @@ public class IrisTextExerciseChatSessionResource {
     @PostMapping("{exerciseId}/sessions")
     @EnforceAtLeastStudentInExercise
     public ResponseEntity<IrisTextExerciseChatSession> createSessionForExercise(@PathVariable Long exerciseId) throws URISyntaxException {
-        var textExercise = textExerciseRepository.findByIdElseThrow(exerciseId);
+        var textExercise = textApi.orElseThrow(() -> new ApiNotPresentException(TextApi.class, PROFILE_CORE)).findByIdElseThrow(exerciseId);
         validateExercise(textExercise);
 
         irisSettingsService.isEnabledForElseThrow(IrisSubSettingsType.TEXT_EXERCISE_CHAT, textExercise);
@@ -115,7 +119,7 @@ public class IrisTextExerciseChatSessionResource {
     @GetMapping("{exerciseId}/sessions")
     @EnforceAtLeastStudentInExercise
     public ResponseEntity<List<IrisTextExerciseChatSession>> getAllSessions(@PathVariable Long exerciseId) {
-        var exercise = textExerciseRepository.findByIdElseThrow(exerciseId);
+        var exercise = textApi.orElseThrow(() -> new ApiNotPresentException(TextApi.class, PROFILE_CORE)).findByIdElseThrow(exerciseId);
         validateExercise(exercise);
 
         irisSettingsService.isEnabledForElseThrow(IrisSubSettingsType.TEXT_EXERCISE_CHAT, exercise);

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/TextPlagiarismDetectionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/TextPlagiarismDetectionService.java
@@ -24,6 +24,7 @@ import de.jplag.clustering.ClusteringOptions;
 import de.jplag.exceptions.ExitException;
 import de.jplag.options.JPlagOptions;
 import de.jplag.text.NaturalLanguage;
+import de.tum.cit.aet.artemis.core.exception.ApiNotPresentException;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.util.TimeLogUtil;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
@@ -31,6 +32,7 @@ import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCheckState;
 import de.tum.cit.aet.artemis.plagiarism.domain.text.TextPlagiarismResult;
 import de.tum.cit.aet.artemis.plagiarism.service.cache.PlagiarismCacheService;
+import de.tum.cit.aet.artemis.text.api.TextSubmissionExportApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 import de.tum.cit.aet.artemis.text.service.TextSubmissionExportService;
@@ -41,6 +43,8 @@ public class TextPlagiarismDetectionService {
 
     private static final Logger log = LoggerFactory.getLogger(TextPlagiarismDetectionService.class);
 
+    private final Optional<TextSubmissionExportApi> textSubmissionExportApi;
+
     private final TextSubmissionExportService textSubmissionExportService;
 
     private final PlagiarismWebsocketService plagiarismWebsocketService;
@@ -49,8 +53,9 @@ public class TextPlagiarismDetectionService {
 
     private final PlagiarismService plagiarismService;
 
-    public TextPlagiarismDetectionService(TextSubmissionExportService textSubmissionExportService, PlagiarismWebsocketService plagiarismWebsocketService,
-            PlagiarismCacheService plagiarismCacheService, PlagiarismService plagiarismService) {
+    public TextPlagiarismDetectionService(Optional<TextSubmissionExportApi> textSubmissionExportApi, TextSubmissionExportService textSubmissionExportService,
+            PlagiarismWebsocketService plagiarismWebsocketService, PlagiarismCacheService plagiarismCacheService, PlagiarismService plagiarismService) {
+        this.textSubmissionExportApi = textSubmissionExportApi;
         this.textSubmissionExportService = textSubmissionExportService;
         this.plagiarismWebsocketService = plagiarismWebsocketService;
         this.plagiarismCacheService = plagiarismCacheService;
@@ -129,7 +134,8 @@ public class TextPlagiarismDetectionService {
                 }
 
                 try {
-                    textSubmissionExportService.saveSubmissionToFile(submission, participantIdentifier, submissionsFolderName);
+                    textSubmissionExportApi.orElseThrow(() -> new ApiNotPresentException(TextSubmissionExportApi.class, PROFILE_CORE)).saveSubmissionToFile(submission,
+                            participantIdentifier, submissionsFolderName);
                 }
                 catch (IOException e) {
                     log.error(e.getMessage());

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/TextPlagiarismDetectionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/TextPlagiarismDetectionService.java
@@ -35,7 +35,6 @@ import de.tum.cit.aet.artemis.plagiarism.service.cache.PlagiarismCacheService;
 import de.tum.cit.aet.artemis.text.api.TextSubmissionExportApi;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
-import de.tum.cit.aet.artemis.text.service.TextSubmissionExportService;
 
 @Profile(PROFILE_CORE)
 @Service
@@ -45,18 +44,15 @@ public class TextPlagiarismDetectionService {
 
     private final Optional<TextSubmissionExportApi> textSubmissionExportApi;
 
-    private final TextSubmissionExportService textSubmissionExportService;
-
     private final PlagiarismWebsocketService plagiarismWebsocketService;
 
     private final PlagiarismCacheService plagiarismCacheService;
 
     private final PlagiarismService plagiarismService;
 
-    public TextPlagiarismDetectionService(Optional<TextSubmissionExportApi> textSubmissionExportApi, TextSubmissionExportService textSubmissionExportService,
-            PlagiarismWebsocketService plagiarismWebsocketService, PlagiarismCacheService plagiarismCacheService, PlagiarismService plagiarismService) {
+    public TextPlagiarismDetectionService(Optional<TextSubmissionExportApi> textSubmissionExportApi, PlagiarismWebsocketService plagiarismWebsocketService,
+            PlagiarismCacheService plagiarismCacheService, PlagiarismService plagiarismService) {
         this.textSubmissionExportApi = textSubmissionExportApi;
-        this.textSubmissionExportService = textSubmissionExportService;
         this.plagiarismWebsocketService = plagiarismWebsocketService;
         this.plagiarismCacheService = plagiarismCacheService;
         this.plagiarismService = plagiarismService;

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/AbstractTextApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/AbstractTextApi.java
@@ -1,0 +1,6 @@
+package de.tum.cit.aet.artemis.text.api;
+
+import de.tum.cit.aet.artemis.core.api.AbstractApi;
+
+public abstract class AbstractTextApi implements AbstractApi {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextApi.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 
 import de.tum.cit.aet.artemis.assessment.repository.TextBlockRepository;
+import de.tum.cit.aet.artemis.core.service.messaging.InstanceMessageSendService;
 import de.tum.cit.aet.artemis.text.domain.TextBlock;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
@@ -21,9 +22,12 @@ public class TextApi extends AbstractTextApi {
 
     private final TextBlockRepository textBlockRepository;
 
-    public TextApi(TextExerciseRepository textExerciseRepository, TextBlockRepository textBlockRepository) {
+    private final InstanceMessageSendService instanceMessageSendService;
+
+    public TextApi(TextExerciseRepository textExerciseRepository, TextBlockRepository textBlockRepository, InstanceMessageSendService instanceMessageSendService) {
         this.textExerciseRepository = textExerciseRepository;
         this.textBlockRepository = textBlockRepository;
+        this.instanceMessageSendService = instanceMessageSendService;
     }
 
     public TextExercise findWithGradingCriteriaByIdElseThrow(long exerciseId) {
@@ -40,5 +44,9 @@ public class TextApi extends AbstractTextApi {
 
     public List<TextExercise> findAllWithCategoriesByCourseId(Long courseId) {
         return textExerciseRepository.findAllWithCategoriesByCourseId(courseId);
+    }
+
+    public void cancelScheduledOperations(long exerciseId) {
+        instanceMessageSendService.sendTextExerciseScheduleCancel(exerciseId);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextApi.java
@@ -5,14 +5,15 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 
 import de.tum.cit.aet.artemis.assessment.repository.TextBlockRepository;
-import de.tum.cit.aet.artemis.core.service.messaging.InstanceMessageSendService;
 import de.tum.cit.aet.artemis.text.domain.TextBlock;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
+import de.tum.cit.aet.artemis.text.service.TextExerciseService;
 
 @Controller
 @Profile(PROFILE_CORE)
@@ -22,12 +23,13 @@ public class TextApi extends AbstractTextApi {
 
     private final TextBlockRepository textBlockRepository;
 
-    private final InstanceMessageSendService instanceMessageSendService;
+    private final TextExerciseService textExerciseService;
 
-    public TextApi(TextExerciseRepository textExerciseRepository, TextBlockRepository textBlockRepository, InstanceMessageSendService instanceMessageSendService) {
+    // TextExerciseService needs to be initialized lazy because of the dependency to InstanceMessageSendService
+    public TextApi(TextExerciseRepository textExerciseRepository, TextBlockRepository textBlockRepository, @Lazy TextExerciseService textExerciseService) {
         this.textExerciseRepository = textExerciseRepository;
         this.textBlockRepository = textBlockRepository;
-        this.instanceMessageSendService = instanceMessageSendService;
+        this.textExerciseService = textExerciseService;
     }
 
     public TextExercise findWithGradingCriteriaByIdElseThrow(long exerciseId) {
@@ -47,6 +49,6 @@ public class TextApi extends AbstractTextApi {
     }
 
     public void cancelScheduledOperations(long exerciseId) {
-        instanceMessageSendService.sendTextExerciseScheduleCancel(exerciseId);
+        textExerciseService.cancelScheduledOperations(exerciseId);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextApi.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.artemis.text.api;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
+import java.util.Optional;
+
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 
@@ -27,7 +29,7 @@ public class TextApi extends AbstractTextApi {
         return textExerciseRepository.findWithGradingCriteriaByIdElseThrow(exerciseId);
     }
 
-    public TextBlock findById(String reference) {
-        return textBlockRepository.findById(reference).orElse(null);
+    public Optional<TextBlock> findById(String reference) {
+        return textBlockRepository.findById(reference);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextApi.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.text.api;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.context.annotation.Profile;
@@ -31,5 +32,13 @@ public class TextApi extends AbstractTextApi {
 
     public Optional<TextBlock> findById(String reference) {
         return textBlockRepository.findById(reference);
+    }
+
+    public TextExercise findByIdElseThrow(long exerciseId) {
+        return textExerciseRepository.findByIdElseThrow(exerciseId);
+    }
+
+    public List<TextExercise> findAllWithCategoriesByCourseId(Long courseId) {
+        return textExerciseRepository.findAllWithCategoriesByCourseId(courseId);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextApi.java
@@ -1,0 +1,33 @@
+package de.tum.cit.aet.artemis.text.api;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Controller;
+
+import de.tum.cit.aet.artemis.assessment.repository.TextBlockRepository;
+import de.tum.cit.aet.artemis.text.domain.TextBlock;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
+import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
+
+@Controller
+@Profile(PROFILE_CORE)
+public class TextApi extends AbstractTextApi {
+
+    private final TextExerciseRepository textExerciseRepository;
+
+    private final TextBlockRepository textBlockRepository;
+
+    public TextApi(TextExerciseRepository textExerciseRepository, TextBlockRepository textBlockRepository) {
+        this.textExerciseRepository = textExerciseRepository;
+        this.textBlockRepository = textBlockRepository;
+    }
+
+    public TextExercise findWithGradingCriteriaByIdElseThrow(long exerciseId) {
+        return textExerciseRepository.findWithGradingCriteriaByIdElseThrow(exerciseId);
+    }
+
+    public TextBlock findById(String reference) {
+        return textBlockRepository.findById(reference).orElse(null);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextExerciseImportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextExerciseImportApi.java
@@ -1,0 +1,39 @@
+package de.tum.cit.aet.artemis.text.api;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import java.util.Optional;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Controller;
+
+import de.tum.cit.aet.artemis.core.exception.NoUniqueQueryException;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
+import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
+import de.tum.cit.aet.artemis.text.service.TextExerciseImportService;
+
+@Controller
+@Profile(PROFILE_CORE)
+public class TextExerciseImportApi extends AbstractTextApi {
+
+    private final TextExerciseRepository textExerciseRepository;
+
+    private final TextExerciseImportService textExerciseImportService;
+
+    public TextExerciseImportApi(TextExerciseRepository textExerciseRepository, TextExerciseImportService textExerciseImportService) {
+        this.textExerciseRepository = textExerciseRepository;
+        this.textExerciseImportService = textExerciseImportService;
+    }
+
+    public Optional<TextExercise> findUniqueWithCompetenciesByTitleAndCourseId(String title, long courseId) throws NoUniqueQueryException {
+        return textExerciseRepository.findUniqueWithCompetenciesByTitleAndCourseId(title, courseId);
+    }
+
+    public TextExercise findByIdWithExampleSubmissionsAndResultsAndGradingCriteriaElseThrow(long exerciseId) {
+        return textExerciseRepository.findByIdWithExampleSubmissionsAndResultsAndGradingCriteriaElseThrow(exerciseId);
+    }
+
+    public TextExercise importTextExercise(final TextExercise templateExercise, TextExercise importedExercise) {
+        return textExerciseImportService.importTextExercise(templateExercise, importedExercise);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextExerciseImportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextExerciseImportApi.java
@@ -36,4 +36,9 @@ public class TextExerciseImportApi extends AbstractTextApi {
     public TextExercise importTextExercise(final TextExercise templateExercise, TextExercise importedExercise) {
         return textExerciseImportService.importTextExercise(templateExercise, importedExercise);
     }
+
+    public Optional<TextExercise> importTextExercise(final long templateExerciseId, final TextExercise exerciseToCopy) {
+        final Optional<TextExercise> optionalOriginalTextExercise = textExerciseRepository.findWithExampleSubmissionsAndResultsById(templateExerciseId);
+        return optionalOriginalTextExercise.map(textExercise -> textExerciseImportService.importTextExercise(textExercise, exerciseToCopy));
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextExerciseSubmissionApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextExerciseSubmissionApi.java
@@ -35,6 +35,10 @@ public class TextExerciseSubmissionApi extends AbstractTextApi {
         return textExerciseImportService.copySubmission(textSubmission, gradingInstructionCopyTracker);
     }
 
+    public TextSubmission saveTextSubmission(TextSubmission textSubmission) {
+        return textSubmissionRepository.save(textSubmission);
+    }
+
     private void checkGivenExerciseIdSameForSubmissionParticipation(long originalExerciseId, long exerciseIdInSubmission) {
         if (!Objects.equals(originalExerciseId, exerciseIdInSubmission)) {
             throw new IllegalArgumentException("ExerciseId does not match with the exerciseId in submission participation");

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextExerciseSubmissionApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextExerciseSubmissionApi.java
@@ -1,0 +1,43 @@
+package de.tum.cit.aet.artemis.text.api;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Controller;
+
+import de.tum.cit.aet.artemis.assessment.domain.GradingInstruction;
+import de.tum.cit.aet.artemis.text.domain.TextSubmission;
+import de.tum.cit.aet.artemis.text.repository.TextSubmissionRepository;
+import de.tum.cit.aet.artemis.text.service.TextExerciseImportService;
+
+@Controller
+@Profile(PROFILE_CORE)
+public class TextExerciseSubmissionApi extends AbstractTextApi {
+
+    private final TextSubmissionRepository textSubmissionRepository;
+
+    private final TextExerciseImportService textExerciseImportService;
+
+    public TextExerciseSubmissionApi(TextSubmissionRepository textSubmissionRepository, TextExerciseImportService textExerciseImportService) {
+        this.textSubmissionRepository = textSubmissionRepository;
+        this.textExerciseImportService = textExerciseImportService;
+    }
+
+    public TextSubmission importStudentSubmission(long submissionId, long exerciseId, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
+        TextSubmission textSubmission = textSubmissionRepository.findByIdWithEagerResultsAndFeedbackAndTextBlocksElseThrow(submissionId);
+        checkGivenExerciseIdSameForSubmissionParticipation(exerciseId, textSubmission.getParticipation().getExercise().getId());
+
+        // example submission does not need participation
+        textSubmission.setParticipation(null);
+        return textExerciseImportService.copySubmission(textSubmission, gradingInstructionCopyTracker);
+    }
+
+    private void checkGivenExerciseIdSameForSubmissionParticipation(long originalExerciseId, long exerciseIdInSubmission) {
+        if (!Objects.equals(originalExerciseId, exerciseIdInSubmission)) {
+            throw new IllegalArgumentException("ExerciseId does not match with the exerciseId in submission participation");
+        }
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextFeedbackApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextFeedbackApi.java
@@ -1,0 +1,25 @@
+package de.tum.cit.aet.artemis.text.api;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Controller;
+
+import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
+import de.tum.cit.aet.artemis.text.service.TextExerciseFeedbackService;
+
+@Controller
+@Profile(PROFILE_CORE)
+public class TextFeedbackApi extends AbstractTextApi {
+
+    private final TextExerciseFeedbackService feedbackService;
+
+    public TextFeedbackApi(TextExerciseFeedbackService feedbackService) {
+        this.feedbackService = feedbackService;
+    }
+
+    public StudentParticipation handleNonGradedFeedbackRequest(StudentParticipation participation, TextExercise textExercise) {
+        return feedbackService.handleNonGradedFeedbackRequest(participation, textExercise);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionApi.java
@@ -9,9 +9,12 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 
 import de.tum.cit.aet.artemis.assessment.domain.GradingInstruction;
+import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 import de.tum.cit.aet.artemis.text.repository.TextSubmissionRepository;
 import de.tum.cit.aet.artemis.text.service.TextExerciseImportService;
+import de.tum.cit.aet.artemis.text.service.TextSubmissionService;
 
 @Controller
 @Profile(PROFILE_CORE)
@@ -21,9 +24,12 @@ public class TextSubmissionApi extends AbstractTextApi {
 
     private final TextExerciseImportService textExerciseImportService;
 
-    public TextSubmissionApi(TextSubmissionRepository textSubmissionRepository, TextExerciseImportService textExerciseImportService) {
+    private final TextSubmissionService textSubmissionService;
+
+    public TextSubmissionApi(TextSubmissionRepository textSubmissionRepository, TextExerciseImportService textExerciseImportService, TextSubmissionService textSubmissionService) {
         this.textSubmissionRepository = textSubmissionRepository;
         this.textExerciseImportService = textExerciseImportService;
+        this.textSubmissionService = textSubmissionService;
     }
 
     public TextSubmission importStudentSubmission(long submissionId, long exerciseId, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
@@ -37,6 +43,12 @@ public class TextSubmissionApi extends AbstractTextApi {
 
     public TextSubmission saveTextSubmission(TextSubmission textSubmission) {
         return textSubmissionRepository.save(textSubmission);
+    }
+
+    public TextSubmission handleTextSubmission(TextSubmission textSubmission, TextExercise exercise, User user) {
+        var submission = textSubmissionService.handleTextSubmission(textSubmission, exercise, user);
+        textSubmissionService.hideDetails(submission, user);
+        return submission;
     }
 
     private void checkGivenExerciseIdSameForSubmissionParticipation(long originalExerciseId, long exerciseIdInSubmission) {

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionApi.java
@@ -24,6 +24,10 @@ public class TextSubmissionApi extends AbstractTextApi {
         this.textSubmissionService = textSubmissionService;
     }
 
+    public TextSubmission findByIdElseThrow(long id) {
+        return textSubmissionRepository.findByIdElseThrow(id);
+    }
+
     public TextSubmission saveTextSubmission(TextSubmission textSubmission) {
         return textSubmissionRepository.save(textSubmission);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionApi.java
@@ -15,13 +15,13 @@ import de.tum.cit.aet.artemis.text.service.TextExerciseImportService;
 
 @Controller
 @Profile(PROFILE_CORE)
-public class TextExerciseSubmissionApi extends AbstractTextApi {
+public class TextSubmissionApi extends AbstractTextApi {
 
     private final TextSubmissionRepository textSubmissionRepository;
 
     private final TextExerciseImportService textExerciseImportService;
 
-    public TextExerciseSubmissionApi(TextSubmissionRepository textSubmissionRepository, TextExerciseImportService textExerciseImportService) {
+    public TextSubmissionApi(TextSubmissionRepository textSubmissionRepository, TextExerciseImportService textExerciseImportService) {
         this.textSubmissionRepository = textSubmissionRepository;
         this.textExerciseImportService = textExerciseImportService;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionApi.java
@@ -2,18 +2,13 @@ package de.tum.cit.aet.artemis.text.api;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
-import java.util.Map;
-import java.util.Objects;
-
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 
-import de.tum.cit.aet.artemis.assessment.domain.GradingInstruction;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 import de.tum.cit.aet.artemis.text.repository.TextSubmissionRepository;
-import de.tum.cit.aet.artemis.text.service.TextExerciseImportService;
 import de.tum.cit.aet.artemis.text.service.TextSubmissionService;
 
 @Controller
@@ -22,23 +17,11 @@ public class TextSubmissionApi extends AbstractTextApi {
 
     private final TextSubmissionRepository textSubmissionRepository;
 
-    private final TextExerciseImportService textExerciseImportService;
-
     private final TextSubmissionService textSubmissionService;
 
-    public TextSubmissionApi(TextSubmissionRepository textSubmissionRepository, TextExerciseImportService textExerciseImportService, TextSubmissionService textSubmissionService) {
+    public TextSubmissionApi(TextSubmissionRepository textSubmissionRepository, TextSubmissionService textSubmissionService) {
         this.textSubmissionRepository = textSubmissionRepository;
-        this.textExerciseImportService = textExerciseImportService;
         this.textSubmissionService = textSubmissionService;
-    }
-
-    public TextSubmission importStudentSubmission(long submissionId, long exerciseId, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
-        TextSubmission textSubmission = textSubmissionRepository.findByIdWithEagerResultsAndFeedbackAndTextBlocksElseThrow(submissionId);
-        checkGivenExerciseIdSameForSubmissionParticipation(exerciseId, textSubmission.getParticipation().getExercise().getId());
-
-        // example submission does not need participation
-        textSubmission.setParticipation(null);
-        return textExerciseImportService.copySubmission(textSubmission, gradingInstructionCopyTracker);
     }
 
     public TextSubmission saveTextSubmission(TextSubmission textSubmission) {
@@ -49,11 +32,5 @@ public class TextSubmissionApi extends AbstractTextApi {
         var submission = textSubmissionService.handleTextSubmission(textSubmission, exercise, user);
         textSubmissionService.hideDetails(submission, user);
         return submission;
-    }
-
-    private void checkGivenExerciseIdSameForSubmissionParticipation(long originalExerciseId, long exerciseIdInSubmission) {
-        if (!Objects.equals(originalExerciseId, exerciseIdInSubmission)) {
-            throw new IllegalArgumentException("ExerciseId does not match with the exerciseId in submission participation");
-        }
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionExportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionExportApi.java
@@ -3,11 +3,17 @@ package de.tum.cit.aet.artemis.text.api;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 
+import de.tum.cit.aet.artemis.core.service.ArchivalReportEntry;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionExportOptionsDTO;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
+import de.tum.cit.aet.artemis.text.service.TextExerciseWithSubmissionsExportService;
 import de.tum.cit.aet.artemis.text.service.TextSubmissionExportService;
 
 @Controller
@@ -16,13 +22,19 @@ public class TextSubmissionExportApi extends AbstractTextApi {
 
     private final TextSubmissionExportService textSubmissionExportService;
 
-    public TextSubmissionExportApi(TextSubmissionExportService textSubmissionExportService) {
+    private final TextExerciseWithSubmissionsExportService textExerciseWithSubmissionsExportService;
+
+    public TextSubmissionExportApi(TextSubmissionExportService textSubmissionExportService, TextExerciseWithSubmissionsExportService textExerciseWithSubmissionsExportService) {
         this.textSubmissionExportService = textSubmissionExportService;
+        this.textExerciseWithSubmissionsExportService = textExerciseWithSubmissionsExportService;
     }
 
     public void saveSubmissionToFile(TextSubmission submission, String studentLogin, String submissionsFolderName) throws IOException {
         textSubmissionExportService.saveSubmissionToFile(submission, studentLogin, submissionsFolderName);
-
     }
 
+    public Path exportTextExerciseWithSubmissions(TextExercise exercise, SubmissionExportOptionsDTO optionsDTO, Path exportDir, List<String> exportErrors,
+            List<ArchivalReportEntry> reportEntries) {
+        return textExerciseWithSubmissionsExportService.exportTextExerciseWithSubmissions(exercise, optionsDTO, exportDir, exportErrors, reportEntries);
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionExportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionExportApi.java
@@ -48,6 +48,11 @@ public class TextSubmissionExportApi extends AbstractTextApi {
         return textExerciseWithSubmissionsExportService.exportTextExerciseWithSubmissions(exercise, optionsDTO, exportDir, exportErrors, reportEntries);
     }
 
+    /**
+     * Prepares a text block for export as an example submission
+     *
+     * @param exampleSubmissionId the submission id to be exported
+     */
     public void prepareTextBlockForExampleSubmission(long exampleSubmissionId) {
         Optional<TextSubmission> textSubmission = textSubmissionRepository.findWithEagerResultsAndFeedbackAndTextBlocksById(exampleSubmissionId);
         if (textSubmission.isPresent() && textSubmission.get().getLatestResult() == null

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionExportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionExportApi.java
@@ -1,0 +1,28 @@
+package de.tum.cit.aet.artemis.text.api;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import java.io.IOException;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Controller;
+
+import de.tum.cit.aet.artemis.text.domain.TextSubmission;
+import de.tum.cit.aet.artemis.text.service.TextSubmissionExportService;
+
+@Controller
+@Profile(PROFILE_CORE)
+public class TextSubmissionExportApi extends AbstractTextApi {
+
+    private final TextSubmissionExportService textSubmissionExportService;
+
+    public TextSubmissionExportApi(TextSubmissionExportService textSubmissionExportService) {
+        this.textSubmissionExportService = textSubmissionExportService;
+    }
+
+    public void saveSubmissionToFile(TextSubmission submission, String studentLogin, String submissionsFolderName) throws IOException {
+        textSubmissionExportService.saveSubmissionToFile(submission, studentLogin, submissionsFolderName);
+
+    }
+
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionImportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionImportApi.java
@@ -27,6 +27,14 @@ public class TextSubmissionImportApi extends AbstractTextApi {
         this.textExerciseImportService = textExerciseImportService;
     }
 
+    /**
+     * Imports a student submission to an exercise.
+     *
+     * @param submissionId                  of the submission to be imported
+     * @param exerciseId                    of the exercise to import the submission into
+     * @param gradingInstructionCopyTracker mapping of the gradingInstructionID to the gradingInstruction
+     * @return the imported text submission
+     */
     public TextSubmission importStudentSubmission(long submissionId, long exerciseId, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
         TextSubmission textSubmission = textSubmissionRepository.findByIdWithEagerResultsAndFeedbackAndTextBlocksElseThrow(submissionId);
         checkGivenExerciseIdSameForSubmissionParticipation(exerciseId, textSubmission.getParticipation().getExercise().getId());

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionImportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionImportApi.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 
 import de.tum.cit.aet.artemis.assessment.domain.GradingInstruction;
+import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 import de.tum.cit.aet.artemis.text.repository.TextSubmissionRepository;
 import de.tum.cit.aet.artemis.text.service.TextExerciseImportService;
@@ -37,7 +38,7 @@ public class TextSubmissionImportApi extends AbstractTextApi {
 
     private void checkGivenExerciseIdSameForSubmissionParticipation(long originalExerciseId, long exerciseIdInSubmission) {
         if (!Objects.equals(originalExerciseId, exerciseIdInSubmission)) {
-            throw new IllegalArgumentException("ExerciseId does not match with the exerciseId in submission participation");
+            throw new BadRequestAlertException("ExerciseId does not match with the exerciseId in submission participation", "exampleSubmission", "idNotMatched");
         }
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionImportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextSubmissionImportApi.java
@@ -1,0 +1,43 @@
+package de.tum.cit.aet.artemis.text.api;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Controller;
+
+import de.tum.cit.aet.artemis.assessment.domain.GradingInstruction;
+import de.tum.cit.aet.artemis.text.domain.TextSubmission;
+import de.tum.cit.aet.artemis.text.repository.TextSubmissionRepository;
+import de.tum.cit.aet.artemis.text.service.TextExerciseImportService;
+
+@Controller
+@Profile(PROFILE_CORE)
+public class TextSubmissionImportApi extends AbstractTextApi {
+
+    private final TextSubmissionRepository textSubmissionRepository;
+
+    private final TextExerciseImportService textExerciseImportService;
+
+    public TextSubmissionImportApi(TextSubmissionRepository textSubmissionRepository, TextExerciseImportService textExerciseImportService) {
+        this.textSubmissionRepository = textSubmissionRepository;
+        this.textExerciseImportService = textExerciseImportService;
+    }
+
+    public TextSubmission importStudentSubmission(long submissionId, long exerciseId, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
+        TextSubmission textSubmission = textSubmissionRepository.findByIdWithEagerResultsAndFeedbackAndTextBlocksElseThrow(submissionId);
+        checkGivenExerciseIdSameForSubmissionParticipation(exerciseId, textSubmission.getParticipation().getExercise().getId());
+
+        // example submission does not need participation
+        textSubmission.setParticipation(null);
+        return textExerciseImportService.copySubmission(textSubmission, gradingInstructionCopyTracker);
+    }
+
+    private void checkGivenExerciseIdSameForSubmissionParticipation(long originalExerciseId, long exerciseIdInSubmission) {
+        if (!Objects.equals(originalExerciseId, exerciseIdInSubmission)) {
+            throw new IllegalArgumentException("ExerciseId does not match with the exerciseId in submission participation");
+        }
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSendingServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSendingServiceTest.java
@@ -21,7 +21,6 @@ import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
 import de.tum.cit.aet.artemis.assessment.domain.GradingInstruction;
 import de.tum.cit.aet.artemis.assessment.domain.Result;
 import de.tum.cit.aet.artemis.assessment.repository.GradingCriterionRepository;
-import de.tum.cit.aet.artemis.assessment.repository.TextBlockRepository;
 import de.tum.cit.aet.artemis.assessment.util.GradingCriterionUtil;
 import de.tum.cit.aet.artemis.athena.AbstractAthenaTest;
 import de.tum.cit.aet.artemis.athena.service.AthenaDTOConverterService;
@@ -34,6 +33,7 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
 import de.tum.cit.aet.artemis.programming.test_repository.ProgrammingExerciseTestRepository;
 import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseUtilService;
+import de.tum.cit.aet.artemis.text.api.TextApi;
 import de.tum.cit.aet.artemis.text.domain.TextBlock;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
@@ -46,10 +46,10 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
     private AthenaModuleService athenaModuleService;
 
     @Mock
-    private TextBlockRepository textBlockRepository;
+    private TextExerciseRepository textExerciseRepository;
 
     @Mock
-    private TextExerciseRepository textExerciseRepository;
+    private TextApi textApi;
 
     @Mock
     private ProgrammingExerciseTestRepository programmingExerciseRepository;
@@ -82,19 +82,19 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
     @BeforeEach
     void setUp() {
         athenaFeedbackSendingService = new AthenaFeedbackSendingService(athenaRequestMockProvider.getRestTemplate(), athenaModuleService,
-                new AthenaDTOConverterService(textBlockRepository, textExerciseRepository, programmingExerciseRepository, gradingCriterionRepository));
+                new AthenaDTOConverterService(Optional.of(textApi), programmingExerciseRepository, gradingCriterionRepository));
 
         athenaRequestMockProvider.enableMockingOfRequests();
 
         textExercise = textExerciseUtilService.createSampleTextExercise(null);
         textExercise.setFeedbackSuggestionModule(ATHENA_MODULE_TEXT_TEST);
-        when(textExerciseRepository.findWithGradingCriteriaByIdElseThrow(textExercise.getId())).thenReturn(textExercise);
+        when(textApi.findWithGradingCriteriaByIdElseThrow(textExercise.getId())).thenReturn(textExercise);
 
         textSubmission = new TextSubmission(2L).text("Test - This is what the feedback references - Submission");
 
         textBlock = new TextBlock().startIndex(7).endIndex(46).text("This is what the feedback references").submission(textSubmission);
         textBlock.computeId();
-        when(textBlockRepository.findById(textBlock.getId())).thenReturn(Optional.of(textBlock));
+        when(textApi.findById(textBlock.getId())).thenReturn(Optional.of(textBlock));
 
         textFeedback = new Feedback().type(FeedbackType.MANUAL).credits(5.0).reference(textBlock.getId());
         textFeedback.setText("Title");

--- a/src/test/java/de/tum/cit/aet/artemis/text/architecture/TextApiArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/architecture/TextApiArchitectureTest.java
@@ -1,0 +1,11 @@
+package de.tum.cit.aet.artemis.text.architecture;
+
+import de.tum.cit.aet.artemis.shared.architecture.module.AbstractModuleAccessArchitectureTest;
+
+class TextApiArchitectureTest extends AbstractModuleAccessArchitectureTest {
+
+    @Override
+    public String getModulePackage() {
+        return ARTEMIS_PACKAGE + ".text";
+    }
+}


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Server
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
As part of the server modularization, we "facade" the service/repository declaration and method calls to module-external classes via a module API provided by the respective module.

### Description
These changes add the module API for text exercises.

Out of scope: Adding a `PROFILE_TEXT` to disable the module on server start. This requires a lot of frontend changes and testing.

### Steps for Testing
Basically try to test all the functionality of text exercises regarding submissions, courses, and import/export.

1. Log in to Artemis
2. Create a text exercise
3. Update the exercise
4. Make a submission
5. Create an example submission
6. Import the student submission as example submission
7. Export the example submissions
8. Import the exercise into a new course
9. Delete the exercise in both courses

#### Exam Mode Testing
1. Log in to Artemis
2. Create a regular text exercise
3. Create an exam
4. Create a text exercise in the exam
5. Import the created text exercise from 2 into the exam
6. Participate in the exam and make submissions

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress

#### Performance Review
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2