### PR TITLE
`Adaptive learning`: Fix translation issues for competency title and description errors

### DIFF
--- a/src/main/webapp/app/course/competencies/forms/common-course-competency-form.component.html
+++ b/src/main/webapp/app/course/competencies/forms/common-course-competency-form.component.html
@@ -16,7 +16,7 @@
                     }
                     @if (titleControl?.errors?.maxlength) {
                         <div
-                            [jhiTranslate]="'artemisApp.' + courseCompetency?.type + '.titleMaxLengthValidationError'"
+                            [jhiTranslate]="'artemisApp.' + courseCompetency?.type + '.create.titleMaxLengthValidationError'"
                             [translateValues]="{ max: competencyValidators.TITLE_MAX }"
                         ></div>
                     }
@@ -41,7 +41,7 @@
                 <div class="alert alert-danger">
                     @if (descriptionControl?.errors?.maxlength) {
                         <div
-                            [jhiTranslate]="'artemisApp.competency.' + courseCompetency?.type + '.descriptionMaxLengthValidationError'"
+                            [jhiTranslate]="'artemisApp.' + courseCompetency?.type + '.create.descriptionMaxLengthValidationError'"
                             [translateValues]="{ max: competencyValidators.DESCRIPTION_MAX }"
                         ></div>
                     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When the title or the description was to long, the error msg translation was could not be found.

### Description
<!-- Describe your changes in detail -->
Fixed the path to the translations.
Closes #10212.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Course

1. Go to a Course
2. Click on `Manage`
3. Click on `Competency` -> `Create Competency` 
4. Put in very long title and description

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Before:**
![Image](https://github.com/user-attachments/assets/4fa85e5c-b356-4dee-a176-a94d5bbd3dac)
![Image](https://github.com/user-attachments/assets/93943b63-7606-4d05-9b3d-dc05dc1d1e8c)

**After:**
![image](https://github.com/user-attachments/assets/c33d8358-abe5-414e-a018-1eb2c49f5b0c)
![image](https://github.com/user-attachments/assets/479ee37f-9b74-4424-83e6-20125744df8a)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated translation keys for form validation error messages to ensure correct display of maximum length validation errors for title and description fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->