### PR TITLE
`Development`: Fix TS3 deployments by removing docker-command override

### DIFF
--- a/docker/test-server-multi-node-postgresql-localci.yml
+++ b/docker/test-server-multi-node-postgresql-localci.yml
@@ -96,8 +96,6 @@ services:
             artemis-app-node-3:
                 condition: service_started
         restart: always
-        command:
-          - rm -rf /var/log/nginx
         volumes:
             - ./nginx/artemis-upstream-multi-node.conf:/etc/nginx/includes/artemis-upstream.conf:ro
             - ./nginx/artemis-ssh-upstream-multi-node.conf:/etc/nginx/includes/artemis-ssh-upstream.conf:ro


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
#10036 added the removed line by default causing TS-3 deployments to fail. Theses changes remove it again.

Prerequisites:
1. Deploy to TS3 via GitHub
2. Verify that the landing page is visible after restart

### Testserver States
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)