### PR TITLE
`Development`: Update thymeleaf email templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Artemis brings interactive learning to life with instant, individual feedback on
    * **Integrated feedback**: Reviews can provide feedback and points directly next to the text segments.
    * **Language detection**: Artemis detects the language of the submission and shows the word and character count. 
 7. **[File upload exercises](https://docs.artemis.cit.tum.de/user/exercises/file-upload/)** allow full flexibility to instructors. Students can create any kind of file (e.g. PDF, PNG) and submit it to Artemis when they have completed their work. Artemis allows instructors and tutors to download the files and assess them manually based on structured grading criteria (see below in the section Assessment).
-8. **[Exam mode](https://docs.artemis.cit.tum.de/user/exam_mode/)**: Instructors can create online exams with exercise variants, integrated plagiarism checks, test runs and student reviews. You can find more information on [Exam mode student features](https://artemis.cit.tum.de/features/students) and on [Exam mode instructor features](https://artemis.cit.tum.de/features/instructors).
+8. **[Exam mode](https://docs.artemis.cit.tum.de/user/exam_mode/)**: Instructors can create online exams with exercise variants, integrated plagiarism checks, test runs and student reviews. You can find more information on [Exam mode student features](https://artemis.tum.de/features/students) and on [Exam mode instructor features](https://artemis.tum.de/features/instructors).
 9. **[Assessment](https://docs.artemis.cit.tum.de/user/exercises/assessment/)**: Artemis uses double-blind grading and structured grading criteria to improve consistency and fairness. 
     * **Training process**: It integrates an assessment training process (based on example submissions and example assessments defined by the instructor), has a grading leader board, and allows students to rate the assessments. Students can complain or ask for more feedback. 
     * **Grading**: Instructors can configure grade keys for courses and exams to automatically calculate grades and display them to students. Grades can be easily exported as csv files to upload them into university systems (such as Campus online). They can define bonus configurations for final exams to improve student grades according to their grades from a midterm exam or course exercises.
@@ -59,7 +59,7 @@ Artemis brings interactive learning to life with instant, individual feedback on
     * **[Adaptive learning](https://docs.artemis.cit.tum.de/user/adaptive-learning)**: Artemis allows instructors and students to define and track competencies. Students can monitor their progress towards these goals, while instructors can provide tailored feedback. This approach integrates lectures and exercises under overarching learning objectives. 
     * **[Learning analytics](https://docs.artemis.cit.tum.de/user/learning-analytics)**: Artemis integrated different statistics for students to compare themselves to the course average. It allows instructors to evaluate the average student performance based on exercises and competencies. 
     * **[Learning paths](https://docs.artemis.cit.tum.de/user/adaptive-learning/adaptive-learning-student.html#learning-paths)**: Based on the competency model and students' individual progress, Artemis creates learning paths that guide students through the course content.
-13. **[Iris](https://artemis.cit.tum.de/about-iris)**: Artemis integrates Iris, a LLM based virtual assistant that supports students and instructors with common questions and tasks.
+13. **[Iris](https://artemis.tum.de/about-iris)**: Artemis integrates Iris, a LLM based virtual assistant that supports students and instructors with common questions and tasks.
     * **Questions**: Iris supports students with answering questions about exercises, lectures, and the learning performance instantly.
     * **Pro-active assistance**: Iris can pro-actively communicate with the students, help them with the next steps in their learning experience and motivate them to continue.
 14. **[Athena](https://github.com/ls1intum/Athena)**: Artemis integrates Athena, a machine learning-based tool that supports instructors with the assessment of text, modeling and programming exercises. Athena offers different modules including automatic feedback suggestions based on generate AI. 
@@ -242,7 +242,7 @@ We communicate using GitHub issues and pull requests. Additionally, you can join
 The following universities are actively using Artemis or are currently evaluating Artemis.
 
 * **Technical University of Munich**  
-  https://artemis.cit.tum.de  
+  https://artemis.tum.de  
   Main contact person: [Stephan Krusche](mailto:krusche@tum.de)  
   
 * **LFU Innsbruck, Uni Salzburg, JKU Linz, AAU Klagenfurt, TU Wien**  

--- a/docs/admin/registration.rst
+++ b/docs/admin/registration.rst
@@ -30,7 +30,7 @@ Example:
                     trust: <host>
     jhipster:
         mail:
-            base-url: https://artemis.cit.tum.de
+            base-url: https://artemis.tum.de
             from: artemis@xcit.tum.de
     management:
         health:

--- a/docs/user/mobile-applications.rst
+++ b/docs/user/mobile-applications.rst
@@ -59,7 +59,7 @@ Server Selection
 
 After installation, users have to first decide which Artemis server they want to connect to. Per default, the user can choose between the following instances:
 
-* TUM: https://artemis.cit.tum.de
+* TUM: https://artemis.tum.de
 * CodeAbility: https://artemis.codeability.uibk.ac.at
 * KIT: https://artemis.praktomat.cs.kit.edu
 
@@ -170,7 +170,7 @@ Server Selection
 
 After installation, users have to first decide which Artemis server they want to connect to. Per default, the user can choose between the following instances:
 
-* TUM: https://artemis.cit.tum.de
+* TUM: https://artemis.tum.de
 * CodeAbility: https://artemis.codeability.uibk.ac.at
 * KIT: https://artemis.praktomat.cs.kit.edu
 * Hochschule Munich: https://artemis.cs.hm.edu/

--- a/docs/user/orion.rst
+++ b/docs/user/orion.rst
@@ -39,8 +39,8 @@ Settings
 
 Orion's settings are at *Settings -> Tools -> Orion*. The settings include:
 
-- Artemis base url: Can be changed to switch to a specific Artemis instance. Defaults to https://artemis.cit.tum.de. **Important:** The url must not end with a ``/``, otherwise it does not work!
-- Artemis git url: Can be changed to switch to a specific Artemis instance. Defaults to https://artemis.cit.tum.de/git
+- Artemis base url: Can be changed to switch to a specific Artemis instance. Defaults to https://artemis.tum.de. **Important:** The url must not end with a ``/``, otherwise it does not work!
+- Artemis git url: Can be changed to switch to a specific Artemis instance. Defaults to https://artemis.tum.de/git
 - Artemis exercise paths: Orion suggests to store newly downloaded exercises at ``default-path/course/exercise-name``, with the default path dependent of the setting.
 - Default commit message: The default message for each commit.
 - Change user agent: The user agent is sent to Artemis to identify Orion. Usually, no changes are required.

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/localvc/LocalVCRepositoryUri.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/localvc/LocalVCRepositoryUri.java
@@ -101,10 +101,10 @@ public class LocalVCRepositoryUri extends VcsRepositoryUri {
      *
      * Examples:
      * <ul>
-     * <li>Correct URL: "https://artemis.cit.tum.de/git/projectKey/repositorySlug.git" - Returns 1 as "git" is at index 1.</li>
-     * <li>Incorrect URL: "https://artemis.cit.tum.de/projectKey/repositorySlug.git" - Throws LocalVCInternalException because the "git" segment is missing.</li>
-     * <li>Incorrect URL: "https://artemis.cit.tum.de/git/projectKey" - Throws LocalVCInternalException because there are not enough segments after "git".</li>
-     * <li>Incorrect URL: "https://artemis.cit.tum.de/git/projectKey/repositorySlug" - Throws LocalVCInternalException because the repository slug does not end with ".git".</li>
+     * <li>Correct URL: "https://artemis.tum.de/git/projectKey/repositorySlug.git" - Returns 1 as "git" is at index 1.</li>
+     * <li>Incorrect URL: "https://artemis.tum.de/projectKey/repositorySlug.git" - Throws LocalVCInternalException because the "git" segment is missing.</li>
+     * <li>Incorrect URL: "https://artemis.tum.de/git/projectKey" - Throws LocalVCInternalException because there are not enough segments after "git".</li>
+     * <li>Incorrect URL: "https://artemis.tum.de/git/projectKey/repositorySlug" - Throws LocalVCInternalException because the repository slug does not end with ".git".</li>
      * </ul>
      *
      * @param urlString The full URL string being analyzed, provided for context in error messages.
@@ -148,13 +148,13 @@ public class LocalVCRepositoryUri extends VcsRepositoryUri {
      * <ul>
      * <li>
      * Input: Local repository path - {@code Paths.get("/local/path/projectX/my-repo/.git")}
-     * and Local VC server URL - {@code new URI("https://artemis.cit.tum.de").getURL()}
-     * Output: {@code https://artemis.cit.tum.de/git/projectX/my-repo.git}
+     * and Local VC server URL - {@code new URI("https://artemis.tum.de").getURL()}
+     * Output: {@code https://artemis.tum.de/git/projectX/my-repo.git}
      * </li>
      * <li>
      * Input: Remote repository path - {@code Paths.get("/remote/path/projectY/my-repo")}
-     * and Local VC server URL - {@code new URI("https://artemis.cit.tum.de").getURL()}
-     * Output: {@code https://artemis.cit.tum.de/git/projectY/my-repo.git}
+     * and Local VC server URL - {@code new URI("https://artemis.tum.de").getURL()}
+     * Output: {@code https://artemis.tum.de/git/projectY/my-repo.git}
      * </li>
      * </ul>
      *

--- a/src/main/resources/templates/mail/dataExportFailedAdminEmail.html
+++ b/src/main/resources/templates/mail/dataExportFailedAdminEmail.html
@@ -2,11 +2,11 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title th:text="#{email.dataExportFailedAdmin.title(${user.login})}">Data export for one of the users failed</title>
-    <th:block th:replace="mail/notification/fragments :: headMetaDataAndIconLink"/>
-    <th:block th:replace="mail/notification/fragments :: css"/>
+    <th:block th:replace="~{mail/notification/fragments :: headMetaDataAndIconLink}"/>
+    <th:block th:replace="~{mail/notification/fragments :: css}"/>
 </head>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
     <span th:text="#{email.dataExportFailedAdmin.text}">A data export creation failed. </span>

--- a/src/main/resources/templates/mail/notification/announcementPostEmail.html
+++ b/src/main/resources/templates/mail/notification/announcementPostEmail.html
@@ -1,25 +1,25 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <div class="notification-content">
         <span th:text="#{email.notification.title.post.announcement(
             ${notificationSubject.getTitle()},
             ${notificationSubject.getConversation().getCourse().getTitle()}
             )}">Notification Content for Announcement Posts
-            </span>
+        </span>
         <div class="bordered-content">
             <p th:utext="${notificationSubject.getContent()}">Post Content</p>
         </div>
-        <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+        <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
     </div>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/attachmentChangedEmail.html
+++ b/src/main/resources/templates/mail/notification/attachmentChangedEmail.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-    <th:block th:replace="mail/notification/fragments :: header"/>
+    <th:block th:replace="~{mail/notification/fragments :: header}"/>
     <!-- Message Body Start -->
     <div id="message-body">
-        <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+        <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
         <div class="notification-content">
             <span th:text="#{email.notification.title.attachment(
                 ${notificationSubject.getName()},
@@ -13,12 +13,12 @@
                 ${notificationSubject.getLecture().getCourse().getTitle()}
                 )}">Notification Content for Attachment Changed</span>
             <!-- Change message : notification text -->
-            <th:block th:replace="mail/notification/fragments :: notificationText"/>
-            <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+            <th:block th:replace="~{mail/notification/fragments :: notificationText}"/>
+            <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
         </div>
-        <th:block th:replace="mail/notification/fragments :: farewell"/>
+        <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
     </div>
     <!-- Message Body End -->
-    <th:block th:replace="mail/notification/fragments :: footer"/>
+    <th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/dataExportCreatedEmail.html
+++ b/src/main/resources/templates/mail/notification/dataExportCreatedEmail.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <span th:text="#{email.notification.title.dataExportCreated}">Your data export has been successfully created</span>
-        <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+        <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/dataExportFailedEmail.html
+++ b/src/main/resources/templates/mail/notification/dataExportFailedEmail.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <span th:text="#{email.notification.title.dataExportFailed}">Your data export creation failed.</span>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/duplicateTestCasesEmail.html
+++ b/src/main/resources/templates/mail/notification/duplicateTestCasesEmail.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <div class="notification-content">
-        <th:block th:replace="mail/notification/fragments :: exerciseTypeTranslation"/>
+        <th:block th:replace="~{mail/notification/fragments :: exerciseTypeTranslation}"/>
         <span th:text="#{email.notification.title.duplicate.test.cases(
                 ${notificationSubject.getTitle()},
                 ${notificationSubject.getCourseViaExerciseGroupOrCourseMember().getTitle()}
@@ -21,11 +21,11 @@
                 <li th:text="#{email.notification.aux.information.due.date(${timeService.convertToHumanReadableDate(notificationSubject.getDueDate())})}">Due Date</li>
             </th:block>
         </ul>
-        <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+        <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
     </div>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/exerciseOpenForPracticeEmail.html
+++ b/src/main/resources/templates/mail/notification/exerciseOpenForPracticeEmail.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <div class="notification-content">
-            <th:block th:replace="mail/notification/fragments :: exerciseTypeTranslation"/>
+            <th:block th:replace="~{mail/notification/fragments :: exerciseTypeTranslation}"/>
             <span th:utext="#{email.notification.title.exercise.practice(
                 ${notificationSubject.getTitle()},
                 ${notificationSubject.getCourseViaExerciseGroupOrCourseMember().getTitle()}
@@ -15,14 +15,14 @@
         <th:block th:if="${notificationSubject.getDifficulty()}">
             <p class="bold-text" th:text="#{email.notification.title.exercise.information}">Information about this exercise:</p>
             <ul>
-                <li th:include="mail/notification/fragments :: difficultyTranslation"/>
+                <li th:include="~{mail/notification/fragments :: difficultyTranslation}"/>
             </ul>
         </th:block>
-        <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+        <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
     </div>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/exerciseReleasedEmail.html
+++ b/src/main/resources/templates/mail/notification/exerciseReleasedEmail.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-    <th:block th:replace="mail/notification/fragments :: header"/>
+    <th:block th:replace="~{mail/notification/fragments :: header}"/>
     <!-- Message Body Start -->
     <div id="message-body">
-        <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+        <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
         <div class="notification-content">
-            <th:block th:replace="mail/notification/fragments :: exerciseTypeTranslation"/>
+            <th:block th:replace="~{mail/notification/fragments :: exerciseTypeTranslation}"/>
             <span th:text="#{email.notification.title.exercise.created(
                 ${notificationSubject.getTitle()},
                 ${notificationSubject.getCourseViaExerciseGroupOrCourseMember().getTitle()}
@@ -15,7 +15,7 @@
             <p class="bold-text" th:text="#{email.notification.title.exercise.information}">Information about this exercise:</p>
             <ul>
                 <th:block th:if="${notificationSubject.getDifficulty()}">
-                    <li th:include="mail/notification/fragments :: difficultyTranslation"/>
+                    <li th:include="~{mail/notification/fragments :: difficultyTranslation}"/>
                 </th:block>
                 <th:block th:if="${notificationSubject.getReleaseDate()}">
                     <li th:text="#{email.notification.aux.information.release.date(${timeService.convertToHumanReadableDate(notificationSubject.getReleaseDate())})}">Release Date</li>
@@ -28,11 +28,11 @@
                     <li th:text="#{email.notification.title.exercise.information.bonus(${notificationSubject.getBonusPoints()})}">Bonus Points</li>
                 </th:block>
             </ul>
-            <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+            <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
         </div>
-        <th:block th:replace="mail/notification/fragments :: farewell"/>
+        <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
     </div>
     <!-- Message Body End -->
-    <th:block th:replace="mail/notification/fragments :: footer"/>
+    <th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/exerciseSubmissionAssessedEmail.html
+++ b/src/main/resources/templates/mail/notification/exerciseSubmissionAssessedEmail.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <div class="notification-content">
         <span th:text="#{email.notification.title.exercise.submission.assessed(
                 ${notificationSubject.getTitle()},
@@ -16,11 +16,11 @@
             <li th:text="#{email.notification.title.exercise.information.possible(${notificationSubject.getMaxPoints()})}">Max Points</li>
             <li th:text="#{email.notification.aux.information.exercise.score(${assessedScore})}">Score</li>
         </ul>
-        <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+        <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
     </div>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/fileSubmissionSuccessfulEmail.html
+++ b/src/main/resources/templates/mail/notification/fileSubmissionSuccessfulEmail.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <div class="notification-content">
         <span th:text="#{email.notification.title.file.submission.successful(
                 ${notificationSubject.getTitle()},
@@ -20,11 +20,11 @@
                 <li th:text="#{email.notification.aux.information.due.date(${timeService.convertToHumanReadableDate(notificationSubject.getDueDate())})}">Exercise Due Date</li>
             </th:block>
         </ul>
-        <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+        <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
     </div>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/fragments.html
+++ b/src/main/resources/templates/mail/notification/fragments.html
@@ -193,10 +193,6 @@
 </div>
 <!-- Message Body End -->
 
-<!--
-     ADDITIONAL AUXILIARY FRAGMENTS
- -->
-
 <!-- Fragment containing footer with additional information (e.g. where/how to (un)subscribe to emails) -->
 <th:block th:fragment="footer">
     <footer>
@@ -206,6 +202,10 @@
         </a>
     </footer>
 </th:block>
+
+<!--
+     ADDITIONAL AUXILIARY FRAGMENTS
+ -->
 
 <!-- Fragment displaying the translated exerciseType (e.g. -> "Quiz") -->
 <th:block th:fragment="exerciseTypeTranslation">

--- a/src/main/resources/templates/mail/notification/fragments.html
+++ b/src/main/resources/templates/mail/notification/fragments.html
@@ -1,178 +1,148 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 
-<!--
- Fragment containing HTML <head/> with <style/> for emails based on notifications
- i.e. the css styling for notification-emails can/should be changed here
--->
+<!-- Fragment containing HTML <head/> with <style/> for emails based on notifications -->
 <th:block th:fragment="head">
     <head>
         <title th:text="${notification.title}">Notification Title</title>
-        <th:block th:replace="mail/notification/fragments :: headMetaDataAndIconLink"/>
-        <th:block th:replace="mail/notification/fragments :: css"/>
+        <th:block th:replace="~{mail/notification/fragments :: headMetaDataAndIconLink}"/>
+        <th:block th:replace="~{mail/notification/fragments :: css}"/>
     </head>
 </th:block>
 <body>
 
-<!--
- Fragment containing CSS
--->
+<!-- Fragment containing CSS -->
 <th:block th:fragment="css">
     <style>
-
-    body {
-        font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-        font-size: 19px;
-        margin: 0 auto;
-        background: white;
-        color: black;
-    }
-
-    a {
-        color: #3e8acc;
-    }
-
-    pre {
-        padding: 10px 24px;
-        max-width: 800px;
-        white-space: pre-wrap;
-        background-color: #47474b;
-        color: white;
-        border-radius: 3px;
-    }
-    code {
-        font-family: Consolas, Monaco, Andale Mono, monospace;
-        line-height: 1.5;
-        font-size: 13px;
-    }
-    p code {
-        background-color: #47474b;
-        color: white;
-        border-radius: 3px;
-        padding: 3px 5px;
-    }
-    blockquote {
-        margin: 1em;
-        max-width: 476px;
-        border-left: 5px solid gray;
-        padding-left: 12px;
-    }
-    blockquote p {
-        color: #666;
-        max-width: 460px;
-    }
-
-    .notification-text-header {
-        padding-top: 10px;
-    }
-
-    .notification-text {
-        font-style: italic;
-        font-weight: bold;
-        padding-top: 3px;
-    }
-
-    ul {
-        padding-left: 20px;
-    }
-
-    .button {
-        background-color: #5B9CD4;
-        color: white !important; /* Without important, color was overridden in Gmail */
-        padding: 8px 12px ;
-        border-radius: 8px;
-        text-decoration: none;
-    }
-
-    .button-wrapper {
-        padding: 25px 25px 25px 0px;
-    }
-
-    .emergency-link {
-        color: gray;
-        font-size: small;
-    }
-
-    .emergency-link > * {
-        margin: 0;
-    }
-
-    .notification-content {
-        margin-top: 10px;
-    }
-
-    .notification-content p {
-        margin-top: 0;
-    }
-
-    .notification-content p:first-child:empty, .notification-content p:last-child:empty {
-        display: none;
-    }
-
-    .bordered-content {
-        border-radius: 3px;
-        border: 1px solid #ccc;
-        background: #f7f7f7;
-        box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
-        margin: 15px 0;
-        padding: 10px;
-    }
-
-    .bold-text {
-        font-weight: bold;
-    }
-
-    header {
-        background-color: #353D47;
-        padding: 10px;
-        color: white;
-    }
-
-    #header-table {
-        border: none;
-    }
-
-    #logo {
-        max-width: 50px;
-        vertical-align: middle;
-    }
-
-    #app-name {
-        padding-left: 10px;
-    }
-
-    #message-body {
-        background-color: white;
-        padding: 10px;
-    }
-
-    footer {
-        background-color: #353D47;
-        color: white;
-        font-size: smaller;
-        padding: 5px;
-    }
-</style>
+        /* CSS styles here */
+        body {
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+            font-size: 19px;
+            margin: 0 auto;
+            background: white;
+            color: black;
+        }
+        a {
+            color: #3e8acc;
+        }
+        pre {
+            padding: 10px 24px;
+            max-width: 800px;
+            white-space: pre-wrap;
+            background-color: #47474b;
+            color: white;
+            border-radius: 3px;
+        }
+        code {
+            font-family: Consolas, Monaco, Andale Mono, monospace;
+            line-height: 1.5;
+            font-size: 13px;
+        }
+        p code {
+            background-color: #47474b;
+            color: white;
+            border-radius: 3px;
+            padding: 3px 5px;
+        }
+        blockquote {
+            margin: 1em;
+            max-width: 476px;
+            border-left: 5px solid gray;
+            padding-left: 12px;
+        }
+        blockquote p {
+            color: #666;
+            max-width: 460px;
+        }
+        .notification-text-header {
+            padding-top: 10px;
+        }
+        .notification-text {
+            font-style: italic;
+            font-weight: bold;
+            padding-top: 3px;
+        }
+        ul {
+            padding-left: 20px;
+        }
+        .button {
+            background-color: #5B9CD4;
+            color: white !important; /* Without important, color was overridden in Gmail */
+            padding: 8px 12px ;
+            border-radius: 8px;
+            text-decoration: none;
+        }
+        .button-wrapper {
+            padding: 25px 25px 25px 0;
+        }
+        .emergency-link {
+            color: gray;
+            font-size: small;
+        }
+        .emergency-link > * {
+            margin: 0;
+        }
+        .notification-content {
+            margin-top: 10px;
+        }
+        .notification-content p {
+            margin-top: 0;
+        }
+        .notification-content p:first-child:empty, .notification-content p:last-child:empty {
+            display: none;
+        }
+        .bordered-content {
+            border-radius: 3px;
+            border: 1px solid #ccc;
+            background: #f7f7f7;
+            box-shadow: rgba(0, 0, 0, 0.24) 0 3px 8px;
+            margin: 15px 0;
+            padding: 10px;
+        }
+        .bold-text {
+            font-weight: bold;
+        }
+        header {
+            background-color: #353D47;
+            padding: 10px;
+            color: white;
+        }
+        #header-table {
+            border: none;
+        }
+        #logo {
+            max-width: 50px;
+            vertical-align: middle;
+        }
+        #app-name {
+            padding-left: 10px;
+        }
+        #message-body {
+            background-color: white;
+            padding: 10px;
+        }
+        footer {
+            background-color: #353D47;
+            color: white;
+            font-size: smaller;
+            padding: 5px;
+        }
+    </style>
 </th:block>
 
-<!--
- Fragment containing Head meta data & icon link
--->
+<!-- Fragment containing Head meta data & icon link -->
 <th:block th:fragment="headMetaDataAndIconLink">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <link rel="icon" type="image/svg+xml" sizes="any" th:href="@{|${baseUrl}/favicon.svg|}" />
 </th:block>
 
-
-<!--
- Fragment containing Artemis Logo email header
--->
+<!-- Fragment containing Artemis Logo email header -->
 <th:block th:fragment="header">
     <header>
         <table id="header-table">
             <tr>
                 <td>
-                    <img id="logo" src="https://artemis.cit.tum.de/public/images/logo.png" alt="artemis logo"/>
+                    <img id="logo" src="https://artemis.tum.de/public/images/logo.png" alt="artemis logo"/>
                 </td>
                 <td>
                     <div id="app-name">Artemis</div>
@@ -185,9 +155,7 @@
 <!-- Message Body Start -->
 <div id="message-body">
 
-    <!--
-    Fragment containing the greetings "Dear 'full-name'"
-    -->
+    <!-- Fragment containing the greetings "Dear 'full-name'" -->
     <th:block th:fragment="greetingsFullName">
         <span th:text="#{email.greetings}">Dear </span>
         <span class="bold-text" th:text="${user.getName()}">fullName</span>
@@ -201,11 +169,8 @@
         </th:block>
     </div>
 
-    <!--
-     Fragment containing the "Open in Artemis" button
-     -->
+    <!-- Fragment containing the "Open in Artemis" button -->
     <th:block th:fragment="openInArtemisButton">
-        <!-- Button/Link that navigates to the respective page in Artemis -->
         <div class="button-wrapper">
             <a class="button" th:href="@{${notificationUrl}}" th:text="#{email.notification.aux.open.button}">Open in Artemis</a>
         </div>
@@ -215,12 +180,9 @@
         </div>
     </th:block>
 
-    <!--
-     Fragment containing the farewell
-     -->
+    <!-- Fragment containing the farewell -->
     <th:block th:fragment="farewell">
         <br>
-        <!-- Farwell -->
         <p>
             <span th:text="#{email.activation.text2}">Regards, </span>
             <br/>
@@ -231,9 +193,7 @@
 </div>
 <!-- Message Body End -->
 
-<!--
- Fragment containing footer with additional information (e.g. where/how to (un)subscribe to emails
--->
+<!-- Fragment containing footer with additional information -->
 <th:block th:fragment="footer">
     <footer>
         <span th:text="#{email.notification.aux.footer}"/>
@@ -243,86 +203,7 @@
     </footer>
 </th:block>
 
-<!--
-    ADDITIONAL AUXILIARY FRAGMENTS
--->
-
-<!-- Fragment displaying the translated exerciseType (e.g. -> "Quiz") -->
-<th:block th:fragment="exerciseTypeTranslation">
-    <th:block th:switch="${exerciseType.toString()}">
-        <th:block th:case="'QUIZ'">
-            <span th:utext="#{email.notification.aux.exercise.type.quiz}"/>
-        </th:block>
-        <th:block th:case="'TEXT'">
-            <span th:utext="#{email.notification.aux.exercise.type.text}"/>
-        </th:block>
-        <th:block th:case="'MODELING'">
-            <span th:utext="#{email.notification.aux.exercise.type.modeling}"/>
-        </th:block>
-        <th:block th:case="'FILE_UPLOAD'">
-            <span th:utext="#{email.notification.aux.exercise.type.upload}"/>
-        </th:block>
-        <th:block th:case="'PROGRAMMING'">
-            <span th:utext="#{email.notification.aux.exercise.type.programming}"/>
-        </th:block>
-    </th:block>
-</th:block>
-
-<!-- Fragment displaying the translated PlagiarismVerdict (e.g. -> "POINT_DEDUCTION") -->
-<th:block th:fragment="plagiarismVerdictTranslation">
-    <th:block th:switch="${notificationSubject.getVerdict().toString()}">
-        <th:block th:case="'PLAGIARISM'">
-            <span th:utext="#{email.notification.aux.plagiarismVerdict.plagiarism}"/>
-        </th:block>
-        <th:block th:case="'POINT_DEDUCTION'">
-            <span th:utext="#{email.notification.aux.plagiarismVerdict.point.deduction}"/>
-        </th:block>
-        <th:block th:case="'WARNING'">
-            <span th:utext="#{email.notification.aux.plagiarismVerdict.warning}"/>
-        </th:block>
-        <th:block th:case="'NO_PLAGIARISM'">
-            <span th:utext="#{email.notification.aux.plagiarismVerdict.no.plagiarism}"/>
-        </th:block>
-    </th:block>
-</th:block>
-
-<!-- Fragment displaying the difficulty of an exercise (e.g. -> "Difficulty: Medium") -->
-<th:block th:fragment="difficultyTranslation">
-    <!-- security check else internal server error -->
-    <th:block th:if="${notificationSubject.getDifficulty()}">
-        <th:block th:switch="${notificationSubject.getDifficulty().toString()}">
-        <th:block th:case="'EASY'">
-            <span th:utext="#{email.notification.title.exercise.information.difficulty(#{email.notification.aux.difficulty.easy})} "/>
-        </th:block>
-        <th:block th:case="'MEDIUM'">
-            <span th:utext="#{email.notification.title.exercise.information.difficulty(#{email.notification.aux.difficulty.medium})} "/>
-        </th:block>
-        <th:block th:case="'HARD'">
-            <span th:utext="#{email.notification.title.exercise.information.difficulty(#{email.notification.aux.difficulty.hard})} "/>
-        </th:block>
-    </th:block>
-    </th:block>
-</th:block>
-
-<!-- ONLY INTENDED IF BASED ON GROUP-NOTIFICATIONS -->
-
-<!-- Fragment displaying the authority of the user (e.g. -> "Instructors") -->
-<th:block th:fragment="authority">
-    <th:block th:switch="${notification.type.toString()}">
-        <th:block th:case="'STUDENT'">
-            <span th:utext="#{email.notification.group.students}"/>
-        </th:block>
-        <th:block th:case="'INSTRUCTOR'">
-            <span th:utext="#{email.notification.group.instructors}"/>
-        </th:block>
-        <th:block th:case="'EDITOR'">
-            <span th:utext="#{email.notification.group.editors}"/>
-        </th:block>
-        <th:block th:case="'TA'">
-        <span th:utext="#{email.notification.group.tutors}"/>
-    </th:block>
-    </th:block>
-</th:block>
-
+<!-- Additional Auxiliary Fragments -->
+<!-- Correct syntax applied throughout -->
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/fragments.html
+++ b/src/main/resources/templates/mail/notification/fragments.html
@@ -193,7 +193,11 @@
 </div>
 <!-- Message Body End -->
 
-<!-- Fragment containing footer with additional information -->
+<!--
+     ADDITIONAL AUXILIARY FRAGMENTS
+ -->
+
+<!-- Fragment containing footer with additional information (e.g. where/how to (un)subscribe to emails) -->
 <th:block th:fragment="footer">
     <footer>
         <span th:text="#{email.notification.aux.footer}"/>
@@ -203,7 +207,81 @@
     </footer>
 </th:block>
 
-<!-- Additional Auxiliary Fragments -->
-<!-- Correct syntax applied throughout -->
+<!-- Fragment displaying the translated exerciseType (e.g. -> "Quiz") -->
+<th:block th:fragment="exerciseTypeTranslation">
+    <th:block th:switch="${exerciseType.toString()}">
+        <th:block th:case="'QUIZ'">
+            <span th:utext="#{email.notification.aux.exercise.type.quiz}"/>
+        </th:block>
+        <th:block th:case="'TEXT'">
+            <span th:utext="#{email.notification.aux.exercise.type.text}"/>
+        </th:block>
+        <th:block th:case="'MODELING'">
+            <span th:utext="#{email.notification.aux.exercise.type.modeling}"/>
+        </th:block>
+        <th:block th:case="'FILE_UPLOAD'">
+            <span th:utext="#{email.notification.aux.exercise.type.upload}"/>
+        </th:block>
+        <th:block th:case="'PROGRAMMING'">
+            <span th:utext="#{email.notification.aux.exercise.type.programming}"/>
+        </th:block>
+    </th:block>
+</th:block>
+
+<!-- Fragment displaying the translated PlagiarismVerdict (e.g. -> "POINT_DEDUCTION") -->
+<th:block th:fragment="plagiarismVerdictTranslation">
+    <th:block th:switch="${notificationSubject.getVerdict().toString()}">
+        <th:block th:case="'PLAGIARISM'">
+            <span th:utext="#{email.notification.aux.plagiarismVerdict.plagiarism}"/>
+        </th:block>
+        <th:block th:case="'POINT_DEDUCTION'">
+            <span th:utext="#{email.notification.aux.plagiarismVerdict.point.deduction}"/>
+        </th:block>
+        <th:block th:case="'WARNING'">
+            <span th:utext="#{email.notification.aux.plagiarismVerdict.warning}"/>
+        </th:block>
+        <th:block th:case="'NO_PLAGIARISM'">
+            <span th:utext="#{email.notification.aux.plagiarismVerdict.no.plagiarism}"/>
+        </th:block>
+    </th:block>
+</th:block>
+
+<!-- Fragment displaying the difficulty of an exercise (e.g. -> "Difficulty: Medium") -->
+<th:block th:fragment="difficultyTranslation">
+    <!-- security check else internal server error -->
+    <th:block th:if="${notificationSubject.getDifficulty()}">
+        <th:block th:switch="${notificationSubject.getDifficulty().toString()}">
+            <th:block th:case="'EASY'">
+                <span th:utext="#{email.notification.title.exercise.information.difficulty(#{email.notification.aux.difficulty.easy})} "/>
+            </th:block>
+            <th:block th:case="'MEDIUM'">
+                <span th:utext="#{email.notification.title.exercise.information.difficulty(#{email.notification.aux.difficulty.medium})} "/>
+            </th:block>
+            <th:block th:case="'HARD'">
+                <span th:utext="#{email.notification.title.exercise.information.difficulty(#{email.notification.aux.difficulty.hard})} "/>
+            </th:block>
+        </th:block>
+    </th:block>
+</th:block>
+
+<!-- ONLY INTENDED IF BASED ON GROUP-NOTIFICATIONS -->
+
+<!-- Fragment displaying the authority of the user (e.g. -> "Instructors") -->
+<th:block th:fragment="authority">
+    <th:block th:switch="${notification.type.toString()}">
+        <th:block th:case="'STUDENT'">
+            <span th:utext="#{email.notification.group.students}"/>
+        </th:block>
+        <th:block th:case="'INSTRUCTOR'">
+            <span th:utext="#{email.notification.group.instructors}"/>
+        </th:block>
+        <th:block th:case="'EDITOR'">
+            <span th:utext="#{email.notification.group.editors}"/>
+        </th:block>
+        <th:block th:case="'TA'">
+            <span th:utext="#{email.notification.group.tutors}"/>
+        </th:block>
+    </th:block>
+</th:block>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/plagiarismCaseEmail.html
+++ b/src/main/resources/templates/mail/notification/plagiarismCaseEmail.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
     <div class="notification-content">
         <div>
             <p th:utext="${notificationSubject.getPost().getContent()}">Post Content</p>
         </div>
-        <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+        <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
     </div>
 </div>
 <!-- Message Body End -->

--- a/src/main/resources/templates/mail/notification/plagiarismVerdictEmail.html
+++ b/src/main/resources/templates/mail/notification/plagiarismVerdictEmail.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <div class="notification-content">
         <span th:text="#{email.notification.title.post.plagiarismVerdict(
             ${notificationSubject.getExercise().getTitle()}
             )}">Notification Content for Plagiarism Verdict
         </span>
         <div class="bordered-content">
-            <th:block th:replace="mail/notification/fragments :: plagiarismVerdictTranslation"/>
+            <th:block th:replace="~{mail/notification/fragments :: plagiarismVerdictTranslation}"/>
         </div>
-        <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+        <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
     </div>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/tutorialGroupBasicEmail.html
+++ b/src/main/resources/templates/mail/notification/tutorialGroupBasicEmail.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <div class="notification-content">
         <div th:switch="${notificationType}">
             <span th:case="'studentRegistration'" th:text="#{email.notification.title.tutorialGroup.registrationStudent(
@@ -47,11 +47,11 @@
             ${notificationSubject.responsibleUser.getName()}
             )}"></span>
         </div>
-        <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+        <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
     </div>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/tutorialGroupDeletedEmail.html
+++ b/src/main/resources/templates/mail/notification/tutorialGroupDeletedEmail.html
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <div class="notification-content">
             <span th:text="#{email.notification.title.tutorialGroup.deleted(
             ${notificationSubject.getTitle()},
             ${notificationSubject.getCourse().getTitle()},
             )}"></span>
     </div>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/notification/tutorialGroupUpdatedEmail.html
+++ b/src/main/resources/templates/mail/notification/tutorialGroupUpdatedEmail.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<th:block th:replace="mail/notification/fragments :: head"/>
+<th:block th:replace="~{mail/notification/fragments :: head}"/>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <div class="notification-content">
             <span th:text="#{email.notification.title.tutorialGroup.updated(
             ${notificationSubject.getTitle()},
             ${notificationSubject.getCourse().getTitle()},
             )}"></span>
-        <th:block th:replace="mail/notification/fragments :: notificationText"/>
-        <th:block th:replace="mail/notification/fragments :: openInArtemisButton"/>
+        <th:block th:replace="~{mail/notification/fragments :: notificationText}"/>
+        <th:block th:replace="~{mail/notification/fragments :: openInArtemisButton}"/>
     </div>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/resources/templates/mail/successfulDataExportsAdminEmail.html
+++ b/src/main/resources/templates/mail/successfulDataExportsAdminEmail.html
@@ -2,11 +2,11 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title th:text="#{email.successfulDataExportCreationsAdmin.title}">Data exports created</title>
-    <th:block th:replace="mail/notification/fragments :: headMetaDataAndIconLink"/>
-    <th:block th:replace="mail/notification/fragments :: css"/>
+    <th:block th:replace="~{mail/notification/fragments :: headMetaDataAndIconLink}"/>
+    <th:block th:replace="~{mail/notification/fragments :: css}"/>
 </head>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
     <p th:text="#{email.successfulDataExportCreationsAdmin.text}">Successful data exports</p>

--- a/src/main/resources/templates/mail/weeklySummary.html
+++ b/src/main/resources/templates/mail/weeklySummary.html
@@ -2,14 +2,14 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Weekly Summary</title>
-    <th:block th:replace="mail/notification/fragments :: headMetaDataAndIconLink"/>
-    <th:block th:replace="mail/notification/fragments :: css"/>
+    <th:block th:replace="~{mail/notification/fragments :: headMetaDataAndIconLink}"/>
+    <th:block th:replace="~{mail/notification/fragments :: css}"/>
 </head>
 <body>
-<th:block th:replace="mail/notification/fragments :: header"/>
+<th:block th:replace="~{mail/notification/fragments :: header}"/>
 <!-- Message Body Start -->
 <div id="message-body">
-    <th:block th:replace="mail/notification/fragments :: greetingsFullName"/>
+    <th:block th:replace="~{mail/notification/fragments :: greetingsFullName}"/>
     <div class="notification-content">
         <span th:text="#{email.weekly.summary.text}">This is your Artemis summary of the last seven days.</span>
         <hr/>
@@ -56,9 +56,9 @@
             </ul>
         </th:block>
     </div>
-    <th:block th:replace="mail/notification/fragments :: farewell"/>
+    <th:block th:replace="~{mail/notification/fragments :: farewell}"/>
 </div>
 <!-- Message Body End -->
-<th:block th:replace="mail/notification/fragments :: footer"/>
+<th:block th:replace="~{mail/notification/fragments :: footer}"/>
 </body>
 </html>

--- a/src/main/webapp/app/core/about-us/about-us.component.ts
+++ b/src/main/webapp/app/core/about-us/about-us.component.ts
@@ -44,7 +44,7 @@ export class AboutUsComponent implements OnInit {
         ['learningAnalytics', { learningAnalyticsUrl: 'https://docs.artemis.cit.tum.de/user/learning-analytics/' }],
         ['adaptiveLearning', { adaptiveLearningUrl: 'https://docs.artemis.cit.tum.de/user/adaptive-learning/' }],
         ['tutorialGroups', { tutorialGroupsUrl: 'https://docs.artemis.cit.tum.de/user/tutorialgroups/' }],
-        ['iris', { irisUrl: 'https://artemis.cit.tum.de/about-iris' }],
+        ['iris', { irisUrl: 'https://artemis.tum.de/about-iris' }],
         ['scalable', { scalingUrl: 'https://docs.artemis.cit.tum.de/user/scaling/' }],
         ['highUserSatisfaction', { userExperienceUrl: 'https://docs.artemis.cit.tum.de/user/user-experience/' }],
         ['customizable', { customizableUrl: 'https://docs.artemis.cit.tum.de/user/courses/customizable' }],

--- a/src/test/java/de/tum/cit/aet/artemis/programming/icl/RepositoryUriTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/icl/RepositoryUriTest.java
@@ -23,7 +23,7 @@ class RepositoryUriTest {
 
     @Test
     void testValidUrlWithGit() {
-        String urlString = "https://artemis.cit.tum.de/git/key/key-repositoryslug.git";
+        String urlString = "https://artemis.tum.de/git/key/key-repositoryslug.git";
 
         assertThatCode(() -> {
             LocalVCRepositoryUri uri = new LocalVCRepositoryUri(urlString);
@@ -40,21 +40,21 @@ class RepositoryUriTest {
 
     @Test
     void testUrlWithoutGit() {
-        String urlString = "https://artemis.cit.tum.de/key/key-repositoryslug.git";
+        String urlString = "https://artemis.tum.de/key/key-repositoryslug.git";
         assertThatThrownBy(() -> new LocalVCRepositoryUri(urlString)).isInstanceOf(LocalVCInternalException.class)
                 .hasMessageContaining("Invalid local VC Repository URI: 'git' directory not found in the URL");
     }
 
     @Test
     void testUrlWithInsufficientSegments() {
-        String urlString = "https://artemis.cit.tum.de/git/key";
+        String urlString = "https://artemis.tum.de/git/key";
         assertThatThrownBy(() -> new LocalVCRepositoryUri(urlString)).isInstanceOf(LocalVCInternalException.class)
                 .hasMessageContaining("URL does not contain enough segments after 'git'");
     }
 
     @Test
     void testUrlRepositorySlugWithoutGitSuffix() {
-        String urlString = "https://artemis.cit.tum.de/git/key/key-repositoryslug";
+        String urlString = "https://artemis.tum.de/git/key/key-repositoryslug";
         assertThatThrownBy(() -> new LocalVCRepositoryUri(urlString)).isInstanceOf(LocalVCInternalException.class)
                 .hasMessageContaining("Repository slug segment 'key-repositoryslug' does not end with '.git'");
     }
@@ -62,10 +62,10 @@ class RepositoryUriTest {
     @Test
     void testLocalRepositoryPath() throws Exception {
         Path repositoryPath = Paths.get("/local/path/projectX/projectX-repo/.git");
-        URL localVCServerUrl = new URI("https://artemis.cit.tum.de").toURL();
+        URL localVCServerUrl = new URI("https://artemis.tum.de").toURL();
         LocalVCRepositoryUri uri = new LocalVCRepositoryUri(repositoryPath, localVCServerUrl);
 
-        assertThat(uri.getURI().toString()).isEqualTo("https://artemis.cit.tum.de/git/projectX/projectX-repo.git");
+        assertThat(uri.getURI().toString()).isEqualTo("https://artemis.tum.de/git/projectX/projectX-repo.git");
         assertThat(uri.getProjectKey()).isEqualTo("projectX");
         assertThat(uri.repositorySlug()).isEqualTo("projectX-repo");
         assertThat(uri.getRepositoryTypeOrUserName()).isEqualTo("repo");
@@ -75,10 +75,10 @@ class RepositoryUriTest {
     @Test
     void testRemoteRepositoryPath() throws Exception {
         Path repositoryPath = Paths.get("/remote/path/projectY/projectY-repo");
-        URL localVCServerUrl = new URI("https://artemis.cit.tum.de").toURL();
+        URL localVCServerUrl = new URI("https://artemis.tum.de").toURL();
         LocalVCRepositoryUri uri = new LocalVCRepositoryUri(repositoryPath, localVCServerUrl);
 
-        assertThat(uri.getURI().toString()).isEqualTo("https://artemis.cit.tum.de/git/projectY/projectY-repo.git");
+        assertThat(uri.getURI().toString()).isEqualTo("https://artemis.tum.de/git/projectY/projectY-repo.git");
         assertThat(uri.getProjectKey()).isEqualTo("projectY");
         assertThat(uri.repositorySlug()).isEqualTo("projectY-repo");
         assertThat(uri.getRepositoryTypeOrUserName()).isEqualTo("repo");
@@ -90,7 +90,7 @@ class RepositoryUriTest {
         Path repositoryPath = Paths.get("/invalid/path");
         URL localVCServerUrl;
         try {
-            localVCServerUrl = new URI("https://artemis.cit.tum.de").toURL();
+            localVCServerUrl = new URI("https://artemis.tum.de").toURL();
             assertThatThrownBy(() -> new LocalVCRepositoryUri(repositoryPath, localVCServerUrl)).isInstanceOf(LocalVCInternalException.class)
                     .hasMessageContaining("Invalid project key and repository slug: invalid, path");
         }
@@ -103,28 +103,28 @@ class RepositoryUriTest {
     void testConstructorWithValidData() throws Exception {
         String projectKey = "projectX";
         String repositorySlug = "my-repo";
-        URL localVCBaseUrl = new URI("https://artemis.cit.tum.de").toURL();
+        URL localVCBaseUrl = new URI("https://artemis.tum.de").toURL();
 
         LocalVCRepositoryUri uri = new LocalVCRepositoryUri(projectKey, repositorySlug, localVCBaseUrl);
 
         assertThat(uri.getProjectKey()).isEqualTo(projectKey);
         assertThat(uri.getRepositoryTypeOrUserName()).isEqualTo(repositorySlug);
         assertThat(uri.isPracticeRepository()).isFalse();
-        assertThat(uri.getURI().toString()).isEqualTo("https://artemis.cit.tum.de/git/projectX/my-repo.git");
+        assertThat(uri.getURI().toString()).isEqualTo("https://artemis.tum.de/git/projectX/my-repo.git");
     }
 
     @Test
     void testConstructorWithPracticeRepository() throws Exception {
         String projectKey = "projectX";
         String repositorySlug = "projectX-practice-my-repo";
-        URL localVCBaseUrl = new URI("https://artemis.cit.tum.de").toURL();
+        URL localVCBaseUrl = new URI("https://artemis.tum.de").toURL();
 
         LocalVCRepositoryUri uri = new LocalVCRepositoryUri(projectKey, repositorySlug, localVCBaseUrl);
 
         assertThat(uri.getProjectKey()).isEqualTo(projectKey);
         assertThat(uri.getRepositoryTypeOrUserName()).isEqualTo("my-repo");
         assertThat(uri.isPracticeRepository()).isTrue();
-        assertThat(uri.getURI().toString()).isEqualTo("https://artemis.cit.tum.de/git/projectX/projectX-practice-my-repo.git");
+        assertThat(uri.getURI().toString()).isEqualTo("https://artemis.tum.de/git/projectX/projectX-practice-my-repo.git");
     }
 
     @Test

--- a/src/test/javascript/spec/service/external-cloning.service.spec.ts
+++ b/src/test/javascript/spec/service/external-cloning.service.spec.ts
@@ -23,7 +23,7 @@ describe('ExternalCloningService', () => {
     it('should build ide deeplink url correctly', () => {
         const cloneUrl = baseUrl + '/git/repo.git';
         const ide = { name: 'VS Code', deepLink: 'vscode://vscode.git/clone?url={cloneUrl}' };
-        const expectedUrl = 'vscode://vscode.git/clone?url=https%3A%2F%2Fartemis.cit.tum.de%2Fgit%2Frepo.git';
+        const expectedUrl = 'vscode://vscode.git/clone?url=https%3A%2F%2Fartemis.tum.de%2Fgit%2Frepo.git';
         expect(service.buildIdeUrl(cloneUrl, ide)).toEqual(expectedUrl);
     });
 

--- a/src/test/javascript/spec/service/external-cloning.service.spec.ts
+++ b/src/test/javascript/spec/service/external-cloning.service.spec.ts
@@ -3,7 +3,7 @@ import { ExternalCloningService } from 'app/exercises/programming/shared/service
 
 describe('ExternalCloningService', () => {
     let service: ExternalCloningService;
-    const baseUrl = 'https://artemis.cit.tum.de';
+    const baseUrl = 'https://artemis.tum.de';
 
     beforeEach(() => {
         TestBed.configureTestingModule({});
@@ -12,7 +12,7 @@ describe('ExternalCloningService', () => {
 
     it('should build source tree url correctly', () => {
         const cloneUrl = baseUrl + '/git/reo.git';
-        const expectedUrl = `sourcetree://cloneRepo?type=stash&cloneUrl=https://artemis.cit.tum.de/git/reo.git&baseWebUrl=https://artemis.cit.tum.de`;
+        const expectedUrl = `sourcetree://cloneRepo?type=stash&cloneUrl=https://artemis.tum.de/git/reo.git&baseWebUrl=https://artemis.tum.de`;
         expect(service.buildSourceTreeUrl(baseUrl, cloneUrl)).toEqual(expectedUrl);
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
Sending emails leads to deprecation warnings, e.g.
Jan 07 18:48:50 artemis-production-node8.artemis.in.tum.de java[3847328]: 2025-01-07T18:48:50.080+01:00  WARN 3847328 --- [Artemis] [ artemis-task-1] actStandardFragmentInsertionTagProcessor : [THYMELEAF][artemis-task-1][mail/notification/announcementPostEmail] Deprecated unwrapped fragment expression "mail/notification/fragments :: head" found in template mail/notification/announcementPostEmail, line 3, col 11. Please use the complete syntax of fragment expressions instead ("~{mail/notification/fragments :: head}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.



### Description
I updated all email templates and while doing that also updated the URLs of the main TUM artemis instance


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Create an announcement 
2. Make sure you receive the email and it looks correct
3. Make sure there are no warnings or errors in the logs


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Documentation**
  - Updated URLs from `artemis.cit.tum.de` to `artemis.tum.de` across multiple documentation files, including user guides, registration documentation, and mobile application server selection.
  - Updated documentation for Orion settings.

- **Configuration**
  - Modified email template fragment references to use new Thymeleaf syntax across various email templates.

- **Test Updates**
  - Adjusted test cases to reflect new base URL in various test files.

- **Frontend**
  - Updated About Us component URL for the IRIS section.

No functional changes were introduced in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->