### PR TITLE
`Communication`: Fix improper deletion of combined emojis in Monaco editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
                 "export-to-csv": "1.4.0",
                 "fast-json-patch": "3.1.1",
                 "franc-min": "6.2.0",
+                "grapheme-splitter": "^1.0.4",
                 "html-diff-ts": "1.4.2",
                 "interactjs": "1.10.27",
                 "ismobilejs-es5": "0.0.1",
@@ -12731,6 +12732,12 @@
             "dependencies": {
                 "tinygradient": "^1.0.0"
             }
+        },
+        "node_modules/grapheme-splitter": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+            "license": "MIT"
         },
         "node_modules/graphemer": {
             "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "export-to-csv": "1.4.0",
         "fast-json-patch": "3.1.1",
         "franc-min": "6.2.0",
+        "grapheme-splitter": "^1.0.4",
         "html-diff-ts": "1.4.2",
         "interactjs": "1.10.27",
         "ismobilejs-es5": "0.0.1",

--- a/src/main/webapp/app/shared/monaco-editor/model/actions/emoji.action.ts
+++ b/src/main/webapp/app/shared/monaco-editor/model/actions/emoji.action.ts
@@ -94,7 +94,7 @@ export class EmojiAction extends TextEditorAction {
 
         this.insertTextAtPosition(editor, position, emoji);
 
-        const newPosition = new TextEditorPosition(position.getLineNumber(), position.getColumn() + 2);
+        const newPosition = new TextEditorPosition(position.getLineNumber(), position.getColumn() + emoji.length);
         editor.setPosition(newPosition);
         editor.focus();
     }

--- a/src/test/javascript/spec/component/shared/monaco-editor/monaco-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/monaco-editor/monaco-editor.component.spec.ts
@@ -327,4 +327,51 @@ describe('MonacoEditorComponent', () => {
         comp.setText('line1\n\nline3');
         expect(comp.getLineContent(2)).toBe('');
     });
+
+    it('should delete a combined emoji entirely on backspace press', fakeAsync(() => {
+        fixture.detectChanges();
+        const combinedEmoji = '🇩🇪';
+        comp.setText(combinedEmoji);
+
+        const lines = combinedEmoji.split('\n');
+        const lastLine = lines[lines.length - 1];
+        comp.setPosition({ lineNumber: lines.length, column: lastLine.length + 1 });
+
+        const commandId = comp.getCustomBackspaceCommandId();
+        expect(commandId).toBeDefined();
+
+        comp['_editor'].trigger('keyboard', commandId!, null);
+        tick();
+
+        expect(comp.getText()).toEqual('');
+    }));
+
+    it('should delete combined emojis one cluster at a time on backspace press', fakeAsync(() => {
+        fixture.detectChanges();
+
+        const emoji1 = '🇩🇪';
+        const emoji2 = '🇫🇷';
+        const combinedText = emoji1 + emoji2;
+
+        comp.setText(combinedText);
+        comp.setPosition({ lineNumber: 1, column: combinedText.length + 1 });
+
+        let commandId = comp.getCustomBackspaceCommandId();
+        expect(commandId).toBeDefined();
+        comp['_editor'].trigger('keyboard', commandId!, null);
+        tick();
+        fixture.detectChanges();
+
+        expect(comp.getText()).toEqual(emoji1);
+
+        comp.setPosition({ lineNumber: 1, column: emoji1.length + 1 });
+
+        commandId = comp.getCustomBackspaceCommandId();
+        expect(commandId).toBeDefined();
+        comp['_editor'].trigger('keyboard', commandId!, null);
+        tick();
+        fixture.detectChanges();
+
+        expect(comp.getText()).toEqual('');
+    }));
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, deleting a combined emoji (e.g., 🇩🇪) leaves behind a partial character instead of fully removing it. (Closes #9944)

### Description
<!-- Describe your changes in detail -->
This issue has been fixed using [grapheme-splitter](https://www.npmjs.com/package/grapheme-splitter). The backspace command in Monaco editor now detects and removes entire grapheme clusters, ensuring proper deletion of multi-character emojis.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 User
- 1 Course with Communication enabled

1. Log in to Artemis.
2. Navigate to the Communication section of a course.
3. Open any channel and type a combined emoji (e.g., 🇩🇪).
4. Press Backspace to delete the emoji and verify that it is fully removed without leaving a partial character.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->


