### PR TITLE
`Development`: Fix issue with server not starting up if Athena is active without scheduling profile

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/athena/api/AthenaApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/athena/api/AthenaApi.java
@@ -21,22 +21,23 @@ public class AthenaApi extends AbstractAthenaApi {
 
     private final AthenaModuleService athenaModuleService;
 
-    private final AthenaScheduleService athenaScheduleService;
+    private final Optional<AthenaScheduleService> athenaScheduleService;
 
     private final AthenaSubmissionSelectionService athenaSubmissionSelectionService;
 
-    public AthenaApi(AthenaModuleService athenaModuleService, AthenaScheduleService athenaScheduleService, AthenaSubmissionSelectionService athenaSubmissionSelectionService) {
+    public AthenaApi(AthenaModuleService athenaModuleService, Optional<AthenaScheduleService> athenaScheduleService,
+            AthenaSubmissionSelectionService athenaSubmissionSelectionService) {
         this.athenaModuleService = athenaModuleService;
         this.athenaScheduleService = athenaScheduleService;
         this.athenaSubmissionSelectionService = athenaSubmissionSelectionService;
     }
 
     public void scheduleExerciseForAthenaIfRequired(Exercise exercise) {
-        athenaScheduleService.scheduleExerciseForAthenaIfRequired(exercise);
+        athenaScheduleService.ifPresent(service -> service.scheduleExerciseForAthenaIfRequired(exercise));
     }
 
     public void cancelScheduledAthena(Long exerciseId) {
-        athenaScheduleService.cancelScheduledAthena(exerciseId);
+        athenaScheduleService.ifPresent(service -> service.cancelScheduledAthena(exerciseId));
     }
 
     public Optional<Long> getProposedSubmissionId(Exercise exercise, List<Long> submissionIds) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Error:

Mar 12 17:21:50 artemis-staging-localci-node-2 java[360795]: Parameter 1 of constructor in de.tum.cit.aet.artemis.athena.api.AthenaApi required a bean of type 'de.tum.cit.aet.artemis.athena.service.AthenaScheduleService' that could not be found.

This is a profile issue, it happens when the `athena` profile is active without `scheduling`. We can fix it by changing the dependency to optional


### Steps for Testing (Optional)
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

- Deploy to a multi-node server (TS1,3,4)
- Check grafana logs of secondary nodes and make sure they all started

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
- [ ] Code Review 3
- [ ] Code Review 4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced handling of a core service dependency to improve overall robustness and stability by ensuring operations run safely only when required resources are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->