### PR TITLE
`Communication`: Fix cursor jump issue during list text editing

### DIFF
--- a/src/main/webapp/app/shared/monaco-editor/model/actions/list.action.ts
+++ b/src/main/webapp/app/shared/monaco-editor/model/actions/list.action.ts
@@ -79,15 +79,12 @@ export abstract class ListAction extends TextEditorAction {
         const lines = selectedText.split('\n');
 
         // Check if the cursor is at the end of the line to add or remove the prefix
-        let position = editor.getPosition();
+        const position = editor.getPosition();
         if (position) {
             const currentLineText = editor.getLineText(position.getLineNumber());
 
             if (!selectedText && position.getColumn() <= currentLineText.length) {
-                const endPosition = new TextEditorPosition(position.getLineNumber(), currentLineText.length + 1);
-                editor.setPosition(endPosition);
-                editor.focus();
-                position = endPosition;
+                return;
             }
 
             if (position.getColumn() === currentLineText.length + 1) {

--- a/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
@@ -590,6 +590,7 @@ describe('PostingsMarkdownEditor', () => {
             getColumn: () => 5,
         } as TextEditorPosition);
         mockEditor.getLineText.mockReturnValue('- First line');
+        mockEditor.getTextAtRange.mockReturnValue('');
 
         const replaceTextSpy = jest.spyOn(mockEditor, 'replaceTextAtRange');
         bulletedListAction.run(mockEditor);

--- a/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-markdown-editor/postings-markdown-editor.component.spec.ts
@@ -582,4 +582,25 @@ describe('PostingsMarkdownEditor', () => {
         (component as any).handleKeyDown(mockModel, mockPosition.lineNumber);
         expect(handleActionClickSpy).not.toHaveBeenCalled();
     });
+
+    it('should keep the cursor position intact when editing text in a list item', () => {
+        const bulletedListAction = component.defaultActions.find((action: any) => action instanceof BulletedListAction) as BulletedListAction;
+        mockEditor.getPosition.mockReturnValue({
+            getLineNumber: () => 1,
+            getColumn: () => 5,
+        } as TextEditorPosition);
+        mockEditor.getLineText.mockReturnValue('- First line');
+
+        const replaceTextSpy = jest.spyOn(mockEditor, 'replaceTextAtRange');
+        bulletedListAction.run(mockEditor);
+
+        expect(replaceTextSpy).not.toHaveBeenCalled();
+
+        const cursorPosition = mockEditor.getPosition();
+        expect(cursorPosition).toEqual({
+            getLineNumber: expect.any(Function),
+            getColumn: expect.any(Function),
+        });
+        expect(cursorPosition?.getColumn()).toBe(5);
+    });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When editing text in a list (unordered or ordered) within a message, the text cursor would previously jump to the end of the line after each character addition. (Closes #10133)


### Description
<!-- Describe your changes in detail -->
The cursor now maintains its position during text modifications, allowing seamless editing. The fix involved introducing a `return;` condition to prevent unnecessary processing when no text is selected, and the cursor is within the current line.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 User
- 1 Course with Communication enabled

1. Log in to Artemis
2. Navigate to Communication section of a course
3. Insert a list (unordered or ordered), write some text in the message input
4. Go to the middle of the text and start writing or deleting some characters
5. Verify correct cursor behavior



### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| list.action.ts | 80.68% | ✅ ❌ |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved list action handling in the markdown editor to preserve cursor position when editing list items
  - Enhanced list prefix detection for more robust markdown formatting

- **Tests**
  - Added test case to verify cursor position stability during list item editing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->