### PR TITLE
`Exam mode`: Fix assessment button on student exam overview page

### DIFF
--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.html
@@ -67,7 +67,11 @@
                     </a>
                 </div>
             }
-            @if (submission && exercise.type === ExerciseType.PROGRAMMING && exercise.assessmentType === AssessmentType.SEMI_AUTOMATIC) {
+            @if (
+                submission &&
+                exercise.type === ExerciseType.PROGRAMMING &&
+                (exercise.assessmentType === AssessmentType.SEMI_AUTOMATIC || exercise.assessmentType === AssessmentType.MANUAL)
+            ) {
                 <div>
                     <a [class.disabled]="busy" [routerLink]="getAssessmentLink(exercise, submission)" class="btn btn-primary btn-sm mb-1">
                         <fa-icon [fixedWidth]="true" [icon]="faFolderOpen" />

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.html
@@ -67,9 +67,9 @@
                     </a>
                 </div>
             }
-            @if (exercise.type === ExerciseType.PROGRAMMING) {
+            @if (submission && exercise.type === ExerciseType.PROGRAMMING && exercise.assessmentType === AssessmentType.SEMI_AUTOMATIC) {
                 <div>
-                    <a [class.disabled]="busy" [routerLink]="getAssessmentLink(exercise)" class="btn btn-primary btn-sm mb-1">
+                    <a [class.disabled]="busy" [routerLink]="getAssessmentLink(exercise, submission)" class="btn btn-primary btn-sm mb-1">
                         <fa-icon [fixedWidth]="true" [icon]="faFolderOpen" />
                         {{ 'artemisApp.examManagement.assessmentDashboard' | artemisTranslate }}
                     </a>

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.ts
@@ -11,6 +11,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { RouterLink } from '@angular/router';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { AssessmentType } from 'app/entities/assessment-type.model';
 
 @Component({
     selector: '[jhi-student-exam-detail-table-row]',
@@ -118,4 +119,6 @@ export class StudentExamDetailTableRowComponent implements OnChanges {
                 return 0;
         }
     }
+
+    protected readonly AssessmentType = AssessmentType;
 }

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.ts
@@ -34,6 +34,7 @@ export class StudentExamDetailTableRowComponent implements OnChanges {
     result: Result;
     openingAssessmentEditorForNewSubmission = false;
     readonly ExerciseType = ExerciseType;
+    readonly AssessmentType = AssessmentType;
     getIcon = getIcon;
 
     // Icons
@@ -119,6 +120,4 @@ export class StudentExamDetailTableRowComponent implements OnChanges {
                 return 0;
         }
     }
-
-    protected readonly AssessmentType = AssessmentType;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, we are facing a bug in production where the `Assessment` button on the student exam overview page doesn't redirect to the assessment of a programming exercise if either manual assessment is enabled or complaints on automatic assessment are enabled. This change fixes that issue.

### Description
<!-- Describe your changes in detail -->
I have extended the condition to check for `SEMI_AUTOMATIC` and `MANUAL` assessment types. The button will not be displayed if the programming exercise is meant to be graded fully automatically or if there is no submission.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exam with a programming exercise

1. As a student, participate in the exam, submit a programming exercise, and hand in the exam.  
2. As an instructor, navigate to **Course Management** -> **Exams** -> Select an Exam -> **Exercise Groups**.  
3. Click **Edit** on the programming exercise and set the assessment type to **Automatic** (see screenshots).  
4. Go to **Student Exams** -> Click **View** on the exam that you previously submitted.  
5. Verify that the **Assessment** button does **not** appear for the programming exercise.  
6. Edit the exercise again and set the assessment type to **Automatic with complaints enabled** (see screenshots).  
7. Verify that the **Assessment** button **appears** for the programming exercise and correctly redirects you to the assessment.  
8. Edit the exercise again and set the assessment type to **Manual** (see screenshots).  
9. Verify that the **Assessment** button **appears** for the programming exercise and correctly redirects you to the assessment.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Fully automatic assessment:
<img width="2556" alt="image" src="https://github.com/user-attachments/assets/f932b484-5f2b-4188-a8ae-ec9ff4c31ebd" />
Automatic assessment with complaints enabled:
<img width="2556" alt="image" src="https://github.com/user-attachments/assets/83eeba95-7b1e-4bd1-b76f-2edc35480102" />

Manual assessment:
<img width="2556" alt="image" src="https://github.com/user-attachments/assets/1fbdb437-3ab8-4864-a469-65557a13f48c" />

