### PR TITLE
`Development`: Run GitHub coverage summary step only on success in default test pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
         name: Coverage Report Server Tests
         path: build/reports/jacoco/test/html
     - name: Append Per-Module Coverage to Job Summary
-      if: success() || failure()
+      if: success()
       run: |
         AGGREGATED_REPORT_FILE=./module_coverage_report.md
         python3 ./supporting_scripts/code-coverage/per_module_cov_report/parse_module_coverage.py build/reports/jacoco $AGGREGATED_REPORT_FILE

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -83,10 +83,10 @@ ext {
         ? ModuleCoverageThresholds.collect {element -> element.key}
         : includedModules as ArrayList
 
-    // we want to ignore some generated files in the domain folders
     ignoredDirectories = [
         "**/$BasePath/**/domain/**/*_*",
         "**/$BasePath/core/config/migration/entries/**",
+        "**/org/gradle/**",
         "**/gradle-wrapper.jar/**"
     ]
 }


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
If the GitHub default test pipeline fails, no coverage report is generated and no summary can be created and uploaded. The step `Append Per-Module Coverage to Job Summary` fails then. 

Note: `Upload Server Test Coverage Report` just ignores the non-existent reports with a warning instead of an upload failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Jacoco coverage configuration to exclude Gradle-related files from test coverage reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->