### PR TITLE
`Development`: Use jhiTranslate directive in create exercise unit component

### DIFF
--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-exercise-unit/create-exercise-unit.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-exercise-unit/create-exercise-unit.component.html
@@ -33,27 +33,27 @@
                                 <fa-icon [icon]="faSort" />
                             </th>
                             <th jhiSortBy="type">
-                                {{ 'artemisApp.exercise.type' | artemisTranslate }}
+                                <span jhiTranslate="artemisApp.exercise.type"></span>
                                 <fa-icon [icon]="faSort" />
                             </th>
                             <th jhiSortBy="title">
-                                {{ 'artemisApp.exercise.title' | artemisTranslate }}
+                                <span jhiTranslate="artemisApp.exercise.title"></span>
                                 <fa-icon [icon]="faSort" />
                             </th>
                             <th jhiSortBy="shortName">
-                                {{ 'artemisApp.exercise.shortName' | artemisTranslate }}
+                                <span jhiTranslate="artemisApp.exercise.shortName"></span>
                                 <fa-icon [icon]="faSort" />
                             </th>
                             <th jhiSortBy="releaseDate">
-                                {{ 'artemisApp.exercise.releaseDate' | artemisTranslate }}
+                                <span jhiTranslate="artemisApp.exercise.releaseDate"></span>
                                 <fa-icon [icon]="faSort" />
                             </th>
                             <th jhiSortBy="dueDate">
-                                {{ 'artemisApp.exercise.dueDate' | artemisTranslate }}
+                                <span jhiTranslate="artemisApp.exercise.dueDate"></span>
                                 <fa-icon [icon]="faSort" />
                             </th>
                             <th jhiSortBy="assessmentDueDate">
-                                {{ 'artemisApp.exercise.assessmentDueDate' | artemisTranslate }}
+                                <span jhiTranslate="artemisApp.exercise.assessmentDueDate"></span>
                                 <fa-icon [icon]="faSort" />
                             </th>
                         </tr>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I translated all newly inserted strings into English and German.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In this [PR](https://github.com/ls1intum/Artemis/pull/10229#pullrequestreview-2584280801) I was asked to remove the translation pipe and replace it with the jhiTranslate directive.

### Description
<!-- Describe your changes in detail -->
Replaced `| artemisTranslate` with `span jhiTranslate`.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- Course with a lecture

1. Go to a Course with lectures
2. Click on `Lectures`
3. Click on `Manage`
4. Click on `Edit`
5. Scroll down till you see `Add a new Lecture Unit` -> Click `Exercise`
6. Take a look at the names in the table if they are correctly translated

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)](https://artemis-test1.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)](https://artemis-test2.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)](https://artemis-test3.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)](https://artemis-test4.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)](https://artemis-test5.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)](https://artemis-test6.artemis.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)](https://artemis-test9.artemis.cit.tum.de)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/user-attachments/assets/aba8b102-64fa-4159-8846-b2c2f4a622f4)
![image](https://github.com/user-attachments/assets/4543f6d2-c827-4c9a-afa2-19814cd45ef6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the display of text in the exercise unit management view to ensure a consistent and uniform look for exercise attributes, including type, title, short name, and dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->