### PR TITLE
`Exam mode`: Fix issue with second correction round results

### DIFF
--- a/src/main/webapp/app/entities/submission.model.ts
+++ b/src/main/webapp/app/entities/submission.model.ts
@@ -70,8 +70,8 @@ export function getLatestSubmissionResult(submission: Submission | undefined): R
  * @returns the results or undefined if submission or the result for the requested correctionRound is undefined
  */
 export function getSubmissionResultByCorrectionRound(submission: Submission | undefined, correctionRound: number): Result | undefined {
-    if (submission?.results && submission?.results.filter((result) => result && result.assessmentType !== AssessmentType.AUTOMATIC_ATHENA).length >= correctionRound) {
-        return submission.results.filter((result) => result && result.assessmentType !== AssessmentType.AUTOMATIC_ATHENA)[correctionRound];
+    if (submission?.results && submission?.results.filter((result) => result?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA).length >= correctionRound) {
+        return submission.results.filter((result) => result?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA)[correctionRound];
     }
     return undefined;
 }

--- a/src/main/webapp/app/entities/submission.model.ts
+++ b/src/main/webapp/app/entities/submission.model.ts
@@ -70,8 +70,8 @@ export function getLatestSubmissionResult(submission: Submission | undefined): R
  * @returns the results or undefined if submission or the result for the requested correctionRound is undefined
  */
 export function getSubmissionResultByCorrectionRound(submission: Submission | undefined, correctionRound: number): Result | undefined {
-    if (submission?.results && submission?.results.filter((result) => result.assessmentType !== AssessmentType.AUTOMATIC_ATHENA).length >= correctionRound) {
-        return submission.results.filter((result) => result.assessmentType !== AssessmentType.AUTOMATIC_ATHENA)[correctionRound];
+    if (submission?.results && submission?.results.filter((result) => result && result.assessmentType !== AssessmentType.AUTOMATIC_ATHENA).length >= correctionRound) {
+        return submission.results.filter((result) => result && result.assessmentType !== AssessmentType.AUTOMATIC_ATHENA)[correctionRound];
     }
     return undefined;
 }

--- a/src/main/webapp/app/exercises/shared/result/result.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/result.component.ts
@@ -147,7 +147,7 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
                 }
                 // Make sure result and participation are connected
                 if (!this.showUngradedResults) {
-                    const firstRatedResult = this.participation.results.find((result) => result && result.rated);
+                    const firstRatedResult = this.participation.results.find((result) => result?.rated);
                     if (firstRatedResult) {
                         this.result = firstRatedResult;
                         this.result.participation = this.participation;

--- a/src/main/webapp/app/exercises/shared/result/result.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/result.component.ts
@@ -147,7 +147,7 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
                 }
                 // Make sure result and participation are connected
                 if (!this.showUngradedResults) {
-                    const firstRatedResult = this.participation.results.find((result) => result.rated);
+                    const firstRatedResult = this.participation.results.find((result) => result && result.rated);
                     if (firstRatedResult) {
                         this.result = firstRatedResult;
                         this.result.participation = this.participation;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We're encountering an issue during the second correction round of an exam where the result and action columns are missing. This occurs because we're attempting to access properties of a result that is null.

### Description
<!-- Describe your changes in detail -->
I added nullability checks to prevent this issue from occurring.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 2 Instructors
- 1 Students
- 1 Exam with a text exercise and 2 correction rounds

1. Log in to Artemis as a student.
2. Participate in the exam as a student.
3. As the first instructor, perform the first assessment of the exercise.
4. As the second instructor, perform the second assessment of the exercise.
5. Verify that all columns are displayed for both the first and second instructor, and that it is possible to view the assessment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

Missing result and action columnd for the second correction round
<img width="2468" alt="image" src="https://github.com/user-attachments/assets/9b6b1139-7a32-48f4-9411-4f30a245ee6e" />

Error appearing in the console
<img width="1071" alt="image" src="https://github.com/user-attachments/assets/4f061c65-9e0d-4435-9218-7933e94a0165" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling to ensure robustness when evaluating and retrieving results. This update prevents runtime issues by verifying that required data exists before processing, thereby improving the stability and reliability of the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->