### PR TITLE
`Development`: Improve exercise import e2e tests

### DIFF
--- a/src/test/playwright/e2e/exam/ExamManagement.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamManagement.spec.ts
@@ -39,7 +39,7 @@ test.describe('Exam management', { tag: '@fast' }, () => {
                 await examManagement.openExerciseGroups(exam.id!);
                 await examExerciseGroups.clickAddTextExercise(exerciseGroup.id!);
                 const textExerciseTitle = 'Text ' + generateUUID();
-                await textExerciseCreation.typeTitle(textExerciseTitle);
+                await textExerciseCreation.setTitle(textExerciseTitle);
                 await textExerciseCreation.typeMaxPoints(10);
                 const response = await textExerciseCreation.create();
                 expect(response.status()).toBe(201);

--- a/src/test/playwright/e2e/exam/test-exam/TestExamManagement.spec.ts
+++ b/src/test/playwright/e2e/exam/test-exam/TestExamManagement.spec.ts
@@ -51,7 +51,7 @@ test.describe('Test Exam management', { tag: '@fast' }, () => {
             await examManagement.openExerciseGroups(exam.id!);
             await examExerciseGroups.clickAddTextExercise(exerciseGroup.id!);
             const textExerciseTitle = 'text' + uid;
-            await textExerciseCreation.typeTitle(textExerciseTitle);
+            await textExerciseCreation.setTitle(textExerciseTitle);
             await textExerciseCreation.typeMaxPoints(10);
             const response = await textExerciseCreation.create();
             expect(response.status()).toBe(201);

--- a/src/test/playwright/e2e/exercise/ExerciseImport.spec.ts
+++ b/src/test/playwright/e2e/exercise/ExerciseImport.spec.ts
@@ -44,6 +44,7 @@ test.describe('Import exercises', () => {
             await courseManagementExercises.importTextExercise();
             await courseManagementExercises.clickImportExercise(textExercise.id!);
 
+            await textExerciseCreation.waitForFormToLoad();
             await expect(page.locator('#field_title')).toHaveValue(textExercise.title!);
             await expect(page.locator('#field_points')).toHaveValue(`${textExercise.maxPoints!}`);
 
@@ -74,10 +75,11 @@ test.describe('Import exercises', () => {
             await courseManagementExercises.importQuizExercise();
             await courseManagementExercises.clickImportExercise(quizExercise.id!);
 
+            await quizExerciseCreation.waitForFormToLoad();
             await expect(page.locator('#field_title')).toHaveValue(quizExercise.title!);
             await expect(page.locator('#quiz-duration-minutes')).toHaveValue(`${quizExercise.duration! / 60}`);
 
-            await quizExerciseCreation.setVisibleFrom(dayjs());
+            await quizExerciseCreation.setReleaseDate(dayjs());
 
             const importResponse = await quizExerciseCreation.import();
             const exercise: QuizExercise = await importResponse.json();
@@ -100,7 +102,7 @@ test.describe('Import exercises', () => {
                 await courseManagementExercises.importModelingExercise();
                 await courseManagementExercises.clickImportExercise(modelingExercise.id!);
 
-                await page.waitForTimeout(10000);
+                await modelingExerciseCreation.waitForFormToLoad();
                 await expect(page.locator('#field_title')).toHaveValue(modelingExercise.title!);
                 await expect(page.locator('#field_points')).toHaveValue(`${modelingExercise.maxPoints!}`);
 
@@ -131,6 +133,7 @@ test.describe('Import exercises', () => {
                 await courseManagementExercises.importProgrammingExercise();
                 await courseManagementExercises.clickImportExercise(programmingExercise.id!);
 
+                await programmingExerciseCreation.waitForFormToLoad();
                 await expect(page.locator('#field_points')).toHaveValue(`${programmingExercise.maxPoints!}`);
 
                 await programmingExerciseCreation.setTitle('Import Test');

--- a/src/test/playwright/e2e/exercise/file-upload/FileUploadExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/file-upload/FileUploadExerciseManagement.spec.ts
@@ -24,7 +24,7 @@ test.describe('File upload exercise management', { tag: '@fast' }, () => {
 
         // Fill out file upload exercise form
         const exerciseTitle = 'file upload exercise' + generateUUID();
-        await fileUploadExerciseCreation.typeTitle(exerciseTitle);
+        await fileUploadExerciseCreation.setTitle(exerciseTitle);
         await fileUploadExerciseCreation.setReleaseDate(dayjs());
         await fileUploadExerciseCreation.setDueDate(dayjs().add(1, 'days'));
         await fileUploadExerciseCreation.setAssessmentDueDate(dayjs().add(2, 'days'));

--- a/src/test/playwright/e2e/exercise/text/TextExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/text/TextExerciseManagement.spec.ts
@@ -32,7 +32,7 @@ test.describe('Text exercise management', { tag: '@fast' }, () => {
 
         // Fill out text exercise form
         const exerciseTitle = 'text exercise' + generateUUID();
-        await textExerciseCreation.typeTitle(exerciseTitle);
+        await textExerciseCreation.setTitle(exerciseTitle);
         await textExerciseCreation.setReleaseDate(dayjs());
         await textExerciseCreation.setDueDate(dayjs().add(1, 'days'));
         await textExerciseCreation.setAssessmentDueDate(dayjs().add(2, 'days'));

--- a/src/test/playwright/support/fixtures.ts
+++ b/src/test/playwright/support/fixtures.ts
@@ -37,7 +37,7 @@ import { ProgrammingExerciseCreationPage } from './pageobjects/exercises/program
 import { QuizExerciseCreationPage } from './pageobjects/exercises/quiz/QuizExerciseCreationPage';
 import { StudentExamManagementPage } from './pageobjects/exam/StudentExamManagementPage';
 import { TextExerciseCreationPage } from './pageobjects/exercises/text/TextExerciseCreationPage';
-import { CreateModelingExercisePage } from './pageobjects/exercises/modeling/CreateModelingExercisePage';
+import { ModelingExerciseCreationPage } from './pageobjects/exercises/modeling/ModelingExerciseCreationPage';
 import { ExamTestRunPage } from './pageobjects/exam/ExamTestRunPage';
 import { CourseManagementExercisesPage } from './pageobjects/course/CourseManagementExercisesPage';
 import { TextExerciseExampleSubmissionsPage } from './pageobjects/exercises/text/TextExerciseExampleSubmissionsPage';
@@ -115,7 +115,7 @@ export type ArtemisPageObjects = {
     fileUploadExerciseCreation: FileUploadExerciseCreationPage;
     fileUploadExerciseEditor: FileUploadEditorPage;
     fileUploadExerciseFeedback: FileUploadExerciseFeedbackPage;
-    modelingExerciseCreation: CreateModelingExercisePage;
+    modelingExerciseCreation: ModelingExerciseCreationPage;
     modelingExerciseEditor: ModelingEditor;
     modelingExerciseFeedback: ModelingExerciseFeedbackPage;
     programmingExerciseCreation: ProgrammingExerciseCreationPage;
@@ -292,7 +292,7 @@ export const test = base.extend<ArtemisPageObjects & ArtemisCommands & ArtemisRe
         await use(new FileUploadExerciseFeedbackPage(page));
     },
     modelingExerciseCreation: async ({ page }, use) => {
-        await use(new CreateModelingExercisePage(page));
+        await use(new ModelingExerciseCreationPage(page));
     },
     modelingExerciseEditor: async ({ page }, use) => {
         await use(new ModelingEditor(page));

--- a/src/test/playwright/support/pageobjects/exercises/AbstractExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/AbstractExerciseCreationPage.ts
@@ -1,0 +1,45 @@
+import { Locator, Page } from '@playwright/test';
+import { Dayjs } from 'dayjs';
+import { enterDate } from '../../utils';
+
+export class AbstractExerciseCreationPage {
+    protected readonly page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    async setTitle(title: string) {
+        const titleField = this.page.locator('#field_title');
+        await titleField.clear();
+        await titleField.fill(title);
+    }
+
+    async setReleaseDate(date: Dayjs) {
+        await enterDate(this.page, '#pick-releaseDate', date);
+    }
+
+    async setDueDate(date: Dayjs) {
+        await enterDate(this.page, '#pick-dueDate', date);
+    }
+
+    async setAssessmentDueDate(date: Dayjs) {
+        await enterDate(this.page, '#pick-assessmentDueDate', date);
+    }
+
+    async clearText(textEditor: Locator) {
+        await textEditor.click();
+        await textEditor.press('Control+a');
+        await textEditor.press('Delete');
+    }
+
+    async importExercise(saveButtonSelector: string, importUrl: string) {
+        const responsePromise = this.page.waitForResponse(importUrl);
+        await this.page.locator(saveButtonSelector).click();
+        return await responsePromise;
+    }
+
+    async waitForFormToLoad() {
+        await this.page.locator('[name*="editForm"]').waitFor({ state: 'visible', timeout: 10000 });
+    }
+}

--- a/src/test/playwright/support/pageobjects/exercises/AbstractExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/AbstractExerciseCreationPage.ts
@@ -33,12 +33,6 @@ export class AbstractExerciseCreationPage {
         await textEditor.press('Delete');
     }
 
-    async importExercise(saveButtonSelector: string, importUrl: string) {
-        const responsePromise = this.page.waitForResponse(importUrl);
-        await this.page.locator(saveButtonSelector).click();
-        return await responsePromise;
-    }
-
     async waitForFormToLoad() {
         await this.page.locator('[name*="editForm"]').waitFor({ state: 'visible', timeout: 10000 });
     }

--- a/src/test/playwright/support/pageobjects/exercises/file-upload/FileUploadExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/file-upload/FileUploadExerciseCreationPage.ts
@@ -1,31 +1,7 @@
-import { Page } from 'playwright';
 import { UPLOAD_EXERCISE_BASE } from '../../../constants';
-import { Dayjs } from 'dayjs';
-import { enterDate } from '../../../utils';
+import { AbstractExerciseCreationPage } from '../AbstractExerciseCreationPage';
 
-export class FileUploadExerciseCreationPage {
-    private readonly page: Page;
-
-    constructor(page: Page) {
-        this.page = page;
-    }
-
-    async typeTitle(title: string) {
-        await this.page.locator('#field_title').fill(title);
-    }
-
-    async setReleaseDate(date: Dayjs) {
-        await enterDate(this.page, '#pick-releaseDate', date);
-    }
-
-    async setDueDate(date: Dayjs) {
-        await enterDate(this.page, '#pick-dueDate', date);
-    }
-
-    async setAssessmentDueDate(date: Dayjs) {
-        await enterDate(this.page, '#pick-assessmentDueDate', date);
-    }
-
+export class FileUploadExerciseCreationPage extends AbstractExerciseCreationPage {
     async typeMaxPoints(maxPoints: number) {
         await this.page.locator('#field_points').fill(maxPoints.toString());
     }

--- a/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseCreationPage.ts
@@ -1,21 +1,7 @@
-import { Page } from '@playwright/test';
 import { MODELING_EXERCISE_BASE } from '../../../constants';
-import { Dayjs } from 'dayjs';
-import { enterDate } from '../../../utils';
+import { AbstractExerciseCreationPage } from '../AbstractExerciseCreationPage';
 
-export class CreateModelingExercisePage {
-    private readonly page: Page;
-
-    constructor(page: Page) {
-        this.page = page;
-    }
-
-    async setTitle(title: string) {
-        const titleField = this.page.locator('#field_title');
-        await titleField.clear();
-        await titleField.fill(title);
-    }
-
+export class ModelingExerciseCreationPage extends AbstractExerciseCreationPage {
     async addCategories(categories: string[]) {
         for (const category of categories) {
             const categoriesField = this.page.locator('#field_categories');
@@ -40,18 +26,6 @@ export class CreateModelingExercisePage {
         const responsePromise = this.page.waitForResponse(`${MODELING_EXERCISE_BASE}/import/*`);
         await this.page.click('#save-entity');
         return await responsePromise;
-    }
-
-    async setReleaseDate(date: Dayjs) {
-        await enterDate(this.page, '#pick-releaseDate', date);
-    }
-
-    async setDueDate(date: Dayjs) {
-        await enterDate(this.page, '#pick-dueDate', date);
-    }
-
-    async setAssessmentDueDate(date: Dayjs) {
-        await enterDate(this.page, '#pick-assessmentDueDate', date);
     }
 
     async includeInOverallScore(selection: string = 'No') {

--- a/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseCreationPage.ts
@@ -1,20 +1,11 @@
-import { Locator, Page, expect } from '@playwright/test';
+import { Locator, expect } from '@playwright/test';
 import { PROGRAMMING_EXERCISE_BASE, ProgrammingLanguage } from '../../../constants';
 import { Dayjs } from 'dayjs';
+import { AbstractExerciseCreationPage } from '../AbstractExerciseCreationPage';
 
 const OWL_DATEPICKER_ARIA_LABEL_DATE_FORMAT = 'MMMM D, YYYY';
 
-export class ProgrammingExerciseCreationPage {
-    private readonly page: Page;
-
-    constructor(page: Page) {
-        this.page = page;
-    }
-
-    async setTitle(title: string) {
-        await this.page.locator('#field_title').fill(title);
-    }
-
+export class ProgrammingExerciseCreationPage extends AbstractExerciseCreationPage {
     async changeEditMode() {
         await this.page.locator('#switch-edit-mode-button').click();
     }

--- a/src/test/playwright/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
@@ -1,24 +1,11 @@
-import { Page, expect } from '@playwright/test';
-import { clearTextField, drag, enterDate } from '../../../utils';
-import { Dayjs } from 'dayjs';
+import { expect } from '@playwright/test';
+import { clearTextField, drag } from '../../../utils';
 import { QUIZ_EXERCISE_BASE } from '../../../constants';
 import { Fixtures } from '../../../../fixtures/fixtures';
+import { AbstractExerciseCreationPage } from '../AbstractExerciseCreationPage';
 
-export class QuizExerciseCreationPage {
-    private readonly page: Page;
+export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
     private readonly DEFAULT_MULTIPLE_CHOICE_ANSWER_COUNT = 4;
-
-    constructor(page: Page) {
-        this.page = page;
-    }
-
-    async setTitle(title: string) {
-        await this.page.locator('#field_title').fill(title);
-    }
-
-    async setVisibleFrom(date: Dayjs) {
-        await enterDate(this.page, '#pick-releaseDate', date);
-    }
 
     async addMultipleChoiceQuestion(title: string, points = 1) {
         await this.page.locator('#quiz-add-mc-question').click();

--- a/src/test/playwright/support/pageobjects/exercises/text/TextExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/text/TextExerciseCreationPage.ts
@@ -1,35 +1,16 @@
-import { Locator, Page } from '@playwright/test';
-import { Dayjs } from 'dayjs';
-import { enterDate } from '../../../utils';
+import { Locator } from '@playwright/test';
 import { TEXT_EXERCISE_BASE } from '../../../constants';
+import { AbstractExerciseCreationPage } from '../AbstractExerciseCreationPage';
 
-export class TextExerciseCreationPage {
-    private readonly page: Page;
-
+export class TextExerciseCreationPage extends AbstractExerciseCreationPage {
     private readonly PROBLEM_STATEMENT_SELECTOR = '#problemStatement';
     private readonly EXAMPLE_SOLUTION_SELECTOR = '#exampleSolution';
     private readonly ASSESSMENT_INSTRUCTIONS_SELECTOR = '#gradingInstructions';
-
-    constructor(page: Page) {
-        this.page = page;
-    }
 
     async typeTitle(title: string) {
         const titleField = this.page.locator('#field_title');
         await titleField.clear();
         await titleField.fill(title);
-    }
-
-    async setReleaseDate(date: Dayjs) {
-        await enterDate(this.page, '#pick-releaseDate', date);
-    }
-
-    async setDueDate(date: Dayjs) {
-        await enterDate(this.page, '#pick-dueDate', date);
-    }
-
-    async setAssessmentDueDate(date: Dayjs) {
-        await enterDate(this.page, '#pick-assessmentDueDate', date);
     }
 
     async typeMaxPoints(maxPoints: number) {
@@ -80,12 +61,6 @@ export class TextExerciseCreationPage {
 
     private getTextEditorLocator(selector: string) {
         return this.page.locator(selector).locator('.monaco-editor');
-    }
-
-    private async clearText(textEditor: Locator) {
-        await textEditor.click();
-        await textEditor.press('Control+a');
-        await textEditor.press('Delete');
     }
 
     private async typeText(textEditor: Locator, text: string) {

--- a/src/test/playwright/support/pageobjects/exercises/text/TextExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/text/TextExerciseCreationPage.ts
@@ -7,12 +7,6 @@ export class TextExerciseCreationPage extends AbstractExerciseCreationPage {
     private readonly EXAMPLE_SOLUTION_SELECTOR = '#exampleSolution';
     private readonly ASSESSMENT_INSTRUCTIONS_SELECTOR = '#gradingInstructions';
 
-    async typeTitle(title: string) {
-        const titleField = this.page.locator('#field_title');
-        await titleField.clear();
-        await titleField.fill(title);
-    }
-
     async typeMaxPoints(maxPoints: number) {
         await this.page.locator('#field_points').fill(maxPoints.toString());
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
While importing an exercise, loading exercise information and displaying it on exercise create/modify form may sometimes take longer. This was causing relevant E2E tests to be flaky, especially on multi-node configuration.

### Description
This PR improves the waiting mechanism during execution of E2E tests. It waits for the exercise information to be loaded before making any assertions. It also removes some code repetition by small refactoring.

### Steps for Testing
- **Code Review**: Ensure that test passes for valid reasons and improvements make sense.
- **CI testing**: Check that all tests pass on both [single-node](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AEPTMA1542) and [multi-node](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AEPAEPTMLM207) Artemis Bamboo builds.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked

![](https://byob.yarr.is/ls1intum/Artemis/artemis-test1)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test2)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test3)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test4)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test5)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test6)
![](https://byob.yarr.is/ls1intum/Artemis/artemis-test9)

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced synchronization in exercise import and creation workflows to ensure all forms load completely before interactions.
  - Updated method calls for setting titles in various exercises to improve clarity and consistency.
- **Refactor**
  - Unified shared functionalities across various exercise types—including file upload, modeling, programming, quiz, and text—streamlining the creation process.
- **Chores**
  - Updated naming conventions for improved clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->