### PR TITLE
`Lectures`: Leave unit form selection available in edit mode

### DIFF
--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-exercise-unit/create-exercise-unit.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-exercise-unit/create-exercise-unit.component.html
@@ -1,92 +1,82 @@
-@if (isLoading) {
-    <div class="d-flex justify-content-center">
-        <div class="spinner-border" role="status">
-            <span class="sr-only" jhiTranslate="loading"></span>
+<div class="container">
+    <div class="row">
+        <div class="col-12 mx-auto">
+            <h2 jhiTranslate="artemisApp.exerciseUnit.createExerciseUnit.headline"></h2>
         </div>
     </div>
-} @else {
-    <div class="container">
-        <div class="row">
-            <div class="col-12 mx-auto">
-                <h2 jhiTranslate="artemisApp.exerciseUnit.createExerciseUnit.headline"></h2>
-            </div>
+    <div class="row">
+        <div class="col-sm-6 mx-auto">
+            <p jhiTranslate="artemisApp.exerciseUnit.createExerciseUnit.description"></p>
         </div>
-        <div class="row">
-            <div class="col-sm-6 mx-auto">
-                <p jhiTranslate="artemisApp.exerciseUnit.createExerciseUnit.description"></p>
-            </div>
-            <div class="col-sm-6 mx-auto text-end">
-                @if (hasCancelButton()) {
-                    <button type="button" (click)="cancelForm()" class="btn btn-default">
-                        <fa-icon [icon]="faTimes" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
-                    </button>
-                }
-                <button
-                    id="createButton"
-                    type="button"
-                    class="btn btn-primary"
-                    [disabled]="exercisesToCreateUnitFor.length === 0"
-                    (click)="createExerciseUnits()"
-                    jhiTranslate="entity.action.submit"
-                ></button>
-            </div>
+        <div class="col-sm-6 mx-auto text-end">
+            @if (hasCancelButton()) {
+                <button type="button" (click)="cancelForm()" class="btn btn-default"><fa-icon [icon]="faTimes" />&nbsp;<span jhiTranslate="entity.action.cancel"></span></button>
+            }
+            <button
+                id="createButton"
+                type="button"
+                class="btn btn-primary"
+                [disabled]="exercisesToCreateUnitFor.length === 0"
+                (click)="createExerciseUnits()"
+                jhiTranslate="entity.action.submit"
+            ></button>
         </div>
-        <div class="row">
-            <div class="col-12 mx-auto">
-                <div class="table-responsive">
-                    <table class="table table-bordered">
-                        <thead class="thead-dark">
-                            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" (sortChange)="sortRows()">
-                                <th jhiSortBy="id">
-                                    id
-                                    <fa-icon [icon]="faSort" />
-                                </th>
-                                <th jhiSortBy="type">
-                                    {{ 'artemisApp.exercise.type' | artemisTranslate }}
-                                    <fa-icon [icon]="faSort" />
-                                </th>
-                                <th jhiSortBy="title">
-                                    {{ 'artemisApp.exercise.title' | artemisTranslate }}
-                                    <fa-icon [icon]="faSort" />
-                                </th>
-                                <th jhiSortBy="shortName">
-                                    {{ 'artemisApp.exercise.shortName' | artemisTranslate }}
-                                    <fa-icon [icon]="faSort" />
-                                </th>
-                                <th jhiSortBy="releaseDate">
-                                    {{ 'artemisApp.exercise.releaseDate' | artemisTranslate }}
-                                    <fa-icon [icon]="faSort" />
-                                </th>
-                                <th jhiSortBy="dueDate">
-                                    {{ 'artemisApp.exercise.dueDate' | artemisTranslate }}
-                                    <fa-icon [icon]="faSort" />
-                                </th>
-                                <th jhiSortBy="assessmentDueDate">
-                                    {{ 'artemisApp.exercise.assessmentDueDate' | artemisTranslate }}
-                                    <fa-icon [icon]="faSort" />
-                                </th>
+    </div>
+    <div class="row">
+        <div class="col-12 mx-auto">
+            <div class="table-responsive">
+                <table class="table table-bordered">
+                    <thead class="thead-dark">
+                        <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" (sortChange)="sortRows()">
+                            <th jhiSortBy="id">
+                                id
+                                <fa-icon [icon]="faSort" />
+                            </th>
+                            <th jhiSortBy="type">
+                                {{ 'artemisApp.exercise.type' | artemisTranslate }}
+                                <fa-icon [icon]="faSort" />
+                            </th>
+                            <th jhiSortBy="title">
+                                {{ 'artemisApp.exercise.title' | artemisTranslate }}
+                                <fa-icon [icon]="faSort" />
+                            </th>
+                            <th jhiSortBy="shortName">
+                                {{ 'artemisApp.exercise.shortName' | artemisTranslate }}
+                                <fa-icon [icon]="faSort" />
+                            </th>
+                            <th jhiSortBy="releaseDate">
+                                {{ 'artemisApp.exercise.releaseDate' | artemisTranslate }}
+                                <fa-icon [icon]="faSort" />
+                            </th>
+                            <th jhiSortBy="dueDate">
+                                {{ 'artemisApp.exercise.dueDate' | artemisTranslate }}
+                                <fa-icon [icon]="faSort" />
+                            </th>
+                            <th jhiSortBy="assessmentDueDate">
+                                {{ 'artemisApp.exercise.assessmentDueDate' | artemisTranslate }}
+                                <fa-icon [icon]="faSort" />
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @for (exercise of exercisesAvailableForUnitCreation; track exercise) {
+                            <tr
+                                (click)="selectExerciseForUnitCreation(exercise)"
+                                [class.table-primary]="isExerciseSelectedForUnitCreation(exercise)"
+                                id="exercise-{{ exercise.id }}"
+                            >
+                                <td>{{ exercise.id ? exercise.id : '' }}</td>
+                                <td>{{ exercise.type ? exercise.type : '' }}</td>
+                                <td>{{ exercise.title ? exercise.title : '' }}</td>
+                                <td>{{ exercise.shortName ? exercise.shortName : '' }}</td>
+                                <td>{{ exercise.releaseDate ? exercise.releaseDate.format('MMM DD YYYY, HH:mm:ss') : '' }}</td>
+                                <td>{{ exercise.dueDate ? exercise.dueDate.format('MMM DD YYYY, HH:mm:ss') : '' }}</td>
+                                <td>{{ exercise.assessmentDueDate ? exercise.assessmentDueDate.format('MMM DD YYYY, HH:mm:ss') : '' }}</td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            @for (exercise of exercisesAvailableForUnitCreation; track exercise) {
-                                <tr
-                                    (click)="selectExerciseForUnitCreation(exercise)"
-                                    [class.table-primary]="isExerciseSelectedForUnitCreation(exercise)"
-                                    id="exercise-{{ exercise.id }}"
-                                >
-                                    <td>{{ exercise.id ? exercise.id : '' }}</td>
-                                    <td>{{ exercise.type ? exercise.type : '' }}</td>
-                                    <td>{{ exercise.title ? exercise.title : '' }}</td>
-                                    <td>{{ exercise.shortName ? exercise.shortName : '' }}</td>
-                                    <td>{{ exercise.releaseDate ? exercise.releaseDate.format('MMM DD YYYY, HH:mm:ss') : '' }}</td>
-                                    <td>{{ exercise.dueDate ? exercise.dueDate.format('MMM DD YYYY, HH:mm:ss') : '' }}</td>
-                                    <td>{{ exercise.assessmentDueDate ? exercise.assessmentDueDate.format('MMM DD YYYY, HH:mm:ss') : '' }}</td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </div>
+                        }
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>
-}
+</div>

--- a/src/main/webapp/app/lecture/lecture-units/lecture-units.component.html
+++ b/src/main/webapp/app/lecture/lecture-units/lecture-units.component.html
@@ -12,10 +12,10 @@
         <jhi-unit-creation-card [emitEvents]="true" (onUnitCreationCardClicked)="onCreateLectureUnit($event)" />
     </div>
     <div class="form-group">
-        @if (!isEditingLectureUnit) {
-            <h4><span jhiTranslate="artemisApp.lecture.newLectureUnit"></span></h4>
-        } @else {
+        @if (isEditingLectureUnit) {
             <h4><span jhiTranslate="artemisApp.lecture.editLectureUnit"></span></h4>
+        } @else if (isAnyUnitFormOpen()) {
+            <h4><span jhiTranslate="artemisApp.lecture.newLectureUnit"></span></h4>
         }
         @if (isTextUnitFormOpen()) {
             <jhi-text-unit-form

--- a/src/main/webapp/app/lecture/lecture-units/lecture-units.component.html
+++ b/src/main/webapp/app/lecture/lecture-units/lecture-units.component.html
@@ -8,63 +8,60 @@
         [showCreationCard]="false"
         [showCompetencies]="false"
     />
-    @if (!isAnyUnitFormOpen()) {
-        <div class="form-group w-100 d-flex justify-content-start">
-            <jhi-unit-creation-card [emitEvents]="true" (onUnitCreationCardClicked)="onCreateLectureUnit($event)" />
-        </div>
-    } @else {
-        <div class="form-group">
-            @if (!isEditingLectureUnit) {
-                <h4><span jhiTranslate="artemisApp.lecture.newLectureUnit"></span></h4>
-            } @else {
-                <h4><span jhiTranslate="artemisApp.lecture.editLectureUnit"></span></h4>
-            }
-            @if (isTextUnitFormOpen()) {
-                <jhi-text-unit-form
-                    [isEditMode]="isEditingLectureUnit"
-                    [hasCancelButton]="true"
-                    (onCancel)="onCloseLectureUnitForms()"
-                    (formSubmitted)="createEditTextUnit($event)"
-                    [formData]="textUnitFormData"
-                />
-            }
-            @if (isVideoUnitFormOpen()) {
-                <jhi-video-unit-form
-                    [isEditMode]="isEditingLectureUnit"
-                    [hasCancelButton]="true"
-                    (onCancel)="onCloseLectureUnitForms()"
-                    (formSubmitted)="createEditVideoUnit($event)"
-                    [formData]="videoUnitFormData"
-                />
-            }
-            @if (isOnlineUnitFormOpen()) {
-                <jhi-online-unit-form
-                    [isEditMode]="isEditingLectureUnit"
-                    [hasCancelButton]="true"
-                    (onCancel)="onCloseLectureUnitForms()"
-                    (formSubmitted)="createEditOnlineUnit($event)"
-                    [formData]="onlineUnitFormData"
-                />
-            }
-            @if (isAttachmentUnitFormOpen()) {
-                <jhi-attachment-unit-form
-                    [isEditMode]="isEditingLectureUnit"
-                    [hasCancelButton]="true"
-                    (onCancel)="onCloseLectureUnitForms()"
-                    (formSubmitted)="createEditAttachmentUnit($event)"
-                    [formData]="attachmentUnitFormData"
-                />
-            }
-            @if (isExerciseUnitFormOpen()) {
-                <jhi-create-exercise-unit
-                    [shouldNavigateOnSubmit]="false"
-                    (onExerciseUnitCreated)="onExerciseUnitCreated()"
-                    [lectureId]="lecture.id"
-                    [courseId]="lecture.course?.id"
-                    [hasCancelButton]="true"
-                    (onCancel)="onCloseLectureUnitForms()"
-                />
-            }
-        </div>
-    }
+    <div class="form-group w-100 d-flex justify-content-start">
+        <jhi-unit-creation-card [emitEvents]="true" (onUnitCreationCardClicked)="onCreateLectureUnit($event)" />
+    </div>
+    <div class="form-group">
+        @if (!isEditingLectureUnit) {
+            <h4><span jhiTranslate="artemisApp.lecture.newLectureUnit"></span></h4>
+        } @else {
+            <h4><span jhiTranslate="artemisApp.lecture.editLectureUnit"></span></h4>
+        }
+        @if (isTextUnitFormOpen()) {
+            <jhi-text-unit-form
+                [isEditMode]="isEditingLectureUnit"
+                [hasCancelButton]="true"
+                (onCancel)="onCloseLectureUnitForms()"
+                (formSubmitted)="createEditTextUnit($event)"
+                [formData]="textUnitFormData"
+            />
+        }
+        @if (isVideoUnitFormOpen()) {
+            <jhi-video-unit-form
+                [isEditMode]="isEditingLectureUnit"
+                [hasCancelButton]="true"
+                (onCancel)="onCloseLectureUnitForms()"
+                (formSubmitted)="createEditVideoUnit($event)"
+                [formData]="videoUnitFormData"
+            />
+        }
+        @if (isOnlineUnitFormOpen()) {
+            <jhi-online-unit-form
+                [isEditMode]="isEditingLectureUnit"
+                [hasCancelButton]="true"
+                (onCancel)="onCloseLectureUnitForms()"
+                (formSubmitted)="createEditOnlineUnit($event)"
+                [formData]="onlineUnitFormData"
+            />
+        }
+        @if (isAttachmentUnitFormOpen()) {
+            <jhi-attachment-unit-form
+                [isEditMode]="isEditingLectureUnit"
+                [hasCancelButton]="true"
+                (onCancel)="onCloseLectureUnitForms()"
+                (formSubmitted)="createEditAttachmentUnit($event)"
+                [formData]="attachmentUnitFormData"
+            />
+        }
+        @if (isExerciseUnitFormOpen()) {
+            <jhi-create-exercise-unit
+                [shouldNavigateOnSubmit]="false"
+                (onExerciseUnitCreated)="onExerciseUnitCreated()"
+                [lectureId]="lecture.id"
+                [courseId]="lecture.course?.id"
+                [hasCancelButton]="true"
+                (onCancel)="onCloseLectureUnitForms()"
+            />
+        }
+    </div>
 </div>

--- a/src/main/webapp/app/lecture/lecture-units/lecture-units.component.ts
+++ b/src/main/webapp/app/lecture/lecture-units/lecture-units.component.ts
@@ -91,7 +91,7 @@ export class LectureUpdateUnitsComponent implements OnInit {
 
     onCreateLectureUnit(type: LectureUnitType) {
         this.isEditingLectureUnit = false;
-
+        this.onCloseLectureUnitForms();
         switch (type) {
             case LectureUnitType.TEXT:
                 this.isTextUnitFormOpen.set(true);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Regarding this PR #10178, there was a suggestion to leave the unit selection open in the form instead of clicking the “Cancel” button.

### Description
<!-- Describe your changes in detail -->
* Removed loading screen in `create-exercise-unit`: I did not see a reason for only this one to have a loading screen and it messed with the layout for the page if clicked for a few moments
* The form for unit selection always remains open, and each time you click on another form, all others are set to “false” so that multiple forms are not open.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Course with a lecture

1. Go to a Course with lectures
2. Click on `Lectures`
3. Click on `Manage`
4. Click on `Edit`
5. Scroll down till you see `Add a new Lecture Unit`
6. Click on one of the unit forms and test it out

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
**Example with expanded `Video Form Unit` and unit form selection bar stays available**
![image](https://github.com/user-attachments/assets/f4868738-0174-47e6-9b94-14b69079cb8a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI/UX Improvements**
  - Simplified lecture unit creation interface
  - Streamlined layout for exercise unit creation
  - Enhanced form management for lecture units
  - Improved form opening and closing logic

- **Bug Fixes**
  - Resolved potential issues with multiple open forms during lecture unit creation

The changes focus on improving the user experience when creating and managing lecture units by simplifying the interface and ensuring more consistent form behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->