### PR TITLE
`Communication`: Fix group chat notifications with null as name

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/conversation/GroupChat.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/conversation/GroupChat.java
@@ -75,7 +75,11 @@ public class GroupChat extends Conversation {
 
     @Override
     public String getHumanReadableNameForReceiver(User sender) {
-        return getName();
+        String name = getName();
+        if (name == null || name.isBlank()) {
+            return generateName();
+        }
+        return name;
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Notifications for group chats with no explicit name set caused decode errors on the mobile applications, because the conversation name was sent as null and the mobile apps expect a non-nullable string there. See https://github.com/ls1intum/artemis-android/issues/391

### Description
<!-- Describe your changes in detail -->
In case the group name is still null when calling the `getHumanReadableNameForReceiver()` method, the generated name is returned. This method is called to populate the notificationPlaceholders that are parsed by the mobile apps.

Added tests to cover the bug.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student in the Webapp
- 1 (another) Student in the Android or iOS app

1. Mobile: Ensure notifications are enabled
2. WebApp: Create a new group chat with webapp-user and mobile-user
3. WebApp: Write a first post to the new group chat
4. Mobile: Observe that a notification is received and displayed


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Group chats now automatically display a valid, easy-to-read name when the original name is missing or blank.
  - Notifications for group chats have been improved to consistently include a proper chat name for clearer message alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->