### PR TITLE
`Development`: Fix flaky communication module test cases

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/communication/ChannelIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/ChannelIntegrationTest.java
@@ -995,7 +995,7 @@ class ChannelIntegrationTest extends AbstractConversationTest {
         request.postWithoutLocation("/api/courses/" + exampleCourseId + "/channels/mark-as-read", null, HttpStatus.OK, null);
         List<Channel> updatedChannels = channelRepository.findChannelsByCourseId(exampleCourseId);
         updatedChannels.forEach(channel -> {
-            await().atMost(2, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
                 var participant = conversationParticipantRepository.findConversationParticipantByConversationIdAndUserId(channel.getId(), instructor1.getId());
                 assertThat(participant).isPresent().get().extracting(ConversationParticipant::getUnreadMessagesCount).isEqualTo(0L);
             });

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -697,8 +697,7 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         final var student1 = userTestRepository.findOneByLogin(TEST_PREFIX + "student1").orElseThrow();
         final var student2 = userTestRepository.findOneByLogin(TEST_PREFIX + "student2").orElseThrow();
 
-        Post postToSave1 = createPostWithOneToOneChat(TEST_PREFIX); // OneToOneChat 1
-        Post postToSave2 = createPostWithOneToOneChat(TEST_PREFIX); // OneToOneChat 1
+        Post postToSave1 = createPostWithOneToOneChat(TEST_PREFIX);
 
         Post createdPost1 = request.postWithResponseBody("/api/courses/" + courseId + "/messages", postToSave1, Post.class, HttpStatus.CREATED);
         final var oneToOneChat1 = createdPost1.getConversation();
@@ -709,25 +708,12 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
             assertThat(getUnreadMessagesCount(oneToOneChat1, student2)).isEqualTo(1);
         });
 
-        Post createdPost2 = request.postWithResponseBody("/api/courses/" + courseId + "/messages", postToSave2, Post.class, HttpStatus.CREATED);
-        final var oneToOneChat2 = createdPost2.getConversation();
-        // student 1 adds a message, so the unread count for student 2 should be 1
-        await().untilAsserted(() -> {
-            SecurityUtils.setAuthorizationObject();
-            assertThat(getUnreadMessagesCount(oneToOneChat1, student1)).isZero();
-            assertThat(getUnreadMessagesCount(oneToOneChat1, student2)).isEqualTo(1);
-        });
-
-        request.delete("/api/courses/" + courseId + "/messages/" + createdPost2.getId(), HttpStatus.OK);
-        // After deleting the message in the second chat, the unread count in the first chat should stay the same, the unread count in the second chat will become 0
+        request.delete("/api/courses/" + courseId + "/messages/" + createdPost1.getId(), HttpStatus.OK);
+        // After deleting the message in the chat, the unread count in the chat should become 0
         await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
             SecurityUtils.setAuthorizationObject();
-            assertThat(getUnreadMessagesCount(oneToOneChat1, student2)).isEqualTo(1);
-            assertThat(getUnreadMessagesCount(oneToOneChat2, student2)).isZero();
-
-            // no changes for student1
+            assertThat(getUnreadMessagesCount(oneToOneChat1, student2)).isZero();
             assertThat(getUnreadMessagesCount(oneToOneChat1, student1)).isZero();
-            assertThat(getUnreadMessagesCount(oneToOneChat2, student1)).isZero();
         });
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -720,7 +720,7 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         request.delete("/api/courses/" + courseId + "/messages/" + createdPost2.getId(), HttpStatus.OK);
         // After deleting the message in the second chat, the unread count in the first chat should stay the same, the unread count in the second chat will become 0
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+        await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
             SecurityUtils.setAuthorizationObject();
             assertThat(getUnreadMessagesCount(oneToOneChat1, student2)).isEqualTo(1);
             assertThat(getUnreadMessagesCount(oneToOneChat2, student2)).isZero();

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -14,7 +14,6 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import jakarta.validation.ConstraintViolation;
@@ -710,7 +709,7 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         request.delete("/api/courses/" + courseId + "/messages/" + createdPost1.getId(), HttpStatus.OK);
         // After deleting the message in the chat, the unread count in the chat should become 0
-        await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
+        await().untilAsserted(() -> {
             SecurityUtils.setAuthorizationObject();
             assertThat(getUnreadMessagesCount(oneToOneChat1, student2)).isZero();
             assertThat(getUnreadMessagesCount(oneToOneChat1, student1)).isZero();

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -720,7 +720,7 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         request.delete("/api/courses/" + courseId + "/messages/" + createdPost2.getId(), HttpStatus.OK);
         // After deleting the message in the second chat, the unread count in the first chat should stay the same, the unread count in the second chat will become 0
-        await().atMost(2, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
             SecurityUtils.setAuthorizationObject();
             assertThat(getUnreadMessagesCount(oneToOneChat1, student2)).isEqualTo(1);
             assertThat(getUnreadMessagesCount(oneToOneChat2, student2)).isZero();

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -720,7 +720,7 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         request.delete("/api/courses/" + courseId + "/messages/" + createdPost2.getId(), HttpStatus.OK);
         // After deleting the message in the second chat, the unread count in the first chat should stay the same, the unread count in the second chat will become 0
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+        await().atMost(2, TimeUnit.SECONDS).pollInterval(50, TimeUnit.MILLISECONDS).pollDelay(300, TimeUnit.MILLISECONDS).untilAsserted(() -> {
             SecurityUtils.setAuthorizationObject();
             assertThat(getUnreadMessagesCount(oneToOneChat1, student2)).isEqualTo(1);
             assertThat(getUnreadMessagesCount(oneToOneChat2, student2)).isZero();

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -14,6 +14,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import jakarta.validation.ConstraintViolation;
@@ -719,7 +720,7 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         request.delete("/api/courses/" + courseId + "/messages/" + createdPost2.getId(), HttpStatus.OK);
         // After deleting the message in the second chat, the unread count in the first chat should stay the same, the unread count in the second chat will become 0
-        await().untilAsserted(() -> {
+        await().atMost(2, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).untilAsserted(() -> {
             SecurityUtils.setAuthorizationObject();
             assertThat(getUnreadMessagesCount(oneToOneChat1, student2)).isEqualTo(1);
             assertThat(getUnreadMessagesCount(oneToOneChat2, student2)).isZero();

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -720,14 +720,14 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         request.delete("/api/courses/" + courseId + "/messages/" + createdPost2.getId(), HttpStatus.OK);
         // After deleting the message in the second chat, the unread count in the first chat should stay the same, the unread count in the second chat will become 0
-        await().atMost(2, TimeUnit.SECONDS).pollInterval(50, TimeUnit.MILLISECONDS).pollDelay(300, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
             SecurityUtils.setAuthorizationObject();
             assertThat(getUnreadMessagesCount(oneToOneChat1, student2)).isEqualTo(1);
             assertThat(getUnreadMessagesCount(oneToOneChat2, student2)).isZero();
 
             // no changes for student1
             assertThat(getUnreadMessagesCount(oneToOneChat1, student1)).isZero();
-            assertThat(getUnreadMessagesCount(oneToOneChat1, student1)).isZero();
+            assertThat(getUnreadMessagesCount(oneToOneChat2, student1)).isZero();
         });
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the `markAllChallesAsRead` test case in the `ChannelIntegrationTest` is flaky (sometimes failing sometimes not). Additionally, the `shouldMarkAllChannelsAsReadWhenCallingResource` test case in the `MessageIntegrationTest` is flaky.

### Description
<!-- Describe your changes in detail -->
I added more specific waiting conditions with explicit timeouts which help to avoid any transactional issues that might occur in the default waiting time. Additionally I stripped down the tests to test exactly the expected behaviour that they wanted to test in the first place.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
1. Run server tests

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
	- Improved test method naming for better clarity and description.
	- Enhanced assertion handling in channel read status test with a maximum wait time of 2 seconds.
	- Refined test method structure to improve readability and added a maximum wait time of 20 seconds for unread message count checks after deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->