### PR TITLE
`Communication`: Show send button within markdown editor only in communication

### DIFF
--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
@@ -45,7 +45,7 @@
                                 <a class="col-auto mx-1" href="https://markdown-it.github.io/">
                                     <fa-icon [icon]="faQuestionCircle" [ngbTooltip]="'artemisApp.markdownEditor.guide' | artemisTranslate" />
                                 </a>
-                                @if (editType() !== EditType.UPDATE) {
+                                @if (editType() !== EditType.UPDATE && isInCommunication()) {
                                     <ng-container [ngTemplateOutlet]="sendButton" [ngTemplateOutletContext]="{ extraClass: 'ms-1 col-auto', testId: 'save' }" />
                                 }
                             </div>
@@ -74,8 +74,7 @@
                                 <div class="p-0 m-0 background-editor-high markdown-preview" [innerHTML]="defaultPreviewHtml"></div>
                             }
                         </ng-content>
-                        @if (editType() !== EditType.UPDATE) {
-                            <!-- <ng-container *ngTemplateOutlet="sendButton; context: {text: 'hallo'}" /> -->
+                        @if (editType() !== EditType.UPDATE && isInCommunication()) {
                             <ng-container [ngTemplateOutlet]="sendButton" [ngTemplateOutletContext]="{ extraClass: 'float-end' }" />
                         }
                     </div>

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.ts
@@ -244,6 +244,7 @@ export class MarkdownEditorMonacoComponent implements AfterContentInit, AfterVie
 
     isButtonLoading = input<boolean>(false);
     isFormGroupValid = input<boolean>(false);
+    isInCommunication = input<boolean>(false);
     editType = input<PostingEditType>();
 
     readonly useCommunicationForFileUpload = input<boolean>(false);

--- a/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.html
+++ b/src/main/webapp/app/shared/metis/posting-markdown-editor/posting-markdown-editor.component.html
@@ -24,6 +24,7 @@
         [isButtonLoading]="isButtonLoading()"
         [isFormGroupValid]="isFormGroupValid()"
         [editType]="editType()"
+        [isInCommunication]="true"
     >
         <ng-container id="previewMonaco">
             @if (previewMode) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The send button below the markdown editor was mistakenly displayed in other areas outside the communication module, such as in programming exercises where the markdown editor is used, too. However, in these cases, the button does not make sense for the user.

### Description
<!-- Describe your changes in detail -->
The send button is now conditionally displayed depending on whether the markdown editor is embedded within the communication module or not.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student

1. Log in to Artemis
2. Navigate to Course Management 
3. Create a new progrmming exercise 
4. Scroll to the Problem Statement
5. Verify that the Send button is not displayed
6. Go to "Communication"
7. Choose a direct message or group channel 
8. Verify that the send button is displayed 

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before: 
<img width="1184" alt="Screenshot 2025-02-28 at 14 36 35" src="https://github.com/user-attachments/assets/6e5b273f-2e86-4bf3-b457-a22facc28032" />
After: 
<img width="1190" alt="Screenshot 2025-02-28 at 14 37 01" src="https://github.com/user-attachments/assets/25410bbb-627f-4bc0-a9b9-bc975bc92cb6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Markdown editor to display the send button only when in an active communication mode.
  - Enhanced the posting interface so that the editor automatically engages this communication mode during markdown submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->