### PR TITLE
`Development`: Update read the docs config

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 TUM Applied Software Engineering
+Copyright (c) 2024 TUM Applied Education Technologies
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -2,11 +2,12 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
 sphinx:
   fail_on_warning: true
+  configuration: conf.py
 python:
   install:
     - requirements: docs/requirements.txt

--- a/docs/admin/setup/distributed.rst
+++ b/docs/admin/setup/distributed.rst
@@ -17,7 +17,7 @@ Setup with multiple instances
 There are certain scenarios, where a setup with multiple instances of the application server is required.
 This can e.g. be due to special requirements regarding fault tolerance or performance.
 
-Artemis also supports this setup (which is also used at the Chair for Applied Software Engineering at TUM).
+Artemis also supports this setup (which is also used at TUM).
 
 Multiple instances of the application server are used to distribute the load:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,8 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Artemis'
-copyright = '2024, Technical University of Munich, Applied Software Engineering'
-author = 'Technical University of Munich, Applied Software Engineering'
+copyright = '2024, Applied Education Technologies, Technical University of Munich'
+author = 'Applied Education Technologies, Technical University of Munich'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).
- [ ] All relevant checks pass

### Motivation and Context
We are announcing the deprecation of projects using Sphinx or MkDocs without an explicit configuration in their .readthedocs.yaml file. After January 20, 2025, Read the Docs will require explicit configuration for all Sphinx and MkDocs projects.

We used to automatically try to find the configuration file for your project, but in order to make builds more explicit and predictable, we are deprecating this behavior. This will also allows us to better support projects that don't use Sphinx or MkDocs in the near future.

What do I need to do?

If you're using Sphinx or MkDocs, ensure your .readthedocs.yaml file includes the appropriate configuration key. For example:

For Sphinx projects:

version: 2
sphinx:
  configuration: docs/conf.py
For MkDocs projects:

version: 2
mkdocs:
  configuration: mkdocs.yml
Note: If you're using build.commands, no changes are required.

Deprecation timeline

We will implement this change gradually:

January 6, 2025: Builds will be temporarily disabled for 12 hours (00:01 PST to 11:59 PST)
January 13, 2025: Builds will be temporarily disabled for 24 hours (00:01 PST to 23:59 PST)
January 20, 2025: Final cutoff date - builds without explicit configuration will be permanently disabled