### PR TITLE
`Development`: Fix mockito warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ node {
 }
 
 apply from: "gradle/liquibase.gradle"
-apply from: "gradle/test.gradle"
 apply from: "gradle/spotless.gradle"
 
 if (project.hasProperty("prod")) {
@@ -80,7 +79,7 @@ modernizer {
 }
 
 configurations {
-    providedRuntime
+    mockitoAgent
 }
 
 repositories {
@@ -418,6 +417,10 @@ dependencies {
     testImplementation "org.springframework.boot:spring-boot-test:${spring_boot_version}"
     testImplementation "org.assertj:assertj-core:3.27.3"
     testImplementation "org.mockito:mockito-core:${mockito_version}"
+    // needed to add mockito as agent and avoid its warning
+    mockitoAgent ("org.mockito:mockito-core:${mockito_version}") {
+        transitive = false
+    }
     testImplementation "org.mockito:mockito-junit-jupiter:${mockito_version}"
 
     testImplementation "io.github.classgraph:classgraph:4.8.179"
@@ -440,6 +443,10 @@ dependencies {
     // NOTE: make sure this corresponds to the version used for JUnit in the testImplementation
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junit_platform_version}"
 }
+
+// we have to apply the test.gradle file after the dependencies block, otherwise we get the error  Cannot change dependencies of dependency configuration ':mockitoAgent' after it has been resolved
+apply from: "gradle/test.gradle"
+
 
 dependencyManagement {
     imports {

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -3,6 +3,9 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 // Taken from here: https://stackoverflow.com/questions/3963708/gradle-how-to-display-test-results-in-the-console-in-real-time
 tasks.withType(Test).configureEach {
+
+    jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
+
     // a collection to track failedTests
     ext.failedTests = []
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #10154 
Mockito logs a warning at the beginning of the server test execution that it currently self-attaches to the inline-mock-maker and this might no longer work in the future.

### Description
<!-- Describe your changes in detail -->
Followed the steps described [here](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3).
Had to change the order when test.gradle is applied in build.gradle to make the gradle build still compile.


### Steps for Testing
Run the server tests locally or check the logs on Github/Bamboo.
Check that the server test logs no longer contain the following text 
`Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK`
Code Review

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Revised the build configuration to streamline dependency management and eliminate resolution issues.
  - Phased out outdated dependency settings in favor of a more robust setup.
  
- **Tests**
  - Enhanced the testing environment by integrating improved support for mocking, leading to more reliable test executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->