### PR TITLE
`Infrastructure`: Add test server 7 to GitHub deployment

### DIFF
--- a/.github/workflows/testserver.yml
+++ b/.github/workflows/testserver.yml
@@ -138,12 +138,13 @@ jobs:
             folder: /opt/artemis
             host_keys: |
 
-          #- environment: artemis-test7.artemis.cit.tum.de
-          #  label-identifier: artemis-test7
-          #  url: https://artemis-test7.artemis.cit.tum.de
-          #  user: deployment
-          #  hosts: artemis-test7.artemis.cit.tum.de
-          #  folder: /opt/artemis
+          - environment: artemis-test7.artemis.cit.tum.de
+            label-identifier: artemis-test7
+            url: https://artemis-test7.artemis.cit.tum.de
+            user: deployment
+            hosts: artemis-test7.artemis.cit.tum.de
+            folder: /opt/artemis
+            host_keys: |
 
           #- environment: artemis-test8.artemis.cit.tum.de
           #  label-identifier: artemis-test8


### PR DESCRIPTION
### Checklist
#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
@ls1intum/helios needs a separate test server for testing deployments.


### Description
This PR adds TS 7 so that it can be deployed via Helios.


### Steps for Testing

You cannot really test this PR.