### PR TITLE
`Communication`: Adjust message container height and send button

### DIFF
--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-header/conversation-header.component.html
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-header/conversation-header.component.html
@@ -33,7 +33,7 @@
                 @if (activeConversationAsChannel.tutorialGroupId && activeConversationAsChannel.tutorialGroupTitle) {
                     <div class="p-2">
                         <a
-                            class="btn btn-info"
+                            class="btn btn-info btn-sm"
                             [routerLink]="['/courses', course.id, 'tutorial-groups', activeConversationAsChannel.tutorialGroupId]"
                             role="button"
                             jhiTranslate="artemisApp.entities.tutorialGroup.channelReverse"

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.html
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.html
@@ -1,122 +1,108 @@
 @if (course) {
-    <div class="py-3 pt-0 justify-content-center conversation-messages">
-        <div class="justify-content-center">
-            <div class="justify-content-center px-3 py-0">
-                <!-- search bar -->
-                @if (!searchbarCollapsed) {
-                    <div class="input-group ps-0" [class.search-active]="!!searchText">
-                        <span class="input-group-text">
-                            <fa-icon [icon]="faSearch" size="sm" />
-                            <span [hidden]="true" id="inputLabel" jhiTranslate="artemisApp.conversationsLayout.conversationMessages.searchLabel"></span>
-                        </span>
-                        <input
-                            id="searchInput"
-                            aria-labelledby="inputLabel"
-                            aria-describedby="searchResult"
-                            #searchInput
-                            (input)="onSearchQueryInput($event)"
-                            class="form-control"
-                            type="text"
-                            placeholder="{{ 'artemisApp.conversationsLayout.conversationMessages.searchBarPlaceholder' | artemisTranslate }}"
-                        />
-                        @if (!!searchText) {
-                            <button
-                                class="btn btn-outline-secondary border-end-0 border-start-0"
-                                type="button"
-                                (click)="clearSearchInput()"
-                                aria-labelledby="clearSearchLabel"
-                                id="clearSearchButton"
-                            >
-                                <span id="clearSearchLabel" [hidden]="true" jhiTranslate="artemisApp.conversationsLayout.conversationMessages.clearSearch"></span>
-                                <fa-icon [icon]="faTimes" size="xs" />
-                            </button>
+    <div class="justify-content-center conversation-messages">
+        <div class="justify-content-center px-3">
+            <!-- search bar -->
+            @if (!searchbarCollapsed) {
+                <div class="input-group channel-search" [class.search-active]="!!searchText">
+                    <span class="input-group-text">
+                        <fa-icon [icon]="faSearch" size="sm" />
+                        <span [hidden]="true" id="inputLabel" jhiTranslate="artemisApp.conversationsLayout.conversationMessages.searchLabel"></span>
+                    </span>
+                    <input
+                        id="searchInput"
+                        aria-labelledby="inputLabel"
+                        aria-describedby="searchResult"
+                        #searchInput
+                        (input)="onSearchQueryInput($event)"
+                        class="form-control"
+                        type="text"
+                        placeholder="{{ 'artemisApp.conversationsLayout.conversationMessages.searchBarPlaceholder' | artemisTranslate }}"
+                    />
+                    @if (!!searchText) {
+                        <button
+                            class="btn btn-outline-secondary border-end-0 border-start-0"
+                            type="button"
+                            (click)="clearSearchInput()"
+                            aria-labelledby="clearSearchLabel"
+                            id="clearSearchButton"
+                        >
+                            <span id="clearSearchLabel" [hidden]="true" jhiTranslate="artemisApp.conversationsLayout.conversationMessages.clearSearch"></span>
+                            <fa-icon [icon]="faTimes" size="xs" />
+                        </button>
+                    }
+                    <span class="input-group-text" [hidden]="!searchText" id="searchResult">
+                        @switch (totalNumberOfPosts) {
+                            @case (0) {
+                                <span jhiTranslate="artemisApp.conversationsLayout.conversationMessages.searchResultsNone"></span>
+                            }
+                            @case (1) {
+                                <span jhiTranslate="artemisApp.conversationsLayout.conversationMessages.searchResultsSingle"></span>
+                            }
+                            @default {
+                                <span
+                                    jhiTranslate="artemisApp.conversationsLayout.conversationMessages.searchResultsMultiple"
+                                    [translateValues]="{ count: totalNumberOfPosts }"
+                                ></span>
+                            }
                         }
-                        <span class="input-group-text" [hidden]="!searchText" id="searchResult">
-                            @switch (totalNumberOfPosts) {
-                                @case (0) {
-                                    <span jhiTranslate="artemisApp.conversationsLayout.conversationMessages.searchResultsNone"></span>
-                                }
-                                @case (1) {
-                                    <span jhiTranslate="artemisApp.conversationsLayout.conversationMessages.searchResultsSingle"></span>
-                                }
-                                @default {
-                                    <span
-                                        jhiTranslate="artemisApp.conversationsLayout.conversationMessages.searchResultsMultiple"
-                                        [translateValues]="{ count: totalNumberOfPosts }"
-                                    ></span>
-                                }
-                            }
-                        </span>
-                    </div>
-                }
-            </div>
-            <div class="mt-3">
-                <!-- loading messages -->
-                @if (isFetchingPosts) {
-                    <div class="envelope">
-                        <fa-icon size="3x" [icon]="faCircleNotch" animation="spin" />
-                    </div>
-                }
-                <!-- no message exist -->
-                @if (!isFetchingPosts && (posts.length === 0 || !_activeConversation)) {
-                    <div class="envelope">
-                        <fa-icon size="5x" [icon]="faEnvelope" />
-                    </div>
-                }
-                <!-- list of messages -->
-                <div
-                    id="scrollableDiv"
-                    #container
-                    [ngClass]="{
-                        'posting-infinite-scroll-container': posts.length !== 0,
-                        'content-height-dev': contentHeightDev,
-                        'is-fetching-posts': isFetchingPosts,
-                        'hide-input-full': isHiddenInputFull,
-                        'hide-input': isHiddenInputWithCallToAction,
-                    }"
-                    infinite-scroll
-                    class="conversation-messages-message-list position-relative"
-                    [scrollWindow]="false"
-                    (scrolledUp)="fetchNextPage()"
-                >
-                    <!-- list of all top level posts -->
-                    <!-- answers are opened in the thread sidebar -->
-                    @for (group of groupedPosts; track postsGroupTrackByFn($index, group)) {
-                        <div class="message-group">
-                            @for (post of group.posts; track postsTrackByFn($index, post)) {
-                                <div class="post-item">
-                                    <jhi-posting-thread
-                                        #postingThread
-                                        [lastReadDate]="_activeConversation?.lastReadDate"
-                                        [hasChannelModerationRights]="!!getAsChannel(_activeConversation)?.hasChannelModerationRights"
-                                        [id]="'item-' + post.id"
-                                        [post]="post"
-                                        [showAnswers]="false"
-                                        [readOnlyMode]="!!getAsChannel(_activeConversation)?.isArchived"
-                                        [isCommunicationPage]="true"
-                                        (openThread)="setPostForThread($event)"
-                                        [isConsecutive]="post.isConsecutive || false"
-                                    />
-                                </div>
-                            }
-                        </div>
-                    }
-
-                    @if (_activeConversation && newPost && canCreateNewMessageInConversation(_activeConversation) && isMobile) {
-                        <div class="px-3">
-                            @if (getAsChannel(_activeConversation)?.isAnnouncementChannel) {
-                                <div class="pt-2">
-                                    <button class="btn btn-md btn-primary" (click)="createEditModal.open()" jhiTranslate="artemisApp.metis.newAnnouncement"></button>
-                                    <jhi-post-create-edit-modal #createEditModal [posting]="newPost!" [isCommunicationPage]="true" (onCreate)="handleNewMessageCreated()" />
-                                </div>
-                            } @else {
-                                <jhi-message-inline-input class="message-input" [posting]="newPost!" (onCreate)="handleNewMessageCreated()" />
-                            }
-                        </div>
-                    }
+                    </span>
                 </div>
-                @if (_activeConversation && newPost && canCreateNewMessageInConversation(_activeConversation) && !isMobile) {
-                    <div class="d-none d-sm-block px-3">
+            }
+        </div>
+        <div class="channel-content">
+            <!-- loading messages -->
+            @if (isFetchingPosts) {
+                <div class="envelope">
+                    <fa-icon size="3x" [icon]="faCircleNotch" animation="spin" />
+                </div>
+            }
+            <!-- no message exist -->
+            @if (!isFetchingPosts && (posts.length === 0 || !_activeConversation)) {
+                <div class="envelope">
+                    <fa-icon size="5x" [icon]="faEnvelope" />
+                </div>
+            }
+            <!-- list of messages -->
+            <div
+                id="scrollableDiv"
+                #container
+                [ngClass]="{
+                    'posting-infinite-scroll-container': posts.length !== 0,
+                    'content-height-dev': contentHeightDev,
+                    'is-fetching-posts': isFetchingPosts,
+                    'hide-input-full': isHiddenInputFull,
+                    'hide-input': isHiddenInputWithCallToAction,
+                }"
+                infinite-scroll
+                class="conversation-messages-message-list position-relative"
+                [scrollWindow]="false"
+                (scrolledUp)="fetchNextPage()"
+            >
+                <!-- list of all top level posts -->
+                <!-- answers are opened in the thread sidebar -->
+                @for (group of groupedPosts; track postsGroupTrackByFn($index, group)) {
+                    <div class="message-group">
+                        @for (post of group.posts; track postsTrackByFn($index, post)) {
+                            <div class="post-item">
+                                <jhi-posting-thread
+                                    #postingThread
+                                    [lastReadDate]="_activeConversation?.lastReadDate"
+                                    [hasChannelModerationRights]="!!getAsChannel(_activeConversation)?.hasChannelModerationRights"
+                                    [id]="'item-' + post.id"
+                                    [post]="post"
+                                    [showAnswers]="false"
+                                    [readOnlyMode]="!!getAsChannel(_activeConversation)?.isArchived"
+                                    [isCommunicationPage]="true"
+                                    (openThread)="setPostForThread($event)"
+                                    [isConsecutive]="post.isConsecutive || false"
+                                />
+                            </div>
+                        }
+                    </div>
+                }
+
+                @if (_activeConversation && newPost && canCreateNewMessageInConversation(_activeConversation) && isMobile) {
+                    <div class="px-3">
                         @if (getAsChannel(_activeConversation)?.isAnnouncementChannel) {
                             <div class="pt-2">
                                 <button class="btn btn-md btn-primary" (click)="createEditModal.open()" jhiTranslate="artemisApp.metis.newAnnouncement"></button>
@@ -128,6 +114,18 @@
                     </div>
                 }
             </div>
+            @if (_activeConversation && newPost && canCreateNewMessageInConversation(_activeConversation) && !isMobile) {
+                <div class="d-none d-sm-block px-3">
+                    @if (getAsChannel(_activeConversation)?.isAnnouncementChannel) {
+                        <div class="pt-2">
+                            <button class="btn btn-md btn-primary" (click)="createEditModal.open()" jhiTranslate="artemisApp.metis.newAnnouncement"></button>
+                            <jhi-post-create-edit-modal #createEditModal [posting]="newPost!" [isCommunicationPage]="true" (onCreate)="handleNewMessageCreated()" />
+                        </div>
+                    } @else {
+                        <jhi-message-inline-input class="message-input" [posting]="newPost!" (onCreate)="handleNewMessageCreated()" />
+                    }
+                </div>
+            }
         </div>
     </div>
 }

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.scss
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.scss
@@ -7,6 +7,8 @@
     --message-input-height-dev: 158px;
     --search-height: 52px;
     --channel-header-height: 52px;
+    --header-height: 68px;
+    --announcement-button-height: 48px;
 
     .search-active {
         input {
@@ -44,19 +46,19 @@
     }
 
     .posting-infinite-scroll-container {
-        max-height: calc(75vh - var(--message-input-height-prod) - var(--search-height) - var(--channel-header-height));
+        max-height: calc(100vh - var(--header-height) - var(--message-input-height-prod) - var(--search-height) - var(--channel-header-height));
         overflow-y: auto;
 
         &.hide-input-full {
-            max-height: calc(94vh - var(--message-input-height-prod) - var(--search-height) - var(--channel-header-height));
+            max-height: calc(100vh - var(--header-height) - var(--search-height) - var(--channel-header-height));
         }
 
         &.hide-input {
-            max-height: calc(87vh - var(--message-input-height-prod) - var(--search-height) - var(--channel-header-height));
+            max-height: calc(100vh - var(--announcement-button-height) - var(--header-height) - var(--search-height) - var(--channel-header-height));
         }
 
         &.content-height-dev {
-            max-height: calc(75vh - var(--message-input-height-dev) - var(--search-height) - var(--channel-header-height));
+            max-height: calc(100vh - var(--header-height) - var(--message-input-height-dev) - var(--search-height) - var(--channel-header-height));
 
             @include media-breakpoint-down(sm) {
                 max-height: calc(90vh - var(--message-input-height-dev) - var(--search-height) - var(--channel-header-height));
@@ -65,11 +67,11 @@
         }
 
         &.hide-input-full.content-height-dev {
-            max-height: calc(94vh - var(--message-input-height-dev) - var(--search-height) - var(--channel-header-height));
+            max-height: calc(100vh - var(--header-height) - var(--search-height) - var(--channel-header-height));
         }
 
         &.hide-input.content-height-dev {
-            max-height: calc(87vh - var(--message-input-height-dev) - var(--search-height) - var(--channel-header-height));
+            max-height: calc(100vh - var(--announcement-button-height) - var(--header-height) - var(--search-height) - var(--channel-header-height));
         }
 
         @include media-breakpoint-down(sm) {
@@ -111,4 +113,21 @@
 
 jhi-posting-thread {
     margin-bottom: 5px;
+}
+
+.channel-content {
+    height: calc(100vh - 15px - var(--header-height) - var(--message-input-height-dev) - var(--channel-header-height));
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.channel-search {
+    z-index: 1040;
+    margin: 0.5rem;
+    position: fixed;
+    right: 1.5rem;
+    max-width: 275px;
+    border-radius: 0.25rem;
+    background-color: var(--bs-card-bg);
 }

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.scss
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.scss
@@ -83,9 +83,8 @@
     .envelope {
         text-align: center;
         opacity: 0.75;
-        height: 250px;
-        padding-top: 100px;
-        padding-bottom: 100px;
+        margin-top: auto;
+        margin-bottom: auto;
     }
 
     .conversation-messages-message-list.is-fetching-posts {
@@ -116,7 +115,10 @@ jhi-posting-thread {
 }
 
 .channel-content {
-    height: calc(100vh - 15px - var(--header-height) - var(--message-input-height-dev) - var(--channel-header-height));
+    height: calc(100vh - 1rem - var(--header-height) - var(--message-input-height-dev) - var(--channel-header-height));
+    @include media-breakpoint-down(md) {
+        height: calc(100vh - var(--header-height) - var(--message-input-height-dev) - var(--channel-header-height));
+    }
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.scss
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.scss
@@ -116,9 +116,11 @@ jhi-posting-thread {
 
 .channel-content {
     height: calc(100vh - 1rem - var(--header-height) - var(--message-input-height-dev) - var(--channel-header-height));
+
     @include media-breakpoint-down(md) {
         height: calc(100vh - var(--header-height) - var(--message-input-height-dev) - var(--channel-header-height));
     }
+
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-thread-sidebar/conversation-thread-sidebar.component.html
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-thread-sidebar/conversation-thread-sidebar.component.html
@@ -36,7 +36,7 @@
                                 [hasChannelModerationRights]="hasChannelModerationRights"
                             />
                         </div>
-                        <div class="message-input mx-3 px-3 pt-2">
+                        <div class="message-input mx-3 pt-2">
                             @if (!readOnlyMode) {
                                 <jhi-message-reply-inline-input
                                     [activeConversation]="conversation"

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
@@ -24,7 +24,7 @@
                             (onBlurEditor)="onBlurEditor.emit()"
                         />
                         @if (enableFileUpload) {
-                            <div class="d-flex" #fileUploadFooter>
+                            <div class="d-flex align-items-center border-top" #fileUploadFooter>
                                 <input
                                     [id]="'file-upload ' + uniqueMarkdownEditorId"
                                     class="file-upload-footer-input"
@@ -40,11 +40,23 @@
                                 >
                                     <div class="row mx-0 align-items-baseline">
                                         <span class="col upload-subtitle" jhiTranslate="artemisApp.markdownEditor.fileUpload"></span>
-                                        <a class="col-auto" href="https://markdown-it.github.io/">
-                                            <fa-icon [icon]="faQuestionCircle" [ngbTooltip]="'artemisApp.markdownEditor.guide' | artemisTranslate" />
-                                        </a>
                                     </div>
                                 </label>
+                                <a class="col-auto mx-1" href="https://markdown-it.github.io/">
+                                    <fa-icon [icon]="faQuestionCircle" [ngbTooltip]="'artemisApp.markdownEditor.guide' | artemisTranslate" />
+                                </a>
+                                @if (editType !== EditType.UPDATE) {
+                                    <button
+                                        jhi-posting-button
+                                        [buttonIcon]="faPaperPlane"
+                                        [buttonLabel]="'artemisApp.conversationsLayout.sendMessage' | artemisTranslate"
+                                        [buttonLoading]="isButtonLoading"
+                                        [disabled]="isButtonLoading || !isFormGroupValid"
+                                        class="ms-1 col-auto btn btn-sm btn-outline-secondary"
+                                        id="save"
+                                        type="submit"
+                                    ></button>
+                                }
                             </div>
                         }
                     </div>
@@ -71,6 +83,18 @@
                                 <div class="p-0 m-0 background-editor-high markdown-preview" [innerHTML]="defaultPreviewHtml"></div>
                             }
                         </ng-content>
+                        @if (editType !== EditType.UPDATE) {
+                            <button
+                                jhi-posting-button
+                                [buttonIcon]="faPaperPlane"
+                                [buttonLabel]="'artemisApp.conversationsLayout.sendMessage' | artemisTranslate"
+                                [buttonLoading]="isButtonLoading"
+                                [disabled]="isButtonLoading || !isFormGroupValid"
+                                class="float-end btn btn-sm btn-outline-secondary"
+                                id="save"
+                                type="submit"
+                            ></button>
+                        }
                     </div>
                 </ng-template>
             </ng-container>
@@ -82,7 +106,7 @@
                             <ng-container [ngTemplateOutlet]="simpleActionButton" [ngTemplateOutletContext]="{ action }" />
                         }
                         <!-- Headers -->
-                        @if (displayedActions.header.length > 0) {
+                        @if (displayedActions.header.length) {
                             <div class="btn-group" ngbDropdown role="group" aria-label="Button group with nested dropdown">
                                 <button class="btn btn-sm px-2 py-0" type="button" id="dropdownBasic1" ngbDropdownToggle>
                                     <span [jhiTranslate]="headerActions!.translationKey"></span>

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
@@ -46,16 +46,7 @@
                                     <fa-icon [icon]="faQuestionCircle" [ngbTooltip]="'artemisApp.markdownEditor.guide' | artemisTranslate" />
                                 </a>
                                 @if (editType !== EditType.UPDATE) {
-                                    <button
-                                        jhi-posting-button
-                                        [buttonIcon]="faPaperPlane"
-                                        [buttonLabel]="'artemisApp.conversationsLayout.sendMessage' | artemisTranslate"
-                                        [buttonLoading]="isButtonLoading"
-                                        [disabled]="isButtonLoading || !isFormGroupValid"
-                                        class="ms-1 col-auto btn btn-sm btn-outline-secondary"
-                                        id="save"
-                                        type="submit"
-                                    ></button>
+                                    <ng-container [ngTemplateOutlet]="sendButton" [ngTemplateOutletContext]="{ extraClass: 'ms-1 col-auto', testId: 'save' }" />
                                 }
                             </div>
                         }
@@ -84,16 +75,8 @@
                             }
                         </ng-content>
                         @if (editType !== EditType.UPDATE) {
-                            <button
-                                jhi-posting-button
-                                [buttonIcon]="faPaperPlane"
-                                [buttonLabel]="'artemisApp.conversationsLayout.sendMessage' | artemisTranslate"
-                                [buttonLoading]="isButtonLoading"
-                                [disabled]="isButtonLoading || !isFormGroupValid"
-                                class="float-end btn btn-sm btn-outline-secondary"
-                                id="save"
-                                type="submit"
-                            ></button>
+                            <!-- <ng-container *ngTemplateOutlet="sendButton; context: {text: 'hallo'}" /> -->
+                            <ng-container [ngTemplateOutlet]="sendButton" [ngTemplateOutletContext]="{ extraClass: 'float-end' }" />
                         }
                     </div>
                 </ng-template>
@@ -288,4 +271,18 @@
 
 <ng-template #noItemsAvailable>
     <button class="ps-1 me-1" mat-button [disabled]="true" jhiTranslate="global.generic.emptyList" type="button"></button>
+</ng-template>
+
+<ng-template #sendButton let-extraClass="extraClass" let-testId="testId">
+    <button
+        jhi-posting-button
+        [buttonIcon]="faPaperPlane"
+        [buttonLabel]="'artemisApp.conversationsLayout.sendMessage' | artemisTranslate"
+        [buttonLoading]="isButtonLoading"
+        [disabled]="isButtonLoading || !isFormGroupValid"
+        class="btn btn-sm btn-outline-secondary"
+        [ngClass]="extraClass ?? ''"
+        id="testId ?? ''"
+        type="submit"
+    ></button>
 </ng-template>

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
@@ -45,7 +45,7 @@
                                 <a class="col-auto mx-1" href="https://markdown-it.github.io/">
                                     <fa-icon [icon]="faQuestionCircle" [ngbTooltip]="'artemisApp.markdownEditor.guide' | artemisTranslate" />
                                 </a>
-                                @if (editType !== EditType.UPDATE) {
+                                @if (editType() !== EditType.UPDATE) {
                                     <ng-container [ngTemplateOutlet]="sendButton" [ngTemplateOutletContext]="{ extraClass: 'ms-1 col-auto', testId: 'save' }" />
                                 }
                             </div>
@@ -74,7 +74,7 @@
                                 <div class="p-0 m-0 background-editor-high markdown-preview" [innerHTML]="defaultPreviewHtml"></div>
                             }
                         </ng-content>
-                        @if (editType !== EditType.UPDATE) {
+                        @if (editType() !== EditType.UPDATE) {
                             <!-- <ng-container *ngTemplateOutlet="sendButton; context: {text: 'hallo'}" /> -->
                             <ng-container [ngTemplateOutlet]="sendButton" [ngTemplateOutletContext]="{ extraClass: 'float-end' }" />
                         }
@@ -278,8 +278,8 @@
         jhi-posting-button
         [buttonIcon]="faPaperPlane"
         [buttonLabel]="'artemisApp.conversationsLayout.sendMessage' | artemisTranslate"
-        [buttonLoading]="isButtonLoading"
-        [disabled]="isButtonLoading || !isFormGroupValid"
+        [buttonLoading]="isButtonLoading()"
+        [disabled]="isButtonLoading() || !isFormGroupValid()"
         class="btn btn-sm btn-outline-secondary"
         [ngClass]="extraClass ?? ''"
         [id]="testId ?? ''"

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
@@ -282,7 +282,7 @@
         [disabled]="isButtonLoading || !isFormGroupValid"
         class="btn btn-sm btn-outline-secondary"
         [ngClass]="extraClass ?? ''"
-        id="testId ?? ''"
+        [id]="testId ?? ''"
         type="submit"
     ></button>
 </ng-template>

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.scss
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.scss
@@ -46,10 +46,7 @@
 .file-upload-footer-label {
     cursor: pointer;
     width: 100%;
-    border-top: 1px dotted var(--border-color);
-    border-bottom: 1px solid var(--border-color);
     border-radius: 0 0.15em 0.15em 0;
-    padding-bottom: 0.15em;
 
     .upload-subtitle {
         font-size: 12px;

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.ts
@@ -242,9 +242,9 @@ export class MarkdownEditorMonacoComponent implements AfterContentInit, AfterVie
     @Input()
     metaActions: TextEditorAction[] = [new FullscreenAction()];
 
-    @Input() isButtonLoading = false;
-    @Input() isFormGroupValid = false;
-    @Input() editType: PostingEditType;
+    isButtonLoading = input<boolean>(false);
+    isFormGroupValid = input<boolean>(false);
+    editType = input<PostingEditType>();
 
     readonly useCommunicationForFileUpload = input<boolean>(false);
     readonly fallbackConversationId = input<number>();

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.ts
@@ -55,7 +55,7 @@ import { TextEditorDomainAction } from 'app/shared/monaco-editor/model/actions/t
 import { TextEditorDomainActionWithOptions } from 'app/shared/monaco-editor/model/actions/text-editor-domain-action-with-options.model';
 import { LectureAttachmentReferenceAction } from 'app/shared/monaco-editor/model/actions/communication/lecture-attachment-reference.action';
 import { LectureUnitType } from 'app/entities/lecture-unit/lectureUnit.model';
-import { ReferenceType } from 'app/shared/metis/metis.util';
+import { PostingEditType, ReferenceType } from 'app/shared/metis/metis.util';
 import { MonacoEditorOptionPreset } from 'app/shared/monaco-editor/model/monaco-editor-option-preset.model';
 import { SafeHtml } from '@angular/platform-browser';
 import { ArtemisMarkdownService } from 'app/shared/markdown.service';
@@ -72,6 +72,8 @@ import { MatButton } from '@angular/material/button';
 import { ArtemisTranslatePipe } from '../../pipes/artemis-translate.pipe';
 import { ArtemisIntelligenceService } from 'app/shared/monaco-editor/model/actions/artemis-intelligence/artemis-intelligence.service';
 import { facArtemisIntelligence } from 'app/icons/icons';
+import { PostingButtonComponent } from 'app/shared/metis/posting-button/posting-button.component';
+import { faPaperPlane } from '@fortawesome/free-regular-svg-icons';
 
 export enum MarkdownEditorHeight {
     INLINE = 125,
@@ -129,6 +131,7 @@ const BORDER_HEIGHT_OFFSET = 2;
         NgbDropdownToggle,
         NgbDropdownMenu,
         ColorSelectorComponent,
+        PostingButtonComponent,
         MatMenuTrigger,
         MatMenu,
         MatMenuItem,
@@ -239,6 +242,10 @@ export class MarkdownEditorMonacoComponent implements AfterContentInit, AfterVie
     @Input()
     metaActions: TextEditorAction[] = [new FullscreenAction()];
 
+    @Input() isButtonLoading = false;
+    @Input() isFormGroupValid = false;
+    @Input() editType: PostingEditType;
+
     readonly useCommunicationForFileUpload = input<boolean>(false);
     readonly fallbackConversationId = input<number>();
 
@@ -308,6 +315,7 @@ export class MarkdownEditorMonacoComponent implements AfterContentInit, AfterVie
     protected readonly faGripLines = faGripLines;
     protected readonly faAngleDown = faAngleDown;
     protected readonly facArtemisIntelligence = facArtemisIntelligence;
+    protected readonly faPaperPlane = faPaperPlane;
     // Types and values exposed to the template
     protected readonly LectureUnitType = LectureUnitType;
     protected readonly ReferenceType = ReferenceType;
@@ -315,6 +323,8 @@ export class MarkdownEditorMonacoComponent implements AfterContentInit, AfterVie
     protected readonly TAB_EDIT = MarkdownEditorMonacoComponent.TAB_EDIT;
     protected readonly TAB_PREVIEW = MarkdownEditorMonacoComponent.TAB_PREVIEW;
     protected readonly TAB_VISUAL = MarkdownEditorMonacoComponent.TAB_VISUAL;
+
+    readonly EditType = PostingEditType;
 
     constructor() {
         this.uniqueMarkdownEditorId = 'markdown-editor-' + uuid();

--- a/src/main/webapp/app/shared/metis/message/message-inline-input/message-inline-input.component.html
+++ b/src/main/webapp/app/shared/metis/message/message-inline-input/message-inline-input.component.html
@@ -6,6 +6,9 @@
             [maxContentLength]="maxContentLength"
             [isInputLengthDisplayed]="false"
             (keydown.enter)="confirm()"
+            [isButtonLoading]="isLoading"
+            [isFormGroupValid]="formGroup.valid"
+            [editType]="editType"
         />
         <div class="col mt-1 text-end">
             @if (!warningDismissed) {
@@ -24,16 +27,16 @@
                     class="btn btn-sm btn-outline-secondary"
                     (click)="isModalOpen.emit()"
                 ></button>
+                <button
+                    jhi-posting-button
+                    [buttonLoading]="isLoading"
+                    [disabled]="isLoading || !formGroup.valid"
+                    [buttonLabel]="'artemisApp.conversationsLayout.saveMessage' | artemisTranslate"
+                    class="btn btn-sm btn-outline-primary"
+                    id="save"
+                    type="submit"
+                ></button>
             }
-            <button
-                jhi-posting-button
-                [buttonLoading]="isLoading"
-                [disabled]="isLoading || !formGroup.valid"
-                [buttonLabel]="'artemisApp.conversationsLayout.sendMessage' | artemisTranslate"
-                class="btn btn-sm btn-outline-secondary"
-                id="save"
-                type="submit"
-            ></button>
         </div>
     </div>
 </form>

--- a/src/main/webapp/app/shared/metis/message/message-reply-inline-input/message-reply-inline-input.component.html
+++ b/src/main/webapp/app/shared/metis/message/message-reply-inline-input/message-reply-inline-input.component.html
@@ -8,6 +8,9 @@
             [isInputLengthDisplayed]="false"
             (keydown.enter)="confirm()"
             (valueChange)="valueChange.emit()"
+            [isButtonLoading]="isLoading"
+            [isFormGroupValid]="formGroup.valid"
+            [editType]="editType"
         />
         <div class="col mt-1 text-end">
             @if (!warningDismissed) {
@@ -26,16 +29,16 @@
                     class="btn btn-sm btn-outline-secondary"
                     (click)="isModalOpen.emit()"
                 ></button>
+                <button
+                    jhi-posting-button
+                    [buttonLoading]="isLoading"
+                    [disabled]="isLoading || !formGroup.valid"
+                    [buttonLabel]="'artemisApp.conversationsLayout.saveMessage' | artemisTranslate"
+                    class="btn btn-sm btn-outline-secondary"
+                    id="save"
+                    type="submit"
+                ></button>
             }
-            <button
-                jhi-posting-button
-                [buttonLoading]="isLoading"
-                [disabled]="isLoading || !formGroup.valid"
-                [buttonLabel]="'artemisApp.conversationsLayout.sendMessage' | artemisTranslate"
-                class="btn btn-sm btn-outline-secondary"
-                id="save"
-                type="submit"
-            ></button>
         </div>
     </div>
 </form>

--- a/src/main/webapp/app/shared/metis/message/message-reply-inline-input/message-reply-inline-input.component.html
+++ b/src/main/webapp/app/shared/metis/message/message-reply-inline-input/message-reply-inline-input.component.html
@@ -34,7 +34,7 @@
                     [buttonLoading]="isLoading"
                     [disabled]="isLoading || !formGroup.valid"
                     [buttonLabel]="'artemisApp.conversationsLayout.saveMessage' | artemisTranslate"
-                    class="btn btn-sm btn-outline-secondary"
+                    class="btn btn-sm btn-outline-primary"
                     id="save"
                     type="submit"
                 ></button>

--- a/src/main/webapp/app/shared/metis/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.html
+++ b/src/main/webapp/app/shared/metis/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.html
@@ -7,6 +7,9 @@
                 [maxContentLength]="maxContentLength"
                 [isInputLengthDisplayed]="false"
                 (keydown.enter)="confirm()"
+                [isButtonLoading]="isLoading"
+                [isFormGroupValid]="formGroup.valid"
+                [editType]="editType"
             />
             <div class="col mt-1 text-end">
                 <button jhi-posting-button [buttonLabel]="'artemisApp.metis.cancel' | artemisTranslate" class="btn btn-sm btn-outline-secondary" (click)="close()"></button>
@@ -16,7 +19,7 @@
                     [disabled]="isLoading || !formGroup.valid"
                     [buttonLabel]="'artemisApp.metis.savePosting' | artemisTranslate"
                     id="save"
-                    class="btn btn-sm btn-outline-secondary"
+                    class="btn btn-sm btn-outline-primary"
                     type="submit"
                 ></button>
             </div>

--- a/src/main/webapp/app/shared/metis/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.html
+++ b/src/main/webapp/app/shared/metis/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.html
@@ -37,20 +37,30 @@
                     <jhi-help-icon text="artemisApp.metis.post.contentTooltip" />
                 </div>
                 <div class="row mb-2">
-                    <jhi-posting-markdown-editor formControlName="content" [editorHeight]="editorHeight" [maxContentLength]="maxContentLength" [suppressNewlineOnEnter]="false" />
+                    <jhi-posting-markdown-editor
+                        formControlName="content"
+                        [editorHeight]="editorHeight"
+                        [maxContentLength]="maxContentLength"
+                        [suppressNewlineOnEnter]="false"
+                        [isButtonLoading]="isLoading"
+                        [isFormGroupValid]="formGroup.valid"
+                        [editType]="editType"
+                    />
                 </div>
             </div>
         </div>
-        <div class="modal-footer">
-            <button
-                jhi-posting-button
-                [buttonLoading]="isLoading"
-                [disabled]="isLoading || !formGroup.valid"
-                [buttonLabel]="'artemisApp.metis.savePosting' | artemisTranslate"
-                id="save"
-                class="btn btn-sm btn-outline-secondary"
-                type="submit"
-            ></button>
-        </div>
+        @if (editType === EditType.UPDATE) {
+            <div class="modal-footer">
+                <button
+                    jhi-posting-button
+                    [buttonLoading]="isLoading"
+                    [disabled]="isLoading || !formGroup.valid"
+                    [buttonLabel]="'artemisApp.conversationsLayout.saveMessage' | artemisTranslate"
+                    class="btn btn-sm btn-outline-primary"
+                    id="save"
+                    type="submit"
+                ></button>
+            </div>
+        }
     </form>
 </ng-template>

--- a/src/main/webapp/app/shared/metis/posting-footer/posting-footer.component.html
+++ b/src/main/webapp/app/shared/metis/posting-footer/posting-footer.component.html
@@ -1,5 +1,5 @@
 @if (showAnswers()) {
-    <div class="d-flex align-items-center mt-2">
+    <div class="d-flex align-items-center mb-1 mx-3">
         <div class="fs-x-small fw-900 me-2">
             {{
                 sortedAnswerPosts().length === 1

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.html
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.html
@@ -21,6 +21,9 @@
         [resizableMinHeight]="editorHeight"
         [resizableMaxHeight]="MarkdownEditorHeight.MEDIUM"
         (keydown)="onKeyDown($event)"
+        [isButtonLoading]="isButtonLoading"
+        [isFormGroupValid]="isFormGroupValid"
+        [editType]="editType"
     >
         <ng-container id="previewMonaco">
             @if (previewMode) {

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.html
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.html
@@ -21,9 +21,9 @@
         [resizableMinHeight]="editorHeight"
         [resizableMaxHeight]="MarkdownEditorHeight.MEDIUM"
         (keydown)="onKeyDown($event)"
-        [isButtonLoading]="isButtonLoading"
-        [isFormGroupValid]="isFormGroupValid"
-        [editType]="editType"
+        [isButtonLoading]="isButtonLoading()"
+        [isFormGroupValid]="isFormGroupValid()"
+        [editType]="editType()"
     >
         <ng-container id="previewMonaco">
             @if (previewMode) {

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
@@ -47,6 +47,7 @@ import { StrikethroughAction } from 'app/shared/monaco-editor/model/actions/stri
 import { PostingContentComponent } from '../posting-content/posting-content.components';
 import { NgStyle } from '@angular/common';
 import { FileService } from 'app/shared/http/file.service';
+import { PostingEditType } from '../metis.util';
 
 @Component({
     selector: 'jhi-posting-markdown-editor',
@@ -78,6 +79,11 @@ export class PostingMarkdownEditorComponent implements OnInit, ControlValueAcces
     @Input() editorHeight: MarkdownEditorHeight = MarkdownEditorHeight.INLINE;
     @Input() isInputLengthDisplayed = true;
     @Input() suppressNewlineOnEnter = true;
+    @Input() isButtonLoading = false;
+    @Input() isFormGroupValid = false;
+    @Input() editType: PostingEditType;
+
+    readonly EditType = PostingEditType;
     /**
      * For AnswerPosts, the MetisService may not always have an active conversation (e.g. when in the 'all messages' view).
      * In this case, file uploads have to rely on the parent post to determine the course.

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
@@ -79,9 +79,10 @@ export class PostingMarkdownEditorComponent implements OnInit, ControlValueAcces
     @Input() editorHeight: MarkdownEditorHeight = MarkdownEditorHeight.INLINE;
     @Input() isInputLengthDisplayed = true;
     @Input() suppressNewlineOnEnter = true;
-    @Input() isButtonLoading = false;
-    @Input() isFormGroupValid = false;
-    @Input() editType: PostingEditType;
+
+    isButtonLoading = input<boolean>(false);
+    isFormGroupValid = input<boolean>(false);
+    editType = input<PostingEditType>();
 
     readonly EditType = PostingEditType.CREATE;
     /**

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.ts
@@ -83,7 +83,7 @@ export class PostingMarkdownEditorComponent implements OnInit, ControlValueAcces
     @Input() isFormGroupValid = false;
     @Input() editType: PostingEditType;
 
-    readonly EditType = PostingEditType;
+    readonly EditType = PostingEditType.CREATE;
     /**
      * For AnswerPosts, the MetisService may not always have an active conversation (e.g. when in the 'all messages' view).
      * In this case, file uploads have to rely on the parent post to determine the course.

--- a/src/main/webapp/i18n/de/conversation.json
+++ b/src/main/webapp/i18n/de/conversation.json
@@ -15,16 +15,17 @@
             "onlyYou": "Nur du",
             "archived": "Archiviert",
             "sendMessage": "Senden",
+            "saveMessage": "Speichern",
             "goToExercise": "Zur Aufgabe gehen",
             "goToLecture": "Zur Vorlesung gehen",
             "goToExam": "Zur Klausur gehen",
             "conversationMessages": {
                 "searchLabel": "Nachrichten durchsuchen",
                 "clearSearch": "Suche löschen",
-                "searchBarPlaceholder": "Suche in der aktuellen Konversation nach Nachrichten",
-                "searchResultsMultiple": "{{ count }} Nachrichten gefunden ",
-                "searchResultsSingle": "1 Nachricht gefunden",
-                "searchResultsNone": "Keine Nachrichten gefunden"
+                "searchBarPlaceholder": "Suche im aktuellen Kanal",
+                "searchResultsMultiple": "{{ count }} Ergebnisse",
+                "searchResultsSingle": "1 Ergebnis",
+                "searchResultsNone": "Keine Ergebnisse"
             },
             "threadSideBar": {
                 "label": "Thread",

--- a/src/main/webapp/i18n/en/conversation.json
+++ b/src/main/webapp/i18n/en/conversation.json
@@ -23,9 +23,9 @@
                 "searchLabel": "Search messages",
                 "clearSearch": "Clear search",
                 "searchBarPlaceholder": "Search within current channel",
-                "searchResultsMultiple": "{{ count }} Results",
-                "searchResultsSingle": "1 Result",
-                "searchResultsNone": "No Results"
+                "searchResultsMultiple": "{{ count }} results",
+                "searchResultsSingle": "1 result",
+                "searchResultsNone": "No results"
             },
             "threadSideBar": {
                 "label": "Thread",

--- a/src/main/webapp/i18n/en/conversation.json
+++ b/src/main/webapp/i18n/en/conversation.json
@@ -15,16 +15,17 @@
             "onlyYou": "Only you",
             "archived": "Archived",
             "sendMessage": "Send",
+            "saveMessage": "Save",
             "goToExercise": "Go to exercise",
             "goToLecture": "Go to lecture",
             "goToExam": "Go to exam",
             "conversationMessages": {
                 "searchLabel": "Search messages",
                 "clearSearch": "Clear search",
-                "searchBarPlaceholder": "Search for messages within the current conversation",
-                "searchResultsMultiple": "{{ count }} messages found",
-                "searchResultsSingle": "1 message found",
-                "searchResultsNone": "No messages found"
+                "searchBarPlaceholder": "Search within current channel",
+                "searchResultsMultiple": "{{ count }} Results",
+                "searchResultsSingle": "1 Result",
+                "searchResultsNone": "No Results"
             },
             "threadSideBar": {
                 "label": "Thread",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

Hint: Use the`hide whitespace` option in the diff view to better track code changes in HTML templates.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Remove unnecessary whitespace and use the full space in Communication.

### Description
<!-- Describe your changes in detail -->
The text field for writing messages is now always positioned at the bottom. The send button is now displayed inside the text field to save space. When editing messages, the "Send" button has been renamed to "Save" for better clarity. The buttons (Save + Cancel) remain located below the text field when editing a message.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student

1. Log in to Artemis
2. Navigate to Communication
3. Open a channel with no messages
4. Verify that the textfield is positioned at the bottom and the envelop is centered 
5. Check that the `Send` button is disabled when the text field is empty
6. Start typing in the text field 
7. Verify that the `Send` button is now enabled
8. Use the `Send` button to send a message
10. Hover over this message and choose `Edit content`
11. Verify that you see a `Cancel` and `Save` button below the text field 
12. Repeat steps 5-11 for a message in a thread 


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| markdown-editor-monaco.component.ts | 98.17% | ✅  |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Old: 
<img width="1279" alt="Screenshot 2025-02-18 at 12 53 03" src="https://github.com/user-attachments/assets/eac4b37b-fa1b-40a2-8f8c-a9fefc02825b" />
New: 
<img width="1230" alt="Screenshot 2025-02-18 at 13 19 23" src="https://github.com/user-attachments/assets/57dfd02e-a34b-418f-8c63-a0e9ec9db6e7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a “Save Message” option during message editing, streamlining the submission process.
  - Updated language in search fields and results for clearer channel discovery (e.g., “Search within current channel” and “Results”).

- **Style**
  - Optimized button sizes and spacing for a cleaner, more compact look.
  - Refined layout structures across conversation and editor views for improved clarity and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->