### PR TITLE
`Development`: Fix failing exam announcements playwright test 

### DIFF
--- a/src/test/playwright/e2e/exam/ExamParticipation.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamParticipation.spec.ts
@@ -396,7 +396,7 @@ test.describe('Exam participation', () => {
                     const exerciseUpdateMessage = `The problem statement of the exercise '${exercise.exerciseGroup!.title!}' was updated. Please open the exercise to see the changes.`;
                     await modalDialog.checkDialogType('Problem Statement Update');
                     await modalDialog.checkDialogMessage(exerciseUpdateMessage);
-                    await modalDialog.checkDialogAuthor(instructor.username);
+                    await modalDialog.checkDialogAuthor('system');
                     await modalDialog.pressModalButton('Navigate to exercise');
                     const examParticipationActions = new ExamParticipationActions(studentPage);
                     await examParticipationActions.checkExerciseProblemStatementDifference([


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The test expects the the author of the event to be a specific user. Due to the change in https://github.com/ls1intum/Artemis/commit/cc09e992ba3d405a5a5d824525ede9fdceb086f8, this no longer works for the problem statement changed notification, as it is triggered by the system itself, when the instructor changes the problem statement.
![image](https://github.com/user-attachments/assets/ffa3a6ab-2a80-441f-93c2-49abbc7d4a8b)


### Description
<!-- Describe your changes in detail -->
Fixes the test, by expecting the author to be 'system'.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
Run all playwright tests locally and make sure all pass, especially the one which failed: https://bamboo.ase.in.tum.de/browse/ARTEMIS-AEPTMA-DA-909/test/case/783743868


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the exam update notification so that it now displays “system” as the credited author instead of the instructor. This change provides clearer and more accurate information for exam participants during update notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->