### PR TITLE
`Development`: Add async server test architecture test

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSendingServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSendingServiceTest.java
@@ -27,7 +27,6 @@ import de.tum.cit.aet.artemis.assessment.domain.Feedback;
 import de.tum.cit.aet.artemis.assessment.domain.FeedbackType;
 import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
 import de.tum.cit.aet.artemis.assessment.domain.GradingInstruction;
-import de.tum.cit.aet.artemis.assessment.domain.Result;
 import de.tum.cit.aet.artemis.assessment.repository.FeedbackRepository;
 import de.tum.cit.aet.artemis.assessment.repository.GradingCriterionRepository;
 import de.tum.cit.aet.artemis.assessment.repository.TextBlockRepository;
@@ -120,8 +119,8 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
         textBlock.computeId();
         textBlock = textBlockRepository.save(textBlock);
 
-        var textResult = new Result();
-        textResult = resultRepository.save(textResult);
+        var textResult = participationUtilService.addResultToParticipation(textParticipation, textSubmission);
+
         textFeedback = new Feedback().type(FeedbackType.MANUAL).credits(5.0).reference(textBlock.getId());
         textFeedback.setText("Title");
         textFeedback.setDetailText("Description");
@@ -138,8 +137,8 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
         programmingSubmission.setParticipation(programmingParticipation);
         programmingSubmission = programmingSubmissionRepository.save(programmingSubmission);
 
-        var programmingResult = new Result();
-        programmingResult = resultRepository.save(programmingResult);
+        var programmingResult = participationUtilService.addResultToParticipation(programmingParticipation, programmingSubmission);
+
         programmingFeedback = new Feedback().type(FeedbackType.MANUAL).credits(5.0).reference("test");
         programmingFeedback.setText("Title");
         programmingFeedback.setDetailText("Description");

--- a/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSendingServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSendingServiceTest.java
@@ -2,67 +2,83 @@ package de.tum.cit.aet.artemis.athena.service.connectors;
 
 import static de.tum.cit.aet.artemis.core.connector.AthenaRequestMockProvider.ATHENA_MODULE_PROGRAMMING_TEST;
 import static de.tum.cit.aet.artemis.core.connector.AthenaRequestMockProvider.ATHENA_MODULE_TEXT_TEST;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
 
+import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import de.tum.cit.aet.artemis.assessment.domain.Feedback;
 import de.tum.cit.aet.artemis.assessment.domain.FeedbackType;
 import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
 import de.tum.cit.aet.artemis.assessment.domain.GradingInstruction;
 import de.tum.cit.aet.artemis.assessment.domain.Result;
+import de.tum.cit.aet.artemis.assessment.repository.FeedbackRepository;
 import de.tum.cit.aet.artemis.assessment.repository.GradingCriterionRepository;
 import de.tum.cit.aet.artemis.assessment.repository.TextBlockRepository;
 import de.tum.cit.aet.artemis.assessment.util.GradingCriterionUtil;
 import de.tum.cit.aet.artemis.athena.AbstractAthenaTest;
-import de.tum.cit.aet.artemis.athena.service.AthenaDTOConverterService;
 import de.tum.cit.aet.artemis.athena.service.AthenaFeedbackSendingService;
-import de.tum.cit.aet.artemis.athena.service.AthenaModuleService;
-import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
-import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
-import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
+import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
 import de.tum.cit.aet.artemis.programming.test_repository.ProgrammingExerciseTestRepository;
+import de.tum.cit.aet.artemis.programming.test_repository.ProgrammingSubmissionTestRepository;
 import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseUtilService;
 import de.tum.cit.aet.artemis.text.domain.TextBlock;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
+import de.tum.cit.aet.artemis.text.test_repository.TextSubmissionTestRepository;
 import de.tum.cit.aet.artemis.text.util.TextExerciseUtilService;
 
 class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
 
-    @Autowired
-    private AthenaModuleService athenaModuleService;
+    private static final String TEST_PREFIX = "athenafeedbacksending";
 
-    @Mock
+    @Autowired
     private TextBlockRepository textBlockRepository;
 
-    @Mock
+    @Autowired
     private TextExerciseRepository textExerciseRepository;
 
-    @Mock
+    @Autowired
     private ProgrammingExerciseTestRepository programmingExerciseRepository;
 
-    @Mock
+    @Autowired
     private GradingCriterionRepository gradingCriterionRepository;
+
+    @Autowired
+    private TextSubmissionTestRepository textSubmissionRepository;
+
+    @Autowired
+    private FeedbackRepository feedbackRepository;
+
+    @Autowired
+    private ProgrammingSubmissionTestRepository programmingSubmissionRepository;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
 
     @Autowired
+    private ParticipationUtilService participationUtilService;
+
+    @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
 
+    @Autowired
     private AthenaFeedbackSendingService athenaFeedbackSendingService;
 
     private TextExercise textExercise;
@@ -79,50 +95,64 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
 
     private Feedback programmingFeedback;
 
+    private ListAppender<ILoggingEvent> asyncExceptionLogAppender;
+
+    private Logger asyncExceptionLog;
+
     @BeforeEach
     void setUp() {
-        athenaFeedbackSendingService = new AthenaFeedbackSendingService(athenaRequestMockProvider.getRestTemplate(), athenaModuleService,
-                new AthenaDTOConverterService(textBlockRepository, textExerciseRepository, programmingExerciseRepository, gradingCriterionRepository));
-
-        athenaRequestMockProvider.enableMockingOfRequests();
+        userUtilService.addUsers(TEST_PREFIX, 2, 0, 0, 0);
 
         textExercise = textExerciseUtilService.createSampleTextExercise(null);
         textExercise.setFeedbackSuggestionModule(ATHENA_MODULE_TEXT_TEST);
-        when(textExerciseRepository.findWithGradingCriteriaByIdElseThrow(textExercise.getId())).thenReturn(textExercise);
+        textExercise = textExerciseRepository.save(textExercise);
 
-        textSubmission = new TextSubmission(2L).text("Test - This is what the feedback references - Submission");
+        var textParticipation = participationUtilService.createAndSaveParticipationForExercise(textExercise, TEST_PREFIX + "student1");
+
+        textSubmission = new TextSubmission().text("Test - This is what the feedback references - Submission");
+        textSubmission.setParticipation(textParticipation);
+        textSubmission = textSubmissionRepository.save(textSubmission);
 
         textBlock = new TextBlock().startIndex(7).endIndex(46).text("This is what the feedback references").submission(textSubmission);
         textBlock.computeId();
-        when(textBlockRepository.findById(textBlock.getId())).thenReturn(Optional.of(textBlock));
+        textBlock = textBlockRepository.save(textBlock);
 
+        var textResult = new Result();
+        textResult = resultRepository.save(textResult);
         textFeedback = new Feedback().type(FeedbackType.MANUAL).credits(5.0).reference(textBlock.getId());
         textFeedback.setText("Title");
         textFeedback.setDetailText("Description");
-        textFeedback.setId(3L);
-        var result = new Result();
-        textFeedback.setResult(result);
-        var participation = new StudentParticipation();
-        participation.setExercise(textExercise);
-        result.setParticipation(participation);
+        textFeedback.setResult(textResult);
+        textFeedback = feedbackRepository.save(textFeedback);
 
         programmingExercise = programmingExerciseUtilService.createSampleProgrammingExercise();
         programmingExercise.setFeedbackSuggestionModule(ATHENA_MODULE_PROGRAMMING_TEST);
-        when(programmingExerciseRepository.findByIdWithGradingCriteriaElseThrow(programmingExercise.getId())).thenReturn(programmingExercise);
+        programmingExercise = programmingExerciseRepository.save(programmingExercise);
+
+        var programmingParticipation = participationUtilService.createAndSaveParticipationForExercise(programmingExercise, TEST_PREFIX + "student2");
 
         programmingSubmission = new ProgrammingSubmission();
-        programmingSubmission.setParticipation(new StudentParticipation());
-        programmingSubmission.getParticipation().setExercise(programmingExercise);
-        programmingSubmission.setId(2L);
+        programmingSubmission.setParticipation(programmingParticipation);
+        programmingSubmission = programmingSubmissionRepository.save(programmingSubmission);
 
+        var programmingResult = new Result();
+        programmingResult = resultRepository.save(programmingResult);
         programmingFeedback = new Feedback().type(FeedbackType.MANUAL).credits(5.0).reference("test");
         programmingFeedback.setText("Title");
         programmingFeedback.setDetailText("Description");
-        programmingFeedback.setId(3L);
         programmingFeedback.setReference("file:src/Test.java_line:12");
-        var programmingResult = new Result();
         programmingFeedback.setResult(programmingResult);
-        programmingResult.setParticipation(programmingSubmission.getParticipation());
+        programmingFeedback = feedbackRepository.save(programmingFeedback);
+
+        asyncExceptionLogAppender = new ListAppender<>();
+        asyncExceptionLogAppender.start();
+        asyncExceptionLog = (Logger) LoggerFactory.getLogger(SimpleAsyncUncaughtExceptionHandler.class);
+        asyncExceptionLog.addAppender(asyncExceptionLogAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        asyncExceptionLog.detachAppender(asyncExceptionLogAppender);
     }
 
     @Test
@@ -135,36 +165,38 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
                 jsonPath("$.feedbacks[0].indexEnd").value(textBlock.getEndIndex()));
 
         athenaFeedbackSendingService.sendFeedback(textExercise, textSubmission, List.of(textFeedback));
-        athenaRequestMockProvider.verify();
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> athenaRequestMockProvider.verify());
     }
 
     private GradingCriterion createExampleGradingCriterion() {
         var gradingInstruction = new GradingInstruction();
-        gradingInstruction.setId(101L);
         gradingInstruction.setCredits(1.0);
         gradingInstruction.setGradingScale("good");
         gradingInstruction.setInstructionDescription("Give this feedback if xyz");
         gradingInstruction.setFeedback("Well done!");
         gradingInstruction.setUsageCount(1);
+
         var gradingCriterion = new GradingCriterion();
-        gradingCriterion.setId(1L);
         gradingCriterion.setTitle("Test");
         gradingCriterion.setExercise(textExercise);
+
         gradingCriterion.setStructuredGradingInstructions(Set.of(gradingInstruction));
-        return gradingCriterion;
+        return gradingCriterionRepository.save(gradingCriterion);
     }
 
     @Test
     void testFeedbackSendingTextWithGradingInstruction() {
-        textExercise.setGradingCriteria(Set.of(createExampleGradingCriterion()));
-        textExerciseRepository.save(textExercise);
+        GradingCriterion gradingCriterion = createExampleGradingCriterion();
+        textExercise.setGradingCriteria(Set.of(gradingCriterion));
+        textExercise = textExerciseRepository.save(textExercise);
 
         final GradingInstruction instruction = GradingCriterionUtil.findAnyInstructionWhere(textExercise.getGradingCriteria(),
                 gradingInstruction -> "Give this feedback if xyz".equals(gradingInstruction.getInstructionDescription())).orElseThrow();
         textFeedback.setGradingInstruction(instruction);
 
-        athenaRequestMockProvider.mockSendFeedbackAndExpect("text", jsonPath("$.exercise.id").value(textExercise.getId()), jsonPath("$.exercise.gradingCriteria[0].id").value(1),
-                jsonPath("$.exercise.gradingCriteria[0].title").value("Test"), jsonPath("$.exercise.gradingCriteria[0].structuredGradingInstructions[0].id").value(101),
+        athenaRequestMockProvider.mockSendFeedbackAndExpect("text", jsonPath("$.exercise.id").value(textExercise.getId()),
+                jsonPath("$.exercise.gradingCriteria[0].id").value(gradingCriterion.getId()), jsonPath("$.exercise.gradingCriteria[0].title").value("Test"),
+                jsonPath("$.exercise.gradingCriteria[0].structuredGradingInstructions[0].id").value(instruction.getId()),
                 jsonPath("$.exercise.gradingCriteria[0].structuredGradingInstructions[0].credits").value(1.0),
                 jsonPath("$.exercise.gradingCriteria[0].structuredGradingInstructions[0].gradingScale").value("good"),
                 jsonPath("$.exercise.gradingCriteria[0].structuredGradingInstructions[0].instructionDescription").value("Give this feedback if xyz"),
@@ -174,10 +206,10 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
                 jsonPath("$.feedbacks[0].exerciseId").value(textExercise.getId()), jsonPath("$.feedbacks[0].title").value(textFeedback.getText()),
                 jsonPath("$.feedbacks[0].description").value(textFeedback.getDetailText()), jsonPath("$.feedbacks[0].credits").value(textFeedback.getCredits()),
                 jsonPath("$.feedbacks[0].credits").value(textFeedback.getCredits()), jsonPath("$.feedbacks[0].indexStart").value(textBlock.getStartIndex()),
-                jsonPath("$.feedbacks[0].indexEnd").value(textBlock.getEndIndex()), jsonPath("$.feedbacks[0].structuredGradingInstructionId").value(101));
+                jsonPath("$.feedbacks[0].indexEnd").value(textBlock.getEndIndex()), jsonPath("$.feedbacks[0].structuredGradingInstructionId").value(instruction.getId()));
 
         athenaFeedbackSendingService.sendFeedback(textExercise, textSubmission, List.of(textFeedback));
-        athenaRequestMockProvider.verify();
+        await().untilAsserted(() -> athenaRequestMockProvider.verify());
     }
 
     @Test
@@ -190,29 +222,30 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
                 jsonPath("$.feedbacks[0].lineEnd").value(12));
 
         athenaFeedbackSendingService.sendFeedback(programmingExercise, programmingSubmission, List.of(programmingFeedback));
-        athenaRequestMockProvider.verify();
-    }
-
-    @Test
-    void testFeedbackSendingModeling() {
-        athenaRequestMockProvider.mockSendFeedbackAndExpect("modeling");
-        assertThatThrownBy(() -> athenaFeedbackSendingService.sendFeedback(new ModelingExercise(), new ModelingSubmission(), List.of()))
-                .isInstanceOf(IllegalArgumentException.class);
+        await().untilAsserted(() -> athenaRequestMockProvider.verify());
     }
 
     @Test
     void testEmptyFeedbackNotSending() {
         athenaFeedbackSendingService.sendFeedback(textExercise, textSubmission, List.of());
         athenaFeedbackSendingService.sendFeedback(programmingExercise, programmingSubmission, List.of());
-        athenaRequestMockProvider.verify(); // Ensure that there was no request
+        await().during(Duration.ofSeconds(2)).untilAsserted(() -> athenaRequestMockProvider.verify()); // Ensure that there was no request
     }
 
     @Test
     void testSendFeedbackWithFeedbackSuggestionsDisabled() {
         textExercise.setFeedbackSuggestionModule(null);
-        assertThatThrownBy(() -> athenaFeedbackSendingService.sendFeedback(textExercise, textSubmission, List.of(textFeedback))).isInstanceOf(IllegalArgumentException.class);
+        textExercise = textExerciseRepository.save(textExercise);
+        athenaFeedbackSendingService.sendFeedback(textExercise, textSubmission, List.of(textFeedback));
+        await().untilAsserted(
+                () -> assertThat(asyncExceptionLogAppender.list).extracting(event -> event.getThrowableProxy().getClassName()).contains(IllegalArgumentException.class.getName()));
+
+        asyncExceptionLogAppender.list.clear();
+
         programmingExercise.setFeedbackSuggestionModule(null);
-        assertThatThrownBy(() -> athenaFeedbackSendingService.sendFeedback(programmingExercise, programmingSubmission, List.of(programmingFeedback)))
-                .isInstanceOf(IllegalArgumentException.class);
+        programmingExerciseRepository.save(programmingExercise);
+        athenaFeedbackSendingService.sendFeedback(programmingExercise, programmingSubmission, List.of(programmingFeedback));
+        await().untilAsserted(
+                () -> assertThat(asyncExceptionLogAppender.list).extracting(event -> event.getThrowableProxy().getClassName()).contains(IllegalArgumentException.class.getName()));
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSendingServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSendingServiceTest.java
@@ -10,6 +10,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.annotation.Nullable;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.core.read.ListAppender;
 import de.tum.cit.aet.artemis.assessment.domain.Feedback;
 import de.tum.cit.aet.artemis.assessment.domain.FeedbackType;
@@ -238,7 +241,7 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
         textExercise = textExerciseRepository.save(textExercise);
         athenaFeedbackSendingService.sendFeedback(textExercise, textSubmission, List.of(textFeedback));
         await().untilAsserted(
-                () -> assertThat(asyncExceptionLogAppender.list).extracting(event -> event.getThrowableProxy().getClassName()).contains(IllegalArgumentException.class.getName()));
+                () -> assertThat(asyncExceptionLogAppender.list).extracting(AthenaFeedbackSendingServiceTest::getExceptionName).contains(IllegalArgumentException.class.getName()));
 
         asyncExceptionLogAppender.list.clear();
 
@@ -246,6 +249,15 @@ class AthenaFeedbackSendingServiceTest extends AbstractAthenaTest {
         programmingExerciseRepository.save(programmingExercise);
         athenaFeedbackSendingService.sendFeedback(programmingExercise, programmingSubmission, List.of(programmingFeedback));
         await().untilAsserted(
-                () -> assertThat(asyncExceptionLogAppender.list).extracting(event -> event.getThrowableProxy().getClassName()).contains(IllegalArgumentException.class.getName()));
+                () -> assertThat(asyncExceptionLogAppender.list).extracting(AthenaFeedbackSendingServiceTest::getExceptionName).contains(IllegalArgumentException.class.getName()));
+    }
+
+    @Nullable
+    private static String getExceptionName(ILoggingEvent event) {
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
+        if (throwableProxy == null) {
+            return null;
+        }
+        return throwableProxy.getClassName();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -299,8 +301,8 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
 
         pyrisEventService.trigger(new NewResultEvent(result));
 
-        verify(irisExerciseChatSessionService, never()).onNewResult(any(Result.class));
-        verify(pyrisPipelineService, never()).executeExerciseChatPipeline(any(), any(), any(), any(), any());
+        verify(irisExerciseChatSessionService, timeout(2000).times(1)).onNewResult(any(Result.class));
+        verify(pyrisPipelineService, after(2000).never()).executeExerciseChatPipeline(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -314,8 +316,8 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
 
         pyrisEventService.trigger(new NewResultEvent(result));
 
-        verify(irisExerciseChatSessionService, never()).onNewResult(any(Result.class));
-        verify(pyrisPipelineService, never()).executeExerciseChatPipeline(any(), any(), any(), any(), any());
+        verify(irisExerciseChatSessionService, timeout(2000).times(1)).onNewResult(any(Result.class));
+        verify(pyrisPipelineService, after(2000).never()).executeExerciseChatPipeline(any(), any(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/shared/architecture/ArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/architecture/ArchitectureTest.java
@@ -12,9 +12,12 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameContaining;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.core.domain.JavaCodeUnit.Predicates.constructor;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With.owner;
+import static com.tngtech.archunit.lang.ConditionEvent.createMessage;
 import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.callMethod;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.is;
@@ -34,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.awaitility.Awaitility;
 import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -42,12 +46,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Repository;
@@ -58,7 +64,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hazelcast.core.HazelcastInstance;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaCall;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
@@ -370,4 +378,63 @@ class ArchitectureTest extends AbstractArchitectureTest {
         }
         return false;
     }
+
+    @Test
+    void testAsyncTestShouldWait() {
+        ArchRule rule = methods().that(areInIntegrationTests()).and(callAnAsyncMethod()).should(callAWaitMethod()).because("tests should wait for async effects");
+        rule.check(testClasses);
+    }
+
+    private static DescribedPredicate<JavaMethod> callAnAsyncMethod() {
+        return new DescribedPredicate<>("call a method annotated with async") {
+
+            @Override
+            public boolean test(JavaMethod javaMethod) {
+                var asyncCalls = javaMethod.getMethodCallsFromSelf().stream().filter(call -> call.getTarget().isAnnotatedWith(Async.class));
+
+                var firstVerifyLineNumberOptional = javaMethod.getMethodCallsFromSelf().stream()
+                        .filter(call -> call.getTarget().getName().equals("verify") && call.getTargetOwner().getFullName().equals("org.mockito.Mockito"))
+                        .mapToInt(JavaAccess::getLineNumber).min();
+
+                if (firstVerifyLineNumberOptional.isEmpty()) {
+                    return asyncCalls.findAny().isPresent();
+                }
+
+                // method calls on and after a verify() line are usually not calls on the actual object
+                var firstVerifyLineNumber = firstVerifyLineNumberOptional.getAsInt();
+                return asyncCalls.anyMatch(call -> call.getLineNumber() < firstVerifyLineNumber);
+            }
+        };
+    }
+
+    private static DescribedPredicate<JavaMethod> areInIntegrationTests() {
+
+        return new DescribedPredicate<>("are in integration tests") {
+
+            @Override
+            public boolean test(JavaMethod javaMethod) {
+                return javaMethod.getOwner().isAssignableTo(AbstractArtemisIntegrationTest.class);
+            }
+        };
+    }
+
+    private static ArchCondition<JavaMethod> callAWaitMethod() {
+        var isWaiting = callMethod(Mockito.class, "timeout").or(callMethod(Mockito.class, "after")).or(callMethod(Awaitility.class, "await"));
+
+        return new ArchCondition<>("call a wait method") {
+
+            @Override
+            public void check(JavaMethod item, ConditionEvents events) {
+                boolean doesNotWait = item.getMethodCallsFromSelf().stream().noneMatch(isWaiting);
+                if (doesNotWait) {
+                    events.add(violated(item, createMessage(item, "does not call a wait method")));
+                }
+            }
+        };
+    }
+
+    private static DescribedPredicate<JavaCall<?>> callMethod(Class<?> owner, String methodName) {
+        return JavaCall.Predicates.target(owner(type(owner))).and(JavaCall.Predicates.target(name(methodName)));
+    }
+
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some integration tests call `@Async` methods without waiting for their effects. Depending on their scheduling the test might fail, causing a flaky test.

These cases are easily missed, especially if the `@Async` annotation is added later on and the tests seem to keep working.

### Description
<!-- Describe your changes in detail -->
This PR adds an architecture test looking for integration tests which call an `@Async` method but do not call any wait method.
Objects which are instantiated without Spring are not affected by `@Async`. That is why unit tests are not tested.

The PyrisEventSystemIntegrationTest is fixed by adding proper waiting methods and reverting the change of `times(1)` to `never()` when `@Async` was added.

The AthenaFeedbackSendingServiceTest is an integration test which had aspects of an unit test. It is changed to properly use Spring injection and reduce mocking, making it more of an integration test.
The `@Async` issues are fixed by waiting. Checks for exceptions are tested by inspection of the logs.
`testFeedbackSendingModeling` is removed because it is an incomplete test, implicitly not testing any more than `testSendFeedbackWithFeedbackSuggestionsDisabled` does.


### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| AthenaFeedbackSendingService | 95% | ✅                           |
| PyrisEventService | 79% | ✅              |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
	- Enhanced test setups by utilizing actual repository interactions for more realistic feedback validations.
	- Updated asynchronous verifications with timing checks to ensure accurate behavior under live conditions.
	- Added new predicates to ensure proper synchronization for asynchronous methods in integration tests.
	- Introduced additional cleanup routines to maintain a stable and reliable testing environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->