### PR TITLE
`Modeling exercises`: Fix manual feedback results not being shown

### DIFF
--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
@@ -15,7 +15,7 @@ import { ModelingAssessmentService } from 'app/exercises/modeling/assess/modelin
 import { ModelingSubmissionService } from 'app/exercises/modeling/participate/modeling-submission.service';
 import { ModelingEditorComponent } from 'app/exercises/modeling/shared/modeling-editor.component';
 import { getExerciseDueDate, hasExerciseDueDatePassed } from 'app/exercises/shared/exercise/exercise.utils';
-import { addParticipationToResult, getAutomaticUnreferencedFeedback } from 'app/exercises/shared/result/result.utils';
+import { addParticipationToResult, getUnreferencedFeedback } from 'app/exercises/shared/result/result.utils';
 import { AccountService } from 'app/core/auth/account.service';
 import { GuidedTourService } from 'app/guided-tour/guided-tour.service';
 import { modelingTour } from 'app/guided-tour/tours/modeling-tour';
@@ -664,7 +664,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
     get unreferencedFeedback(): Feedback[] | undefined {
         if (this.assessmentResult?.feedbacks) {
             checkSubsequentFeedbackInAssessment(this.assessmentResult.feedbacks);
-            return getAutomaticUnreferencedFeedback(this.assessmentResult.feedbacks);
+            return getUnreferencedFeedback(this.assessmentResult.feedbacks);
         }
         return undefined;
     }

--- a/src/main/webapp/app/exercises/shared/result/result.utils.ts
+++ b/src/main/webapp/app/exercises/shared/result/result.utils.ts
@@ -125,12 +125,16 @@ export const getManualUnreferencedFeedback = (feedbacks: Feedback[] | undefined)
 };
 
 /**
- * searches for all automatic unreferenced feedback in an array of feedbacks of a result
+ * searches for all unreferenced feedback in an array of feedbacks of a result
  * @param feedbacks the feedback of a result
  * @returns an array with the unreferenced feedback of the result
  */
-export const getAutomaticUnreferencedFeedback = (feedbacks: Feedback[] | undefined): Feedback[] | undefined => {
-    return feedbacks ? feedbacks.filter((feedbackElement) => !feedbackElement.reference && feedbackElement.type === FeedbackType.AUTOMATIC) : undefined;
+export const getUnreferencedFeedback = (feedbacks: Feedback[] | undefined): Feedback[] | undefined => {
+    return feedbacks
+        ? feedbacks.filter(
+              (feedbackElement) => !feedbackElement.reference && (feedbackElement.type === FeedbackType.MANUAL_UNREFERENCED || feedbackElement.type === FeedbackType.AUTOMATIC),
+          )
+        : undefined;
 };
 
 export function isAIResultAndFailed(result: Result | undefined): boolean {

--- a/src/test/javascript/spec/component/utils/result.utils.spec.ts
+++ b/src/test/javascript/spec/component/utils/result.utils.spec.ts
@@ -1,10 +1,10 @@
 import {
     ResultTemplateStatus,
     breakCircularResultBackReferences,
-    getAutomaticUnreferencedFeedback,
     getManualUnreferencedFeedback,
     getResultIconClass,
     getTextColorClass,
+    getUnreferencedFeedback,
     isOnlyCompilationTested,
 } from 'app/exercises/shared/result/result.utils';
 import { Feedback, FeedbackType, STATIC_CODE_ANALYSIS_FEEDBACK_IDENTIFIER } from 'app/entities/feedback.model';
@@ -39,7 +39,7 @@ describe('ResultUtils', () => {
             { type: FeedbackType.MANUAL_UNREFERENCED },
             {},
         ];
-        const unreferencedFeedbacks = getAutomaticUnreferencedFeedback(feedbacks);
+        const unreferencedFeedbacks = getUnreferencedFeedback(feedbacks);
         expect(unreferencedFeedbacks).toEqual([{ type: FeedbackType.AUTOMATIC }]);
     });
 

--- a/src/test/javascript/spec/component/utils/result.utils.spec.ts
+++ b/src/test/javascript/spec/component/utils/result.utils.spec.ts
@@ -31,7 +31,7 @@ describe('ResultUtils', () => {
         expect(unreferencedFeedbacks).toEqual([{ type: FeedbackType.MANUAL_UNREFERENCED }]);
     });
 
-    it('should filter out all non unreferenced feedbacks that do not have type AUTOMATIC', () => {
+    it('should filter out all non unreferenced feedbacks', () => {
         const feedbacks = [
             { reference: 'foo' },
             { reference: 'foo', type: FeedbackType.AUTOMATIC },
@@ -40,7 +40,7 @@ describe('ResultUtils', () => {
             {},
         ];
         const unreferencedFeedbacks = getUnreferencedFeedback(feedbacks);
-        expect(unreferencedFeedbacks).toEqual([{ type: FeedbackType.AUTOMATIC }]);
+        expect(unreferencedFeedbacks).toEqual([{ type: FeedbackType.AUTOMATIC }, { type: FeedbackType.MANUAL_UNREFERENCED }]);
     });
 
     it.each([


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
For modeling exercises, the results don't show manual unreferenced feedback.

### Description
This PR fixes the issue by returning both automatic and manual unreferenced feedbacks for modeling exercise results.

### Steps for Testing
- **Code Review**: Ensure that test passes for valid reasons and improvements make sense.
- **CI testing**: Check that all tests pass.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced feedback retrieval functionality to include both manual and automatic unreferenced feedback
	- Simplified feedback processing by consolidating unreferenced feedback methods

- **Refactor**
	- Renamed `getAutomaticUnreferencedFeedback` to `getUnreferencedFeedback` across multiple components
	- Updated test cases to reflect new feedback retrieval approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->