### PR TITLE
`Communication`: Fix broken link when referencing a lecture attachment in a post

### DIFF
--- a/src/main/webapp/app/shared/http/file.service.ts
+++ b/src/main/webapp/app/shared/http/file.service.ts
@@ -73,6 +73,13 @@ export class FileService {
         return newWindow;
     }
 
+    /**
+     * Creates the URL to download a attachment file
+     *
+     * @param downloadUrl url that is stored in the attachment model
+     * @param downloadName the name given to the attachment
+     * @param encodeName whether or not to encode the downloadName
+     */
     createAttachmentFileUrl(downloadUrl: string, downloadName: string, encodeName: boolean) {
         const downloadUrlComponents = downloadUrl.split('/');
         // take the last element

--- a/src/main/webapp/app/shared/http/file.service.ts
+++ b/src/main/webapp/app/shared/http/file.service.ts
@@ -67,14 +67,19 @@ export class FileService {
      * @param downloadName the name given to the attachment
      */
     downloadFileByAttachmentName(downloadUrl: string, downloadName: string) {
+        const normalizedDownloadUrl = this.createAttachmentFileUrl(downloadUrl, downloadName, true);
+        const newWindow = window.open('about:blank');
+        newWindow!.location.href = normalizedDownloadUrl;
+        return newWindow;
+    }
+
+    createAttachmentFileUrl(downloadUrl: string, downloadName: string, encodeName: boolean) {
         const downloadUrlComponents = downloadUrl.split('/');
         // take the last element
         const extension = downloadUrlComponents.pop()!.split('.').pop();
         const restOfUrl = downloadUrlComponents.join('/');
-        const normalizedDownloadUrl = restOfUrl + '/' + encodeURIComponent(downloadName + '.' + extension);
-        const newWindow = window.open('about:blank');
-        newWindow!.location.href = normalizedDownloadUrl;
-        return newWindow;
+        const encodedDownloadName = encodeName ? encodeURIComponent(downloadName + '.' + extension) : downloadName + '.' + extension;
+        return restOfUrl + '/' + encodedDownloadName;
     }
 
     /**

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
@@ -46,6 +46,7 @@ import { OrderedListAction } from 'app/shared/monaco-editor/model/actions/ordere
 import { StrikethroughAction } from 'app/shared/monaco-editor/model/actions/strikethrough.action';
 import { PostingContentComponent } from '../posting-content/posting-content.components';
 import { NgStyle } from '@angular/common';
+import { FileService } from 'app/shared/http/file.service';
 
 @Component({
     selector: 'jhi-posting-markdown-editor',
@@ -64,6 +65,7 @@ import { NgStyle } from '@angular/common';
 export class PostingMarkdownEditorComponent implements OnInit, ControlValueAccessor, AfterContentChecked, AfterViewInit {
     private cdref = inject(ChangeDetectorRef);
     private metisService = inject(MetisService);
+    private fileService = inject(FileService);
     private courseManagementService = inject(CourseManagementService);
     private lectureService = inject(LectureService);
     private channelService = inject(ChannelService);
@@ -119,7 +121,7 @@ export class PostingMarkdownEditorComponent implements OnInit, ControlValueAcces
             ...faqAction,
         ];
 
-        this.lectureAttachmentReferenceAction = new LectureAttachmentReferenceAction(this.metisService, this.lectureService);
+        this.lectureAttachmentReferenceAction = new LectureAttachmentReferenceAction(this.metisService, this.lectureService, this.fileService);
     }
 
     ngAfterViewInit(): void {

--- a/src/main/webapp/app/shared/monaco-editor/model/actions/communication/lecture-attachment-reference.action.ts
+++ b/src/main/webapp/app/shared/monaco-editor/model/actions/communication/lecture-attachment-reference.action.ts
@@ -9,6 +9,8 @@ import { Slide } from 'app/entities/lecture-unit/slide.model';
 import { LectureUnitType } from 'app/entities/lecture-unit/lectureUnit.model';
 import { TextEditor } from 'app/shared/monaco-editor/model/actions/adapter/text-editor.interface';
 import { sanitizeStringForMarkdownEditor } from 'app/shared/util/markdown.util';
+import { FileService } from 'app/shared/http/file.service';
+import { cloneDeep } from 'lodash-es';
 
 interface LectureWithDetails {
     id: number;
@@ -37,6 +39,7 @@ export class LectureAttachmentReferenceAction extends TextEditorAction {
     constructor(
         private readonly metisService: MetisService,
         private readonly lectureService: LectureService,
+        private readonly fileService: FileService,
     ) {
         super(LectureAttachmentReferenceAction.ID, 'artemisApp.metis.editor.lecture');
         firstValueFrom(this.lectureService.findAllByCourseIdWithSlides(this.metisService.getCourse().id!)).then((response) => {
@@ -44,12 +47,28 @@ export class LectureAttachmentReferenceAction extends TextEditorAction {
             if (lectures) {
                 this.lecturesWithDetails = lectures
                     .filter((lecture) => !!lecture.id && !!lecture.title)
-                    .map((lecture) => ({
-                        id: lecture.id!,
-                        title: lecture.title!,
-                        attachmentUnits: lecture.lectureUnits?.filter((unit) => unit.type === LectureUnitType.ATTACHMENT),
-                        attachments: lecture.attachments,
-                    }));
+                    .map((lecture) => {
+                        let attachmentCopy = cloneDeep(lecture.attachments);
+
+                        if (attachmentCopy) {
+                            attachmentCopy = attachmentCopy.map((attachment) => {
+                                if (attachment.link && attachment.name) {
+                                    attachment.link = this.fileService.createAttachmentFileUrl(attachment.link!, attachment.name!, false);
+                                }
+
+                                return attachment;
+                            });
+                        } else {
+                            attachmentCopy = lecture.attachments;
+                        }
+
+                        return {
+                            id: lecture.id!,
+                            title: lecture.title!,
+                            attachmentUnits: lecture.lectureUnits?.filter((unit) => unit.type === LectureUnitType.ATTACHMENT),
+                            attachments: attachmentCopy,
+                        };
+                    });
             }
         });
     }

--- a/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
@@ -36,8 +36,10 @@ import { TextEditorRange } from 'app/shared/monaco-editor/model/actions/adapter/
 import { TextEditorPosition } from 'app/shared/monaco-editor/model/actions/adapter/text-editor-position.model';
 import { BulletedListAction } from 'app/shared/monaco-editor/model/actions/bulleted-list.action';
 import { OrderedListAction } from 'app/shared/monaco-editor/model/actions/ordered-list.action';
-import { ListAction } from '../../../../../../../main/webapp/app/shared/monaco-editor/model/actions/list.action';
+import { ListAction } from 'app/shared/monaco-editor/model/actions/list.action';
 import monaco from 'monaco-editor';
+import { FileService } from 'app/shared/http/file.service';
+import { MockFileService } from '../../../../helpers/mocks/service/mock-file.service';
 
 describe('PostingsMarkdownEditor', () => {
     let component: PostingMarkdownEditorComponent;
@@ -45,6 +47,7 @@ describe('PostingsMarkdownEditor', () => {
     let debugElement: DebugElement;
     let mockMarkdownEditorComponent: MarkdownEditorMonacoComponent;
     let metisService: MetisService;
+    let fileService: FileService;
     let lectureService: LectureService;
     let findLectureWithDetailsSpy: jest.SpyInstance;
 
@@ -120,6 +123,7 @@ describe('PostingsMarkdownEditor', () => {
         return TestBed.configureTestingModule({
             providers: [
                 { provide: MetisService, useClass: MockMetisService },
+                { provide: FileService, useClass: MockFileService },
                 MockProvider(LectureService),
                 MockProvider(CourseManagementService),
                 MockProvider(ChannelService),
@@ -134,6 +138,7 @@ describe('PostingsMarkdownEditor', () => {
                 fixture = TestBed.createComponent(PostingMarkdownEditorComponent);
                 component = fixture.componentInstance;
                 debugElement = fixture.debugElement;
+                fileService = TestBed.inject(FileService);
                 metisService = TestBed.inject(MetisService);
                 lectureService = TestBed.inject(LectureService);
 
@@ -154,14 +159,14 @@ describe('PostingsMarkdownEditor', () => {
         containDefaultActions(component.defaultActions);
         expect(component.defaultActions).toEqual(expect.arrayContaining([expect.any(UserMentionAction), expect.any(ChannelReferenceAction)]));
 
-        expect(component.lectureAttachmentReferenceAction).toEqual(new LectureAttachmentReferenceAction(metisService, lectureService));
+        expect(component.lectureAttachmentReferenceAction).toEqual(new LectureAttachmentReferenceAction(metisService, lectureService, fileService));
     });
 
     it('should have set the correct default commands on init if communication is disabled', () => {
         jest.spyOn(CourseModel, 'isCommunicationEnabled').mockReturnValueOnce(false);
         component.ngOnInit();
         containDefaultActions(component.defaultActions);
-        expect(component.lectureAttachmentReferenceAction).toEqual(new LectureAttachmentReferenceAction(metisService, lectureService));
+        expect(component.lectureAttachmentReferenceAction).toEqual(new LectureAttachmentReferenceAction(metisService, lectureService, fileService));
     });
 
     function containDefaultActions(defaultActions: TextEditorAction[]) {
@@ -186,7 +191,7 @@ describe('PostingsMarkdownEditor', () => {
         component.ngOnInit();
         containDefaultActions(component.defaultActions);
         expect(component.defaultActions).toEqual(expect.arrayContaining([expect.any(FaqReferenceAction)]));
-        expect(component.lectureAttachmentReferenceAction).toEqual(new LectureAttachmentReferenceAction(metisService, lectureService));
+        expect(component.lectureAttachmentReferenceAction).toEqual(new LectureAttachmentReferenceAction(metisService, lectureService, fileService));
     });
 
     it('should have set the correct default commands on init if faq is disabled', () => {
@@ -194,7 +199,7 @@ describe('PostingsMarkdownEditor', () => {
         component.ngOnInit();
         containDefaultActions(component.defaultActions);
         expect(component.defaultActions).toEqual(expect.not.arrayContaining([expect.any(FaqReferenceAction)]));
-        expect(component.lectureAttachmentReferenceAction).toEqual(new LectureAttachmentReferenceAction(metisService, lectureService));
+        expect(component.lectureAttachmentReferenceAction).toEqual(new LectureAttachmentReferenceAction(metisService, lectureService, fileService));
     });
 
     it('should show the correct amount of characters below the markdown input', () => {

--- a/src/test/javascript/spec/helpers/mocks/service/mock-file.service.ts
+++ b/src/test/javascript/spec/helpers/mocks/service/mock-file.service.ts
@@ -16,6 +16,10 @@ export class MockFileService {
         return of();
     };
 
+    createAttachmentFileUrl(downloadUrl: string, downloadName: string, encodeName: boolean) {
+        return 'attachments/' + downloadName.replace(' ', '-') + '.pdf';
+    }
+
     replaceLectureAttachmentPrefixAndUnderscores = (link: string) => link;
     replaceAttachmentPrefixAndUnderscores = (link: string) => link;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, when referencing a lecture attachment in the markdown editor and creating a post, clicking the link results in a 404 error. However, the attachment itself is functional and accessible within the lecture.

Addresses #9943 

### Description
<!-- Describe your changes in detail -->
I changed the behaviour of generating the link so that it matches the behaviour inside the lecture. With this future posts will not run into the same issue when referencing lecture attachments.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student/Tutor/Instructor
- 1 Course with communication enabled
- 1 Lecture with atleast one published attachment (Manage Course -> Lectures -> Select Lecture -> Attachments)

1. Log in to Artemis
2. Navigate to course
3. Navigate to the communication tab
4. Select a channel
5. Write a post and reference a lecture attachment
6. Click on the lecture attachment reference
7. Observe that it shows the proper attachment and no 404 error

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Previous behaviour:
![392764413-fb71289d-ae9e-424d-bfbf-101a69408d76](https://github.com/user-attachments/assets/a8d01af4-682b-4cd4-a66d-7a8d5f9d1931)
