### PR TITLE
`Lectures`: Add reference between video unit and attachment unit

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/AttachmentUnit.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/AttachmentUnit.java
@@ -32,6 +32,10 @@ public class AttachmentUnit extends LectureUnit {
     @JsonIgnoreProperties("attachmentUnit")
     private List<Slide> slides = new ArrayList<>();
 
+    @OneToOne(mappedBy = "correspondingAttachmentUnit")
+    @JsonIgnoreProperties({ "correspondingAttachmentUnit", "lecture" })
+    private VideoUnit correspondingVideoUnit;
+
     @Override
     public boolean isVisibleToStudents() {
         if (attachment == null) {
@@ -64,6 +68,14 @@ public class AttachmentUnit extends LectureUnit {
 
     public void setSlides(List<Slide> slides) {
         this.slides = slides;
+    }
+
+    public VideoUnit getCorrespondingVideoUnit() {
+        return correspondingVideoUnit;
+    }
+
+    public void setCorrespondingVideoUnit(VideoUnit videoUnit) {
+        this.correspondingVideoUnit = videoUnit;
     }
 
     @Override

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/VideoUnit.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/VideoUnit.java
@@ -3,7 +3,10 @@ package de.tum.cit.aet.artemis.lecture.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @Entity
@@ -31,6 +34,19 @@ public class VideoUnit extends LectureUnit {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    @OneToOne
+    @JoinColumn(name = "corresponding_attachment_unit_id")
+    @JsonIgnoreProperties({ "correspondingVideoUnit", "lecture" })
+    private AttachmentUnit correspondingAttachmentUnit;
+
+    public AttachmentUnit getCorrespondingAttachmentUnit() {
+        return correspondingAttachmentUnit;
+    }
+
+    public void setCorrespondingAttachmentUnit(AttachmentUnit attachmentUnit) {
+        this.correspondingAttachmentUnit = attachmentUnit;
     }
 
     // IMPORTANT NOTICE: The following string has to be consistent with the one defined in LectureUnit.java

--- a/src/main/resources/config/liquibase/changelog/20250312010510_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20250312010510_changelog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="20250312010510" author="sebastianloose">
+        <addColumn tableName="lecture_unit">
+            <column name="corresponding_attachment_unit_id" type="BIGINT">
+                <constraints nullable="true" unique="true"/>
+            </column>
+        </addColumn>
+        <addForeignKeyConstraint baseColumnNames="corresponding_attachment_unit_id"
+                                 baseTableName="lecture_unit"
+                                 constraintName="FK_VIDEO_UNIT_ON_ATTACHMENT_UNIT"
+                                 referencedColumnNames="id"
+                                 referencedTableName="lecture_unit"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -56,6 +56,7 @@
     <include file="classpath:config/liquibase/changelog/20250129173003_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20250218181818_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20250222125010_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20250312010510_changelog.xml" relativeToChangelogFile="false"/>
 
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->

--- a/src/main/webapp/app/entities/lecture-unit/attachmentUnit.model.ts
+++ b/src/main/webapp/app/entities/lecture-unit/attachmentUnit.model.ts
@@ -1,12 +1,14 @@
 import { LectureUnit, LectureUnitType } from 'app/entities/lecture-unit/lectureUnit.model';
 import { Attachment } from 'app/entities/attachment.model';
 import { Slide } from 'app/entities/lecture-unit/slide.model';
+import { VideoUnit } from 'app/entities/lecture-unit/videoUnit.model';
 
 export class AttachmentUnit extends LectureUnit {
     public description?: string;
     public attachment?: Attachment;
     public slides?: Slide[];
     public pyrisIngestionState?: IngestionState;
+    public correspondingVideoUnit?: VideoUnit;
 
     constructor() {
         super(LectureUnitType.ATTACHMENT);

--- a/src/main/webapp/app/entities/lecture-unit/videoUnit.model.ts
+++ b/src/main/webapp/app/entities/lecture-unit/videoUnit.model.ts
@@ -1,9 +1,12 @@
 import { LectureUnit, LectureUnitType } from 'app/entities/lecture-unit/lectureUnit.model';
+import { AttachmentUnit } from 'app/entities/lecture-unit/attachmentUnit.model';
 
 export class VideoUnit extends LectureUnit {
     public description?: string;
     // src link of a video
     public source?: string;
+
+    public correspondingAttachmentUnit?: AttachmentUnit;
 
     constructor() {
         super(LectureUnitType.VIDEO);

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-video-unit/create-video-unit.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-video-unit/create-video-unit.component.html
@@ -1,3 +1,3 @@
 <jhi-lecture-unit-layout [isLoading]="isLoading">
-    <jhi-video-unit-form [isEditMode]="false" (formSubmitted)="createVideoUnit($event)" />
+    <jhi-video-unit-form [formData]="formData" [availableAttachmentUnits]="availableAttachmentUnits" [isEditMode]="false" (formSubmitted)="createVideoUnit($event)" />
 </jhi-lecture-unit-layout>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-video-unit/create-video-unit.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-video-unit/create-video-unit.component.ts
@@ -1,4 +1,3 @@
-import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { VideoUnit } from 'app/entities/lecture-unit/videoUnit.model';
@@ -6,10 +5,15 @@ import { VideoUnitFormData } from 'app/lecture/lecture-unit/lecture-unit-managem
 import { VideoUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/videoUnit.service';
 import { onError } from 'app/shared/util/global.utils';
 import { AlertService } from 'app/core/util/alert.service';
-import { finalize } from 'rxjs/operators';
+import { finalize, switchMap, take } from 'rxjs/operators';
+import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { combineLatest } from 'rxjs';
 import { LectureUnitLayoutComponent } from '../lecture-unit-layout/lecture-unit-layout.component';
 import { VideoUnitFormComponent } from '../video-unit-form/video-unit-form.component';
+import { AttachmentUnit } from 'app/entities/lecture-unit/attachmentUnit.model';
+import { LectureService } from 'app/lecture/lecture.service';
+import { Lecture } from 'app/entities/lecture.model';
+import { LectureUnit, LectureUnitType } from 'app/entities/lecture-unit/lectureUnit.model';
 
 @Component({
     selector: 'jhi-create-video-unit',
@@ -21,18 +25,44 @@ export class CreateVideoUnitComponent implements OnInit {
     private router = inject(Router);
     private videoUnitService = inject(VideoUnitService);
     private alertService = inject(AlertService);
+    private lectureService = inject(LectureService);
 
     videoUnitToCreate: VideoUnit = new VideoUnit();
     isLoading: boolean;
     lectureId: number;
     courseId: number;
 
+    formData: VideoUnitFormData;
+    availableAttachmentUnits: AttachmentUnit[];
+
     ngOnInit(): void {
         const lectureRoute = this.activatedRoute.parent!.parent!;
-        combineLatest([lectureRoute.paramMap, lectureRoute.parent!.paramMap]).subscribe(([params, parentParams]) => {
-            this.lectureId = Number(params.get('lectureId'));
-            this.courseId = Number(parentParams.get('courseId'));
-        });
+        combineLatest([lectureRoute.paramMap, lectureRoute.parent!.paramMap])
+            .pipe(
+                take(1),
+                switchMap(([params, parentParams]) => {
+                    this.lectureId = Number(params.get('lectureId'));
+                    this.courseId = Number(parentParams.get('courseId'));
+                    return this.lectureService.findWithDetails(this.lectureId);
+                }),
+                finalize(() => {
+                    this.isLoading = false;
+                }),
+            )
+            .subscribe({
+                next: (lecture: HttpResponse<Lecture>) => {
+                    this.availableAttachmentUnits = [
+                        {},
+                        ...(lecture.body?.lectureUnits ?? []).filter((unit: LectureUnit) => {
+                            if (unit.type !== LectureUnitType.ATTACHMENT) return false;
+
+                            const attachmentUnit = unit as AttachmentUnit;
+                            return !attachmentUnit.correspondingVideoUnit;
+                        }),
+                    ];
+                },
+                error: (res: HttpErrorResponse) => onError(this.alertService, res),
+            });
         this.videoUnitToCreate = new VideoUnit();
     }
 
@@ -41,13 +71,14 @@ export class CreateVideoUnitComponent implements OnInit {
             return;
         }
 
-        const { name, description, releaseDate, source, competencyLinks } = formData;
+        const { name, description, releaseDate, source, competencyLinks, correspondingAttachmentUnitId } = formData;
 
         this.videoUnitToCreate.name = name || undefined;
         this.videoUnitToCreate.releaseDate = releaseDate || undefined;
         this.videoUnitToCreate.description = description || undefined;
         this.videoUnitToCreate.source = source || undefined;
         this.videoUnitToCreate.competencyLinks = competencyLinks || [];
+        this.videoUnitToCreate.correspondingAttachmentUnit = correspondingAttachmentUnitId ? { id: correspondingAttachmentUnitId, type: LectureUnitType.ATTACHMENT } : undefined;
 
         this.isLoading = true;
 

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/edit-video-unit/edit-video-unit.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/edit-video-unit/edit-video-unit.component.html
@@ -1,3 +1,3 @@
 <jhi-lecture-unit-layout [isLoading]="isLoading">
-    <jhi-video-unit-form [formData]="formData" (formSubmitted)="updateVideoUnit($event)" [isEditMode]="true" />
+    <jhi-video-unit-form [formData]="formData" [availableAttachmentUnits]="availableAttachmentUnits" (formSubmitted)="updateVideoUnit($event)" [isEditMode]="true" />
 </jhi-lecture-unit-layout>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/edit-video-unit/edit-video-unit.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/edit-video-unit/edit-video-unit.component.ts
@@ -6,10 +6,13 @@ import { VideoUnitService } from 'app/lecture/lecture-unit/lecture-unit-manageme
 import { AlertService } from 'app/core/util/alert.service';
 import { onError } from 'app/shared/util/global.utils';
 import { finalize, switchMap, take } from 'rxjs/operators';
-import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
-import { combineLatest } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { combineLatest, forkJoin } from 'rxjs';
 import { LectureUnitLayoutComponent } from '../lecture-unit-layout/lecture-unit-layout.component';
 import { VideoUnitFormComponent } from '../video-unit-form/video-unit-form.component';
+import { LectureUnit, LectureUnitType } from 'app/entities/lecture-unit/lectureUnit.model';
+import { LectureService } from 'app/lecture/lecture.service';
+import { AttachmentUnit } from 'app/entities/lecture-unit/attachmentUnit.model';
 
 @Component({
     selector: 'jhi-edit-video-unit',
@@ -20,12 +23,16 @@ export class EditVideoUnitComponent implements OnInit {
     private activatedRoute = inject(ActivatedRoute);
     private router = inject(Router);
     private videoUnitService = inject(VideoUnitService);
+    private lectureService = inject(LectureService);
     private alertService = inject(AlertService);
 
     isLoading = false;
     videoUnit: VideoUnit;
     formData: VideoUnitFormData;
     lectureId: number;
+    videoUnitId: number;
+
+    availableAttachmentUnits: AttachmentUnit[];
 
     ngOnInit(): void {
         this.isLoading = true;
@@ -34,37 +41,51 @@ export class EditVideoUnitComponent implements OnInit {
             .pipe(
                 take(1),
                 switchMap(([params, parentParams]) => {
-                    const videoUnitId = Number(params.get('videoUnitId'));
+                    this.videoUnitId = Number(params.get('videoUnitId'));
                     this.lectureId = Number(parentParams.get('lectureId'));
-                    return this.videoUnitService.findById(videoUnitId, this.lectureId);
+                    const videoUnitObservable = this.videoUnitService.findById(this.videoUnitId, this.lectureId);
+                    const lectureObservable = this.lectureService.findWithDetails(this.lectureId);
+                    return forkJoin([videoUnitObservable, lectureObservable]);
                 }),
                 finalize(() => {
                     this.isLoading = false;
                 }),
             )
             .subscribe({
-                next: (videoUnitResponse: HttpResponse<VideoUnit>) => {
-                    this.videoUnit = videoUnitResponse.body!;
-
+                next: ([videoUnit, lecture]) => {
+                    this.videoUnit = videoUnit.body!;
                     this.formData = {
                         name: this.videoUnit.name,
                         description: this.videoUnit.description,
                         releaseDate: this.videoUnit.releaseDate,
                         source: this.videoUnit.source,
                         competencyLinks: this.videoUnit.competencyLinks,
+                        correspondingAttachmentUnitId: this.videoUnit.correspondingAttachmentUnit?.id,
                     };
+
+                    this.availableAttachmentUnits = [
+                        {},
+                        ...(lecture.body?.lectureUnits ?? []).filter((unit: LectureUnit) => {
+                            if (unit.type !== LectureUnitType.ATTACHMENT) return false;
+
+                            const attachmentUnit = unit as AttachmentUnit;
+                            return !attachmentUnit.correspondingVideoUnit || attachmentUnit.correspondingVideoUnit.id === this.videoUnitId;
+                        }),
+                    ];
                 },
                 error: (res: HttpErrorResponse) => onError(this.alertService, res),
             });
     }
 
     updateVideoUnit(formData: VideoUnitFormData) {
-        const { name, description, releaseDate, source, competencyLinks } = formData;
+        const { name, description, releaseDate, source, competencyLinks, correspondingAttachmentUnitId } = formData;
         this.videoUnit.name = name;
         this.videoUnit.description = description;
         this.videoUnit.releaseDate = releaseDate;
         this.videoUnit.source = source;
         this.videoUnit.competencyLinks = competencyLinks;
+        this.videoUnit.correspondingAttachmentUnit = correspondingAttachmentUnitId ? { id: correspondingAttachmentUnitId, type: LectureUnitType.ATTACHMENT } : undefined;
+
         this.isLoading = true;
         this.videoUnitService
             .update(this.videoUnit, this.lectureId)

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/video-unit-form/video-unit-form.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/video-unit-form/video-unit-form.component.html
@@ -105,6 +105,14 @@
                         </div>
                     </div>
                 </div>
+                <div class="form-group">
+                    <label for="attachmentUnit">{{ 'artemisApp.videoUnit.createVideoUnit.attachmentUnit' | artemisTranslate }}</label>
+                    <select id="attachmentUnit" class="form-select" formControlName="correspondingAttachmentUnitId">
+                        @for (attachmentUnit of availableAttachmentUnits(); track attachmentUnit.id) {
+                            <option [ngValue]="attachmentUnit.id">{{ attachmentUnit.name }}</option>
+                        }
+                    </select>
+                </div>
                 <div class="row">
                     <div class="col-12">
                         <button id="submitButton" class="btn btn-primary" type="submit" [disabled]="!isFormValid()">

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/video-unit-form/video-unit-form.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/video-unit-form/video-unit-form.component.ts
@@ -10,6 +10,7 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { CompetencySelectionComponent } from 'app/shared/competency-selection/competency-selection.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { AttachmentUnit } from 'app/entities/lecture-unit/attachmentUnit.model';
 
 export interface VideoUnitFormData {
     name?: string;
@@ -17,6 +18,7 @@ export interface VideoUnitFormData {
     releaseDate?: dayjs.Dayjs;
     source?: string;
     competencyLinks?: CompetencyLectureUnitLink[];
+    correspondingAttachmentUnitId?: number;
 }
 
 function isTumLiveUrl(url: URL): boolean {
@@ -71,6 +73,7 @@ export class VideoUnitFormComponent {
     private readonly formBuilder = inject(FormBuilder);
 
     formData = input<VideoUnitFormData>();
+    availableAttachmentUnits = input<AttachmentUnit[]>();
     isEditMode = input<boolean>(false);
 
     formSubmitted = output<VideoUnitFormData>();
@@ -90,6 +93,7 @@ export class VideoUnitFormComponent {
         source: [undefined as string | undefined, [Validators.required, this.videoSourceUrlValidator]],
         urlHelper: [undefined as string | undefined, this.videoSourceTransformUrlValidator],
         competencyLinks: [undefined as CompetencyLectureUnitLink[] | undefined],
+        correspondingAttachmentUnitId: [undefined as number | undefined],
     });
     private readonly statusChanges = toSignal(this.form.statusChanges ?? 'INVALID');
     isFormValid = computed(() => this.statusChanges() === 'VALID' && this.datePickerComponent()?.isValid());

--- a/src/main/webapp/app/lecture/lecture-units/lecture-units.component.html
+++ b/src/main/webapp/app/lecture/lecture-units/lecture-units.component.html
@@ -33,6 +33,7 @@
                 (onCancel)="onCloseLectureUnitForms()"
                 (formSubmitted)="createEditVideoUnit($event)"
                 [formData]="videoUnitFormData"
+                [availableAttachmentUnits]="availableAttachmentUnits"
             />
         }
         @if (isOnlineUnitFormOpen()) {

--- a/src/main/webapp/i18n/de/lectureUnit.json
+++ b/src/main/webapp/i18n/de/lectureUnit.json
@@ -69,7 +69,8 @@
                 "sourceURLValidationError": "Keine valide URL",
                 "urlVideoHelper": "Umwandlung in einbettbares Format ",
                 "urlHelperPlaceholder": "Du kannst hier eine Video-URL eingeben und den Pfeil benutzen, um sie in die korrekte einbettbare URL umzuwandeln",
-                "urlHelperValidationError": "Automatische Formatumwandlung ist nicht möglich für diese URL"
+                "urlHelperValidationError": "Automatische Formatumwandlung ist nicht möglich für diese URL",
+                "attachmentUnit": "Dateieinheit"
             },
             "editVideoUnit": {
                 "title": "Bearbeite eine Videoeinheit"

--- a/src/main/webapp/i18n/en/lectureUnit.json
+++ b/src/main/webapp/i18n/en/lectureUnit.json
@@ -69,7 +69,8 @@
                 "sourceURLValidationError": "Not a valid URL",
                 "urlVideoHelper": "Transform into embeddable format ",
                 "urlHelperPlaceholder": "You can enter a Video URL here and use the arrow to create the correct embeddable URL from it",
-                "urlHelperValidationError": "Automatic embed link generation is not possible for this URL"
+                "urlHelperValidationError": "Automatic embed link generation is not possible for this URL",
+                "attachmentUnit": "Attachment Unit"
             },
             "editVideoUnit": {
                 "title": "Edit Video Unit"

--- a/src/test/javascript/spec/component/lecture-unit/video-unit/create-video-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/video-unit/create-video-unit.component.spec.ts
@@ -17,8 +17,12 @@ import { TranslateService } from '@ngx-translate/core';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../../helpers/mocks/service/mock-account.service';
-import { ProfileService } from '../../../../../../main/webapp/app/shared/layouts/profiles/profile.service';
+import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { MockProfileService } from '../../../helpers/mocks/service/mock-profile.service';
+import { LectureService } from 'app/lecture/lecture.secrvice';
+import { AttachmentUnit } from 'app/entities/lecture-unit/attachmentUnit.model';
+import { TextUnit } from 'app/entities/lecture-unit/textUnit.model';
+import { Lecture } from 'app/entities/lecture.model';
 
 describe('CreateVideoUnitComponent', () => {
     let createVideoUnitComponentFixture: ComponentFixture<CreateVideoUnitComponent>;
@@ -30,6 +34,7 @@ describe('CreateVideoUnitComponent', () => {
             providers: [
                 MockProvider(VideoUnitService),
                 MockProvider(AlertService),
+                MockProvider(LectureService),
                 { provide: Router, useClass: MockRouter },
                 {
                     provide: ActivatedRoute,
@@ -124,5 +129,67 @@ describe('CreateVideoUnitComponent', () => {
 
             navigateSpy.mockRestore();
         });
+    }));
+
+    it('should provide all attachment units', fakeAsync(() => {
+        const lectureService = TestBed.inject(LectureService);
+
+        const attachmentUnit1 = new AttachmentUnit();
+        attachmentUnit1.id = 1;
+
+        const attachmentUnit2 = new AttachmentUnit();
+        attachmentUnit2.id = 2;
+
+        const textUnit1 = new TextUnit();
+        textUnit1.id = 3;
+
+        const lecture = new Lecture();
+        lecture.lectureUnits = [attachmentUnit1, attachmentUnit2, textUnit1];
+
+        const response: HttpResponse<VideoUnit> = new HttpResponse({
+            body: lecture,
+            status: 201,
+        });
+
+        jest.spyOn(lectureService, 'findWithDetails').mockReturnValue(of(response));
+
+        createVideoUnitComponentFixture.detectChanges();
+        tick();
+
+        expect(createVideoUnitComponent.availableAttachmentUnits.length).toBe(3);
+        expect(createVideoUnitComponent.availableAttachmentUnits).toEqual([{}, attachmentUnit1, attachmentUnit2]);
+    }));
+
+    it('should provide all attachment units expect attachment unit a attached to a different video unit', fakeAsync(() => {
+        const lectureService = TestBed.inject(LectureService);
+
+        const attachmentUnit1 = new AttachmentUnit();
+        attachmentUnit1.id = 1;
+
+        const videoUnit = new VideoUnit();
+        videoUnit.id = 5;
+
+        const attachmentUnit2 = new AttachmentUnit();
+        attachmentUnit2.id = 2;
+        attachmentUnit2.correspondingVideoUnit = videoUnit;
+
+        const textUnit1 = new TextUnit();
+        textUnit1.id = 4;
+
+        const lecture = new Lecture();
+        lecture.lectureUnits = [attachmentUnit1, attachmentUnit2, textUnit1];
+
+        const response: HttpResponse<VideoUnit> = new HttpResponse({
+            body: lecture,
+            status: 201,
+        });
+
+        jest.spyOn(lectureService, 'findWithDetails').mockReturnValue(of(response));
+
+        createVideoUnitComponentFixture.detectChanges();
+        tick();
+
+        expect(createVideoUnitComponent.availableAttachmentUnits.length).toBe(2);
+        expect(createVideoUnitComponent.availableAttachmentUnits).toEqual([{}, attachmentUnit1]);
     }));
 });

--- a/src/test/javascript/spec/component/lecture-unit/video-unit/create-video-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/video-unit/create-video-unit.component.spec.ts
@@ -19,7 +19,7 @@ import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../../helpers/mocks/service/mock-account.service';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { MockProfileService } from '../../../helpers/mocks/service/mock-profile.service';
-import { LectureService } from 'app/lecture/lecture.secrvice';
+import { LectureService } from 'app/lecture/lecture.service';
 import { AttachmentUnit } from 'app/entities/lecture-unit/attachmentUnit.model';
 import { TextUnit } from 'app/entities/lecture-unit/textUnit.model';
 import { Lecture } from 'app/entities/lecture.model';

--- a/src/test/javascript/spec/component/lecture-unit/video-unit/edit-video-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/video-unit/edit-video-unit.component.spec.ts
@@ -89,7 +89,7 @@ describe('EditVideoUnitComponent', () => {
         const videoUnitService = TestBed.inject(VideoUnitService);
         const lectureService = TestBed.inject(LectureService);
 
-        const lectureResponse: HttpResponse<VideoUnit> = new HttpResponse({
+        const lectureResponse: HttpResponse<Lecture> = new HttpResponse({
             body: new Lecture(),
             status: 201,
         });
@@ -126,7 +126,7 @@ describe('EditVideoUnitComponent', () => {
         const videoUnitService = TestBed.inject(VideoUnitService);
         const lectureService = TestBed.inject(LectureService);
 
-        const lectureResponse: HttpResponse<VideoUnit> = new HttpResponse({
+        const lectureResponse: HttpResponse<Lecture> = new HttpResponse({
             body: new Lecture(),
             status: 201,
         });
@@ -205,7 +205,7 @@ describe('EditVideoUnitComponent', () => {
         const lecture = new Lecture();
         lecture.lectureUnits = [attachmentUnit1, attachmentUnit2, textUnit1];
 
-        const lectureResponse: HttpResponse<VideoUnit> = new HttpResponse({
+        const lectureResponse: HttpResponse<Lecture> = new HttpResponse({
             body: lecture,
             status: 201,
         });

--- a/src/test/javascript/spec/component/lecture-unit/video-unit/edit-video-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/video-unit/edit-video-unit.component.spec.ts
@@ -16,7 +16,7 @@ import { MockTranslateService } from '../../../helpers/mocks/service/mock-transl
 import { TranslateService } from '@ngx-translate/core';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../../helpers/mocks/service/mock-account.service';
-import { ProfileService } from '../../../../../../main/webapp/app/shared/layouts/profiles/profile.service';
+import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { MockProfileService } from '../../../helpers/mocks/service/mock-profile.service';
 import { LectureService } from 'app/lecture/lecture.service';
 import { AttachmentUnit } from 'app/entities/lecture-unit/attachmentUnit.model';
@@ -87,6 +87,14 @@ describe('EditVideoUnitComponent', () => {
 
     it('should set form data correctly', () => {
         const videoUnitService = TestBed.inject(VideoUnitService);
+        const lectureService = TestBed.inject(LectureService);
+
+        const lectureResponse: HttpResponse<VideoUnit> = new HttpResponse({
+            body: new Lecture(),
+            status: 201,
+        });
+
+        jest.spyOn(lectureService, 'findWithDetails').mockReturnValue(of(lectureResponse));
 
         const videoUnitOfResponse = new VideoUnit();
         videoUnitOfResponse.id = 1;
@@ -116,6 +124,14 @@ describe('EditVideoUnitComponent', () => {
     it('should send PUT request upon form submission and navigate', () => {
         const router: Router = TestBed.inject(Router);
         const videoUnitService = TestBed.inject(VideoUnitService);
+        const lectureService = TestBed.inject(LectureService);
+
+        const lectureResponse: HttpResponse<VideoUnit> = new HttpResponse({
+            body: new Lecture(),
+            status: 201,
+        });
+
+        jest.spyOn(lectureService, 'findWithDetails').mockReturnValue(of(lectureResponse));
 
         const videoUnitInDatabase: VideoUnit = new VideoUnit();
         videoUnitInDatabase.id = 1;

--- a/src/test/javascript/spec/component/lecture-unit/video-unit/video-unit-form.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/video-unit/video-unit-form.component.spec.ts
@@ -125,6 +125,7 @@ describe('VideoUnitFormComponent', () => {
                 competencyLinks: null,
                 source: validYouTubeUrlInEmbeddableFormat,
                 urlHelper: null,
+                correspondingAttachmentUnitId: null,
             });
 
             submitFormSpy.mockRestore();

--- a/src/test/javascript/spec/component/lecture/lecture-units.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture/lecture-units.component.spec.ts
@@ -1,5 +1,5 @@
 import { VideoUnitFormComponent, VideoUnitFormData } from 'app/lecture/lecture-unit/lecture-unit-management/video-unit-form/video-unit-form.component';
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { VideoUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/videoUnit.service';
 import { MockComponent, MockProvider } from 'ng-mocks';
 import { AlertService } from 'app/core/util/alert.service';
@@ -30,6 +30,7 @@ import { CompetencyLectureUnitLink } from 'app/entities/competency.model';
 import { UnitCreationCardComponent } from 'app/lecture/lecture-unit/lecture-unit-management/unit-creation-card/unit-creation-card.component';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
+import { LectureService } from 'app/lecture/lecture.service';
 
 describe('LectureUpdateUnitsComponent', () => {
     let wizardUnitComponentFixture: ComponentFixture<LectureUpdateUnitsComponent>;
@@ -50,6 +51,7 @@ describe('LectureUpdateUnitsComponent', () => {
                 MockProvider(TextUnitService),
                 MockProvider(OnlineUnitService),
                 MockProvider(AttachmentUnitService),
+                MockProvider(LectureService),
                 MockProvider(LectureUnitManagementComponent),
                 { provide: Router, useClass: MockRouter },
                 {
@@ -77,6 +79,15 @@ describe('LectureUpdateUnitsComponent', () => {
     });
 
     it('should open video form when clicked', fakeAsync(() => {
+        const lectureService = TestBed.inject(LectureService);
+
+        const response: HttpResponse<VideoUnit> = new HttpResponse({
+            body: new Lecture(),
+            status: 201,
+        });
+
+        jest.spyOn(lectureService, 'findWithDetails').mockReturnValue(of(response));
+
         wizardUnitComponentFixture.detectChanges();
         tick();
         const unitCreationCard: UnitCreationCardComponent = wizardUnitComponentFixture.debugElement.query(By.directive(UnitCreationCardComponent)).componentInstance;
@@ -757,6 +768,15 @@ describe('LectureUpdateUnitsComponent', () => {
     }));
 
     it('should be in edit mode when clicked', fakeAsync(() => {
+        const lectureService = TestBed.inject(LectureService);
+
+        const response: HttpResponse<VideoUnit> = new HttpResponse({
+            body: new Lecture(),
+            status: 201,
+        });
+
+        jest.spyOn(lectureService, 'findWithDetails').mockReturnValue(of(response));
+
         wizardUnitComponentFixture.detectChanges();
         tick();
         wizardUnitComponent.startEditLectureUnit(new VideoUnit());
@@ -767,6 +787,15 @@ describe('LectureUpdateUnitsComponent', () => {
     }));
 
     it('should open edit video form when clicked', fakeAsync(() => {
+        const lectureService = TestBed.inject(LectureService);
+
+        const response: HttpResponse<VideoUnit> = new HttpResponse({
+            body: new Lecture(),
+            status: 201,
+        });
+
+        jest.spyOn(lectureService, 'findWithDetails').mockReturnValue(of(response));
+
         wizardUnitComponentFixture.detectChanges();
         tick();
 
@@ -775,6 +804,81 @@ describe('LectureUpdateUnitsComponent', () => {
         wizardUnitComponentFixture.whenStable().then(() => {
             expect(wizardUnitComponent.isVideoUnitFormOpen).toBeTrue();
         });
+    }));
+
+    it('should provide all attachment units', fakeAsync(() => {
+        const lectureService = TestBed.inject(LectureService);
+
+        const attachmentUnit1 = new AttachmentUnit();
+        attachmentUnit1.id = 1;
+
+        const attachmentUnit2 = new AttachmentUnit();
+        attachmentUnit2.id = 2;
+
+        const textUnit1 = new TextUnit();
+        textUnit1.id = 3;
+
+        const lecture = new Lecture();
+        lecture.lectureUnits = [attachmentUnit1, attachmentUnit2, textUnit1];
+
+        const response: HttpResponse<VideoUnit> = new HttpResponse({
+            body: lecture,
+            status: 201,
+        });
+
+        jest.spyOn(lectureService, 'findWithDetails').mockReturnValue(of(response));
+
+        wizardUnitComponentFixture.detectChanges();
+        tick();
+
+        wizardUnitComponent.startEditLectureUnit(new VideoUnit());
+
+        tick();
+
+        expect(wizardUnitComponent.availableAttachmentUnits.length).toBe(3);
+        expect(wizardUnitComponent.availableAttachmentUnits).toEqual([{}, attachmentUnit1, attachmentUnit2]);
+    }));
+
+    it('should provide all attachment units expect attachment unit a attached to a different video unit', fakeAsync(() => {
+        const lectureService = TestBed.inject(LectureService);
+
+        const videoUnit = new VideoUnit();
+        videoUnit.id = 5;
+
+        const attachmentUnit1 = new AttachmentUnit();
+        attachmentUnit1.id = 1;
+
+        const attachmentUnit2 = new AttachmentUnit();
+        attachmentUnit2.id = 2;
+        attachmentUnit2.correspondingVideoUnit = new VideoUnit();
+        attachmentUnit2.correspondingVideoUnit.id = 6;
+
+        const attachmentUnit3 = new AttachmentUnit();
+        attachmentUnit3.id = 3;
+        attachmentUnit3.correspondingVideoUnit = videoUnit;
+
+        const textUnit1 = new TextUnit();
+        textUnit1.id = 4;
+
+        const lecture = new Lecture();
+        lecture.lectureUnits = [attachmentUnit1, attachmentUnit2, attachmentUnit3, textUnit1];
+
+        const response: HttpResponse<VideoUnit> = new HttpResponse({
+            body: lecture,
+            status: 201,
+        });
+
+        jest.spyOn(lectureService, 'findWithDetails').mockReturnValue(of(response));
+
+        wizardUnitComponentFixture.detectChanges();
+        tick();
+
+        wizardUnitComponent.startEditLectureUnit(videoUnit);
+
+        tick();
+
+        expect(wizardUnitComponent.availableAttachmentUnits.length).toBe(3);
+        expect(wizardUnitComponent.availableAttachmentUnits).toEqual([{}, attachmentUnit1, attachmentUnit3]);
     }));
 
     it('should open edit online form when clicked', fakeAsync(() => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

# ⚠️ Do not deploy - contains database migration ⚠️

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Iris needs to know which video unit belongs to which attachment unit.


### Description
<!-- Describe your changes in detail -->
To enhance Iris chats and answer with more context from video units and attachment units, Iris needs to know exactly which video unit is connected to which attachment unit. This ensures both types of units are used when answering students queries. For that a OneToOne reference between video units and attachment units has been added.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Lecture
- Multiple attachment and video units

1. Log in to Artemis.
2. Navigate to a lecture.
3. Edit or create a new video unit.
4. Select an attachment unit from the dropdown menu and save the video unit.
5. Edit or create another video unit.
6. Verify that the previously selected attachment unit no longer appears in the dropdown menu (since it is already linked to another video unit).
7. Edit the first video unit and select the blank option from the dropdown to remove its connection to the attachment unit.
8. Edit or create another video unit and confirm that the previously linked attachment unit now appears again in the dropdown menu, allowing you to select it and save the video unit.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<img width="1799" alt="image" src="https://github.com/user-attachments/assets/15bc5ab5-8d3b-4174-a7de-1ef51aff1c5a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled bidirectional linking between video and attachment units for a richer content management experience.
  - Enhanced video unit management forms to allow selecting an associated attachment unit via a new dropdown.
  - Improved localization by incorporating new attachment unit labels in multiple languages.

- **Tests**
  - Extended test coverage to verify proper attachment unit selection and filtering during video unit creation and editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->