### PR TITLE
`Integrated code lifecycle`: Fix stale container cleanup

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -221,9 +223,10 @@ public class BuildJobContainerService {
     }
 
     /**
-     * Stops or kills a container in case a build job has failed or the container is unresponsive.
+     * Stops, kills or removes a container in case a build job has failed or the container is unresponsive.
      * Adding a file "stop_container.txt" like in {@link #stopContainer(String)} might not work for unresponsive containers, thus we use
-     * {@link DockerClient#stopContainerCmd(String)} and {@link DockerClient#killContainerCmd(String)} to stop or kill the container.
+     * {@link DockerClient#stopContainerCmd(String)}, {@link DockerClient#killContainerCmd(String)} and {@link DockerClient#removeContainerCmd(String)} to stop, kill or remove the
+     * container.
      *
      * @param containerId The ID of the container to stop or kill.
      */
@@ -246,28 +249,53 @@ public class BuildJobContainerService {
                 // Await the future with a timeout
                 future.get(20, TimeUnit.SECONDS);  // Wait for the stop command to complete with a timeout
             }
-            catch (NotFoundException | NotModifiedException e) {
-                log.warn("Container with id {} is already stopped.", containerId, e);
-            }
             catch (Exception e) {
-                log.error("Failed to stop container with id {}. Attempting to kill container.", containerId, e);
-
-                // Attempt to kill the container if stop fails
-                try (final var killCommand = buildAgentConfiguration.getDockerClient().killContainerCmd(containerId)) {
-                    Future<Void> killFuture = executor.submit(() -> {
-                        killCommand.exec();
-                        return null;
-                    });
-
-                    killFuture.get(10, TimeUnit.SECONDS);  // Wait for the kill command to complete with a timeout
+                Throwable cause = e.getCause();
+                // e will be ExecutionException if thrown in executor service by submitted task
+                // We are interested in the underlying cause in this case
+                if (e instanceof ExecutionException && (cause instanceof NotFoundException || cause instanceof NotModifiedException)) {
+                    log.warn("Container with id {} is already stopped. Attempting to remove container.", containerId, cause);
+                    // this can also happen for containers that are stuck in "Ready" state so they can not be stopped or killed
+                    // try to remove the container so it won't show up in the next cleanup again
+                    removeContainer(containerId, executor);
                 }
-                catch (Exception killException) {
-                    log.error("Failed to kill container with id {}.", containerId, killException);
+                else {
+                    log.error("Failed to stop container with id {}. Attempting to kill container.", containerId, e);
+
+                    // Attempt to kill the container if stop fails
+                    killContainer(containerId, executor);
                 }
             }
             finally {
                 executor.shutdown();
             }
+        }
+    }
+
+    private void killContainer(String containerId, ExecutorService executor) {
+        try (final var killCommand = buildAgentConfiguration.getDockerClient().killContainerCmd(containerId)) {
+            Future<Void> killFuture = executor.submit(() -> {
+                killCommand.exec();
+                return null;
+            });
+
+            killFuture.get(10, TimeUnit.SECONDS);  // Wait for the kill command to complete with a timeout
+        }
+        catch (Exception e) {
+            log.error("Failed to kill container with id {}.", containerId, e);
+        }
+    }
+
+    private void removeContainer(String containerId, ExecutorService executor) {
+        try (final var removeCommand = buildAgentConfiguration.getDockerClient().removeContainerCmd(containerId)) {
+            Future<Void> removeFuture = executor.submit(() -> {
+                removeCommand.exec();
+                return null;
+            });
+            removeFuture.get(10, TimeUnit.SECONDS); // Wait for the remove command to complete with a timeout
+        }
+        catch (Exception e) {
+            log.error("Failed to remove container with id {}", containerId, e);
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -272,6 +272,13 @@ public class BuildJobContainerService {
         }
     }
 
+    /**
+     * Kills a Docker container asynchronously using the given container ID and executor.
+     * Waits up to 10 seconds for completion. Logs an error if the operation fails.
+     *
+     * @param containerId The ID of the container to kill.
+     * @param executor    The ExecutorService for running the command.
+     */
     private void killContainer(String containerId, ExecutorService executor) {
         try (final var killCommand = buildAgentConfiguration.getDockerClient().killContainerCmd(containerId)) {
             Future<Void> killFuture = executor.submit(() -> {
@@ -286,6 +293,13 @@ public class BuildJobContainerService {
         }
     }
 
+    /**
+     * Removes a Docker container asynchronously using the given container ID and executor.
+     * Waits up to 10 seconds for completion. Logs an error if the operation fails.
+     *
+     * @param containerId The ID of the container to remove.
+     * @param executor    The ExecutorService for running the command.
+     */
     private void removeContainer(String containerId, ExecutorService executor) {
         try (final var removeCommand = buildAgentConfiguration.getDockerClient().removeContainerCmd(containerId)) {
             Future<Void> removeFuture = executor.submit(() -> {

--- a/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerServiceTest.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.artemis.buildagent.service;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -24,6 +25,7 @@ import com.github.dockerjava.api.command.InspectImageCmd;
 import com.github.dockerjava.api.command.ListContainersCmd;
 import com.github.dockerjava.api.command.StopContainerCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.exception.NotModifiedException;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Info;
 import com.hazelcast.core.HazelcastInstance;
@@ -150,7 +152,7 @@ class BuildAgentDockerServiceTest extends AbstractSpringIntegrationLocalCILocalV
 
         buildAgentDockerService.cleanUpContainers();
 
-        // Verify that removeContainerCmd() was called
+        // Verify that stopContainerCmd() was called
         verify(dockerClient, times(1)).stopContainerCmd(anyString());
 
         // Mock container creation time to be younger than 5 minutes
@@ -158,7 +160,7 @@ class BuildAgentDockerServiceTest extends AbstractSpringIntegrationLocalCILocalV
 
         buildAgentDockerService.cleanUpContainers();
 
-        // Verify that removeContainerCmd() was not called a second time
+        // Verify that stopContainerCmd() was not called a second time
         verify(dockerClient, times(1)).stopContainerCmd(anyString());
 
         // Mock container creation time to be older than 5 minutes
@@ -167,11 +169,19 @@ class BuildAgentDockerServiceTest extends AbstractSpringIntegrationLocalCILocalV
         // Mock exception when stopping container
         StopContainerCmd stopContainerCmd = mock(StopContainerCmd.class);
         doReturn(stopContainerCmd).when(dockerClient).stopContainerCmd(anyString());
+        doReturn(stopContainerCmd).when(stopContainerCmd).withTimeout(anyInt());
         doThrow(new RuntimeException("Container stopping failed")).when(stopContainerCmd).exec();
 
         buildAgentDockerService.cleanUpContainers();
 
         // Verify that killContainerCmd() was called
         verify(dockerClient, times(1)).killContainerCmd(anyString());
+
+        // Mock NotModified exception when stopping container
+        doThrow(new NotModifiedException("Container not running")).when(stopContainerCmd).exec();
+        buildAgentDockerService.cleanUpContainers();
+
+        // Verify that removeContainerCmd() was called
+        verify(dockerClient, times(1)).removeContainerCmd(anyString());
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The exceptions thrown when failing to stop a container in the `stopUnresponsiveContainer ` method are currently not catched as excpected because they are wrapped in a ExceutionException. This causes a small bug where containers that are not stoppable because they are not running (anymore) are tried to kill, which will also fail (because they are not running).
I noticed the issue because a ci container was stuck in "READY" state in the dev cluster forever, and will show up in every cleanup until manually removed.
There might be other scenarios where non-running containers are not removed properly too.

example logs for non running stale container: 
```
2025-02-16T00:56:52.898+01:00  INFO 233701 --- [Artemis] [artemis-scheduling-80918] d.t.c.a.a.b.s.BuildAgentDockerService    : Found 2 dangling build containers
2025-02-16T00:56:52.898+01:00  INFO 233701 --- [Artemis] [artemis-scheduling-80918] d.t.c.a.a.b.s.BuildJobContainerService   : Stopping container with id 8e7888270dbb1b9da2dde3d30ff25aa196b5d039e8dedbf3c1b7bcf86f48669c
2025-02-16T00:56:52.901+01:00 ERROR 233701 --- [Artemis] [artemis-scheduling-80918] d.t.c.a.a.b.s.BuildJobContainerService   : Failed to stop container with id 8e7888270dbb1b9da2dde3d30ff25aa196b5d039e8dedbf3c1b7bcf86f48669c. Attempting to kill container.

java.util.concurrent.ExecutionException: com.github.dockerjava.api.exception.NotModifiedException: Status 304: 
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
	at de.tum.cit.aet.artemis.buildagent.service.BuildJobContainerService.stopUnresponsiveContainer(BuildJobContainerService.java:240)
	at de.tum.cit.aet.artemis.buildagent.service.BuildAgentDockerService.lambda$cleanUpContainers$3(BuildAgentDockerService.java:163)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at de.tum.cit.aet.artemis.buildagent.service.BuildAgentDockerService.cleanUpContainers(BuildAgentDockerService.java:163)
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
Caused by: com.github.dockerjava.api.exception.NotModifiedException: Status 304: 
	at com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:235)
	at com.github.dockerjava.core.DefaultInvocationBuilder.post(DefaultInvocationBuilder.java:102)
	at com.github.dockerjava.core.exec.StopContainerCmdExec.execute(StopContainerCmdExec.java:33)
	at com.github.dockerjava.core.exec.StopContainerCmdExec.execute(StopContainerCmdExec.java:13)
	at com.github.dockerjava.core.exec.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:21)
	at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:33)
	at com.github.dockerjava.core.command.StopContainerCmdImpl.exec(StopContainerCmdImpl.java:63)
	at de.tum.cit.aet.artemis.buildagent.service.BuildJobContainerService.lambda$stopUnresponsiveContainer$0(BuildJobContainerService.java:235)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)

2025-02-16T00:56:52.904+01:00 ERROR 233701 --- [Artemis] [artemis-scheduling-80918] d.t.c.a.a.b.s.BuildJobContainerService   : Failed to kill container with id 8e7888270dbb1b9da2dde3d30ff25aa196b5d039e8dedbf3c1b7bcf86f48669c.
```
### Description
- catching the ExecutionException and checking the underlying cause we can log the message for non running containers.
- added removal of such containers, so they will not stay stale forever and show up in the next cleanup schedule again.
- small refactoring into methods

Logging example:
```
2025-02-16T22:54:50.097+01:00  INFO 441355 --- [Artemis] [artemis-scheduling-3] d.t.c.a.a.b.s.BuildAgentDockerService    : Start cleanup dangling build containers
2025-02-16T22:54:50.281+01:00  INFO 441355 --- [Artemis] [artemis-scheduling-3] d.t.c.a.a.b.s.BuildAgentDockerService    : Found 1 dangling build containers
2025-02-16T22:54:50.281+01:00  WARN 441355 --- [Artemis] [artemis-scheduling-3] d.t.c.a.a.b.s.BuildJobContainerService   : Stopping unresponsive container with id 7a8f84cffa4aa83cd1dfd2da72c96343fdeb988e9eec1d98d88290b659ddfa46
2025-02-16T22:54:50.289+01:00  WARN 441355 --- [Artemis] [artemis-scheduling-3] d.t.c.a.a.b.s.BuildJobContainerService   : Container with id 7a8f84cffa4aa83cd1dfd2da72c96343fdeb988e9eec1d98d88290b659ddfa46 is already stopped. Attempting to remove container.
```

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
1. Simulate a container that is not running, with correct name prefix (artemis.continuous-integration.build-container-prefix)
`$ docker container create --name local-ci-test1 hello-world`
2. Start Artemis to trigger the initial container cleanup ( you can also wait for the scheduled cleanup or increase the schedule frequency in that case you might also want to reduce artemis.continuous-integration.container-cleanup.expiry-minutes (or wait 5 mintes by default)
3. The container cannot be stopped or killed, but now it will be removed.
4. check the logs regarding stopping and removal of container
5. check that the container was removed successfully: e.g.
`$ docker ps -a | grep local-ci-test1`

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| BuildJobContainerService.java | 79% | ✅ ❌ |

increased coverage of changed method to 100%: 

https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS7790-4/artifact/shared/Coverage-Report-Server-Tests/de.tum.cit.aet.artemis.buildagent.service/BuildJobContainerService.html

vs. 

https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS7789-1/artifact/shared/Coverage-Report-Server-Tests/de.tum.cit.aet.artemis.buildagent.service/BuildJobContainerService.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced container management with new actions for stopping and removing unresponsive containers.
  - Introduced asynchronous processes to improve robustness in container control.

- **Bug Fixes**
  - Refined error handling to better manage exceptions during container shutdown operations.

- **Tests**
  - Updated test cases to validate the improved container cleanup behavior and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->