### PR TITLE
`Development`: Fix false positive client test for exercise details

### DIFF
--- a/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
@@ -466,9 +466,9 @@ describe('CourseExerciseDetailsComponent', () => {
             ...exercise,
             course: { id: 1, courseInformationSharingConfiguration: CourseInformationSharingConfiguration.DISABLED },
         };
-        getExerciseDetailsMock.mockReturnValue(of({ body: newExercise }));
+        getExerciseDetailsMock.mockReturnValue(of({ body: { exercise: newExercise } }));
 
-        comp.handleNewExercise({ exercise });
+        fixture.detectChanges();
 
         const discussionSection = fixture.nativeElement.querySelector('jhi-discussion-section');
         expect(discussionSection).toBeFalsy();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The test case `CourseExerciseDetailsComponent > should not show discussion section when communication is disabled` is only passing since the test itself is not triggering the change detection.

### Description
<!-- Describe your changes in detail -->
- add trigger for change detection
- fix mocked data return type

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated internal tests for the course exercise details view to better simulate realistic data structures.
	- Enhanced change detection to ensure exercise updates and course sharing configurations correctly drive the discussion display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->