### PR TITLE
`Development`: Unify deployment workflow inputs

### DIFF
--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -15,6 +15,10 @@ on:
         type: choice
         options: 
           - artemis-staging-localci.artemis.cit.tum.de
+      triggered_by:
+        description: "Username that triggered deployment (not required, shown if triggered via GitHub UI, logged if triggered via GitHub app)"
+        required: false
+        type: string
 
 concurrency: ${{ github.event.inputs.environment_name }}
 
@@ -32,6 +36,7 @@ jobs:
           echo "Branch: ${{ github.event.inputs.branch_name }}"
           echo "Commit SHA: ${{ github.event.inputs.commit_sha }}"
           echo "Environment: ${{ github.event.inputs.environment_name }}"
+          echo "Triggered by: ${{ github.event.inputs.triggered_by }}"
 
       - name: Fetch workflow runs by branch and commit
         id: get_workflow_run

--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -7,6 +7,9 @@ on:
         description: "Which branch to deploy"
         required: true
         type: string
+      commit_sha:
+        description: 'Commit SHA to deploy'
+        required: false
       environment_name:
         description: "Which environment to deploy (e.g. artemis-test7.artemis.cit.tum.de, etc.)."
         required: true


### PR DESCRIPTION
### Description

After discussing with the @ls1intum/helios team, we decided to unify the workflow inputs used for staging/production and test server deployments via [Helios](https://helios.aet.cit.tum.de/). By providing a single, flexible set of inputs, each repository can decide which inputs they actually need.

For instance, in Artemis:

Test Server Deployments don’t require a commit SHA, because the workflow checks the latest commit of that branch for a successful build.
Staging/Production Deployments require a specific commit SHA.
These changes won’t affect current deployments since the new inputs are optional, and existing Helios parameters remain the same until future PRs use these variables. 

This PR adds optional inputs for the deployment workflow, so that all workflows can be dispatched with the same inputs.
The goal is that all workflows across all repositories will use the same inputs and this will be the only requirement for the [Helios](https://helios.aet.cit.tum.de/) setup.