### PR TITLE
`Development`: Reduce number of flaky server tests

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/MailService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/MailService.java
@@ -131,7 +131,7 @@ public class MailService implements InstantNotificationService {
         Locale locale = Locale.forLanguageTag(admin.getLangKey());
         Context context = createBaseContext(admin, locale);
         context.setVariable(DATA_EXPORT, dataExport);
-        context.setVariable(REASON, reason);
+        context.setVariable(REASON, reason.getMessage());
         prepareTemplateAndSendEmailWithArgumentInSubject(admin, templateName, titleKey, dataExport.getUser().getLogin(), context);
     }
 

--- a/src/main/resources/templates/mail/dataExportFailedAdminEmail.html
+++ b/src/main/resources/templates/mail/dataExportFailedAdminEmail.html
@@ -13,7 +13,7 @@
     <span class="bold-text" th:text="${user.login}">Username</span>
     <span th:text="#{email.dataExportFailedAdmin.textFailed}">failed</span>
 
-    <p th:text="#{email.dataExportFailedAdmin.reason(${reason.getMessage()})}">The error message </p>
+    <p th:text="#{email.dataExportFailedAdmin.reason(${reason})}">The error message </p>
     <p
         th:text="#{email.dataExportFailedAdmin.actionItemList}">
     </p>

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/ResultListenerIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/ResultListenerIntegrationTest.java
@@ -115,8 +115,13 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
         exercise.setBonusPoints(100.0);
         userUtilService.changeUser(TEST_PREFIX + "instructor1");
         request.put("/api/text-exercises", exercise, HttpStatus.OK);
+
+        participantScoreScheduleService.executeScheduledTasks();
+        await().until(() -> participantScoreScheduleService.isIdle());
+
         List<ParticipantScore> savedParticipantScores = participantScoreRepository.findAllByExercise(exercise);
         assertThat(savedParticipantScores).isNotEmpty().hasSize(1);
+
         ParticipantScore savedParticipantScore = savedParticipantScores.getFirst();
         assertThat(savedParticipantScore.getLastPoints()).isEqualTo(200.0);
         assertThat(savedParticipantScore.getLastRatedPoints()).isEqualTo(200.0);

--- a/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadExerciseIntegrationTest.java
@@ -421,7 +421,7 @@ class FileUploadExerciseIntegrationTest extends AbstractFileUploadIntegrationTes
         assertThat(updatedFileUploadExercise.isCourseExercise()).as("course was not set for exam exercise").isFalse();
         assertThat(updatedFileUploadExercise.getExerciseGroup()).as("exerciseGroup was set for exam exercise").isNotNull();
         assertThat(updatedFileUploadExercise.getExerciseGroup().getId()).as("exerciseGroupId was not updated").isEqualTo(fileUploadExercise.getExerciseGroup().getId());
-        verify(examLiveEventsService, times(1)).createAndSendProblemStatementUpdateEvent(any(), any(), any());
+        verify(examLiveEventsService, timeout(2000).times(1)).createAndSendProblemStatementUpdateEvent(any(), any(), any());
         verify(groupNotificationScheduleService, never()).checkAndCreateAppropriateNotificationsWhenUpdatingExercise(any(), any(), any());
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
@@ -316,7 +316,7 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
 
         pyrisEventService.trigger(new NewResultEvent(result));
 
-        verify(irisExerciseChatSessionService, timeout(2000).times(1)).onNewResult(any(Result.class));
+        verify(irisExerciseChatSessionService, timeout(2000).times(1)).onNewResult(result);
         verify(pyrisPipelineService, after(2000).never()).executeExerciseChatPipeline(any(), any(), any(), any(), any());
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTest.java
@@ -4,7 +4,7 @@ import static de.tum.cit.aet.artemis.core.util.RequestUtilService.deleteProgramm
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import java.time.ZonedDateTime;
@@ -103,7 +103,7 @@ class ProgrammingExerciseTest extends AbstractProgrammingIntegrationJenkinsGitla
 
         assertThat(updatedProgrammingExercise.getProblemStatement()).isEqualTo(newProblem);
         verify(examLiveEventsService, never()).createAndSendProblemStatementUpdateEvent(any(), any(), any());
-        verify(groupNotificationScheduleService, times(1)).checkAndCreateAppropriateNotificationsWhenUpdatingExercise(any(), any(), any());
+        verify(groupNotificationScheduleService, timeout(2000).times(1)).checkAndCreateAppropriateNotificationsWhenUpdatingExercise(any(), any(), any());
 
         ProgrammingExercise fromDb = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId).orElseThrow();
         assertThat(fromDb.getProblemStatement()).isEqualTo(newProblem);
@@ -122,7 +122,7 @@ class ProgrammingExerciseTest extends AbstractProgrammingIntegrationJenkinsGitla
         ProgrammingExercise updatedProgrammingExercise = request.patchWithResponseBody(endpoint, newProblem, ProgrammingExercise.class, HttpStatus.OK, MediaType.TEXT_PLAIN);
 
         assertThat(updatedProgrammingExercise.getProblemStatement()).isEqualTo(newProblem);
-        verify(examLiveEventsService, times(1)).createAndSendProblemStatementUpdateEvent(any(), any(), any());
+        verify(examLiveEventsService, timeout(2000).times(1)).createAndSendProblemStatementUpdateEvent(any(), any(), any());
         verify(groupNotificationScheduleService, never()).checkAndCreateAppropriateNotificationsWhenUpdatingExercise(any(), any(), any());
 
         ProgrammingExercise fromDb = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExercise.getId())

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationLocalCILocalVCTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationLocalCILocalVCTest.java
@@ -13,10 +13,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static tech.jhipster.config.JHipsterConstants.SPRING_PROFILE_TEST;
 
 import java.io.IOException;
@@ -232,16 +231,16 @@ public abstract class AbstractSpringIntegrationLocalCILocalVCTest extends Abstra
         // Mock dockerClient.inspectImageCmd(String dockerImage).exec()
         InspectImageCmd inspectImageCmd = mock(InspectImageCmd.class);
         InspectImageResponse inspectImageResponse = new InspectImageResponse();
-        doReturn(inspectImageCmd).when(dockerClient).inspectImageCmd(anyString());
-        doReturn(inspectImageResponse).when(inspectImageCmd).exec();
+        when(dockerClient.inspectImageCmd(anyString())).thenReturn(inspectImageCmd);
+        when(inspectImageCmd.exec()).thenReturn(inspectImageResponse);
 
         // Mock PullImageCmd
         PullImageCmd pullImageCmd = mock(PullImageCmd.class);
-        doReturn(pullImageCmd).when(dockerClient).pullImageCmd(anyString());
-        doReturn(pullImageCmd).when(pullImageCmd).withPlatform(anyString());
+        when(dockerClient.pullImageCmd(anyString())).thenReturn(pullImageCmd);
+        when(pullImageCmd.withPlatform(anyString())).thenReturn(pullImageCmd);
         BuildAgentDockerService.MyPullImageResultCallback callback1 = mock(BuildAgentDockerService.MyPullImageResultCallback.class);
-        doReturn(callback1).when(pullImageCmd).exec(any(BuildAgentDockerService.MyPullImageResultCallback.class));
-        doReturn(null).when(callback1).awaitCompletion();
+        when(pullImageCmd.exec(any(BuildAgentDockerService.MyPullImageResultCallback.class))).thenReturn(callback1);
+        when(callback1.awaitCompletion()).thenReturn(null);
 
         String dummyContainerId = "1234567890";
 
@@ -249,100 +248,100 @@ public abstract class AbstractSpringIntegrationLocalCILocalVCTest extends Abstra
         CreateContainerCmd createContainerCmd = mock(CreateContainerCmd.class);
         CreateContainerResponse createContainerResponse = new CreateContainerResponse();
         createContainerResponse.setId(dummyContainerId);
-        doReturn(createContainerCmd).when(dockerClient).createContainerCmd(anyString());
-        doReturn(createContainerCmd).when(createContainerCmd).withName(anyString());
-        doReturn(createContainerCmd).when(createContainerCmd).withHostConfig(any());
-        doReturn(createContainerCmd).when(createContainerCmd).withEnv(anyList());
-        doReturn(createContainerCmd).when(createContainerCmd).withUser(anyString());
-        doReturn(createContainerCmd).when(createContainerCmd).withEntrypoint();
-        doReturn(createContainerCmd).when(createContainerCmd).withCmd(anyString(), anyString(), anyString());
-        doReturn(createContainerResponse).when(createContainerCmd).exec();
+        when(dockerClient.createContainerCmd(anyString())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withName(anyString())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withHostConfig(any())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withEnv(anyList())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withUser(anyString())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withEntrypoint()).thenReturn(createContainerCmd);
+        when(createContainerCmd.withCmd(anyString(), anyString(), anyString())).thenReturn(createContainerCmd);
+        when(createContainerCmd.exec()).thenReturn(createContainerResponse);
 
         // Mock dockerClient.startContainerCmd(String containerId)
         StartContainerCmd startContainerCmd = mock(StartContainerCmd.class);
-        doReturn(startContainerCmd).when(dockerClient).startContainerCmd(anyString());
+        when(dockerClient.startContainerCmd(anyString())).thenReturn(startContainerCmd);
 
         // Mock dockerClient.copyArchiveToContainer(String containerId).withRemotePath(String path).withTarInputStream(InputStream uploadStream).exec()
         CopyArchiveToContainerCmd copyArchiveToContainerCmd = mock(CopyArchiveToContainerCmd.class);
-        doReturn(copyArchiveToContainerCmd).when(dockerClient).copyArchiveToContainerCmd(anyString());
-        doReturn(copyArchiveToContainerCmd).when(copyArchiveToContainerCmd).withRemotePath(anyString());
-        doReturn(copyArchiveToContainerCmd).when(copyArchiveToContainerCmd).withTarInputStream(any());
+        when(dockerClient.copyArchiveToContainerCmd(anyString())).thenReturn(copyArchiveToContainerCmd);
+        when(copyArchiveToContainerCmd.withRemotePath(anyString())).thenReturn(copyArchiveToContainerCmd);
+        when(copyArchiveToContainerCmd.withTarInputStream(any())).thenReturn(copyArchiveToContainerCmd);
         doNothing().when(copyArchiveToContainerCmd).exec();
 
         // Mock dockerClient.execCreateCmd(String containerId).withAttachStdout(Boolean attachStdout).withAttachStderr(Boolean attachStderr).withCmd(String... cmd).exec()
         ExecCreateCmd execCreateCmd = mock(ExecCreateCmd.class);
         ExecCreateCmdResponse execCreateCmdResponse = mock(ExecCreateCmdResponse.class);
-        doReturn(execCreateCmd).when(dockerClient).execCreateCmd(anyString());
-        doReturn(execCreateCmd).when(execCreateCmd).withCmd(any(String[].class));
-        doReturn(execCreateCmd).when(execCreateCmd).withUser(anyString());
-        doReturn(execCreateCmd).when(execCreateCmd).withAttachStdout(anyBoolean());
-        doReturn(execCreateCmd).when(execCreateCmd).withAttachStderr(anyBoolean());
-        doReturn(execCreateCmd).when(execCreateCmd).withCmd(anyString(), anyString());
-        doReturn(execCreateCmdResponse).when(execCreateCmd).exec();
-        doReturn("1234").when(execCreateCmdResponse).getId();
+        when(dockerClient.execCreateCmd(anyString())).thenReturn(execCreateCmd);
+        when(execCreateCmd.withCmd(any(String[].class))).thenReturn(execCreateCmd);
+        when(execCreateCmd.withUser(anyString())).thenReturn(execCreateCmd);
+        when(execCreateCmd.withAttachStdout(anyBoolean())).thenReturn(execCreateCmd);
+        when(execCreateCmd.withAttachStderr(anyBoolean())).thenReturn(execCreateCmd);
+        when(execCreateCmd.withCmd(anyString(), anyString())).thenReturn(execCreateCmd);
+        when(execCreateCmd.exec()).thenReturn(execCreateCmdResponse);
+        when(execCreateCmdResponse.getId()).thenReturn("1234");
 
         // Mock dockerClient.execStartCmd(String execId).exec(T resultCallback)
         ExecStartCmd execStartCmd = mock(ExecStartCmd.class);
-        doReturn(execStartCmd).when(dockerClient).execStartCmd(anyString());
-        doReturn(execStartCmd).when(execStartCmd).withDetach(anyBoolean());
-        doAnswer(invocation -> {
+        when(dockerClient.execStartCmd(anyString())).thenReturn(execStartCmd);
+        when(execStartCmd.withDetach(anyBoolean())).thenReturn(execStartCmd);
+        when(execStartCmd.exec(any())).thenAnswer(invocation -> {
             // Stub the 'exec' method of the 'ExecStartCmd' to call the 'onComplete' method of the provided 'ResultCallback.Adapter', which simulates the command completing
             // immediately.
             ResultCallback.Adapter<?> callback = invocation.getArgument(0);
             callback.onComplete();
             return null;
-        }).when(execStartCmd).exec(any());
+        });
 
         // Mock listContainerCmd() method.
         ListContainersCmd listContainersCmd = mock(ListContainersCmd.class);
-        doReturn(listContainersCmd).when(dockerClient).listContainersCmd();
-        doReturn(listContainersCmd).when(listContainersCmd).withShowAll(anyBoolean());
+        when(dockerClient.listContainersCmd()).thenReturn(listContainersCmd);
+        when(listContainersCmd.withShowAll(anyBoolean())).thenReturn(listContainersCmd);
 
         // Mock container class
         Container container = mock(Container.class);
-        doReturn(new String[] { "dummy-container-name" }).when(container).getNames();
-        doReturn("dummy-image-id").when(container).getImageId();
-        doReturn(List.of(container)).when(listContainersCmd).exec();
+        when(container.getNames()).thenReturn(new String[] { "dummy-container-name" });
+        when(container.getImageId()).thenReturn("dummy-image-id");
+        when(listContainersCmd.exec()).thenReturn(List.of(container));
 
         // Mock listImagesCmd() method.
         ListImagesCmd listImagesCmd = mock(ListImagesCmd.class);
-        doReturn(listImagesCmd).when(dockerClient).listImagesCmd();
+        when(dockerClient.listImagesCmd()).thenReturn(listImagesCmd);
         Image image = mock(Image.class);
-        doReturn("test-image-id").when(image).getId();
-        doReturn(new String[] { "test-image-name" }).when(image).getRepoTags();
-        doReturn(List.of(image)).when(listImagesCmd).exec();
+        when(image.getId()).thenReturn("test-image-id");
+        when(image.getRepoTags()).thenReturn(new String[] { "test-image-name" });
+        when(listImagesCmd.exec()).thenReturn(List.of(image));
 
         // Mock removeImageCmd method.
         RemoveImageCmd removeImageCmd = mock(RemoveImageCmd.class);
-        doReturn(removeImageCmd).when(dockerClient).removeImageCmd(anyString());
+        when(dockerClient.removeImageCmd(anyString())).thenReturn(removeImageCmd);
         doNothing().when(removeImageCmd).exec();
 
         // Mock removeContainerCmd
         RemoveContainerCmd removeContainerCmd = mock(RemoveContainerCmd.class);
-        doReturn(removeContainerCmd).when(dockerClient).removeContainerCmd(anyString());
-        doReturn(removeContainerCmd).when(removeContainerCmd).withForce(true);
+        when(dockerClient.removeContainerCmd(anyString())).thenReturn(removeContainerCmd);
+        when(removeContainerCmd.withForce(true)).thenReturn(removeContainerCmd);
 
         // Mock stopContainerCmd
         StopContainerCmd stopContainerCmd = mock(StopContainerCmd.class);
-        doReturn(stopContainerCmd).when(dockerClient).stopContainerCmd(anyString());
-        doReturn(stopContainerCmd).when(stopContainerCmd).withTimeout(any());
+        when(dockerClient.stopContainerCmd(anyString())).thenReturn(stopContainerCmd);
+        when(stopContainerCmd.withTimeout(any())).thenReturn(stopContainerCmd);
 
         // Mock killContainerCmd
         KillContainerCmd killContainerCmd = mock(KillContainerCmd.class);
-        doReturn(killContainerCmd).when(dockerClient).killContainerCmd(anyString());
+        when(dockerClient.killContainerCmd(anyString())).thenReturn(killContainerCmd);
 
         // Mock DisconnectFromNetworkCmd
         DisconnectFromNetworkCmd disconnectFromNetworkCmd = mock(DisconnectFromNetworkCmd.class);
-        doReturn(disconnectFromNetworkCmd).when(dockerClient).disconnectFromNetworkCmd();
-        doReturn(disconnectFromNetworkCmd).when(disconnectFromNetworkCmd).withContainerId(anyString());
-        doReturn(disconnectFromNetworkCmd).when(disconnectFromNetworkCmd).withNetworkId(anyString());
+        when(dockerClient.disconnectFromNetworkCmd()).thenReturn(disconnectFromNetworkCmd);
+        when(disconnectFromNetworkCmd.withContainerId(anyString())).thenReturn(disconnectFromNetworkCmd);
+        when(disconnectFromNetworkCmd.withNetworkId(anyString())).thenReturn(disconnectFromNetworkCmd);
 
         dockerClientMock = dockerClient;
     }
 
     @BeforeEach
     protected void mockBuildAgentServices() {
-        doReturn(dockerClientMock).when(buildAgentConfiguration).getDockerClient();
+        when(buildAgentConfiguration.getDockerClient()).thenReturn(dockerClientMock);
         this.dockerClient = dockerClientMock;
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
@@ -9,7 +9,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.ZoneId;
@@ -430,7 +429,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         assertThat(updatedTextExercise.getExerciseGroup()).as("exerciseGroup was not set for normal exercise").isNull();
         assertThat(updatedTextExercise.getCourseViaExerciseGroupOrCourseMember().getId()).as("courseId was not updated").isEqualTo(course.getId());
         verify(examLiveEventsService, never()).createAndSendProblemStatementUpdateEvent(any(), any(), any());
-        verify(groupNotificationScheduleService, times(1)).checkAndCreateAppropriateNotificationsWhenUpdatingExercise(any(), any(), any());
+        verify(groupNotificationScheduleService, timeout(2000).times(1)).checkAndCreateAppropriateNotificationsWhenUpdatingExercise(any(), any(), any());
         verify(competencyProgressApi, timeout(1000).times(1)).updateProgressForUpdatedLearningObjectAsync(eq(textExercise), eq(Optional.of(textExercise)));
     }
 
@@ -525,7 +524,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         assertThat(updatedTextExercise.isCourseExercise()).as("course was not set for exam exercise").isFalse();
         assertThat(updatedTextExercise.getExerciseGroup()).as("exerciseGroup was set for exam exercise").isNotNull();
         assertThat(updatedTextExercise.getExerciseGroup().getId()).as("exerciseGroupId was not updated").isEqualTo(exerciseGroup.getId());
-        verify(examLiveEventsService, times(1)).createAndSendProblemStatementUpdateEvent(any(), any(), any());
+        verify(examLiveEventsService, timeout(2000).times(1)).createAndSendProblemStatementUpdateEvent(any(), any(), any());
         verify(groupNotificationScheduleService, never()).checkAndCreateAppropriateNotificationsWhenUpdatingExercise(any(), any(), any());
     }
 


### PR DESCRIPTION
### Motivation and Context
Ongoing attempts to reduce flaky tests.

### Description
- make mockito verification consider a max timeout when verifying
- replace doReturn/doAnswer with newer syntax. (mockBuildAgentServices() caused a failure with this description once)
- fix rare issue with BadAccess to Exception in thymeleaf mail templating

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Enhanced administrative error notifications for data export failures. Administrators now receive clearer, more user-friendly messages that succinctly explain the issue, aiding in quicker understanding and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->