### PR TITLE
`Assessment`: Fix an edge case issue in course score page with team exercises

### DIFF
--- a/src/main/webapp/app/course/course-scores/course-scores.component.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores.component.ts
@@ -482,7 +482,10 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
             participation.results?.forEach((result) => (result.participation = participation));
 
             // find all students by iterating through the participations
-            const participationStudents = participation.student ? [participation.student] : participation.team!.students!;
+            const participationStudents = participation.student ? [participation.student] : participation.team!.students;
+            if (!participationStudents) {
+                continue;
+            }
             for (const participationStudent of participationStudents) {
                 let student = studentsMap.get(participationStudent.id!);
                 if (!student) {

--- a/src/main/webapp/app/exercises/shared/team/team-update-dialog/team-update-dialog.component.ts
+++ b/src/main/webapp/app/exercises/shared/team/team-update-dialog/team-update-dialog.component.ts
@@ -123,7 +123,7 @@ export class TeamUpdateDialogComponent implements OnInit {
     }
 
     private get recommendedTeamSize(): boolean {
-        const pendingTeamSize = this.pendingTeam.students!.length;
+        const pendingTeamSize = this.pendingTeam.students?.length || 0;
         return pendingTeamSize >= this.config.minTeamSize! && pendingTeamSize <= this.config.maxTeamSize!;
     }
 
@@ -162,6 +162,9 @@ export class TeamUpdateDialogComponent implements OnInit {
      */
     onAddStudent(student: User) {
         if (!this.isStudentAlreadyInPendingTeam(student)) {
+            if (!this.pendingTeam.students) {
+                this.pendingTeam.students = [];
+            }
             this.pendingTeam.students!.push(student);
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/ls1intum/Artemis/issues/10310
Fixes the issue, where adding team members to teams without any team members does not work.
### Description
<!-- Describe your changes in detail -->
When a team has a participation, but all team members get removed from the team, this breaks the scores page.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Scores page:
1. Create a Programming team exercise
2. Add team members
3. As a student participate in the exercise and submit code
4. As the instructor, delete all the team members from the Team, but do not delete the participation
5. Navigate to the course scores page and verify the view shows correctly

Alternatively:  simply check that https://artemis-test3.artemis.cit.tum.de/course-management/51/scores works, this course and a team exercise are setup to produce the bug without the fix.

Team creation:
1. Create a Programming Team Exercise
2. Add a Team with team members
3. Delete all team members and save
4. Add team members again
5. There shouldn't be any errors in the logs for any of those steps

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2



### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| course-scores.component.ts | 94.16% | ✅ ❌ |
| team-update-dialog.component.ts | 75% | ✅ ❌ |


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before the fix:
![image](https://github.com/user-attachments/assets/2c2906a5-821b-421a-853a-f2584c52690e)
With the fix:
![image](https://github.com/user-attachments/assets/d42c9d75-3c98-4bd6-9ae0-58f54f44452b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the processing of course participation data to only display valid scores, ensuring a more robust and error-free user experience.
	- Improved error handling for team updates by ensuring the students array is initialized before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->