### PR TITLE
`Development`: Refactor course sidebar into its own component

### DIFF
--- a/src/main/webapp/app/overview/course-overview.component.html
+++ b/src/main/webapp/app/overview/course-overview.component.html
@@ -23,8 +23,6 @@
                     [courses]="courses"
                     [sidebarItems]="sidebarItems"
                     [courseActionItems]="courseActionItems"
-                    [hiddenItems]="hiddenItems"
-                    [anyItemHidden]="anyItemHidden"
                     [isNavbarCollapsed]="isNavbarCollapsed"
                     [isExamStarted]="isExamStarted"
                     [isProduction]="isProduction"

--- a/src/main/webapp/app/overview/course-overview.component.html
+++ b/src/main/webapp/app/overview/course-overview.component.html
@@ -18,118 +18,25 @@
                 mode="side"
                 [hidden]="isExamStarted"
             >
-                <div class="sidebar-container d-flex h-100 justify-content-between flex-column" [ngClass]="{ collapsed: isNavbarCollapsed }">
-                    <div>
-                        <!-- Course Icon + Title -->
-                        <div id="container" class="d-flex p-3 align-items-center text-decoration-none" [title]="course?.title">
-                            <div ngbDropdown container="body" class="d-flex">
-                                @if (course) {
-                                    @if (courses?.length) {
-                                        <div ngbDropdownToggle class="pointer">
-                                            <ng-template *ngTemplateOutlet="courseImage; context: { $implicit: course.courseIcon, courseTitle: course.title }" />
-                                        </div>
-                                    } @else {
-                                        <ng-template *ngTemplateOutlet="courseImage; context: { $implicit: course.courseIcon, courseTitle: course.title }" />
-                                    }
-                                }
-
-                                <div ngbDropdownMenu class="dropdown-menu py-1 ms-n2">
-                                    @for (course of courses; track course) {
-                                        <button ngbDropdownItem (click)="switchCourse(course)" class="d-flex align-items-center py-1 px-2">
-                                            <ng-template *ngTemplateOutlet="courseImage; context: { $implicit: course.courseIcon, courseTitle: course.title }" />
-                                            <div class="h6 fw-normal mb-0 course-title text-wrap">{{ course?.title }}</div>
-                                        </button>
-                                    }
-                                </div>
-                            </div>
-                            @if (!isNavbarCollapsed) {
-                                <div id="test-course-title" class="course-title h6 mb-0 fw-bold text-body auto-collapse">{{ course?.title }}</div>
-                            }
-                        </div>
-                        <!-- NavItems -->
-                        <div>
-                            <hr class="mt-0" />
-                            <ul ngbDropdown #itemsDrop="ngbDropdown" container="body" placement="right" class="navbar-nav justify-content-end flex-grow-1 text-decoration-none">
-                                @for (sidebarItem of sidebarItems; track sidebarItem) {
-                                    <li class="nav-item" [hidden]="sidebarItem.hidden">
-                                        @if (sidebarItem.hasInOrionProperty && sidebarItem.showInOrionWindow !== undefined) {
-                                            <ng-template *ngTemplateOutlet="navItemOrionFilter; context: { $implicit: sidebarItem, iconTextTemplate: navIconAndText }" />
-                                        } @else {
-                                            <ng-template *ngTemplateOutlet="navItem; context: { $implicit: sidebarItem, iconTextTemplate: navIconAndText }" />
-                                        }
-                                    </li>
-                                }
-                                <li ngbDropdownToggle class="nav-item">
-                                    <div [hidden]="!anyItemHidden" class="three-dots nav-link px-3">
-                                        <fa-icon [fixedWidth]="true" [icon]="faEllipsis" class="ms-2 me-3" />
-                                        <span
-                                            class="more"
-                                            [ngClass]="{ 'auto-collapse': !isNavbarCollapsed, 'sidebar-collapsed-course-overview': isNavbarCollapsed }"
-                                            [jhiTranslate]="'artemisApp.courseOverview.menu.more'"
-                                        ></span>
-                                    </div>
-                                </li>
-                                <div ngbDropdownMenu class="dropdown-content" [ngClass]="{ fixedContentSize: hiddenItems.length >= 4 }">
-                                    @for (hiddenItem of hiddenItems; track hiddenItem) {
-                                        <li class="nav-item">
-                                            @if (hiddenItem.hasInOrionProperty && hiddenItem.showInOrionWindow !== undefined) {
-                                                <ng-template *ngTemplateOutlet="navItemOrionFilter; context: { $implicit: hiddenItem, iconTextTemplate: navIconAndTextHidden }" />
-                                            } @else {
-                                                <ng-template *ngTemplateOutlet="navItem; context: { $implicit: hiddenItem, iconTextTemplate: navIconAndTextHidden }" />
-                                            }
-                                        </li>
-                                    }
-                                    @if (courseActionItems?.length && anyItemHidden) {
-                                        @for (courseActionItem of courseActionItems; track courseActionItem) {
-                                            <li class="nav-item">
-                                                <a
-                                                    class="nav-link nav-link-sidebar px-3 py-2"
-                                                    [ngClass]="{ collapsed: isNavbarCollapsed }"
-                                                    (click)="courseActionItemClick(courseActionItem)"
-                                                    [title]="courseActionItem.title"
-                                                >
-                                                    <ng-template *ngTemplateOutlet="navIconAndTextHidden; context: { $implicit: courseActionItem }" />
-                                                </a>
-                                            </li>
-                                        }
-                                    }
-                                </div>
-                            </ul>
-                        </div>
-                    </div>
-                    <!-- Course Action Items  -->
-                    <div>
-                        @if (courseActionItems?.length && !anyItemHidden) {
-                            <div ngbDropdown placement="top" class="navbar-nav mb-2">
-                                <li class="nav-item">
-                                    @for (courseActionItem of courseActionItems; track courseActionItem) {
-                                        <a
-                                            class="nav-link nav-link-sidebar px-3"
-                                            [ngClass]="{ collapsed: isNavbarCollapsed }"
-                                            (click)="courseActionItemClick(courseActionItem)"
-                                            [title]="courseActionItem.title"
-                                        >
-                                            <ng-template *ngTemplateOutlet="navIconAndText; context: { $implicit: courseActionItem }" />
-                                        </a>
-                                    }
-                                </li>
-                            </div>
-                        }
-                        <!-- Collapse Chevron -->
-                        <div
-                            class="double-arrow mb-2"
-                            [ngClass]="{ 'menu-closed': isNavbarCollapsed }"
-                            [ngbTooltip]="(isNavbarCollapsed ? 'Expand' : 'Collapse') + ' Menu (Ctrl + M)'"
-                            (click)="toggleCollapseState()"
-                        >
-                            <div class="double-arrow-icon" [attr.aria-expanded]="!isNavbarCollapsed" aria-controls="collapseBasic">
-                                <fa-icon class="me-negative fa-xs" [icon]="faChevronRight" />
-                                <fa-icon class="fa-xs" [icon]="faChevronRight" />
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                <jhi-course-sidebar
+                    [course]="course"
+                    [courses]="courses"
+                    [sidebarItems]="sidebarItems"
+                    [courseActionItems]="courseActionItems"
+                    [hiddenItems]="hiddenItems"
+                    [anyItemHidden]="anyItemHidden"
+                    [isNavbarCollapsed]="isNavbarCollapsed"
+                    [isExamStarted]="isExamStarted"
+                    [isProduction]="isProduction"
+                    [isTestServer]="isTestServer"
+                    [hasUnreadMessages]="hasUnreadMessages"
+                    [communicationRouteLoaded]="communicationRouteLoaded"
+                    (switchCourse)="switchCourse($event)"
+                    (courseActionItemClick)="courseActionItemClick($event)"
+                    (toggleCollapseState)="toggleCollapseState()"
+                />
             </mat-sidenav>
+
             <mat-sidenav-content
                 [ngClass]="{
                     'exam-wrapper': isExamStarted,
@@ -223,72 +130,4 @@
     <div class="refresh-overlay" [class.active]="refreshingCourse">
         <fa-icon size="lg" [icon]="faCircleNotch" animation="spin" />
     </div>
-</ng-template>
-
-<ng-template #courseImage let-courseImage let-courseTitle="courseTitle">
-    @if (courseImage) {
-        <div class="d-flex align-items-center justify-content-center">
-            <jhi-secured-image [src]="courseImage" />
-        </div>
-    } @else {
-        <div class="course-circle d-flex align-items-center justify-content-center">
-            <span class="fs-4">{{ courseTitle | slice: 0 : 1 }}</span>
-        </div>
-    }
-</ng-template>
-
-<ng-template #navIconAndText let-sidebarItem>
-    @if (sidebarItem.icon) {
-        <fa-icon [fixedWidth]="true" [icon]="sidebarItem.icon" class="ms-2 me-3" />
-    }
-    @if (!isNavbarCollapsed) {
-        <span class="auto-collapse" [jhiTranslate]="sidebarItem.translation"></span>
-    }
-</ng-template>
-
-<ng-template #navIconAndTextHidden let-sidebarItem>
-    @if (sidebarItem.icon) {
-        <fa-icon [fixedWidth]="true" [icon]="sidebarItem.icon" class="ms-2 me-3" />
-        <span [jhiTranslate]="sidebarItem.translation"></span>
-    }
-</ng-template>
-
-<ng-template #navItemOrionFilter let-sidebarItem let-iconTextTemplate="iconTextTemplate">
-    <a
-        class="nav-link nav-link-sidebar px-3 py-2"
-        [id]="sidebarItem.testId ?? ''"
-        [ngClass]="{
-            'guided-tour': sidebarItem.guidedTour,
-            newMessage: hasUnreadMessages && sidebarItem.title === 'Communication',
-            collapsed: isNavbarCollapsed,
-        }"
-        jhiOrionFilter
-        [showInOrionWindow]="sidebarItem.showInOrionWindow"
-        [routerLink]="sidebarItem.routerLink"
-        routerLinkActive="active"
-        [jhiFeatureToggleHide]="sidebarItem.featureToggle"
-        [title]="sidebarItem.title"
-        (click)="itemsDrop?.close()"
-    >
-        <ng-template *ngTemplateOutlet="iconTextTemplate; context: { $implicit: sidebarItem }" />
-    </a>
-</ng-template>
-
-<ng-template #navItem let-sidebarItem let-iconTextTemplate="iconTextTemplate">
-    <a
-        class="nav-link nav-link-sidebar px-3 py-2"
-        [id]="sidebarItem.testId ?? ''"
-        [ngClass]="{
-            'guided-tour': sidebarItem.guidedTour,
-            newMessage: !communicationRouteLoaded && hasUnreadMessages && sidebarItem.title === 'Communication',
-            collapsed: isNavbarCollapsed,
-        }"
-        [routerLink]="sidebarItem.routerLink"
-        routerLinkActive="active"
-        [jhiFeatureToggleHide]="sidebarItem.featureToggle"
-        [title]="sidebarItem.title"
-        (click)="itemsDrop?.close()"
-    >
-        <ng-template *ngTemplateOutlet="iconTextTemplate; context: { $implicit: sidebarItem }" />
-    </a>
 </ng-template>

--- a/src/main/webapp/app/overview/course-overview.component.scss
+++ b/src/main/webapp/app/overview/course-overview.component.scss
@@ -13,12 +13,267 @@ $transition-chevron-rotate-length: 0.2s;
 $transition-chevron-max-width-length: 0.2s;
 $transition-color-length: 0.2s;
 
-.sidebar-container {
-    width: $menu-width-open;
-    &.collapsed {
-        width: $menu-width-closed !important;
+// ng-deep needed to remove scrollbar from mat-sidebar
+::ng-deep .mat-drawer-inner-container {
+    overflow: hidden !important;
+}
+
+.sidebar-wrapper {
+    overflow-x: hidden;
+    position: sticky;
+    width: 100vw;
+    margin: -1rem -1rem;
+}
+
+.mat-drawer-side {
+    border: none;
+}
+
+.mat-drawer-container {
+    height: calc(100vh - var(--sidebar-footer-height-prod) - var(--spacing-modules));
+
+    &.sidenav-height-dev {
+        height: calc(100vh - var(--sidebar-footer-height-dev) - var(--spacing-modules));
+    }
+
+    @media (max-width: 768px) {
+        height: calc(100vh - var(--sidebar-footer-height-prod) - var(--spacing-modules)) !important;
+        height: calc(100dvh - var(--sidebar-footer-height-prod) - var(--spacing-modules)) !important;
+    }
+
+    &.exam-wrapper {
+        height: 100vh !important;
+    }
+
+    .mat-drawer {
+        box-sizing: content-box;
+        width: $menu-width-open;
+        transition: width 0.2s ease-in-out !important;
+        height: calc(100vh - var(--sidebar-footer-height-prod) - var(--spacing-modules));
+
+        &.sidenav-height-dev {
+            height: calc(100vh - var(--sidebar-footer-height-dev) - var(--spacing-modules));
+        }
+
+        @media (max-width: 768px) {
+            height: calc(100vh - var(--sidebar-footer-height-prod) - var(--spacing-modules)) !important;
+        }
+    }
+
+    .mat-drawer-content {
+        position: sticky;
+        z-index: 1;
+        display: block;
+        height: calc(100vh - var(--sidebar-footer-height-prod));
+        width: calc(100vw - $menu-width-open);
+        overflow: hidden;
+        margin-left: $menu-width-open !important;
+        transition:
+            width 0.2s ease-in-out,
+            margin-left 0.2s ease-in-out !important;
+
+        &.exam-wrapper {
+            height: 100vh !important;
+        }
+
+        &.sidenav-height-dev {
+            height: calc(100vh - var(--sidebar-footer-height-dev));
+        }
+
+        @media (max-width: 768px) {
+            height: calc(100vh - var(--sidebar-footer-height-prod)) !important;
+            height: calc(100dvh - var(--sidebar-footer-height-prod)) !important;
+        }
+    }
+
+    &.container-closed {
+        .mat-drawer {
+            width: $menu-width-closed;
+        }
+
+        .mat-drawer-content {
+            width: calc(100vw - $menu-width-closed);
+            margin-left: $menu-width-closed !important;
+        }
+    }
+
+    &.exam-is-active {
+        .mat-drawer-content {
+            width: 100vw;
+            margin-left: 0px !important;
+        }
+    }
+
+    @media screen and (max-width: 960px) {
+        .mat-drawer {
+            width: $menu-width-closed;
+        }
+
+        .mat-drawer-content {
+            width: calc(100vw - $menu-width-closed);
+            margin-left: $menu-width-closed !important;
+        }
     }
 }
+
+a:not(.btn):not(.tab-link):hover {
+    text-decoration: none !important;
+}
+
+.refresh-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+
+    opacity: 0;
+    pointer-events: none;
+    transition: 0.1s ease-out opacity;
+
+    &.active {
+        background-color: var(--overview-refresh-overlay-bg-color);
+        opacity: 1;
+        pointer-events: auto;
+        transition: 0.2s ease-in opacity;
+    }
+
+    .ng-fa-icon {
+        position: relative;
+        top: calc(50vh - 150px - 2.5vh);
+        transform: translateY(-50%);
+        color: var(--overview-refresh-overlay-color);
+    }
+}
+
+.module-bg {
+    background-color: var(--module-bg);
+}
+
+.btn-sidebar-collapse {
+    position: relative;
+    overflow: hidden;
+    display: inline-flex;
+    align-items: center;
+    justify-content: start;
+    background-color: transparent;
+    &:hover {
+        color: var(--primary);
+    }
+    &:focus {
+        border-color: transparent;
+    }
+
+    transition: border-color $transition-color-length $transition-delay + $transition-chevron-rotate-length * 2 ease-in-out;
+}
+
+.btn-sidebar-collapse::after,
+.btn-sidebar-collapse::before {
+    content: '';
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -2;
+    position: absolute;
+
+    transition: background-color $transition-color-length ease-in-out;
+}
+
+.btn-sidebar-collapse::after {
+    background-color: var(--link-item-bg);
+}
+
+.btn-sidebar-collapse::before {
+    opacity: 0;
+    z-index: -1;
+    background-color: var(--module-bg);
+
+    transition: opacity $transition-color-length $transition-delay + $transition-chevron-rotate-length * 2 ease-in-out;
+}
+
+.btn-sidebar-collapse:hover::after {
+    background-color: var(--sidebar-card-selected-bg);
+}
+
+.btn-sidebar-collapse:hover::before {
+    background-color: var(--link-item-bg);
+}
+
+.btn-sidebar-collapse:active::after {
+    background-color: var(--link-item-bg);
+}
+
+.btn-sidebar-collapse:active::before {
+    background-color: var(--sidebar-card-selected-bg);
+}
+
+.btn-sidebar-collapse.is-collapsed {
+    border-color: var(--bs-secondary);
+}
+
+.is-collapsed.btn-sidebar-collapse::before {
+    opacity: 1;
+}
+
+.btn-sidebar-collapse-chevron-start {
+    margin-right: -0.7rem;
+}
+
+.btn-sidebar-collapse-chevron {
+    transform: rotateZ(-180deg);
+    display: inline-block;
+    overflow: hidden;
+    margin-left: 0.3rem;
+
+    transition: transform $transition-chevron-rotate-length $transition-delay ease-in-out;
+}
+
+.is-collapsed .btn-sidebar-collapse-chevron {
+    transform: rotateZ(0deg);
+    transition: transform $transition-chevron-rotate-length $transition-delay ease-in-out;
+}
+
+@media print {
+    .mat-drawer {
+        display: none !important; /* Hide the sidebar */
+    }
+
+    .mat-drawer-container,
+    .mat-drawer-container.container-closed {
+        .mat-drawer-content {
+            margin-left: 0 !important; /* Remove any left margin or padding if necessary */
+            width: 100% !important; /* Make the content full width */
+        }
+    }
+}
+
+@include media-breakpoint-down(sm) {
+    .is-communication-module .btn-sidebar-collapse-chevron {
+        transform: rotateZ(0deg);
+    }
+
+    .is-collapsed.is-communication-module .btn-sidebar-collapse-chevron {
+        transform: rotateZ(-180deg);
+    }
+}
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/mixins';
+
+$menu-width-closed: 64px;
+$menu-width-open: 220px;
+$breadcrumb-height: 45px; // needed to make the exam fullscreen
+
+// Sidebar Button Transition Variables
+$transition-delay: 0.3s;
+$transition-in-between-delay: 0.2s;
+$transition-chevron-rotate-length: 0.2s;
+$transition-chevron-max-width-length: 0.2s;
+$transition-color-length: 0.2s;
 
 // ng-deep needed to remove scrollbar from mat-sidebar
 ::ng-deep .mat-drawer-inner-container {
@@ -127,18 +382,6 @@ a:not(.btn):not(.tab-link):hover {
     text-decoration: none !important;
 }
 
-.nav-link {
-    white-space: nowrap;
-    color: var(--bs-body-color);
-}
-
-.nav-link-sidebar:hover,
-.nav-link-sidebar.active {
-    width: 100%;
-    background-color: var(--link-item-bg);
-    color: var(--link-item-color);
-}
-
 .refresh-overlay {
     position: absolute;
     top: 0;
@@ -168,100 +411,8 @@ a:not(.btn):not(.tab-link):hover {
     }
 }
 
-// Displays a red circle at the top right corner of the tab item.
-// Used to indicate that there are new messages.
-%message-block {
-    position: relative;
-    content: '';
-    border-radius: 50%;
-    background-color: var(--bs-danger);
-    padding-left: 0.7rem;
-    top: -5px;
-    right: 0;
-    transform: translate(50%, -50%);
-    font-size: xx-small;
-}
-
-.newMessage:after,
-.dropdown-content > .nav-item > .newMessage:after {
-    @extend %message-block;
-    margin-left: 0.25rem;
-}
-
-.collapsed.newMessage:after {
-    @extend %message-block;
-    margin-left: -0.9rem;
-}
-
-jhi-secured-image {
-    ::ng-deep img {
-        border-radius: 50%;
-        height: 36px;
-        width: auto;
-    }
-}
-
-.double-arrow.menu-closed {
-    transform: translate(16px);
-}
-
-.double-arrow {
-    transform: translate(180px);
-    transition: transform ease 0.3s;
-    cursor: pointer;
-    width: 30px;
-    align-items: center;
-    justify-content: center;
-    display: flex;
-}
-
-.menu-closed .double-arrow-icon {
-    transform: rotate(0deg);
-}
-
-.double-arrow-icon {
-    transform: rotate(180deg);
-
-    transition: transform ease 0.3s 0.3s;
-}
-
-.me-negative {
-    margin-right: -5px;
-}
-
 .module-bg {
     background-color: var(--module-bg);
-}
-
-.course-circle {
-    height: 36px;
-    min-width: 36px;
-    background-color: var(--course-image-bg);
-    border-radius: 50%;
-    display: inline-block;
-    color: var(--bs-body-color);
-}
-
-.course-title {
-    margin-left: 0.75rem;
-}
-
-.max-width-collapsed {
-    max-width: 44px !important;
-    min-width: 44px !important;
-}
-
-@media screen and (max-width: 960px) {
-    .sidebar-container {
-        width: $menu-width-closed !important;
-    }
-    .auto-collapse {
-        display: none;
-    }
-    .newMessage:after {
-        @extend %message-block;
-        margin-left: -0.9rem;
-    }
 }
 
 .btn-sidebar-collapse {
@@ -346,43 +497,6 @@ jhi-secured-image {
 .is-collapsed .btn-sidebar-collapse-chevron {
     transform: rotateZ(0deg);
     transition: transform $transition-chevron-rotate-length $transition-delay ease-in-out;
-}
-
-.three-dots {
-    cursor: pointer;
-    &:hover {
-        color: var(--link-item-color);
-    }
-}
-
-.dropdown-li {
-    display: block;
-    text-decoration: none;
-}
-
-.dropdown-content {
-    overflow-y: auto;
-    position: absolute;
-    background-color: var(--dropdown-bg);
-    border: 1px solid var(--border-color);
-    z-index: 3000;
-    border-radius: 4px;
-    &.fixedContentSize {
-        max-height: 171px; // To avoid cut offs in the dropdown menu content (4 items)
-    }
-}
-
-.dropdown-menu {
-    min-width: 204px;
-    max-width: 294px;
-}
-
-.dropdown-courses.active {
-    display: block;
-}
-
-.dropdown-toggle::after {
-    display: none;
 }
 
 @media print {

--- a/src/main/webapp/app/overview/course-overview.component.ts
+++ b/src/main/webapp/app/overview/course-overview.component.ts
@@ -73,7 +73,6 @@ import { CourseSidebarService } from 'app/overview/course-sidebar.service';
 import { PROFILE_ATLAS } from 'app/app.constants';
 import { TranslateDirective } from '../shared/language/translate.directive';
 
-// Component imports
 import { CourseExercisesComponent } from './course-exercises/course-exercises.component';
 import { CourseLecturesComponent } from './course-lectures/course-lectures.component';
 import { CourseExamsComponent } from './course-exams/course-exams.component';
@@ -162,11 +161,9 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
     isShownViaLti = false;
     private ltiSubscription: Subscription;
 
-    // Properties to track hidden items for dropdown menu
-    anyItemHidden = false;
-    hiddenItems: SidebarItem[] = [];
-    readonly WINDOW_OFFSET: number = 300;
-    readonly ITEM_HEIGHT: number = 38;
+    // Properties to track hidden items for dropdown menu - moved to sidebar component
+    anyItemHidden = false; // kept for backwards compatibility but no longer used
+    hiddenItems: SidebarItem[] = []; // kept for backwards compatibility but no longer used
 
     private conversationServiceInstantiated = false;
     private checkedForUnreadMessages = false;
@@ -228,6 +225,7 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
         this.toggleSidebarEventSubscription = this.courseSidebarService.toggleSidebar$.subscribe(() => {
             this.isSidebarCollapsed = this.activatedComponentReference?.isCollapsed ?? !this.isSidebarCollapsed;
         });
+
         this.subscription = this.route.params.subscribe((params: { courseId: string }) => {
             this.courseId = Number(params.courseId);
         });
@@ -264,45 +262,11 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
         await this.initAfterCourseLoad();
         this.sidebarItems = this.getSidebarItems();
         this.courseActionItems = this.getCourseActionItems();
-        this.updateVisibleNavbarItems(window.innerHeight);
         await this.updateRecentlyAccessedCourses();
         this.isSidebarCollapsed = this.activatedComponentReference?.isCollapsed ?? false;
         this.ltiSubscription = this.ltiService.isShownViaLti$.subscribe((isShownViaLti: boolean) => {
             this.isShownViaLti = isShownViaLti;
         });
-    }
-
-    /** Listen window resize event by height */
-    @HostListener('window: resize', ['$event'])
-    onResize() {
-        this.updateVisibleNavbarItems(window.innerHeight);
-    }
-
-    /** Update sidebar item's hidden property based on the window height to display three-dots */
-    updateVisibleNavbarItems(height: number) {
-        const threshold = this.calculateThreshold();
-        this.applyThreshold(threshold, height);
-    }
-
-    /**  Applies the visibility threshold to sidebar items, determining which items should be hidden.*/
-    private applyThreshold(threshold: number, height: number) {
-        this.anyItemHidden = false;
-        this.hiddenItems = [];
-        // Reverse the sidebar items to remove items starting from the bottom
-        const reversedSidebarItems = [...this.sidebarItems].reverse();
-        reversedSidebarItems.forEach((item, index) => {
-            const currentThreshold = threshold - index * this.ITEM_HEIGHT;
-            item.hidden = height <= currentThreshold;
-            if (item.hidden) {
-                this.anyItemHidden = true;
-                this.hiddenItems.unshift(item);
-            }
-        });
-    }
-
-    /** Calculate threshold levels based on the number of entries in the sidebar */
-    calculateThreshold(): number {
-        return this.sidebarItems.length * this.ITEM_HEIGHT + this.WINDOW_OFFSET;
     }
 
     /** initialize courses attribute by retrieving all courses from the server */

--- a/src/main/webapp/app/overview/course-overview.component.ts
+++ b/src/main/webapp/app/overview/course-overview.component.ts
@@ -18,14 +18,11 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { Observable, Subject, Subscription, firstValueFrom, of, throwError } from 'rxjs';
 import { catchError, map, takeUntil } from 'rxjs/operators';
 import dayjs from 'dayjs/esm';
-
-// Angular Material and Bootstrap imports
 import { NgClass, NgStyle, NgTemplateOutlet } from '@angular/common';
 import { MatSidenav, MatSidenavContainer, MatSidenavContent } from '@angular/material/sidenav';
 import { NgbModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
-// Icon imports
 import {
     faChalkboardUser,
     faChartBar,
@@ -51,7 +48,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { facSidebar } from 'app/icons/icons';
 
-// Service imports
 import { WebsocketService } from 'app/core/websocket/websocket.service';
 import { CourseAccessStorageService } from 'app/course/course-access-storage.service';
 import { CourseStorageService } from 'app/course/manage/course-storage.service';
@@ -82,7 +78,6 @@ import { CourseUnenrollmentModalComponent } from './course-unenrollment-modal.co
 import { sortCourses } from 'app/shared/util/course.util';
 import { ExamParticipationService } from 'app/exam/participate/exam-participation.service';
 
-// Sidebar component imports
 import { CourseActionItem, CourseSidebarComponent, SidebarItem } from './course-sidebar/course-sidebar.component';
 
 @Component({
@@ -160,10 +155,6 @@ export class CourseOverviewComponent implements OnInit, OnDestroy, AfterViewInit
     readonly MIN_DISPLAYED_COURSES: number = 6;
     isShownViaLti = false;
     private ltiSubscription: Subscription;
-
-    // Properties to track hidden items for dropdown menu - moved to sidebar component
-    anyItemHidden = false; // kept for backwards compatibility but no longer used
-    hiddenItems: SidebarItem[] = []; // kept for backwards compatibility but no longer used
 
     private conversationServiceInstantiated = false;
     private checkedForUnreadMessages = false;

--- a/src/main/webapp/app/overview/course-sidebar/course-sidebar.component.html
+++ b/src/main/webapp/app/overview/course-sidebar/course-sidebar.component.html
@@ -1,0 +1,181 @@
+<!-- Sidebar Component Template -->
+<div class="sidebar-container d-flex h-100 justify-content-between flex-column" [ngClass]="{ collapsed: isNavbarCollapsed }">
+    <div>
+        <!-- Course Icon + Title -->
+        <div id="container" class="d-flex p-3 align-items-center text-decoration-none" [title]="course?.title">
+            <div ngbDropdown container="body" class="d-flex">
+                @if (course) {
+                    @if (courses?.length) {
+                        <div ngbDropdownToggle class="pointer">
+                            <ng-template *ngTemplateOutlet="courseImage; context: { $implicit: course.courseIcon, courseTitle: course.title }" />
+                        </div>
+                    } @else {
+                        <ng-template *ngTemplateOutlet="courseImage; context: { $implicit: course.courseIcon, courseTitle: course.title }" />
+                    }
+                }
+
+                <div ngbDropdownMenu class="dropdown-menu py-1 ms-n2">
+                    @for (course of courses; track course) {
+                        <button ngbDropdownItem (click)="switchCourse.emit(course)" class="d-flex align-items-center py-1 px-2">
+                            <ng-template *ngTemplateOutlet="courseImage; context: { $implicit: course.courseIcon, courseTitle: course.title }" />
+                            <div class="h6 fw-normal mb-0 course-title text-wrap">{{ course?.title }}</div>
+                        </button>
+                    }
+                </div>
+            </div>
+            @if (!isNavbarCollapsed) {
+                <div id="test-course-title" class="course-title h6 mb-0 fw-bold text-body auto-collapse">{{ course?.title }}</div>
+            }
+        </div>
+        <!-- NavItems -->
+        <div>
+            <hr class="mt-0" />
+            <ul ngbDropdown #itemsDrop="ngbDropdown" container="body" placement="right" class="navbar-nav justify-content-end flex-grow-1 text-decoration-none">
+                @for (sidebarItem of sidebarItems; track sidebarItem) {
+                    <li class="nav-item" [hidden]="sidebarItem.hidden">
+                        @if (sidebarItem.hasInOrionProperty && sidebarItem.showInOrionWindow !== undefined) {
+                            <ng-template *ngTemplateOutlet="navItemOrionFilter; context: { $implicit: sidebarItem, iconTextTemplate: navIconAndText }" />
+                        } @else {
+                            <ng-template *ngTemplateOutlet="navItem; context: { $implicit: sidebarItem, iconTextTemplate: navIconAndText }" />
+                        }
+                    </li>
+                }
+                <li ngbDropdownToggle class="nav-item">
+                    <div [hidden]="!anyItemHidden" class="three-dots nav-link px-3">
+                        <fa-icon [fixedWidth]="true" [icon]="faEllipsis" class="ms-2 me-3" />
+                        <span
+                            class="more"
+                            [ngClass]="{ 'auto-collapse': !isNavbarCollapsed, 'sidebar-collapsed-course-overview': isNavbarCollapsed }"
+                            [jhiTranslate]="'artemisApp.courseOverview.menu.more'"
+                        ></span>
+                    </div>
+                </li>
+                <div ngbDropdownMenu class="dropdown-content" [ngClass]="{ fixedContentSize: hiddenItems.length >= 4 }">
+                    @for (hiddenItem of hiddenItems; track hiddenItem) {
+                        <li class="nav-item">
+                            @if (hiddenItem.hasInOrionProperty && hiddenItem.showInOrionWindow !== undefined) {
+                                <ng-template *ngTemplateOutlet="navItemOrionFilter; context: { $implicit: hiddenItem, iconTextTemplate: navIconAndTextHidden }" />
+                            } @else {
+                                <ng-template *ngTemplateOutlet="navItem; context: { $implicit: hiddenItem, iconTextTemplate: navIconAndTextHidden }" />
+                            }
+                        </li>
+                    }
+                    @if (courseActionItems?.length && anyItemHidden) {
+                        @for (courseActionItem of courseActionItems; track courseActionItem) {
+                            <li class="nav-item">
+                                <a
+                                    class="nav-link nav-link-sidebar px-3 py-2"
+                                    [ngClass]="{ collapsed: isNavbarCollapsed }"
+                                    (click)="courseActionItemClick.emit(courseActionItem)"
+                                    [title]="courseActionItem.title"
+                                >
+                                    <ng-template *ngTemplateOutlet="navIconAndTextHidden; context: { $implicit: courseActionItem }" />
+                                </a>
+                            </li>
+                        }
+                    }
+                </div>
+            </ul>
+        </div>
+    </div>
+    <!-- Course Action Items  -->
+    <div>
+        @if (courseActionItems?.length && !anyItemHidden) {
+            <div ngbDropdown placement="top" class="navbar-nav mb-2">
+                <li class="nav-item">
+                    @for (courseActionItem of courseActionItems; track courseActionItem) {
+                        <a
+                            class="nav-link nav-link-sidebar px-3"
+                            [ngClass]="{ collapsed: isNavbarCollapsed }"
+                            (click)="courseActionItemClick.emit(courseActionItem)"
+                            [title]="courseActionItem.title"
+                        >
+                            <ng-template *ngTemplateOutlet="navIconAndText; context: { $implicit: courseActionItem }" />
+                        </a>
+                    }
+                </li>
+            </div>
+        }
+        <!-- Collapse Chevron -->
+        <div
+            class="double-arrow mb-2"
+            [ngClass]="{ 'menu-closed': isNavbarCollapsed }"
+            [ngbTooltip]="(isNavbarCollapsed ? 'Expand' : 'Collapse') + ' Menu (Ctrl + M)'"
+            (click)="toggleCollapseState.emit()"
+        >
+            <div class="double-arrow-icon" [attr.aria-expanded]="!isNavbarCollapsed" aria-controls="collapseBasic">
+                <fa-icon class="me-negative fa-xs" [icon]="faChevronRight" />
+                <fa-icon class="fa-xs" [icon]="faChevronRight" />
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- TEMPLATES -->
+<ng-template #courseImage let-courseImage let-courseTitle="courseTitle">
+    @if (courseImage) {
+        <div class="d-flex align-items-center justify-content-center">
+            <jhi-secured-image [src]="courseImage" />
+        </div>
+    } @else {
+        <div class="course-circle d-flex align-items-center justify-content-center">
+            <span class="fs-4">{{ courseTitle | slice: 0 : 1 }}</span>
+        </div>
+    }
+</ng-template>
+
+<ng-template #navIconAndText let-sidebarItem>
+    @if (sidebarItem.icon) {
+        <fa-icon [fixedWidth]="true" [icon]="sidebarItem.icon" class="ms-2 me-3" />
+    }
+    @if (!isNavbarCollapsed) {
+        <span class="auto-collapse" [jhiTranslate]="sidebarItem.translation"></span>
+    }
+</ng-template>
+
+<ng-template #navIconAndTextHidden let-sidebarItem>
+    @if (sidebarItem.icon) {
+        <fa-icon [fixedWidth]="true" [icon]="sidebarItem.icon" class="ms-2 me-3" />
+        <span [jhiTranslate]="sidebarItem.translation"></span>
+    }
+</ng-template>
+
+<ng-template #navItemOrionFilter let-sidebarItem let-iconTextTemplate="iconTextTemplate">
+    <a
+        class="nav-link nav-link-sidebar px-3 py-2"
+        [id]="sidebarItem.testId ?? ''"
+        [ngClass]="{
+            'guided-tour': sidebarItem.guidedTour,
+            newMessage: hasUnreadMessages && sidebarItem.title === 'Communication',
+            collapsed: isNavbarCollapsed,
+        }"
+        jhiOrionFilter
+        [showInOrionWindow]="sidebarItem.showInOrionWindow"
+        [routerLink]="sidebarItem.routerLink"
+        routerLinkActive="active"
+        [jhiFeatureToggleHide]="sidebarItem.featureToggle"
+        [title]="sidebarItem.title"
+        (click)="itemsDrop?.close()"
+    >
+        <ng-template *ngTemplateOutlet="iconTextTemplate; context: { $implicit: sidebarItem }" />
+    </a>
+</ng-template>
+
+<ng-template #navItem let-sidebarItem let-iconTextTemplate="iconTextTemplate">
+    <a
+        class="nav-link nav-link-sidebar px-3 py-2"
+        [id]="sidebarItem.testId ?? ''"
+        [ngClass]="{
+            'guided-tour': sidebarItem.guidedTour,
+            newMessage: !communicationRouteLoaded && hasUnreadMessages && sidebarItem.title === 'Communication',
+            collapsed: isNavbarCollapsed,
+        }"
+        [routerLink]="sidebarItem.routerLink"
+        routerLinkActive="active"
+        [jhiFeatureToggleHide]="sidebarItem.featureToggle"
+        [title]="sidebarItem.title"
+        (click)="itemsDrop?.close()"
+    >
+        <ng-template *ngTemplateOutlet="iconTextTemplate; context: { $implicit: sidebarItem }" />
+    </a>
+</ng-template>

--- a/src/main/webapp/app/overview/course-sidebar/course-sidebar.component.html
+++ b/src/main/webapp/app/overview/course-sidebar/course-sidebar.component.html
@@ -83,8 +83,9 @@
         @if (courseActionItems?.length && !anyItemHidden) {
             <div ngbDropdown placement="top" class="navbar-nav mb-2">
                 <li class="nav-item">
-                    @for (courseActionItem of courseActionItems; track courseActionItem) {
+                    @for (courseActionItem of courseActionItems; track courseActionItem; let i = $index) {
                         <a
+                            [id]="'action-item-' + i"
                             class="nav-link nav-link-sidebar px-3"
                             [ngClass]="{ collapsed: isNavbarCollapsed }"
                             (click)="courseActionItemClick.emit(courseActionItem)"

--- a/src/main/webapp/app/overview/course-sidebar/course-sidebar.component.scss
+++ b/src/main/webapp/app/overview/course-sidebar/course-sidebar.component.scss
@@ -1,0 +1,167 @@
+// Import common variables to ensure consistent styling
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/mixins';
+
+$menu-width-closed: 64px;
+$menu-width-open: 220px;
+
+// Sidebar Button Transition Variables
+$transition-delay: 0.3s;
+$transition-in-between-delay: 0.2s;
+$transition-chevron-rotate-length: 0.2s;
+$transition-chevron-max-width-length: 0.2s;
+$transition-color-length: 0.2s;
+
+.sidebar-container {
+    width: $menu-width-open;
+    &.collapsed {
+        width: $menu-width-closed !important;
+    }
+}
+
+// Displays a red circle at the top right corner of the tab item.
+// Used to indicate that there are new messages.
+%message-block {
+    position: relative;
+    content: '';
+    border-radius: 50%;
+    background-color: var(--bs-danger);
+    padding-left: 0.7rem;
+    top: -5px;
+    right: 0;
+    transform: translate(50%, -50%);
+    font-size: xx-small;
+}
+
+.newMessage:after,
+.dropdown-content > .nav-item > .newMessage:after {
+    @extend %message-block;
+    margin-left: 0.25rem;
+}
+
+.collapsed.newMessage:after {
+    @extend %message-block;
+    margin-left: -0.9rem;
+}
+
+jhi-secured-image {
+    ::ng-deep img {
+        border-radius: 50%;
+        height: 36px;
+        width: auto;
+    }
+}
+
+.double-arrow.menu-closed {
+    transform: translate(16px);
+}
+
+.double-arrow {
+    transform: translate(180px);
+    transition: transform ease 0.3s;
+    cursor: pointer;
+    width: 30px;
+    align-items: center;
+    justify-content: center;
+    display: flex;
+}
+
+.menu-closed .double-arrow-icon {
+    transform: rotate(0deg);
+}
+
+.double-arrow-icon {
+    transform: rotate(180deg);
+    transition: transform ease 0.3s 0.3s;
+}
+
+.me-negative {
+    margin-right: -5px;
+}
+
+.course-circle {
+    height: 36px;
+    min-width: 36px;
+    background-color: var(--course-image-bg);
+    border-radius: 50%;
+    display: inline-block;
+    color: var(--bs-body-color);
+}
+
+.course-title {
+    margin-left: 0.75rem;
+}
+
+.max-width-collapsed {
+    max-width: 44px !important;
+    min-width: 44px !important;
+}
+
+@media screen and (max-width: 960px) {
+    .sidebar-container {
+        width: $menu-width-closed !important;
+    }
+    .auto-collapse {
+        display: none;
+    }
+    .newMessage:after {
+        @extend %message-block;
+        margin-left: -0.9rem;
+    }
+}
+
+.nav-link {
+    white-space: nowrap;
+    color: var(--bs-body-color);
+}
+
+.nav-link-sidebar:hover,
+.nav-link-sidebar.active {
+    width: 100%;
+    background-color: var(--link-item-bg);
+    color: var(--link-item-color);
+}
+
+.three-dots {
+    cursor: pointer;
+    &:hover {
+        color: var(--link-item-color);
+    }
+}
+
+.dropdown-li {
+    display: block;
+    text-decoration: none;
+}
+
+.dropdown-content {
+    overflow-y: auto;
+    position: absolute;
+    background-color: var(--dropdown-bg);
+    border: 1px solid var(--border-color);
+    z-index: 3000;
+    border-radius: 4px;
+    &.fixedContentSize {
+        max-height: 171px; // To avoid cut offs in the dropdown menu content (4 items)
+    }
+}
+
+.dropdown-menu {
+    min-width: 204px;
+    max-width: 294px;
+}
+
+.dropdown-courses.active {
+    display: block;
+}
+
+.dropdown-toggle::after {
+    display: none;
+}
+
+@media print {
+    :host {
+        display: none; /* Hide the sidebar when printing */
+    }
+}

--- a/src/main/webapp/app/overview/course-sidebar/course-sidebar.component.ts
+++ b/src/main/webapp/app/overview/course-sidebar/course-sidebar.component.ts
@@ -1,0 +1,81 @@
+import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { Course } from 'app/entities/course.model';
+import { IconDefinition, faChevronRight, faEllipsis } from '@fortawesome/free-solid-svg-icons';
+import { NgbDropdown, NgbDropdownButtonItem, NgbDropdownItem, NgbDropdownMenu, NgbDropdownToggle, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
+import { NgClass, NgTemplateOutlet, SlicePipe } from '@angular/common';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { TranslateDirective } from '../../shared/language/translate.directive';
+import { SecuredImageComponent } from '../../shared/image/secured-image.component';
+import { OrionFilterDirective } from '../../shared/orion/orion-filter.directive';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { FeatureToggleHideDirective } from '../../shared/feature-toggle/feature-toggle-hide.directive';
+
+export interface CourseActionItem {
+    title: string;
+    icon?: IconDefinition;
+    translation: string;
+    action?: (item?: CourseActionItem) => void;
+}
+
+export interface SidebarItem {
+    routerLink: string;
+    icon?: IconDefinition;
+    title: string;
+    testId?: string;
+    translation: string;
+    hasInOrionProperty?: boolean;
+    showInOrionWindow?: boolean;
+    guidedTour?: boolean;
+    featureToggle?: FeatureToggle;
+    hidden: boolean;
+}
+
+@Component({
+    selector: 'jhi-course-sidebar',
+    templateUrl: './course-sidebar.component.html',
+    styleUrls: ['../course-overview.scss', '../course-overview.component.scss'],
+    standalone: true,
+    imports: [
+        NgClass,
+        NgbDropdown,
+        NgbDropdownToggle,
+        NgTemplateOutlet,
+        NgbDropdownMenu,
+        NgbDropdownButtonItem,
+        NgbDropdownItem,
+        FaIconComponent,
+        TranslateDirective,
+        NgbTooltip,
+        RouterLink,
+        SecuredImageComponent,
+        OrionFilterDirective,
+        RouterLinkActive,
+        FeatureToggleHideDirective,
+        SlicePipe,
+    ],
+})
+export class CourseSidebarComponent {
+    @Input() course: Course | undefined;
+    @Input() courses: Course[] | undefined;
+    @Input() sidebarItems: SidebarItem[] = [];
+    @Input() courseActionItems: CourseActionItem[] = [];
+    @Input() hiddenItems: SidebarItem[] = [];
+    @Input() anyItemHidden = false;
+    @Input() isNavbarCollapsed = false;
+    @Input() isExamStarted = false;
+    @Input() isProduction = true;
+    @Input() isTestServer = false;
+    @Input() hasUnreadMessages = false;
+    @Input() communicationRouteLoaded = false;
+
+    @Output() switchCourse = new EventEmitter<Course>();
+    @Output() courseActionItemClick = new EventEmitter<CourseActionItem>();
+    @Output() toggleCollapseState = new EventEmitter<void>();
+
+    @ViewChild('itemsDrop') itemsDrop: NgbDropdown;
+
+    // Icons
+    faChevronRight = faChevronRight;
+    faEllipsis = faEllipsis;
+}

--- a/src/main/webapp/app/overview/course-sidebar/course-sidebar.component.ts
+++ b/src/main/webapp/app/overview/course-sidebar/course-sidebar.component.ts
@@ -5,11 +5,11 @@ import { NgbDropdown, NgbDropdownItem, NgbDropdownMenu, NgbDropdownToggle, NgbTo
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 import { NgClass, NgTemplateOutlet, SlicePipe } from '@angular/common';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { TranslateDirective } from '../../shared/language/translate.directive';
-import { SecuredImageComponent } from '../../shared/image/secured-image.component';
-import { OrionFilterDirective } from '../../shared/orion/orion-filter.directive';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { SecuredImageComponent } from 'app/shared/image/secured-image.component';
+import { OrionFilterDirective } from 'app/shared/orion/orion-filter.directive';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { FeatureToggleHideDirective } from '../../shared/feature-toggle/feature-toggle-hide.directive';
+import { FeatureToggleHideDirective } from 'app/shared/feature-toggle/feature-toggle-hide.directive';
 
 export interface CourseActionItem {
     title: string;
@@ -111,7 +111,7 @@ export class CourseSidebarComponent implements OnInit, OnChanges {
     }
 
     /**  Applies the visibility threshold to sidebar items, determining which items should be hidden.*/
-    private applyThreshold(threshold: number, height: number) {
+    applyThreshold(threshold: number, height: number) {
         this.anyItemHidden = false;
         this.hiddenItems = [];
 

--- a/src/test/javascript/spec/component/course/course-sidebar.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-sidebar.component.spec.ts
@@ -1,0 +1,284 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
+import { Course, CourseInformationSharingConfiguration } from 'app/entities/course.model';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { NgbDropdown, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgClass, NgTemplateOutlet, SlicePipe } from '@angular/common';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { ActivatedRoute, RouterLink, RouterLinkActive } from '@angular/router';
+import { MockComponent, MockDirective, MockModule, MockPipe } from 'ng-mocks';
+import { TranslateService } from '@ngx-translate/core';
+import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { SimpleChanges } from '@angular/core';
+import { faChalkboardUser, faChartColumn, faGraduationCap, faListAlt } from '@fortawesome/free-solid-svg-icons';
+import { CourseActionItem, CourseSidebarComponent, SidebarItem } from 'app/overview/course-sidebar/course-sidebar.component';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { SecuredImageComponent } from 'app/shared/image/secured-image.component';
+import { OrionFilterDirective } from 'app/shared/orion/orion-filter.directive';
+import { FeatureToggleHideDirective } from 'app/shared/feature-toggle/feature-toggle-hide.directive';
+import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
+import { MockActivatedRoute } from '../../helpers/mocks/activated-route/mock-activated-route';
+
+describe('CourseSidebarComponent', () => {
+    let component: CourseSidebarComponent;
+    let fixture: ComponentFixture<CourseSidebarComponent>;
+
+    const course1: Course = {
+        id: 1,
+        title: 'Course1',
+        description: 'Description of course 1',
+        courseInformationSharingConfiguration: CourseInformationSharingConfiguration.COMMUNICATION_AND_MESSAGING,
+        courseIcon: 'path/to/icon.png',
+        studentCourseAnalyticsDashboardEnabled: true,
+    };
+
+    const course2: Course = {
+        id: 2,
+        title: 'Course2',
+        description: 'Description of course 2',
+        courseInformationSharingConfiguration: CourseInformationSharingConfiguration.COMMUNICATION_AND_MESSAGING,
+    };
+
+    const mockSidebarItems: SidebarItem[] = [
+        {
+            routerLink: 'dashboard',
+            icon: faListAlt,
+            title: 'Dashboard',
+            translation: 'artemisApp.courseOverview.menu.dashboard',
+            hasInOrionProperty: false,
+            showInOrionWindow: false,
+            featureToggle: FeatureToggle.StudentCourseAnalyticsDashboard,
+            hidden: false,
+        },
+        {
+            routerLink: 'exercises',
+            icon: faListAlt,
+            title: 'Exercises',
+            translation: 'artemisApp.courseOverview.menu.exercises',
+            hidden: false,
+        },
+        {
+            routerLink: 'statistics',
+            icon: faChartColumn,
+            title: 'Statistics',
+            translation: 'artemisApp.courseOverview.menu.statistics',
+            hasInOrionProperty: true,
+            showInOrionWindow: false,
+            guidedTour: true,
+            hidden: false,
+        },
+        {
+            routerLink: 'lectures',
+            icon: faChalkboardUser,
+            title: 'Lectures',
+            translation: 'artemisApp.courseOverview.menu.lectures',
+            hasInOrionProperty: true,
+            showInOrionWindow: false,
+            hidden: false,
+        },
+        {
+            routerLink: 'exams',
+            icon: faGraduationCap,
+            title: 'Exams',
+            testId: 'exam-tab',
+            translation: 'artemisApp.courseOverview.menu.exams',
+            hasInOrionProperty: true,
+            showInOrionWindow: false,
+            hidden: false,
+        },
+    ];
+
+    const mockActionItems: CourseActionItem[] = [
+        {
+            title: 'Unenroll',
+            translation: 'artemisApp.courseOverview.exerciseList.details.unenrollmentButton',
+            action: () => {},
+        },
+    ];
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [
+                NgClass,
+                NgTemplateOutlet,
+                SlicePipe,
+                MockModule(NgbTooltipModule),
+                MockModule(BrowserAnimationsModule),
+                RouterLink,
+                RouterLinkActive,
+                CourseSidebarComponent,
+                MockComponent(SecuredImageComponent),
+                MockDirective(NgbDropdown),
+                MockDirective(TranslateDirective),
+                MockComponent(FaIconComponent),
+                MockDirective(OrionFilterDirective),
+                MockDirective(FeatureToggleHideDirective),
+                MockPipe(ArtemisDatePipe),
+                MockPipe(ArtemisTranslatePipe),
+            ],
+            declarations: [],
+            providers: [
+                { provide: TranslateService, useClass: MockTranslateService },
+                { provide: ActivatedRoute, useValue: new MockActivatedRoute() },
+            ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(CourseSidebarComponent);
+        component = fixture.componentInstance;
+
+        // Set up initial inputs
+        component.course = course1;
+        component.courses = [course1, course2];
+        component.sidebarItems = [...mockSidebarItems];
+        component.courseActionItems = [...mockActionItems];
+        component.isNavbarCollapsed = false;
+        component.isExamStarted = false;
+        component.isProduction = true;
+        component.isTestServer = false;
+        component.hasUnreadMessages = false;
+        component.communicationRouteLoaded = false;
+        fixture.detectChanges();
+    });
+
+    it('should initialize visible/hidden items on component initialization', () => {
+        const updateVisibleNavbarItemsSpy = jest.spyOn(component, 'updateVisibleNavbarItems');
+
+        component.ngOnInit();
+
+        expect(updateVisibleNavbarItemsSpy).toHaveBeenCalledWith(window.innerHeight);
+    });
+
+    it('should recalculate hidden items when sidebarItems change', () => {
+        const updateVisibleNavbarItemsSpy = jest.spyOn(component, 'updateVisibleNavbarItems');
+
+        const changes: SimpleChanges = {
+            sidebarItems: {
+                previousValue: [],
+                currentValue: mockSidebarItems,
+                firstChange: false,
+                isFirstChange: () => false,
+            },
+        };
+
+        component.ngOnChanges(changes);
+
+        expect(updateVisibleNavbarItemsSpy).toHaveBeenCalledWith(window.innerHeight);
+    });
+
+    it('should call updateVisibleNavbarItems on window resize', () => {
+        const updateVisibleNavbarItemsSpy = jest.spyOn(component, 'updateVisibleNavbarItems');
+
+        window.dispatchEvent(new Event('resize'));
+
+        expect(updateVisibleNavbarItemsSpy).toHaveBeenCalledWith(window.innerHeight);
+    });
+
+    it('should check if dropdown should be closed when updating visible navbar items', () => {
+        const mockDropdown = {
+            open: jest.fn(),
+            close: jest.fn(),
+        };
+        component.itemsDrop = mockDropdown as unknown as NgbDropdown;
+
+        jest.spyOn(component, 'applyThreshold').mockImplementation((threshold, height) => {
+            component.anyItemHidden = false;
+            component.hiddenItems = [];
+        });
+
+        component.updateVisibleNavbarItems(window.innerHeight);
+
+        expect(mockDropdown.close).toHaveBeenCalled();
+    });
+
+    it('should calculate threshold based on sidebar items length', () => {
+        const threshold = component.calculateThreshold();
+
+        // WINDOW_OFFSET = 300, ITEM_HEIGHT = 38, sidebarItems.length = 5
+        const expectedThreshold = 300 + 5 * 38;
+
+        expect(threshold).toBe(expectedThreshold);
+    });
+
+    it('should apply threshold to determine hidden items', () => {
+        const threshold = 1000; // High value to force items to be hidden
+        const height = 500;
+
+        component.applyThreshold(threshold, height);
+
+        expect(component.anyItemHidden).toBe(true);
+        expect(component.hiddenItems.length).toBeGreaterThan(0);
+
+        component.applyThreshold(100, 1000);
+
+        expect(component.anyItemHidden).toBe(false);
+        expect(component.hiddenItems.length).toBe(0);
+    });
+
+    it('should display course title when navbar is not collapsed', () => {
+        component.isNavbarCollapsed = false;
+        fixture.detectChanges();
+
+        const titleElement = fixture.debugElement.query(By.css('#test-course-title'));
+        expect(titleElement).toBeTruthy();
+        expect(titleElement.nativeElement.textContent).toBe('Course1');
+    });
+
+    it('should display more icon and label if at least one item gets hidden in the sidebar', () => {
+        component.anyItemHidden = true;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('.three-dots').hidden).toBeFalse();
+
+        component.anyItemHidden = false;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('.three-dots').hidden).toBeTrue();
+    });
+    it('should display course icon when available', () => {
+        fixture.detectChanges();
+
+        const iconElement = fixture.nativeElement.querySelector('jhi-secured-image');
+        expect(iconElement).not.toBeNull();
+    });
+
+    it('should not display course icon when not available', () => {
+        // course without icon
+        component.course = course2;
+        component.courses = [course2];
+        fixture.detectChanges();
+
+        const iconElement = fixture.debugElement.query(By.directive(SecuredImageComponent));
+        const iconElement2 = fixture.nativeElement.querySelector('.course-circle');
+        expect(iconElement).toBeNull();
+        expect(iconElement2).not.toBeNull();
+    });
+
+    it('should emit toggleCollapseState when collapse chevron is clicked', () => {
+        const toggleCollapseStateSpy = jest.spyOn(component.toggleCollapseState, 'emit');
+        fixture.detectChanges();
+        const collapseButton = fixture.debugElement.query(By.css('.double-arrow'));
+        expect(collapseButton).toBeTruthy();
+        collapseButton.nativeElement.click();
+        expect(toggleCollapseStateSpy).toHaveBeenCalled();
+    });
+
+    it('should emit switchCourse when a course is selected from dropdown', () => {
+        const switchCourseSpy = jest.spyOn(component.switchCourse, 'emit');
+        component.courses = [course1, course2];
+        fixture.detectChanges();
+
+        const courseDropdownItem = fixture.debugElement.query(By.css('[ngbDropdownItem]'));
+        courseDropdownItem.nativeElement.click();
+        expect(switchCourseSpy).toHaveBeenCalled();
+    });
+
+    it('should emit courseActionItemClick when an action item is clicked', () => {
+        const courseActionItemClickSpy = jest.spyOn(component.courseActionItemClick, 'emit');
+        component.courseActionItems = [mockActionItems[0]];
+        component.anyItemHidden = false;
+        fixture.detectChanges();
+        const actionItem = fixture.debugElement.query(By.css('#action-item-0'));
+        actionItem.nativeElement.click();
+        expect(courseActionItemClickSpy).toHaveBeenCalledWith(mockActionItems[0]);
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We want to introduce the sidebar layout in the course management view with the next major release. 
As first step make the sidebar in the student course view its own component to be able to reuse it in the management view


### Description
<!-- Describe your changes in detail -->
Created a new component `course-sidebar` and adjusted `course-overview` to use the new `course-sidebar`.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student
1. Log in to Artemis
2. Navigate to any course
3. Try out the sidebar, make sure nothing breaks and behaves differently to before
4. When the space is not sufficient to display all items, a more menu should be shown. This should open with the hidden items when you click on it
5. When clicking on the course icon, a list of courses should be shown

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Student

1. Log in to Artemis
2. Participate in the exam as a student
6. Make sure the sidebar is not shown in exam mode

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| course-sidebar.component | 100% | ✅                           |
|  course-overview.component |  95% | ✅              |

