### PR TITLE
`Communication`: Resolve reactivity issues when displaying replies to a post

### DIFF
--- a/src/main/webapp/app/overview/course-conversations/course-conversations.component.html
+++ b/src/main/webapp/app/overview/course-conversations/course-conversations.component.html
@@ -54,7 +54,7 @@
                     <jhi-conversation-header (collapseSearch)="toggleChannelSearch()" (onUpdateSidebar)="prepareSidebarData()" />
                     <jhi-conversation-messages
                         [contentHeightDev]="!isProduction || isTestServer"
-                        (openThread)="postInThread = $event"
+                        (openThread)="openThread($event)"
                         [course]="course"
                         [searchbarCollapsed]="channelSearchCollapsed"
                         [focusPostId]="focusPostId"

--- a/src/main/webapp/app/overview/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/course-conversations.component.ts
@@ -565,8 +565,8 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
         this.channelSearchCollapsed = !this.channelSearchCollapsed;
     }
 
-    openThread(e: Post | undefined) {
-        this.postInThread = e;
+    openThread(postToOpen: Post | undefined) {
+        this.postInThread = postToOpen;
     }
 
     @HostListener('document:keydown', ['$event'])

--- a/src/main/webapp/app/overview/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/course-conversations.component.ts
@@ -565,6 +565,10 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
         this.channelSearchCollapsed = !this.channelSearchCollapsed;
     }
 
+    openThread(e: Post | undefined) {
+        this.postInThread = e;
+    }
+
     @HostListener('document:keydown', ['$event'])
     handleSearchShortcut(event: KeyboardEvent) {
         if ((event.metaKey || event.ctrlKey) && event.key === 'k') {

--- a/src/main/webapp/app/shared/metis/posting-content/posting-content-part/posting-content-part.components.ts
+++ b/src/main/webapp/app/shared/metis/posting-content/posting-content-part/posting-content-part.components.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { PostingContentPart, ReferenceType } from '../../metis.util';
 import { FileService } from 'app/shared/http/file.service';
 
@@ -27,7 +27,7 @@ import { AccountService } from 'app/core/auth/account.service';
     templateUrl: './posting-content-part.component.html',
     styleUrls: ['./../../metis.component.scss'],
 })
-export class PostingContentPartComponent implements OnInit {
+export class PostingContentPartComponent implements OnInit, OnChanges {
     @Input() postingContentPart: PostingContentPart;
     @Output() userReferenceClicked = new EventEmitter<string>();
     @Output() channelReferenceClicked = new EventEmitter<number>();
@@ -57,6 +57,10 @@ export class PostingContentPartComponent implements OnInit {
     ) {}
 
     ngOnInit() {
+        this.processContent();
+    }
+
+    ngOnChanges(): void {
         this.processContent();
     }
 

--- a/src/main/webapp/app/shared/metis/posting-content/posting-content.component.html
+++ b/src/main/webapp/app/shared/metis/posting-content/posting-content.component.html
@@ -16,7 +16,7 @@
             <span class="toggle-content" jhiTranslate="{{ showContent ? 'artemisApp.metis.post.collapseContent' : 'artemisApp.metis.post.showContent' }}"></span>
             @if (showContent) {
                 <div>
-                    @for (postingContentPart of postingContentParts(); track $index) {
+                    @for (postingContentPart of postingContentParts(); track contentPartTrack($index)) {
                         <jhi-posting-content-part
                             [postingContentPart]="postingContentPart"
                             (userReferenceClicked)="userReferenceClicked.emit($event)"
@@ -33,7 +33,7 @@
     <!-- not in preview mode: content always shown -->
     @if (!previewMode) {
         <div class="pb-1">
-            @for (postingContentPart of postingContentParts(); track $index) {
+            @for (postingContentPart of postingContentParts(); track contentPartTrack($index)) {
                 <jhi-posting-content-part
                     [postingContentPart]="postingContentPart"
                     (userReferenceClicked)="userReferenceClicked.emit($event)"

--- a/src/main/webapp/app/shared/metis/posting-content/posting-content.components.ts
+++ b/src/main/webapp/app/shared/metis/posting-content/posting-content.components.ts
@@ -63,6 +63,9 @@ export class PostingContentComponent implements OnInit, OnChanges, OnDestroy {
         if (!this.isSubscribeToMetis()) {
             this.computeContentPartsOfPosts();
         }
+
+        const patternMatches: PatternMatch[] = this.getPatternMatches();
+        this.computePostingContentParts(patternMatches);
     }
 
     /**
@@ -252,5 +255,9 @@ export class PostingContentComponent implements OnInit, OnChanges, OnDestroy {
             match = pattern.exec(this.content!);
         }
         return patternMatches;
+    }
+
+    contentPartTrack(index: number) {
+        return this.posting?.id + '_' + index;
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, when opening a thread using either the "Reply in thread" or "Show X Replies" option, the content of the main post and its associated replies are displayed correctly. However, if a different thread is opened while the initial thread remains active, the main post content fails to update and retains the content of the previously opened post.

### Description
<!-- Describe your changes in detail -->
I implemented function calls to compute the posting content within the `onChanges` lifecycle hook. This ensures that the post content is properly updated whenever changes occur.

Addresses #9754 and #9803, Closes #10071

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student/Tutor/Instructor
- 1 Course with communication enabled

1. Log in to Artemis
2. Navigate to course
3. Navigate to the communication tab
4. Select a channel with atleast 2 posts or go to a channel and create 2 posts
5. Select "Reply in thread"/"Show X Replies" of one post
6. Without closing the thread, select "Reply in thread"/"Show X Replies" of the other post
7. Check if the thread displays the newly selected post properly

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| course-conversations.component.ts | 90.55% | ✅ |
| posting-content-part.components.ts | 94.23% | ✅ |
| posting-content.components.ts | 91.39% | ✅ |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![context-switch](https://github.com/user-attachments/assets/1f737f0e-10a5-41f3-8dbd-848f8c87dba1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced thread opening mechanism in conversation messages.
	- Improved content part tracking and processing in posting content components.

- **Refactor**
	- Updated event handling for conversation threads.
	- Implemented more responsive content change detection.

- **Bug Fixes**
	- Improved tracking of content parts to optimize rendering performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->