### PR TITLE
`Development`: Update markdown editor cursor postion on backspace

### DIFF
--- a/src/main/webapp/app/shared/monaco-editor/monaco-editor.component.ts
+++ b/src/main/webapp/app/shared/monaco-editor/monaco-editor.component.ts
@@ -178,7 +178,8 @@ export class MonacoEditorComponent implements OnInit, OnDestroy {
 
                 if (graphemes.length === 0) return;
 
-                graphemes.pop();
+                const lastGrapheme = graphemes.pop();
+                const deletedLength = lastGrapheme?.length ?? 1;
                 const newTextBeforeCursor = graphemes.join('');
                 const textAfterCursor = lineContent.substring(column - 1);
 
@@ -193,6 +194,8 @@ export class MonacoEditorComponent implements OnInit, OnDestroy {
                     ],
                     () => null,
                 );
+                const newCursorPosition = column - deletedLength;
+                this._editor.setSelection(new monaco.Range(lineNumber, newCursorPosition, lineNumber, newCursorPosition));
             }) || undefined;
     }
 

--- a/src/test/javascript/spec/component/shared/monaco-editor/monaco-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/monaco-editor/monaco-editor.component.spec.ts
@@ -395,9 +395,9 @@ describe('MonacoEditorComponent', () => {
     it('should place the cursor correctly after deleting an emoji', fakeAsync(() => {
         fixture.detectChanges();
 
-        const text = 'Hello 👋';
-        comp.setText(text);
-        comp.setPosition({ lineNumber: 1, column: text.length + 1 });
+        const fullText = 'Hello 👋 World!';
+        comp.setText(fullText);
+        comp.setPosition({ lineNumber: 1, column: 9 });
 
         const commandId = comp.getCustomBackspaceCommandId();
         comp['_editor'].trigger('keyboard', commandId!, null);


### PR DESCRIPTION
### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


### Description
<!-- Describe your changes in detail -->
Currently, the position of the cursor is not updated if you delete something via backspace. This is cumbersome if you want to correct mistakes

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student

1. Log in to Artemis
2. Navigate to any Markdown editor (for example, in the FAQ creation page)
3. Write in some text.
4. Update the text WITHIN the string. Also make sure to do the same with an emoji 
5. the cursor should be on the right spot and not jump to the right

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an 

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


https://github.com/user-attachments/assets/dd0fc510-1166-4feb-a9ee-762633819855
Old behaviour

https://github.com/user-attachments/assets/fadcffd6-9b66-41a7-ab29-b5e4e03b7e20
new behaviour


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deletion behavior to ensure accurate cursor positioning after backspace actions, including when handling special characters.
  
- **Tests**
  - Updated test cases to validate the refined cursor positioning after text deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->