### PR TITLE
`Development`: Standardize Dockerfile syntax

### DIFF
--- a/docker/artemis/Dockerfile
+++ b/docker/artemis/Dockerfile
@@ -103,9 +103,9 @@ RUN \
   echo "Fixing locales" \
   && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
   && locale-gen
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
 
 # Create directories for volumes, create artemis user and set right owners
 RUN \

--- a/docker/artemis/Dockerfile
+++ b/docker/artemis/Dockerfile
@@ -22,7 +22,7 @@ ARG WAR_FILE_STAGE="builder"
 #-----------------------------------------------------------------------------------------------------------------------
 # build stage
 #-----------------------------------------------------------------------------------------------------------------------
-FROM --platform=$BUILDPLATFORM docker.io/library/eclipse-temurin:21-jdk as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/eclipse-temurin:21-jdk AS builder
 
 # some Apple M1 (arm64) builds need python3 and build-essential(make+gcc) for node-gyp to not fail
 RUN echo "Installing build dependencies" \
@@ -66,7 +66,7 @@ RUN \
 #-----------------------------------------------------------------------------------------------------------------------
 # external build stage
 #-----------------------------------------------------------------------------------------------------------------------
-FROM docker.io/library/alpine:3 as external_builder
+FROM docker.io/library/alpine:3 AS external_builder
 
 #default path of the built .war files
 ARG WAR_FILE_PATH="/opt/artemis/build/libs"
@@ -78,12 +78,12 @@ COPY ./build/libs/*.war Artemis.war
 #-----------------------------------------------------------------------------------------------------------------------
 # war file stage (decides whether an external .war file will be used or the Docker built .war file)
 #-----------------------------------------------------------------------------------------------------------------------
-FROM ${WAR_FILE_STAGE} as war_file
+FROM ${WAR_FILE_STAGE} AS war_file
 
 #-----------------------------------------------------------------------------------------------------------------------
 # runtime stage
 #-----------------------------------------------------------------------------------------------------------------------
-FROM docker.io/library/eclipse-temurin:21-jdk as runtime
+FROM docker.io/library/eclipse-temurin:21-jdk AS runtime
 
 #default path of the built .war files
 ARG WAR_FILE_PATH="/opt/artemis/build/libs"


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This PR ensures Dockerfile best practices by:
- Standardizing the casing of `AS` in `FROM ... AS` statements for consistency
- Replacing the deprecated legacy `ENV key value` format with `ENV key=value`

References:  
- **[Legacy Key-Value Format](https://docs.docker.com/reference/build-checks/legacy-key-value-format/)**  
- **[FROM AS Casing](https://docs.docker.com/reference/build-checks/from-as-casing)**  

### Description
<!-- Describe your changes in detail -->
- Updated all `FROM ... AS` statements to use uppercase `AS`.
- Refactored `ENV` instructions to use the `key=value` format instead of the legacy `key value` format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the container build instructions for consistent alias naming.
  - Reformatted environment variable declarations for a cleaner, uniform presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->