### PR TITLE
`Communication`: Rename 'hidden' to 'archived' for conversations

### DIFF
--- a/src/main/webapp/app/overview/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/course-conversations.component.ts
@@ -3,8 +3,8 @@ import { ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, O
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
-    faBan,
     faBookmark,
+    faBoxArchive,
     faClock,
     faComment,
     faComments,
@@ -67,7 +67,7 @@ const DEFAULT_CHANNEL_GROUPS: AccordionGroups = {
     lectureChannels: { entityData: [] },
     examChannels: { entityData: [] },
     feedbackDiscussion: { entityData: [] },
-    hiddenChannels: { entityData: [] },
+    archivedChannels: { entityData: [] },
     savedPosts: { entityData: [] },
 };
 
@@ -79,7 +79,7 @@ const CHANNEL_TYPE_ICON: ChannelTypeIcons = {
     directMessages: faComment,
     favoriteChannels: faHeart,
     lectureChannels: faFile,
-    hiddenChannels: faBan,
+    archivedChannels: faBoxArchive,
     feedbackDiscussion: faPersonChalkboard,
     savedPosts: faBookmark,
     recents: faClock,
@@ -93,7 +93,7 @@ const DEFAULT_COLLAPSE_STATE: CollapseState = {
     directMessages: true,
     favoriteChannels: false,
     lectureChannels: true,
-    hiddenChannels: true,
+    archivedChannels: true,
     feedbackDiscussion: true,
     savedPosts: true,
     recents: true,
@@ -107,7 +107,7 @@ const DEFAULT_SHOW_ALWAYS: SidebarItemShowAlways = {
     directMessages: true,
     favoriteChannels: true,
     lectureChannels: false,
-    hiddenChannels: false,
+    archivedChannels: false,
     feedbackDiscussion: false,
     savedPosts: true,
     recents: true,

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.ts
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-messages/conversation-messages.component.ts
@@ -185,6 +185,9 @@ export class ConversationMessagesComponent implements OnInit, AfterViewInit, OnD
 
     private subscribeToActiveConversation() {
         this.metisConversationService.activeConversation$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((conversation: ConversationDTO) => {
+            if (this._activeConversation && getAsChannelDTO(conversation)?.isArchived !== getAsChannelDTO(this._activeConversation)?.isArchived) {
+                this._activeConversation = conversation;
+            }
             // This statement avoids a bug that reloads the messages when the conversation is already displayed
             if (conversation && this._activeConversation?.id === conversation.id) {
                 return;

--- a/src/main/webapp/app/overview/course-overview.service.ts
+++ b/src/main/webapp/app/overview/course-overview.service.ts
@@ -65,7 +65,7 @@ const DEFAULT_CHANNEL_GROUPS: AccordionGroups = {
     lectureChannels: { entityData: [] },
     examChannels: { entityData: [] },
     feedbackDiscussion: { entityData: [] },
-    hiddenChannels: { entityData: [] },
+    archivedChannels: { entityData: [] },
 };
 
 @Injectable({
@@ -174,7 +174,7 @@ export class CourseOverviewService {
         const groups: ChannelGroupCategory[] = [];
 
         if (conversation.isHidden) {
-            groups.push('hiddenChannels');
+            groups.push('archivedChannels');
             return groups;
         }
 

--- a/src/main/webapp/app/shared/sidebar/conversation-options/conversation-options.component.html
+++ b/src/main/webapp/app/shared/sidebar/conversation-options/conversation-options.component.html
@@ -26,8 +26,8 @@
                         : ('artemisApp.conversationsLayout.conversationSelectionSideBar.sideBarSection.mute' | artemisTranslate)
                 }}
             </button>
-            <button class="hide" ngbDropdownItem (click)="onHiddenClicked($event)">
-                <fa-icon [icon]="conversation.isHidden ? faEye : faEyeSlash" size="sm" class="me-1" />
+            <button class="hide" ngbDropdownItem (click)="onArchiveClicked($event)">
+                <fa-icon [icon]="conversation.isHidden ? faBoxOpen : faBoxArchive" size="sm" class="me-1" />
                 {{
                     conversation.isHidden
                         ? ('artemisApp.conversationsLayout.conversationSelectionSideBar.sideBarSection.show' | artemisTranslate)

--- a/src/main/webapp/app/shared/sidebar/conversation-options/conversation-options.component.ts
+++ b/src/main/webapp/app/shared/sidebar/conversation-options/conversation-options.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnI
 import { ConversationDTO, shouldNotifyRecipient } from 'app/entities/metis/conversation/conversation.model';
 import { ChannelDTO, getAsChannelDTO } from 'app/entities/metis/conversation/channel.model';
 import { ConversationService } from 'app/shared/metis/conversations/conversation.service';
-import { faEllipsisVertical, faEye, faEyeSlash, faGear, faHeart as faHearthSolid, faVolumeUp, faVolumeXmark } from '@fortawesome/free-solid-svg-icons';
+import { faBoxArchive, faBoxOpen, faEllipsisVertical, faGear, faHeart as faHearthSolid, faVolumeUp, faVolumeXmark } from '@fortawesome/free-solid-svg-icons';
 import { faHeart as faHeartRegular } from '@fortawesome/free-regular-svg-icons';
 import { EMPTY, Subject, debounceTime, distinctUntilChanged, from, takeUntil } from 'rxjs';
 import { catchError, mergeWith } from 'rxjs/operators';
@@ -58,8 +58,8 @@ export class ConversationOptionsComponent implements OnInit, OnDestroy {
     faEllipsisVertical = faEllipsisVertical;
     faHeartSolid = faHearthSolid;
     faHeartRegular = faHeartRegular;
-    faEye = faEye;
-    faEyeSlash = faEyeSlash;
+    faBoxArchive = faBoxArchive;
+    faBoxOpen = faBoxOpen;
     faVolumeXmark = faVolumeXmark;
     faVolumeUp = faVolumeUp;
     faGear = faGear;
@@ -79,7 +79,7 @@ export class ConversationOptionsComponent implements OnInit, OnDestroy {
         this.channelSubTypeReferenceRouterLink = this.metisService.getLinkForChannelSubType(this.conversationAsChannel);
     }
 
-    onHiddenClicked(event: MouseEvent) {
+    onArchiveClicked(event: MouseEvent) {
         event.stopPropagation();
         if (!this.course.id || !this.conversation.id) {
             return;

--- a/src/main/webapp/app/types/sidebar.ts
+++ b/src/main/webapp/app/types/sidebar.ts
@@ -25,7 +25,7 @@ export type ChannelGroupCategory =
     | 'examChannels'
     | 'feedbackDiscussion'
     | 'savedPosts'
-    | 'hiddenChannels';
+    | 'archivedChannels';
 export type CollapseState = {
     [key: string]: boolean;
 } & (Record<TimeGroupCategory, boolean> | Record<ChannelGroupCategory, boolean> | Record<ExamGroupCategory, boolean> | Record<TutorialGroupCategory, boolean>);

--- a/src/main/webapp/i18n/de/conversation.json
+++ b/src/main/webapp/i18n/de/conversation.json
@@ -36,8 +36,8 @@
             },
             "conversationSelectionSideBar": {
                 "header": "Konversationen",
-                "show": "Konversationen zeigen",
-                "hide": "Konversationen ausblenden",
+                "show": "Dearchivieren",
+                "hide": "Archivieren",
                 "notFound": "Keine Konversation gefunden",
                 "favoriteChannels": "Favoriten",
                 "hiddenChannels": "Ausgeblendet",

--- a/src/main/webapp/i18n/de/student-dashboard.json
+++ b/src/main/webapp/i18n/de/student-dashboard.json
@@ -66,7 +66,7 @@
                 "hide": "Konversationen ausblenden",
                 "notFound": "Keine Konversation gefunden",
                 "favoriteChannels": "Favoriten",
-                "hiddenChannels": "Ausgeblendet",
+                "archivedChannels": "Archiviert",
                 "savedPosts": "Gespeicherte Beiträge",
                 "progress": "In Bearbeitung",
                 "completed": "Erledigt",

--- a/src/main/webapp/i18n/en/conversation.json
+++ b/src/main/webapp/i18n/en/conversation.json
@@ -54,8 +54,8 @@
                 "sideBarSection": {
                     "shown": "shown",
                     "hidden": "hidden",
-                    "show": "Show",
-                    "hide": "Hide",
+                    "show": "Unarchive",
+                    "hide": "Archive",
                     "favorite": "Favorite",
                     "unfavorite": "Unfavorite",
                     "mute": "Mute",

--- a/src/main/webapp/i18n/en/student-dashboard.json
+++ b/src/main/webapp/i18n/en/student-dashboard.json
@@ -66,7 +66,7 @@
                 "hide": "Hide conversations",
                 "notFound": "No conversation found",
                 "favoriteChannels": "Favorites",
-                "hiddenChannels": "Hidden",
+                "archivedChannels": "Archived",
                 "savedPosts": "Saved Messages",
                 "progress": "In Progress",
                 "completed": "Completed",

--- a/src/test/javascript/spec/component/course/course-overview.service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.service.spec.ts
@@ -453,7 +453,7 @@ describe('CourseOverviewService', () => {
         expect(getAsChannelDTO(groupedConversations['generalChannels'].entityData[1].conversation)?.name).toBe('General 2');
     });
 
-    it('should group favorite and hidden conversations correctly', () => {
+    it('should group favorite and archived conversations correctly', () => {
         const conversations = [generalChannel, examChannel, exerciseChannel, generalChannel2, favoriteChannel, hiddenChannel];
 
         jest.spyOn(service, 'getCorrespondingChannelSubType');
@@ -466,7 +466,7 @@ describe('CourseOverviewService', () => {
         expect(groupedConversations['examChannels'].entityData).toHaveLength(1);
         expect(groupedConversations['exerciseChannels'].entityData).toHaveLength(1);
         expect(groupedConversations['favoriteChannels'].entityData).toHaveLength(1);
-        expect(groupedConversations['hiddenChannels'].entityData).toHaveLength(1);
+        expect(groupedConversations['archivedChannels'].entityData).toHaveLength(1);
         expect(service.mapConversationToSidebarCardElement).toHaveBeenCalledTimes(6);
         expect(service.getConversationGroup).toHaveBeenCalledTimes(6);
         expect(service.getCorrespondingChannelSubType).toHaveBeenCalledTimes(5);
@@ -476,7 +476,7 @@ describe('CourseOverviewService', () => {
         expect(getAsChannelDTO(groupedConversations['examChannels'].entityData[0].conversation)?.name).toBe('exam-test');
         expect(getAsChannelDTO(groupedConversations['exerciseChannels'].entityData[0].conversation)?.name).toBe('exercise-test');
         expect(getAsChannelDTO(groupedConversations['favoriteChannels'].entityData[0].conversation)?.name).toBe('fav-channel');
-        expect(getAsChannelDTO(groupedConversations['hiddenChannels'].entityData[0].conversation)?.name).toBe('hidden-channel');
+        expect(getAsChannelDTO(groupedConversations['archivedChannels'].entityData[0].conversation)?.name).toBe('hidden-channel');
     });
 
     it('should not remove favorite conversations from their original section but keep them at the top of the related section', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.




### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

1. If a channel is currently open and gets archived for everyone, the channel should become read-only immediately, and the input area should become invisible. Currently, the input area remains visible until a refresh, leading to error messages.  (Closes #9986)

2. As decided in the communication subgroup, the "Hide" channel feature should be renamed to "Archive" to avoid confusion:

- The "Hide" button should be renamed to "Archive".
- The "Hidden" section in the sidebar should be renamed to "Archived".
- The global archive feature should remain unchanged. When a channel is archived by a moderator from the channel settings, the channel will receive the suffix "(Archived)".




### Description
<!-- Describe your changes in detail -->

- The "Hide" button is now labeled "Archive".
- The "Hidden" section in the sidebar has been renamed to "Archived".
- The input area now correctly becomes invisible immediately when a currently open channel is archived for everyone, without requiring a page refresh.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. ...


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
