### PR TITLE
`Development`: Make compose for playwright tests more reliable

### DIFF
--- a/docker/artemis/config/playwright-local.env
+++ b/docker/artemis/config/playwright-local.env
@@ -5,7 +5,7 @@
 SPRING_PROFILES_ACTIVE="artemis,scheduling,localvc,localci,buildagent,core,prod,docker"
 
 ARTEMIS_USERMANAGEMENT_USEEXTERNAL="false"
-ARTEMIS_VERSIONCONTROL_URL='http://localhost:8080'
+ARTEMIS_VERSIONCONTROL_URL='http://artemis-app:8080'
 ARTEMIS_VERSIONCONTROL_USER="${bamboo_artemis_admin_username}"
 ARTEMIS_VERSIONCONTROL_PASSWORD="${bamboo_artemis_admin_password}"
 ARTEMIS_CONTINUOUSINTEGRATION_ARTEMISAUTHENTICATIONTOKENVALUE='demo'

--- a/docker/artemis/config/playwright-local.env
+++ b/docker/artemis/config/playwright-local.env
@@ -5,7 +5,7 @@
 SPRING_PROFILES_ACTIVE="artemis,scheduling,localvc,localci,buildagent,core,prod,docker"
 
 ARTEMIS_USERMANAGEMENT_USEEXTERNAL="false"
-ARTEMIS_VERSIONCONTROL_URL='http://artemis-app:8080'
+ARTEMIS_VERSIONCONTROL_URL='http://localhost:8080'
 ARTEMIS_VERSIONCONTROL_USER="${bamboo_artemis_admin_username}"
 ARTEMIS_VERSIONCONTROL_PASSWORD="${bamboo_artemis_admin_password}"
 ARTEMIS_CONTINUOUSINTEGRATION_ARTEMISAUTHENTICATIONTOKENVALUE='demo'

--- a/docker/playwright-E2E-tests-multi-node.yml
+++ b/docker/playwright-E2E-tests-multi-node.yml
@@ -109,6 +109,8 @@ services:
         condition: service_healthy
     environment:
       PLAYWRIGHT_DB_TYPE: 'MySQL'
+    networks:
+      - artemis
 
 networks:
   artemis:

--- a/docker/playwright-E2E-tests-mysql-localci.yml
+++ b/docker/playwright-E2E-tests-mysql-localci.yml
@@ -47,6 +47,7 @@ services:
                 condition: service_healthy
         environment:
             PLAYWRIGHT_DB_TYPE: 'MySQL'
+        network_mode: service:artemis-app
 
 networks:
     artemis:

--- a/docker/playwright-E2E-tests-mysql-localci.yml
+++ b/docker/playwright-E2E-tests-mysql-localci.yml
@@ -47,7 +47,6 @@ services:
                 condition: service_healthy
         environment:
             PLAYWRIGHT_DB_TYPE: 'MySQL'
-        network_mode: service:artemis-app
 
 networks:
     artemis:

--- a/docker/playwright-E2E-tests-mysql-localci.yml
+++ b/docker/playwright-E2E-tests-mysql-localci.yml
@@ -47,8 +47,6 @@ services:
                 condition: service_healthy
         environment:
             PLAYWRIGHT_DB_TYPE: 'MySQL'
-        networks:
-            - artemis
 
 networks:
     artemis:

--- a/docker/playwright-E2E-tests-mysql-localci.yml
+++ b/docker/playwright-E2E-tests-mysql-localci.yml
@@ -47,6 +47,8 @@ services:
                 condition: service_healthy
         environment:
             PLAYWRIGHT_DB_TYPE: 'MySQL'
+        networks:
+            - artemis
 
 networks:
     artemis:

--- a/docker/playwright-E2E-tests-mysql-localci.yml
+++ b/docker/playwright-E2E-tests-mysql-localci.yml
@@ -47,8 +47,6 @@ services:
                 condition: service_healthy
         environment:
             PLAYWRIGHT_DB_TYPE: 'MySQL'
-        network_mode: service:artemis-app
-        networks: !reset []
 
 networks:
     artemis:

--- a/docker/playwright.yml
+++ b/docker/playwright.yml
@@ -38,8 +38,3 @@ services:
         stdin_open: true
         tty: true
         ipc: host
-
-networks:
-    artemis:
-        driver: 'bridge'
-        name: artemis

--- a/docker/playwright.yml
+++ b/docker/playwright.yml
@@ -35,13 +35,6 @@ services:
           '
         volumes:
             - ..:/app/artemis
-        networks:
-            - artemis
         stdin_open: true
         tty: true
         ipc: host
-
-networks:
-    artemis:
-        driver: 'bridge'
-        name: artemis

--- a/docker/playwright.yml
+++ b/docker/playwright.yml
@@ -38,3 +38,8 @@ services:
         stdin_open: true
         tty: true
         ipc: host
+
+networks:
+    artemis:
+        driver: 'bridge'
+        name: artemis


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
Currently, the build plans for Playwright tests have inconsistent behavior and compose command sometimes fails due to having `networks` and `network_mode` both specified at the same time for artemis-playwright service. This happens because we override the `networks` using `!reset []` action, but it is not an official compose syntax and sometimes the networks are not reset before the network_mode is used, which causes an error.

### Description
This PR removes the `networks` section from `playwright.yml` compose file and leaves the networking to its extension. This change avoids the inconsistency caused by `networks: !reset []` trick used on `playwright-E2E-tests-mysql-localci.yml`. Instead we specify only `network-mode` on it and we don't have to reset the networks as it's not specified on the parent compose file anymore.

### Steps for Testing
- **Code Review**: Ensure that tests pass for valid reasons and improvements make sense.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

