### PR TITLE
`Development`: Fix missing source files in Jacoco report

### DIFF
--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -155,10 +155,8 @@ private JacocoCoverageVerification registerJacocoTestCoverageVerification(String
  * @param rootTask the JacocoReportBase root task
  */
 private void prepareJacocoReportTask(JacocoReportBase task, String moduleName, JacocoReportBase rootTask) {
-    task.group = "Reporting"
-    task.executionData = project.fileTree("${project.layout.buildDirectory.get()}/jacoco") {
-        include "test.exec"
-    }
+    task.group = rootTask.group
+    task.executionData = rootTask.executionData
 
     def classPath
     if (moduleName == "aggregated") {


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
The Jacoco report did not pick up the correct source files as the path was wrong (should be "src/main/java" instead of including any specific sub-path.


### Description
Changes the sourceDirectories to be the exact same one coming from the root task.
Also, use the group and execution data from the rootTask instead of defining explicitly.


### Steps for Testing
1. Download a coverage report generated on develop ([example](https://github.com/ls1intum/Artemis/actions/runs/13354067287), scroll to the end and look for `Coverage Report Server Tests`)
2. Open a single file
3. See the message `Source file ... was not found during generation of report`. You cannot click on any methods.
4. Download a coverage report generated by a commit in this branch ([example](https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS7789-JAVATEST-1/artifact), click on `Coverage Report Server Tests`)
5. Open the same file, see that this message is gone and you can open a code-view (by clicking on the method name). This code view should highlight covered line green, uncovered lines in red.

### Review Process
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
**Before:**
![image](https://github.com/user-attachments/assets/c719b1a0-7c26-4087-81b6-dd37a3d812dd)

**After:**
<img width="887" alt="Screenshot 2025-02-16 at 13 33 29" src="https://github.com/user-attachments/assets/3cffdeab-1978-40ca-b686-3330e4792041" />
Clicking on a single file:
![image (1)](https://github.com/user-attachments/assets/bf621a86-c0d0-47c0-bace-18140ecd3c6b)

