### PR TITLE
`Communication`: Fix an issue with unread message count

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/conversation/ConversationRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/conversation/ConversationRepository.java
@@ -52,7 +52,7 @@ public interface ConversationRepository extends ArtemisJpaRepository<Conversatio
             FROM Conversation conv
                 LEFT JOIN Channel channel ON conv.id = channel.id
                 LEFT JOIN ConversationParticipant cp ON conv.id = cp.conversation.id AND cp.user.id = :userId
-                LEFT JOIN Post p ON conv.id = p.conversation.id AND (p.creationDate > cp.lastRead OR (channel.isCourseWide = TRUE AND cp.lastRead IS NULL))
+                LEFT JOIN Post p ON conv.id = p.conversation.id AND p.author.id <> :userId AND (p.creationDate > cp.lastRead OR (channel.isCourseWide = TRUE AND cp.lastRead IS NULL))
             WHERE conv.id IN :conversationIds
                 AND (channel.isCourseWide = TRUE OR (conv.id = cp.conversation.id AND cp.user.id = :userId))
             GROUP BY conv.id, cp.id, cp.isModerator, cp.isFavorite, cp.isHidden, cp.lastRead
@@ -84,6 +84,7 @@ public interface ConversationRepository extends ArtemisJpaRepository<Conversatio
                 LEFT JOIN ConversationParticipant cp ON c.id = cp.conversation.id AND cp.user.id = :userId
                 LEFT JOIN Channel ch ON c.id = ch.id
             WHERE c.course.id = :courseId
+            AND p.author.id <> :userId
             AND (
                 p.creationDate > cp.lastRead OR
                 (ch.isCourseWide = TRUE AND cp.id IS NULL)


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, when composing a message in a channel and quickly switching to another, the message is counted toward the unread message count in that channel. This occurs because the `last_read` column updates asynchronously, leading to a delay in the server's update process. The issue is particularly noticeable on test servers, where the update can take up to 30 seconds to complete.

Addresses #10035 

### Description
<!-- Describe your changes in detail -->
I changed the query that counts the posts to not include posts with user id equal to the queried user.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student/Tutor/Instructor

1. Log in to Artemis
2. Navigate to course
3. Navigate to the communication tab
4. Select a channel with zero unread messages
5. Write many posts (the more the more likely to reproduce the issue)
6. Quickly change to another channel
7. Observe that the "unread" count is still at zero

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved conversation filtering so that only messages from others are displayed.
	- Updated the unread message indicator to exclude your own posts, ensuring more accurate notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->