### PR TITLE
`Integrated code lifecycle`: Fix issue in result processing

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/localci/LocalCIResultProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/localci/LocalCIResultProcessingService.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.programming.service.localci;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LOCALCI;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -140,7 +141,7 @@ public class LocalCIResultProcessingService {
         }
         log.info("Processing build job result with id {}", resultQueueItem.buildJobQueueItem().id());
         log.debug("Build jobs waiting in queue: {}", resultQueue.size());
-        log.debug("Queued build jobs: {}", resultQueue.stream().map(i -> i.buildJobQueueItem().id()).toList());
+        log.debug("Queued build jobs: {}", getResultQueueBuildJobIds());
 
         BuildJobQueueItem buildJob = resultQueueItem.buildJobQueueItem();
         BuildResult buildResult = resultQueueItem.buildResult();
@@ -346,5 +347,10 @@ public class LocalCIResultProcessingService {
     private boolean isSolutionBuildOfTestOrAuxPush(BuildJobQueueItem buildJob) {
         return buildJob.repositoryInfo().repositoryType() == RepositoryType.SOLUTION
                 && (buildJob.repositoryInfo().triggeredByPushTo() == RepositoryType.TESTS || buildJob.repositoryInfo().triggeredByPushTo() == RepositoryType.AUXILIARY);
+    }
+
+    private List<String> getResultQueueBuildJobIds() {
+        List<ResultQueueItem> resultQueueList = new ArrayList<>(resultQueue);
+        return resultQueueList.stream().map(i -> i.buildJobQueueItem().id()).toList();
     }
 }

--- a/src/main/webapp/app/localci/build-queue/build-queue.component.html
+++ b/src/main/webapp/app/localci/build-queue/build-queue.component.html
@@ -488,8 +488,9 @@
                         <th class="finish-jobs-column">
                             <span jhiTranslate="artemisApp.buildQueue.buildJob.duration"></span>
                         </th>
-                        <th class="finish-jobs-column">
+                        <th jhiSortBy="buildSubmissionDate" class="finish-jobs-column">
                             <span jhiTranslate="artemisApp.buildQueue.buildJob.submissionDate"></span>
+                            <fa-icon [icon]="faSort" />
                         </th>
                         <th jhiSortBy="buildStartDate" class="finish-jobs-column">
                             <span jhiTranslate="artemisApp.buildQueue.buildJob.start"></span>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There is an issue with the result processing that would cause an exception and interrupt the flow. The exception is caused when a high number of items are added to the result queue in a short amount of time, which causes an error when casting back to the list.

This PR also includes a small UI fix in the build overview page


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Finished build jobs display updated with a new "Build Submission Date" column featuring integrated sorting capabilities. This update enhances the user interface by providing clearer tracking of build submission times, helping users manage and review their build history more effectively. The change offers a more intuitive experience and improved accessibility in monitoring build status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->