### PR TITLE
`Team exercises`: Fix synchronization for empty submissions

### DIFF
--- a/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
@@ -18,7 +18,7 @@ import { ComponentCanDeactivate } from 'app/shared/guard/can-deactivate.model';
 import { Feedback } from 'app/entities/feedback.model';
 import { hasExerciseDueDatePassed } from 'app/exercises/shared/exercise/exercise.utils';
 import { TextExercise } from 'app/entities/text/text-exercise.model';
-import { ButtonType } from 'app/shared/components/button.component';
+import { ButtonComponent, ButtonType } from 'app/shared/components/button.component';
 import { Result } from 'app/entities/result.model';
 import { TextSubmission } from 'app/entities/text/text-submission.model';
 import { StringCountService } from 'app/exercises/text/participate/string-count.service';
@@ -37,7 +37,6 @@ import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { PROFILE_IRIS } from 'app/app.constants';
 import { IrisSettingsService } from 'app/iris/settings/shared/iris-settings.service';
 import { AssessmentType } from 'app/entities/assessment-type.model';
-import { ButtonComponent } from 'app/shared/components/button.component';
 import { RequestFeedbackButtonComponent } from 'app/overview/exercise-details/request-feedback-button/request-feedback-button.component';
 import { ResultHistoryComponent } from 'app/overview/result-history/result-history.component';
 import { ResizeableContainerComponent } from 'app/shared/resizeable-container/resizeable-container.component';
@@ -286,6 +285,8 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
 
             if (this.submission?.text) {
                 this.answer = this.submission.text;
+            } else {
+                this.answer = '';
             }
         }
         // check whether the student looks at the result

--- a/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
@@ -286,6 +286,7 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
             if (this.submission?.text) {
                 this.answer = this.submission.text;
             } else {
+                // handles the case when a submission is empty
                 this.answer = '';
             }
         }

--- a/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
@@ -1,7 +1,7 @@
 import { DebugElement, input, runInInjectionContext } from '@angular/core';
 import dayjs from 'dayjs/esm';
-import { ActivatedRoute, RouterModule, convertToParamMap } from '@angular/router';
-import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, RouterModule } from '@angular/router';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { AlertService } from 'app/core/util/alert.service';
 import { ArtemisTestModule } from '../../test.module';
 import { TranslateService } from '@ngx-translate/core';
@@ -328,6 +328,27 @@ describe('TextEditorComponent', () => {
         comp.onReceiveSubmissionFromTeam(submission);
         expect(comp['updateParticipation']).toHaveBeenCalledOnce();
         expect(comp.answer).toBe('abc');
+    });
+
+    it('should receive empty submission from team', () => {
+        comp.participation = { id: 1, team: { id: 1 } } as StudentParticipation;
+        comp.textExercise = {
+            id: 1,
+            studentParticipations: [] as StudentParticipation[],
+        } as TextExercise;
+        const submission = {
+            id: 1,
+            participation: {
+                id: 1,
+                exercise: { id: 1 } as Exercise,
+                submissions: [] as Submission[],
+            } as Participation,
+        } as TextSubmission;
+        // @ts-ignore
+        jest.spyOn(comp, 'updateParticipation');
+        comp.onReceiveSubmissionFromTeam(submission);
+        expect(comp['updateParticipation']).toHaveBeenCalledOnce();
+        expect(comp.answer).toBe('');
     });
 
     it('should set latest submission if submissionId is undefined in updateParticipation', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).

### Description
<!-- Describe your changes in detail -->
When testing #10087, an issue was discovered: text editors do not synchronize properly when one user deletes all text from the editor. This pull request addresses the issue, ensuring this edge case is handled correctly. 

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 2 Students
- 1 Team Text Exercise

1. Start a team text exercise in two browsers (or in an incognito tab).
2. Type some text in one editor and verify that both users' editors are synchronized.
3. Delete some parts of the text in one editor and verify that both users' editors remain synchronized.
4. Delete all text in one editor and verify that both users' editors remain synchronized.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced text editor component to utilize the ButtonComponent.
  - Improved test coverage for submission handling.

- **Bug Fixes**
  - Ensured `answer` property is correctly initialized when submission is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->