### PR TITLE
`Development`: Remove unused localVCenabled value from client

### DIFF
--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.html
@@ -211,17 +211,11 @@
                 @if (exercise.type === ExerciseType.PROGRAMMING) {
                     <div class="col-12">
                         <h4 jhiTranslate="artemisApp.exerciseAssessmentDashboard.exampleSolution"></h4>
-                        @if (!localVCEnabled) {
-                            <a jhiSecureLink [href]="programmingExercise.solutionParticipation?.repositoryUri || ''">
-                                <jhi-button jhiTranslate="artemisApp.exerciseAssessmentDashboard.programmingExercise.exampleSolution" />
-                            </a>
-                        } @else {
-                            <jhi-code-button
-                                [smallButtons]="true"
-                                [repositoryUri]="programmingExercise.solutionParticipation?.repositoryUri || ''"
-                                [routerLinkForRepositoryView]="['/course-management', courseId, 'programming-exercises', exerciseId, 'repository', 'SOLUTION']"
-                            />
-                        }
+                        <jhi-code-button
+                            [smallButtons]="true"
+                            [repositoryUri]="programmingExercise.solutionParticipation?.repositoryUri || ''"
+                            [routerLinkForRepositoryView]="['/course-management', courseId, 'programming-exercises', exerciseId, 'repository', 'SOLUTION']"
+                        />
                     </div>
                 }
 

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
@@ -57,7 +57,6 @@ import { SecondCorrectionEnableButtonComponent } from './second-correction-butto
 import { SidePanelComponent } from 'app/shared/side-panel/side-panel.component';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { ButtonComponent } from 'app/shared/components/button.component';
 import { CodeButtonComponent } from 'app/shared/components/code-button/code-button.component';
 import { StructuredGradingInstructionsAssessmentLayoutComponent } from 'app/assessment/manage/structured-grading-instructions-assessment-layout/structured-grading-instructions-assessment-layout.component';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
@@ -73,7 +72,6 @@ import { ArtemisDurationFromSecondsPipe } from 'app/shared/pipes/artemis-duratio
 import { AssessmentDashboardInformationEntry } from 'app/assessment/shared/assessment-dashboard/assessment-dashboard-information.component';
 import { HeaderExercisePageWithDetailsComponent } from 'app/exercise/exercise-headers/header-exercise-page-with-details.component';
 import { InfoPanelComponent } from 'app/assessment/shared/info-panel/info-panel.component';
-import { SecureLinkDirective } from 'app/assessment/manage/secure-link.directive';
 import { ResultComponent } from 'app/exercise/result/result.component';
 import { TutorParticipationService } from 'app/assessment/shared/assessment-dashboard/exercise-dashboard/tutor-participation.service';
 
@@ -99,8 +97,6 @@ export interface ExampleSubmissionQueryParams {
         InfoPanelComponent,
         ProgrammingExerciseInstructionComponent,
         ModelingEditorComponent,
-        SecureLinkDirective,
-        ButtonComponent,
         CodeButtonComponent,
         StructuredGradingInstructionsAssessmentLayoutComponent,
         NgbTooltip,

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
@@ -51,7 +51,6 @@ import { LegendPosition, PieChartModule } from '@swimlane/ngx-charts';
 import dayjs from 'dayjs/esm';
 import { faCheckCircle, faExclamationTriangle, faFolderOpen, faListAlt, faQuestionCircle, faSort, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { GraphColors } from 'app/exercise/shared/entities/statistics.model';
-import { PROFILE_LOCALVC } from 'app/app.constants';
 import { isManualResult } from 'app/exercise/result/result.utils';
 import { TutorParticipationGraphComponent } from 'app/shared/dashboards/tutor-participation-graph/tutor-participation-graph.component';
 import { SecondCorrectionEnableButtonComponent } from './second-correction-button/second-correction-enable-button.component';
@@ -76,7 +75,6 @@ import { HeaderExercisePageWithDetailsComponent } from 'app/exercise/exercise-he
 import { InfoPanelComponent } from 'app/assessment/shared/info-panel/info-panel.component';
 import { SecureLinkDirective } from 'app/assessment/manage/secure-link.directive';
 import { ResultComponent } from 'app/exercise/result/result.component';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { TutorParticipationService } from 'app/assessment/shared/assessment-dashboard/exercise-dashboard/tutor-participation.service';
 
 export interface ExampleSubmissionQueryParams {
@@ -136,7 +134,6 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
     private programmingSubmissionService = inject(ProgrammingSubmissionService);
     private guidedTourService = inject(GuidedTourService);
     private sortService = inject(SortService);
-    private profileService = inject(ProfileService);
 
     readonly roundScoreSpecifiedByCourseSettings = roundValueSpecifiedByCourseSettings;
     readonly getCourseFromExercise = getCourseFromExercise;
@@ -151,8 +148,6 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
     isExamMode = false;
     isTestRun = false;
     isLoading = false;
-
-    localVCEnabled = true;
 
     statsForDashboard = new StatsForDashboard();
 
@@ -261,9 +256,6 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
         this.accountService.identity().then((user: User) => (this.tutor = user));
         this.translateService.onLangChange.subscribe(() => {
             this.setupGraph();
-        });
-        this.profileService.getProfileInfo().subscribe((profileInfo) => {
-            this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
         });
     }
 

--- a/src/main/webapp/app/core/course/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/core/course/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -14,7 +14,7 @@ import { faEye, faFolderOpen, faPlayCircle, faRedo, faUsers } from '@fortawesome
 import { ParticipationService } from 'app/exercise/participation/participation.service';
 import dayjs from 'dayjs/esm';
 import { QuizExercise } from 'app/quiz/shared/entities/quiz-exercise.model';
-import { PROFILE_ATHENA, PROFILE_LOCALVC } from 'app/app.constants';
+import { PROFILE_ATHENA } from 'app/app.constants';
 import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
 import { ButtonType } from 'app/shared/components/button.component';
 import { NgTemplateOutlet } from '@angular/common';
@@ -79,7 +79,6 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
     hasRatedGradedResult: boolean;
     beforeDueDate: boolean;
     editorLabel?: string;
-    localVCEnabled = true;
     athenaEnabled = false;
     routerLink: string;
 
@@ -98,7 +97,6 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit, OnChanges
         } else if (this.exercise.type === ExerciseType.PROGRAMMING) {
             this.programmingExercise = this.exercise as ProgrammingExercise;
             this.profileService.getProfileInfo().subscribe((profileInfo) => {
-                this.localVCEnabled = profileInfo.activeProfiles?.includes(PROFILE_LOCALVC);
                 this.athenaEnabled = profileInfo.activeProfiles?.includes(PROFILE_ATHENA);
             });
         } else if (this.exercise.type === ExerciseType.MODELING) {

--- a/src/main/webapp/app/core/user/settings/user-settings-container/user-settings-container.component.html
+++ b/src/main/webapp/app/core/user/settings/user-settings-container/user-settings-container.component.html
@@ -29,17 +29,15 @@
                     jhiTranslate="artemisApp.userSettings.notificationSettings"
                 ></a>
                 <a class="list-group-item btn btn-outline-primary" routerLink="science" routerLinkActive="active" jhiTranslate="artemisApp.userSettings.scienceSettings"></a>
-                @if (localVCEnabled) {
-                    <a class="list-group-item btn btn-outline-primary" routerLink="ssh" routerLinkActive="active" jhiTranslate="artemisApp.userSettings.sshSettings"></a>
-                    @if (isAtLeastTutor) {
-                        <a
-                            class="list-group-item btn btn-outline-primary"
-                            routerLink="vcs-token"
-                            routerLinkActive="active"
-                            jhiTranslate="artemisApp.userSettings.vcsAccessTokenSettings"
-                        >
-                        </a>
-                    }
+                <a class="list-group-item btn btn-outline-primary" routerLink="ssh" routerLinkActive="active" jhiTranslate="artemisApp.userSettings.sshSettings"></a>
+                @if (isAtLeastTutor) {
+                    <a
+                        class="list-group-item btn btn-outline-primary"
+                        routerLink="vcs-token"
+                        routerLinkActive="active"
+                        jhiTranslate="artemisApp.userSettings.vcsAccessTokenSettings"
+                    >
+                    </a>
                 }
                 <a class="list-group-item btn btn-outline-primary" routerLink="ide-preferences" routerLinkActive="active">
                     <!--Default IDE Settings-->

--- a/src/main/webapp/app/core/user/settings/user-settings-container/user-settings-container.component.ts
+++ b/src/main/webapp/app/core/user/settings/user-settings-container/user-settings-container.component.ts
@@ -24,7 +24,6 @@ export class UserSettingsContainerComponent implements OnInit {
     faUser = faUser;
 
     currentUser?: User;
-    localVCEnabled = true;
     isAtLeastTutor = false;
 
     ngOnInit() {

--- a/src/main/webapp/app/core/user/settings/user-settings-container/user-settings-container.component.ts
+++ b/src/main/webapp/app/core/user/settings/user-settings-container/user-settings-container.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
-import { PROFILE_LOCALVC, addPublicFilePrefix } from 'app/app.constants';
+import { addPublicFilePrefix } from 'app/app.constants';
 import { User } from 'app/core/user/user.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { tap } from 'rxjs';
@@ -19,7 +18,6 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
     imports: [TranslateDirective, RouterModule, FontAwesomeModule],
 })
 export class UserSettingsContainerComponent implements OnInit {
-    private readonly profileService = inject(ProfileService);
     private readonly accountService = inject(AccountService);
 
     // Icons
@@ -30,10 +28,6 @@ export class UserSettingsContainerComponent implements OnInit {
     isAtLeastTutor = false;
 
     ngOnInit() {
-        this.profileService.getProfileInfo().subscribe((profileInfo) => {
-            this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
-        });
-
         this.accountService
             .getAuthenticationState()
             .pipe(

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -132,11 +132,7 @@
                                         <button
                                             jhiDeleteButton
                                             [entityTitle]="exerciseGroup.title || ''"
-                                            deleteQuestion="{{
-                                                localVCEnabled
-                                                    ? 'artemisApp.examManagement.exerciseGroup.delete.questionLocalVC'
-                                                    : 'artemisApp.examManagement.exerciseGroup.delete.question'
-                                            }}"
+                                            deleteQuestion="artemisApp.examManagement.exerciseGroup.delete.questionLocalVC"
                                             deleteConfirmationText="artemisApp.examManagement.exerciseGroup.delete.typeNameToConfirm"
                                             [additionalChecks]="
                                                 localCIEnabled

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.ts
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.ts
@@ -32,7 +32,7 @@ import {
 import { ExamImportComponent } from 'app/exam/manage/exams/exam-import/exam-import.component';
 import { ExerciseImportWrapperComponent } from 'app/exercise/import/exercise-import-wrapper/exercise-import-wrapper.component';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
-import { PROFILE_LOCALCI, PROFILE_LOCALVC } from 'app/app.constants';
+import { PROFILE_LOCALCI } from 'app/app.constants';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { HelpIconComponent } from 'app/shared/components/help-icon.component';
@@ -86,7 +86,6 @@ export class ExerciseGroupsComponent implements OnInit {
     latestIndividualEndDate?: dayjs.Dayjs;
     exerciseGroupToExerciseTypesDict = new Map<number, ExerciseType[]>();
 
-    localVCEnabled = true;
     localCIEnabled = true;
 
     // Icons
@@ -121,7 +120,6 @@ export class ExerciseGroupsComponent implements OnInit {
             error: (res: HttpErrorResponse) => onError(this.alertService, res),
         });
         this.profileService.getProfileInfo().subscribe((profileInfo) => {
-            this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
             this.localCIEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALCI);
         });
     }

--- a/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.html
@@ -8,15 +8,7 @@
         <div>
             <div>
                 @if (exercise().templateParticipation?.repositoryUri) {
-                    <!--Checks if the programming exercise has a setup with VCS and CI, if this not the case
-                                            the links/clone-buttons are disabled--->
-                    @if (!localVCEnabled) {
-                        <span>
-                            <a href="{{ exercise().templateParticipation?.repositoryUri || '' }}" target="_blank">Template</a>
-                        </span>
-                    } @else {
-                        <a [routerLink]="" (click)="downloadRepository(RepositoryType.TEMPLATE)"> <fa-icon [icon]="faDownload" /> Template </a>
-                    }
+                    <a (click)="downloadRepository(RepositoryType.TEMPLATE)"> <fa-icon [icon]="faDownload" /> Template </a>
                 }
                 @if (exercise().templateParticipation?.results?.length) {
                     <jhi-programming-exercise-instructor-status
@@ -28,13 +20,7 @@
             </div>
             <div>
                 @if (exercise().solutionParticipation?.repositoryUri) {
-                    @if (!localVCEnabled) {
-                        <span>
-                            <a href="{{ exercise().solutionParticipation?.repositoryUri || '' }}" target="_blank">Solution</a>
-                        </span>
-                    } @else {
-                        <a [routerLink]="" (click)="downloadRepository(RepositoryType.SOLUTION)"> <fa-icon [icon]="faDownload" /> Solution </a>
-                    }
+                    <a (click)="downloadRepository(RepositoryType.SOLUTION)"> <fa-icon [icon]="faDownload" /> Solution </a>
                 }
                 @if (exercise().solutionParticipation?.results?.length) {
                     <jhi-programming-exercise-instructor-status
@@ -46,13 +32,7 @@
             </div>
             <div>
                 @if (exercise().testRepositoryUri) {
-                    @if (!localVCEnabled) {
-                        <span>
-                            <a href="{{ exercise().testRepositoryUri }}" target="_blank">Test</a>
-                        </span>
-                    } @else {
-                        <a [routerLink]="" (click)="downloadRepository(RepositoryType.TESTS)"> <fa-icon [icon]="faDownload" /> Test </a>
-                    }
+                    <a (click)="downloadRepository(RepositoryType.TESTS)"> <fa-icon [icon]="faDownload" /> Test </a>
                 }
             </div>
         </div>
@@ -61,21 +41,13 @@
         <div>
             @if (exercise().templateParticipation?.buildPlanId) {
                 <span>
-                    @if (!localVCEnabled) {
-                        <a target="_blank" rel="noreferrer" href="{{ exercise().templateParticipation!.buildPlanUrl }}">Template</a>
-                    } @else {
-                        {{ exercise().templateParticipation!.buildPlanId }}
-                    }
+                    {{ exercise().templateParticipation!.buildPlanId }}
                 </span>
             }
             <br />
             @if (exercise().solutionParticipation?.buildPlanId) {
                 <span>
-                    @if (!localVCEnabled) {
-                        <a target="_blank" rel="noreferrer" href="{{ exercise().solutionParticipation!.buildPlanUrl }}">Solution</a>
-                    } @else {
-                        {{ exercise().solutionParticipation!.buildPlanId }}
-                    }
+                    {{ exercise().templateParticipation!.buildPlanId }}
                 </span>
             }
             <br />

--- a/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.ts
+++ b/src/main/webapp/app/exam/manage/exercise-groups/programming-exercise-cell/programming-exercise-group-cell.component.ts
@@ -7,8 +7,7 @@ import { ProgrammingExerciseService } from 'app/programming/manage/services/prog
 import { downloadZipFileFromResponse } from 'app/shared/util/download.util';
 import { AlertService } from 'app/shared/service/alert.service';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
-import { PROFILE_LOCALVC, PROFILE_THEIA } from 'app/app.constants';
-import { RouterLink } from '@angular/router';
+import { PROFILE_THEIA } from 'app/app.constants';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ProgrammingExerciseInstructorStatusComponent } from 'app/programming/manage/status/programming-exercise-instructor-status.component';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
@@ -19,7 +18,7 @@ import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service
     selector: 'jhi-programming-exercise-group-cell',
     templateUrl: './programming-exercise-group-cell.component.html',
     styles: [':host{display: contents}'],
-    imports: [RouterLink, FaIconComponent, ProgrammingExerciseInstructorStatusComponent, TranslateDirective],
+    imports: [FaIconComponent, ProgrammingExerciseInstructorStatusComponent, TranslateDirective],
 })
 export class ProgrammingExerciseGroupCellComponent implements OnInit {
     private profileService = inject(ProfileService);
@@ -30,7 +29,6 @@ export class ProgrammingExerciseGroupCellComponent implements OnInit {
 
     protected readonly RepositoryType = RepositoryType;
 
-    localVCEnabled = true;
     onlineIdeEnabled = false;
 
     displayShortName = input(false);
@@ -43,7 +41,6 @@ export class ProgrammingExerciseGroupCellComponent implements OnInit {
 
     ngOnInit(): void {
         this.profileService.getProfileInfo().subscribe((profileInfo) => {
-            this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
             this.onlineIdeEnabled = profileInfo.activeProfiles.includes(PROFILE_THEIA);
 
             const projectKey = this.exercise()?.projectKey;
@@ -62,16 +59,13 @@ export class ProgrammingExerciseGroupCellComponent implements OnInit {
     }
 
     /**
-     * Downloads the instructor repository. Used when the "localvc" profile is active.
-     * For the local VCS, linking to an external site displaying the repository does not work.
-     * Instead, the repository is downloaded.
+     * Downloads the instructor repository.
      *
      * @param repositoryType
      */
     downloadRepository(repositoryType: RepositoryType): void {
         const programmingExerciseId = this.exercise()?.id;
         if (programmingExerciseId) {
-            // Repository type cannot be 'AUXILIARY' as auxiliary repositories are currently not supported for the local VCS.
             this.programmingExerciseService.exportInstructorRepository(programmingExerciseId, repositoryType, undefined).subscribe((response: HttpResponse<Blob>) => {
                 downloadZipFileFromResponse(response);
                 this.alertService.success('artemisApp.programmingExercise.export.successMessageRepos');

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
@@ -21,8 +21,6 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { WebsocketService } from 'app/shared/service/websocket.service';
 import { convertDateFromServer } from 'app/shared/util/date.utils';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
-import { PROFILE_LOCALVC } from 'app/app.constants';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { StudentExamStatusComponent } from './student-exam-status/student-exam-status.component';
@@ -67,7 +65,6 @@ export class StudentExamsComponent implements OnInit, OnDestroy {
     private accountService = inject(AccountService);
     private artemisTranslatePipe = inject(ArtemisTranslatePipe);
     private websocketService = inject(WebsocketService);
-    private profileService = inject(ProfileService);
 
     courseId: number;
     examId: number;
@@ -85,7 +82,6 @@ export class StudentExamsComponent implements OnInit, OnDestroy {
     isExamOver = false;
     longestWorkingTime?: number;
     isAdmin = false;
-    localVCEnabled = true;
 
     exercisePreparationStatus?: ExamExerciseStartPreparationStatus;
     exercisePreparationRunning = false;
@@ -103,10 +99,6 @@ export class StudentExamsComponent implements OnInit, OnDestroy {
         this.courseId = Number(this.route.snapshot.paramMap.get('courseId'));
         this.examId = Number(this.route.snapshot.paramMap.get('examId'));
         this.loadAll();
-
-        this.profileService.getProfileInfo().subscribe((profileInfo) => {
-            this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
-        });
 
         const channel = getWebsocketChannel(this.examId);
         this.websocketService.subscribe(channel);

--- a/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.ts
@@ -13,7 +13,6 @@ import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { createCommitUrl } from 'app/programming/shared/utils/programming-exercise.utils';
 import { Router } from '@angular/router';
-import { PROFILE_LOCALVC } from 'app/app.constants';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { CodeButtonComponent } from 'app/shared/components/code-button/code-button.component';
 import { FeedbackComponent } from 'app/exercise/feedback/feedback.component';
@@ -66,7 +65,6 @@ export class ProgrammingExamSummaryComponent implements OnInit {
     commitHash: string | undefined;
 
     routerLink: string;
-    localVCEnabled = true;
     isInCourseManagement = false;
 
     ngOnInit() {
@@ -98,7 +96,6 @@ export class ProgrammingExamSummaryComponent implements OnInit {
         this.profileService.getProfileInfo().subscribe((profileInfo) => {
             const commitHashURLTemplate = profileInfo?.commitHashURLTemplate;
             this.commitUrl = createCommitUrl(commitHashURLTemplate, this.exercise.projectKey, this.participation, this.submission);
-            this.localVCEnabled = profileInfo.activeProfiles?.includes(PROFILE_LOCALVC);
         });
     }
 

--- a/src/main/webapp/app/exercise/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercise/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -144,7 +144,7 @@
         <button
             jhiDeleteButton
             [entityTitle]="exercise.title || ''"
-            deleteQuestion="{{ localVCEnabled ? 'artemisApp.programmingExercise.delete.questionLocalVC.single' : 'artemisApp.programmingExercise.delete.question' }}"
+            deleteQuestion="artemisApp.programmingExercise.delete.questionLocalVC.single"
             (delete)="deleteProgrammingExercise($event)"
             [dialogError]="dialogError$"
             deleteConfirmationText="artemisApp.exercise.delete.typeNameToConfirm"

--- a/src/main/webapp/app/exercise/exam-exercise-row-buttons/exam-exercise-row-buttons.component.ts
+++ b/src/main/webapp/app/exercise/exam-exercise-row-buttons/exam-exercise-row-buttons.component.ts
@@ -14,7 +14,7 @@ import { QuizExercise } from 'app/quiz/shared/entities/quiz-exercise.model';
 import { EventManager } from 'app/shared/service/event-manager.service';
 import { faBook, faExclamationTriangle, faEye, faFileExport, faFileSignature, faPencilAlt, faSignal, faTable, faTrash, faUsers, faWrench } from '@fortawesome/free-solid-svg-icons';
 import { faListAlt } from '@fortawesome/free-regular-svg-icons';
-import { PROFILE_LOCALCI, PROFILE_LOCALVC } from 'app/app.constants';
+import { PROFILE_LOCALCI } from 'app/app.constants';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { RouterLink } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -62,12 +62,10 @@ export class ExamExerciseRowButtonsComponent implements OnInit {
     faFileSignature = faFileSignature;
     farListAlt = faListAlt;
 
-    localVCEnabled = true;
     localCIEnabled = true;
 
     ngOnInit(): void {
         this.profileService.getProfileInfo().subscribe((profileInfo) => {
-            this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
             this.localCIEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALCI);
         });
     }

--- a/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.html
@@ -308,19 +308,12 @@
                                     @if (exercise.type === ExerciseType.PROGRAMMING) {
                                         <div class="mb-2">
                                             @if (getRepositoryLink(value)) {
-                                                @if (!localVCEnabled) {
-                                                    <a class="btn btn-primary btn-sm me-1" href="{{ getRepositoryLink(value) }}">
-                                                        <fa-icon [icon]="faCodeBranch" class="me-1" />
-                                                        Repository
-                                                    </a>
-                                                } @else {
-                                                    <jhi-code-button
-                                                        class="me-1"
-                                                        [smallButtons]="true"
-                                                        [repositoryUri]="getRepositoryLink(value) || ''"
-                                                        [routerLinkForRepositoryView]="['..', 'repository', RepositoryType.USER, value.id]"
-                                                    />
-                                                }
+                                                <jhi-code-button
+                                                    class="me-1"
+                                                    [smallButtons]="true"
+                                                    [repositoryUri]="getRepositoryLink(value) || ''"
+                                                    [routerLinkForRepositoryView]="['..', 'repository', RepositoryType.USER, value.id]"
+                                                />
                                             }
                                             @if (buildPlanId(value) && !localVCEnabled) {
                                                 <a target="_blank" rel="noreferrer" href="{{ value.buildPlanUrl }}" class="btn btn-primary btn-sm me-1">

--- a/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.html
@@ -315,12 +315,6 @@
                                                     [routerLinkForRepositoryView]="['..', 'repository', RepositoryType.USER, value.id]"
                                                 />
                                             }
-                                            @if (buildPlanId(value) && !localVCEnabled) {
-                                                <a target="_blank" rel="noreferrer" href="{{ value.buildPlanUrl }}" class="btn btn-primary btn-sm me-1">
-                                                    <fa-icon class="me-1" [icon]="farFileCode" />
-                                                    Build plan
-                                                </a>
-                                            }
                                             <!-- TODO This should ideally be a course management route. Used for the code editor where instructors can add commits to student repositories. -->
                                             <a
                                                 [routerLink]="['/courses', course.id, 'exercises', 'programming-exercises', exercise.id, 'code-editor', value.id]"

--- a/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.ts
@@ -8,7 +8,6 @@ import { Course } from 'app/core/shared/entities/course.model';
 import { CourseManagementService } from 'app/core/course/manage/course-management.service';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 import { ProgrammingSubmissionService } from 'app/programming/overview/programming-submission.service';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { areManualResultsAllowed } from 'app/exercise/exercise.utils';
 import { ResultService } from 'app/exercise/result/result.service';
 import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
@@ -25,7 +24,6 @@ import { Range } from 'app/shared/util/utils';
 import dayjs from 'dayjs/esm';
 import { ExerciseCacheService } from 'app/exercise/exercise-cache.service';
 import { NgbDropdown, NgbDropdownMenu, NgbDropdownToggle, NgbPopover, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
-import { PROFILE_LOCALVC } from 'app/app.constants';
 import { isManualResult } from 'app/exercise/result/result.utils';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -98,7 +96,6 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
     private courseService = inject(CourseManagementService);
     private exerciseService = inject(ExerciseService);
     private resultService = inject(ResultService);
-    private profileService = inject(ProfileService);
     private programmingSubmissionService = inject(ProgrammingSubmissionService);
     private participationService = inject(ParticipationService);
 
@@ -142,8 +139,6 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
     isLoading: boolean;
 
     afterDueDate = false;
-
-    localVCEnabled = true;
 
     // Icons
     faDownload = faDownload;
@@ -229,14 +224,6 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
             }
         });
         this.filteredParticipations = this.filterByScoreRange(this.participations);
-        if (this.exercise.type === ExerciseType.PROGRAMMING) {
-            const programmingExercise = this.exercise as ProgrammingExercise;
-            if (programmingExercise.projectKey) {
-                this.profileService.getProfileInfo().subscribe((profileInfo) => {
-                    this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
-                });
-            }
-        }
 
         for (const filter of Object.values(FilterProp)) {
             if (this.isFilterRelevantForConfiguration(filter)) {

--- a/src/main/webapp/app/exercise/participation/participation.component.html
+++ b/src/main/webapp/app/exercise/participation/participation.component.html
@@ -122,16 +122,12 @@
                         <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
                             @if (value && getRepositoryLink(row, value)) {
                                 <span>
-                                    @if (!localVCEnabled) {
-                                        <a href="{{ getRepositoryLink(row, value) }}" target="_blank" rel="noreferrer noopener">Repository Link</a>
-                                    } @else {
-                                        <jhi-code-button
-                                            class="ms-2"
-                                            [smallButtons]="true"
-                                            [routerLinkForRepositoryView]="['..', 'repository', RepositoryType.USER, row.id]"
-                                            [repositoryUri]="getRepositoryLink(row, value)!"
-                                        />
-                                    }
+                                    <jhi-code-button
+                                        class="ms-2"
+                                        [smallButtons]="true"
+                                        [routerLinkForRepositoryView]="['..', 'repository', RepositoryType.USER, row.id]"
+                                        [repositoryUri]="getRepositoryLink(row, value)!"
+                                    />
                                 </span>
                             }
                         </ng-template>
@@ -148,13 +144,7 @@
                         <ng-template ngx-datatable-cell-template let-row="row">
                             @if (row) {
                                 <span>
-                                    @if (!localVCEnabled) {
-                                        <a href="{{ row.buildPlanUrl }}" target="_blank" rel="noreferrer">
-                                            {{ row.buildPlanId }}
-                                        </a>
-                                    } @else {
-                                        {{ row.buildPlanId }}
-                                    }
+                                    {{ row.buildPlanId }}
                                 </span>
                             }
                         </ng-template>

--- a/src/main/webapp/app/exercise/participation/participation.component.ts
+++ b/src/main/webapp/app/exercise/participation/participation.component.ts
@@ -16,11 +16,9 @@ import dayjs from 'dayjs/esm';
 import { ProgrammingExerciseStudentParticipation } from 'app/exercise/shared/entities/participation/programming-exercise-student-participation.model';
 import { AlertService } from 'app/shared/service/alert.service';
 import { EventManager } from 'app/shared/service/event-manager.service';
-import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { faCircleNotch, faCodeBranch, faEraser, faFilePowerpoint, faTable, faTimes, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { GradingSystemService } from 'app/assessment/manage/grading-system/grading-system.service';
 import { GradeStepsDTO } from 'app/assessment/shared/entities/grade-step.model';
-import { PROFILE_LOCALVC } from 'app/app.constants';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FormsModule } from '@angular/forms';
 import { ProgrammingExerciseInstructorSubmissionStateComponent } from 'app/programming/shared/actions/programming-exercise-instructor-submission-state.component';
@@ -36,7 +34,6 @@ import { FeatureToggleDirective } from 'app/shared/feature-toggle/feature-toggle
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { RepositoryType } from 'app/programming/shared/code-editor/model/code-editor.model';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 
 enum FilterProp {
     ALL = 'all',
@@ -74,7 +71,6 @@ export class ParticipationComponent implements OnInit, OnDestroy {
     private exerciseService = inject(ExerciseService);
     private programmingSubmissionService = inject(ProgrammingSubmissionService);
     private accountService = inject(AccountService);
-    private profileService = inject(ProfileService);
     private gradingSystemService = inject(GradingSystemService);
 
     // make constants available to html for comparison
@@ -97,8 +93,6 @@ export class ParticipationComponent implements OnInit, OnDestroy {
 
     gradeStepsDTO?: GradeStepsDTO;
     gradeStepsDTOSub: Subscription;
-
-    localVCEnabled = true;
 
     private dialogErrorSource = new Subject<string>();
     dialogError = this.dialogErrorSource.asObservable();
@@ -185,14 +179,6 @@ export class ParticipationComponent implements OnInit, OnDestroy {
     private loadParticipations(exerciseId: number) {
         this.participationService.findAllParticipationsByExercise(exerciseId, false).subscribe((participationsResponse) => {
             this.participations = participationsResponse.body!;
-            if (this.exercise.type === ExerciseType.PROGRAMMING) {
-                const programmingExercise = this.exercise as ProgrammingExercise;
-                if (programmingExercise.projectKey) {
-                    this.profileService.getProfileInfo().subscribe((profileInfo) => {
-                        this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
-                    });
-                }
-            }
             this.isLoading = false;
         });
     }

--- a/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-container.component.html
+++ b/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-container.component.html
@@ -91,7 +91,7 @@
             </span>
         </ng-template>
         <ng-template #editorToolbar>
-            @if (isAtLeastEditor && localVCEnabled && !isTestRun) {
+            @if (isAtLeastEditor && !isTestRun) {
                 <a class="btn btn-secondary btn-sm me-2 open-repository-button" [routerLink]="localRepositoryLink" target="_blank" rel="noopener noreferrer">
                     <fa-icon [icon]="faExternalLink" />
                     <span jhiTranslate="artemisApp.exerciseAssessmentDashboard.programmingExercise.goToRepo"></span>
@@ -102,15 +102,6 @@
                 [singleParticipantMode]="true"
                 [participationIdList]="participation ? [participation!.id!] : []"
             />
-            @if (isAtLeastEditor && !localVCEnabled) {
-                <a
-                    class="ms-2 me-5"
-                    href="{{ participation?.userIndependentRepositoryUri }}"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    jhiTranslate="artemisApp.exerciseAssessmentDashboard.programmingExercise.goToRepo"
-                ></a>
-            }
             <!--            </ng-container>-->
             @if (participation) {
                 <jhi-result

--- a/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-container.component.ts
@@ -39,8 +39,6 @@ import { breakCircularResultBackReferences } from 'app/exercise/result/result.ut
 import { faExternalLink, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 import { cloneDeep } from 'lodash-es';
 import { AssessmentAfterComplaint } from 'app/assessment/manage/complaints-for-tutor/complaints-for-tutor.component';
-import { PROFILE_LOCALVC } from 'app/app.constants';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { AthenaService } from 'app/assessment/shared/athena.service';
 import { FeedbackSuggestionsPendingConfirmationDialogComponent } from 'app/exercise/feedback/feedback-suggestions-pending-confirmation-dialog/feedback-suggestions-pending-confirmation-dialog.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
@@ -80,7 +78,6 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
     private structuredGradingCriterionService = inject(StructuredGradingCriterionService);
     private repositoryFileService = inject(CodeEditorRepositoryFileService);
     private programmingExerciseService = inject(ProgrammingExerciseService);
-    private profileService = inject(ProfileService);
     private modalService = inject(NgbModal);
     private athenaService = inject(AthenaService);
 
@@ -125,7 +122,6 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
     loadingInitialSubmission = true;
     highlightDifferences = false;
 
-    localVCEnabled = true;
     isAtLeastEditor = false;
 
     unreferencedFeedback: Feedback[] = [];
@@ -234,10 +230,6 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
                     }),
                 )
                 .subscribe();
-        });
-
-        this.profileService.getProfileInfo().subscribe((profileInfo) => {
-            this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
         });
     }
 

--- a/src/main/webapp/app/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/programming/manage/programming-exercise-detail.component.html
@@ -141,9 +141,7 @@
                             <button
                                 jhiDeleteButton
                                 [entityTitle]="programmingExercise.title || ''"
-                                deleteQuestion="{{
-                                    localVCEnabled ? 'artemisApp.programmingExercise.delete.questionLocalVC.single' : 'artemisApp.programmingExercise.delete.question'
-                                }}"
+                                deleteQuestion="artemisApp.programmingExercise.delete.questionLocalVC.single"
                                 (delete)="deleteProgrammingExercise($event)"
                                 [dialogError]="dialogError$"
                                 [additionalChecks]="

--- a/src/main/webapp/app/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/programming/manage/programming-exercise-detail.component.ts
@@ -44,7 +44,7 @@ import {
 import { ButtonSize } from 'app/shared/components/button.component';
 import { ProgrammingLanguageFeatureService } from 'app/programming/service/programming-language-feature/programming-language-feature.service';
 import { DocumentationButtonComponent, DocumentationType } from 'app/shared/components/documentation-button/documentation-button.component';
-import { PROFILE_IRIS, PROFILE_LOCALCI, PROFILE_LOCALVC } from 'app/app.constants';
+import { PROFILE_IRIS, PROFILE_LOCALCI } from 'app/app.constants';
 import { ArtemisMarkdownService } from 'app/shared/markdown.service';
 import { DetailOverviewListComponent, DetailOverviewSection, DetailType } from 'app/shared/detail-overview-list/detail-overview-list.component';
 import { IrisSettingsService } from 'app/iris/manage/settings/shared/iris-settings.service';
@@ -147,7 +147,6 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
     courseId: number;
     doughnutStats: ExerciseManagementStatisticsDto;
     formattedGradingInstructions: SafeHtml;
-    localVCEnabled = true;
     localCIEnabled = true;
     irisEnabled = false;
     irisChatEnabled = false;
@@ -225,7 +224,6 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
                             this.supportsAuxiliaryRepositories =
                                 this.programmingLanguageFeatureService.getProgrammingLanguageFeature(programmingExercise.programmingLanguage)?.auxiliaryRepositoriesSupported ??
                                 false;
-                            this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
                             this.localCIEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALCI);
                             this.irisEnabled = profileInfo.activeProfiles.includes(PROFILE_IRIS);
                             if (this.irisEnabled && !this.isExamExercise) {

--- a/src/main/webapp/app/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/programming/manage/programming-exercise.component.html
@@ -78,13 +78,9 @@
                                     <span>
                                         <!--Checks if the programming exercise has a setup with VCS and CI, if this not the case
                              the links are disabled--->
-                                        @if (!localVCEnabled) {
-                                            <a href="{{ programmingExercise.templateParticipation!.repositoryUri! }}" target="_blank">Template</a>
-                                        } @else {
-                                            <a [routerLink]="" (click)="downloadRepository(programmingExercise.id, RepositoryType.TEMPLATE)"
-                                                ><fa-icon [icon]="faDownload" /> Template</a
-                                            >
-                                        }
+                                        <a [routerLink]="" (click)="downloadRepository(programmingExercise.id, RepositoryType.TEMPLATE)"
+                                            ><fa-icon [icon]="faDownload" /> Template</a
+                                        >
                                     </span>
                                 }
                                 @if (programmingExercise.templateParticipation?.results?.length) {
@@ -98,13 +94,9 @@
                             <div class="d-flex justify-content-between">
                                 @if (programmingExercise.solutionParticipation?.repositoryUri) {
                                     <span>
-                                        @if (!localVCEnabled) {
-                                            <a href="{{ programmingExercise.solutionParticipation!.repositoryUri! }}" target="_blank">Solution</a>
-                                        } @else {
-                                            <a [routerLink]="" (click)="downloadRepository(programmingExercise.id, RepositoryType.SOLUTION)"
-                                                ><fa-icon [icon]="faDownload" /> Solution</a
-                                            >
-                                        }
+                                        <a [routerLink]="" (click)="downloadRepository(programmingExercise.id, RepositoryType.SOLUTION)"
+                                            ><fa-icon [icon]="faDownload" /> Solution</a
+                                        >
                                     </span>
                                 }
                                 @if (programmingExercise.solutionParticipation?.results?.length) {
@@ -118,25 +110,11 @@
                             <div>
                                 @if (programmingExercise.testRepositoryUri) {
                                     <span>
-                                        @if (!localVCEnabled) {
-                                            <a href="{{ programmingExercise.testRepositoryUri }}" target="_blank">Test</a>
-                                        } @else {
-                                            <a [routerLink]="" (click)="downloadRepository(programmingExercise.id, RepositoryType.TESTS)"><fa-icon [icon]="faDownload" /> Test</a>
-                                        }
+                                        <a [routerLink]="" (click)="downloadRepository(programmingExercise.id, RepositoryType.TESTS)"><fa-icon [icon]="faDownload" /> Test</a>
                                     </span>
                                 }
                             </div>
                         </td>
-                        @if (!localVCEnabled) {
-                            <td>
-                                @if (programmingExercise.templateParticipation?.buildPlanId) {
-                                    <span> <a target="_blank" rel="noreferrer" href="{{ programmingExercise.templateParticipation!.buildPlanUrl }}">Template</a> </span>
-                                }
-                                @if (programmingExercise.solutionParticipation?.buildPlanId) {
-                                    <span> <a target="_blank" rel="noreferrer" href="{{ programmingExercise.solutionParticipation!.buildPlanUrl }}">Solution</a> </span>
-                                }
-                            </td>
-                        }
                         <td class="d-md-table-cell">
                             <div class="d-flex justify-content-between">
                                 <span class="colon-suffix" [jhiTranslate]="'artemisApp.programmingExercise.offlineIde'"></span>
@@ -262,9 +240,7 @@
                                             [jhiFeatureToggle]="FeatureToggle.ProgrammingExercises"
                                             jhiDeleteButton
                                             [entityTitle]="programmingExercise.title!"
-                                            deleteQuestion="{{
-                                                localVCEnabled ? 'artemisApp.programmingExercise.delete.questionLocalVC.single' : 'artemisApp.programmingExercise.delete.question'
-                                            }}"
+                                            deleteQuestion="artemisApp.programmingExercise.delete.questionLocalVC.single"
                                             (delete)="deleteProgrammingExercise(programmingExercise.id!, $event)"
                                             [dialogError]="dialogError$"
                                             [additionalChecks]="
@@ -312,9 +288,7 @@
                         [jhiFeatureToggle]="FeatureToggle.ProgrammingExercises"
                         jhiDeleteButton
                         [entityTitle]="'Multiple Programming Exercises'"
-                        deleteQuestion="{{
-                            localVCEnabled ? 'artemisApp.programmingExercise.delete.questionLocalVC.multiple' : 'artemisApp.exerciseActions.deleteMultipleExercisesQuestion'
-                        }}"
+                        deleteQuestion="artemisApp.programmingExercise.delete.questionLocalVC.multiple"
                         (delete)="deleteMultipleProgrammingExercises(selectedExercises, $event)"
                         [requireConfirmationOnlyForAdditionalChecks]="true"
                         [additionalChecks]="

--- a/src/main/webapp/app/programming/manage/programming-exercise.component.ts
+++ b/src/main/webapp/app/programming/manage/programming-exercise.component.ts
@@ -33,7 +33,7 @@ import {
     faWrench,
 } from '@fortawesome/free-solid-svg-icons';
 import { downloadZipFileFromResponse } from 'app/shared/util/download.util';
-import { PROFILE_LOCALCI, PROFILE_LOCALVC, PROFILE_THEIA } from 'app/app.constants';
+import { PROFILE_LOCALCI, PROFILE_THEIA } from 'app/app.constants';
 import { SortDirective } from 'app/shared/sort/sort.directive';
 import { FormsModule } from '@angular/forms';
 import { SortByDirective } from 'app/shared/sort/sort-by.directive';
@@ -93,7 +93,6 @@ export class ProgrammingExerciseComponent extends ExerciseComponent implements O
     FeatureToggle = FeatureToggle;
     solutionParticipationType = ProgrammingExerciseParticipationType.SOLUTION;
     templateParticipationType = ProgrammingExerciseParticipationType.TEMPLATE;
-    localVCEnabled = true;
     localCIEnabled = true;
     onlineIdeEnabled = false;
 
@@ -129,7 +128,6 @@ export class ProgrammingExerciseComponent extends ExerciseComponent implements O
                 this.programmingExercises = res.body!;
                 this.profileService.getProfileInfo().subscribe((profileInfo) => {
                     this.buildPlanLinkTemplate = profileInfo.buildPlanURLTemplate;
-                    this.localVCEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
                     this.localCIEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALCI);
                     this.onlineIdeEnabled = profileInfo.activeProfiles.includes(PROFILE_THEIA);
                 });
@@ -239,16 +237,13 @@ export class ProgrammingExerciseComponent extends ExerciseComponent implements O
     }
 
     /**
-     * Downloads the instructor repository. Used when the "localvc" profile is active.
-     * For the local VCS, linking to an external site displaying the repository does not work.
-     * Instead, the repository is downloaded.
+     * Downloads the instructor repository
      *
      * @param programmingExerciseId
      * @param repositoryType
      */
     downloadRepository(programmingExerciseId: number | undefined, repositoryType: RepositoryType) {
         if (programmingExerciseId) {
-            // Repository type cannot be 'AUXILIARY' as auxiliary repositories are currently not supported for the local VCS.
             this.programmingExerciseService.exportInstructorRepository(programmingExerciseId, repositoryType, undefined).subscribe((response: HttpResponse<Blob>) => {
                 downloadZipFileFromResponse(response);
                 this.alertService.success('artemisApp.programmingExercise.export.successMessageRepos');

--- a/src/main/webapp/app/programming/shared/repository-view/repository-view.component.html
+++ b/src/main/webapp/app/programming/shared/repository-view/repository-view.component.html
@@ -34,7 +34,7 @@
                         <span jhiTranslate="artemisApp.repository.commitHistory.openCommitHistory"></span>
                     </a>
                 }
-                @if (vcsAccessLogRoute && enableVcsAccessLog && allowVcsAccessLog && localVcEnabled) {
+                @if (vcsAccessLogRoute && enableVcsAccessLog && allowVcsAccessLog) {
                     <a [routerLink]="vcsAccessLogRoute" class="btn btn-primary">
                         <fa-icon [icon]="faClockRotateLeft" />
                         <span jhiTranslate="artemisApp.repository.vcsAccessLog.openVcsAccessLog"></span>

--- a/src/main/webapp/app/programming/shared/repository-view/repository-view.component.ts
+++ b/src/main/webapp/app/programming/shared/repository-view/repository-view.component.ts
@@ -14,8 +14,6 @@ import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons';
 import { ProgrammingExerciseService } from 'app/programming/manage/services/programming-exercise.service';
 import { ButtonComponent, ButtonSize, ButtonType } from 'app/shared/components/button.component';
 import { Feedback } from 'app/assessment/shared/entities/feedback.model';
-import { PROFILE_LOCALVC } from 'app/app.constants';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ResultComponent } from 'app/exercise/result/result.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -46,7 +44,6 @@ export class RepositoryViewComponent implements OnInit, OnDestroy {
     private accountService = inject(AccountService);
     domainService = inject(DomainService);
     private route = inject(ActivatedRoute);
-    private profileService = inject(ProfileService);
     private programmingExerciseParticipationService = inject(ProgrammingExerciseParticipationService);
     private programmingExerciseService = inject(ProgrammingExerciseService);
     private router = inject(Router);
@@ -77,7 +74,6 @@ export class RepositoryViewComponent implements OnInit, OnDestroy {
     result: Result;
     resultHasInlineFeedback = false;
     showInlineFeedback = false;
-    localVcEnabled = true;
 
     faClockRotateLeft = faClockRotateLeft;
     participationWithLatestResultSub: Subscription;
@@ -118,9 +114,6 @@ export class RepositoryViewComponent implements OnInit, OnDestroy {
             } else {
                 this.loadDifferentParticipation(this.repositoryType, exerciseId);
             }
-        });
-        this.profileService.getProfileInfo().subscribe((profileInfo) => {
-            this.localVcEnabled = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
         });
     }
 

--- a/src/main/webapp/app/shared/components/code-button/code-button.component.html
+++ b/src/main/webapp/app/shared/components/code-button/code-button.component.html
@@ -82,27 +82,15 @@
                 >{{ getHttpOrSshRepositoryUri() }} </pre
             >
             <div class="d-flex align-items-center">
-                @if (!localVCEnabled()) {
-                    <a
-                        [style.flex]="1"
-                        class="btn btn-secondary btn-sm me-2 open-repository-button"
-                        [href]="getHttpRepositoryUri() | safeUrl"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        <fa-icon [icon]="faExternalLink" />
-                    </a>
-                } @else {
-                    <a
-                        [style.flex]="1"
-                        class="btn btn-secondary btn-sm me-2 open-repository-button"
-                        [routerLink]="routerLinkForRepositoryView()"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        <fa-icon [icon]="faExternalLink" />
-                    </a>
-                }
+                <a
+                    [style.flex]="1"
+                    class="btn btn-secondary btn-sm me-2 open-repository-button"
+                    [routerLink]="routerLinkForRepositoryView()"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    <fa-icon [icon]="faExternalLink" />
+                </a>
             </div>
         </div>
         <button

--- a/src/main/webapp/app/shared/components/code-button/code-button.component.ts
+++ b/src/main/webapp/app/shared/components/code-button/code-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, effect, inject, input, signal } from '@angular/core';
+import { Component, OnInit, effect, inject, input } from '@angular/core';
 import { ProgrammingExercise, ProgrammingLanguage } from 'app/programming/shared/entities/programming-exercise.model';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 import { ExternalCloningService } from 'app/programming/service/external-cloning.service';
@@ -98,8 +98,6 @@ export class CodeButtonComponent implements OnInit {
     sshTemplateUrl?: string;
     versionControlUrl: string;
 
-    localVCEnabled = signal<boolean>(true);
-
     copyEnabled = false;
     doesUserHaveSSHkeys = false;
     areAnySshKeysExpired = false;
@@ -145,7 +143,7 @@ export class CodeButtonComponent implements OnInit {
         });
 
         effect(() => {
-            if (!this.isInCourseManagement && this.localVCEnabled()) {
+            if (!this.isInCourseManagement) {
                 this.loadVcsAccessTokensForAllParticipations();
             }
         });
@@ -175,7 +173,7 @@ export class CodeButtonComponent implements OnInit {
             }
 
             this.localVCEnabled.set(profileInfo.activeProfiles.includes(PROFILE_LOCALVC));
-            this.configureTooltips(profileInfo);
+            this.configureTooltips();
             this.initTheia(profileInfo);
         });
 
@@ -418,13 +416,10 @@ export class CodeButtonComponent implements OnInit {
         }
     }
 
-    private configureTooltips(profileInfo: ProfileInfo) {
-        if (this.localVCEnabled()) {
-            this.vcsTokenSettingsUrl = `${window.location.origin}/user-settings/vcs-token`;
-            this.sshSettingsUrl = `${window.location.origin}/user-settings/ssh`;
-        } else {
-            this.sshSettingsUrl = profileInfo.sshKeysURL;
-        }
+    private configureTooltips() {
+        this.vcsTokenSettingsUrl = `${window.location.origin}/user-settings/vcs-token`;
+        this.sshSettingsUrl = `${window.location.origin}/user-settings/ssh`;
+
         this.tokenMissingTip = this.formatTip('artemisApp.exerciseActions.vcsTokenTip', this.vcsTokenSettingsUrl);
         this.tokenExpiredTip = this.formatTip('artemisApp.exerciseActions.vcsTokenExpiredTip', this.vcsTokenSettingsUrl);
         this.sshKeyMissingTip = this.formatTip('artemisApp.exerciseActions.sshKeyTip', this.sshSettingsUrl);

--- a/src/main/webapp/app/shared/components/code-button/code-button.component.ts
+++ b/src/main/webapp/app/shared/components/code-button/code-button.component.ts
@@ -9,7 +9,7 @@ import { User } from 'app/core/user/user.model';
 import { LocalStorageService } from 'ngx-webstorage';
 import { ProgrammingExerciseStudentParticipation } from 'app/exercise/shared/entities/participation/programming-exercise-student-participation.model';
 import { ParticipationService } from 'app/exercise/participation/participation.service';
-import { PROFILE_LOCALVC, PROFILE_THEIA } from 'app/app.constants';
+import { PROFILE_THEIA } from 'app/app.constants';
 import dayjs from 'dayjs/esm';
 import { isPracticeMode } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { faCode, faExternalLink } from '@fortawesome/free-solid-svg-icons';
@@ -172,7 +172,6 @@ export class CodeButtonComponent implements OnInit {
                 this.versionControlUrl = profileInfo.versionControlUrl;
             }
 
-            this.localVCEnabled.set(profileInfo.activeProfiles.includes(PROFILE_LOCALVC));
             this.configureTooltips();
             this.initTheia(profileInfo);
         });

--- a/src/main/webapp/app/shared/detail-overview-list/detail-overview-list.component.ts
+++ b/src/main/webapp/app/shared/detail-overview-list/detail-overview-list.component.ts
@@ -8,7 +8,7 @@ import { AlertService } from 'app/shared/service/alert.service';
 import { Detail } from 'app/shared/detail-overview-list/detail.model';
 import { UMLModel } from '@ls1intum/apollon';
 import { Subscription } from 'rxjs';
-import { PROFILE_LOCALVC, addPublicFilePrefix } from 'app/app.constants';
+import { addPublicFilePrefix } from 'app/app.constants';
 import { DetailOverviewNavigationBarComponent } from '../detail-overview-navigation-bar/detail-overview-navigation-bar.component';
 import { HelpIconComponent } from '../components/help-icon.component';
 import { ProgrammingExerciseInstructionComponent } from 'app/programming/shared/instructions-render/programming-exercise-instruction.component';
@@ -23,7 +23,6 @@ import { ExerciseDetailDirective } from './exercise-detail.directive';
 import { NoDataComponent } from '../no-data-component';
 import { ArtemisTranslatePipe } from '../pipes/artemis-translate.pipe';
 import { ProgrammingExerciseParticipationType } from 'app/programming/shared/entities/programming-exercise-participation.model';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 
 export interface DetailOverviewSection {
     headline: string;
@@ -82,7 +81,6 @@ export class DetailOverviewListComponent implements OnInit, OnDestroy {
 
     private readonly modelingExerciseService = inject(ModelingExerciseService);
     private readonly alertService = inject(AlertService);
-    private readonly profileService = inject(ProfileService);
 
     sections = input.required<DetailOverviewSection[]>();
 
@@ -92,7 +90,6 @@ export class DetailOverviewListComponent implements OnInit, OnDestroy {
     headlinesRecord: Record<string, string>;
 
     profileSubscription: Subscription;
-    isLocalVC = false;
 
     ngOnInit() {
         this.headlines = this.sections().map((section) => {
@@ -100,9 +97,6 @@ export class DetailOverviewListComponent implements OnInit, OnDestroy {
                 id: section.headline.replaceAll('.', '-'),
                 translationKey: section.headline,
             };
-        });
-        this.profileSubscription = this.profileService.getProfileInfo().subscribe((profileInfo) => {
-            this.isLocalVC = profileInfo.activeProfiles.includes(PROFILE_LOCALVC);
         });
         this.headlinesRecord = this.headlines.reduce((previousValue, currentValue) => {
             return { ...previousValue, [currentValue.translationKey]: currentValue.id };

--- a/src/main/webapp/app/shared/detail-overview-list/detail-overview-list.component.ts
+++ b/src/main/webapp/app/shared/detail-overview-list/detail-overview-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewEncapsulation, inject, input } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, inject, input } from '@angular/core';
 import { isEmpty } from 'lodash-es';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 import { ButtonSize } from 'app/shared/components/button.component';
@@ -7,7 +7,6 @@ import { ModelingExerciseService } from 'app/modeling/manage/modeling-exercise.s
 import { AlertService } from 'app/shared/service/alert.service';
 import { Detail } from 'app/shared/detail-overview-list/detail.model';
 import { UMLModel } from '@ls1intum/apollon';
-import { Subscription } from 'rxjs';
 import { addPublicFilePrefix } from 'app/app.constants';
 import { DetailOverviewNavigationBarComponent } from '../detail-overview-navigation-bar/detail-overview-navigation-bar.component';
 import { HelpIconComponent } from '../components/help-icon.component';
@@ -71,7 +70,7 @@ export enum DetailType {
         ArtemisTranslatePipe,
     ],
 })
-export class DetailOverviewListComponent implements OnInit, OnDestroy {
+export class DetailOverviewListComponent implements OnInit {
     protected readonly isEmpty = isEmpty;
     protected readonly DetailType = DetailType;
     protected readonly FeatureToggle = FeatureToggle;
@@ -88,8 +87,6 @@ export class DetailOverviewListComponent implements OnInit, OnDestroy {
     headlines: { id: string; translationKey: string }[];
     // headline record to avoid function call in html
     headlinesRecord: Record<string, string>;
-
-    profileSubscription: Subscription;
 
     ngOnInit() {
         this.headlines = this.sections().map((section) => {
@@ -111,10 +108,6 @@ export class DetailOverviewListComponent implements OnInit, OnDestroy {
                 },
             });
         }
-    }
-
-    ngOnDestroy() {
-        this.profileSubscription?.unsubscribe();
     }
 
     protected readonly addPublicFilePrefix = addPublicFilePrefix;

--- a/src/test/javascript/spec/component/account/user-settings-container.component.spec.ts
+++ b/src/test/javascript/spec/component/account/user-settings-container.component.spec.ts
@@ -1,12 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
-import { of } from 'rxjs';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MockNgbModalService } from '../../helpers/mocks/service/mock-ngb-modal.service';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { PROFILE_LOCALVC } from 'app/app.constants';
 import { MockRouter } from '../../helpers/mocks/mock-router';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
@@ -17,21 +14,15 @@ describe('UserSettingsContainerComponent', () => {
     let fixture: ComponentFixture<UserSettingsContainerComponent>;
     let comp: UserSettingsContainerComponent;
 
-    let profileServiceMock: { getProfileInfo: jest.Mock };
     let translateService: TranslateService;
-
+    let accountService: AccountService;
     const router = new MockRouter();
     router.setUrl('');
 
     beforeEach(async () => {
-        profileServiceMock = {
-            getProfileInfo: jest.fn(),
-        };
-
         await TestBed.configureTestingModule({
-            imports: [UserSettingsContainerComponent, RouterModule],
+            imports: [UserSettingsContainerComponent],
             providers: [
-                { provide: ProfileService, useValue: profileServiceMock },
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: NgbModal, useClass: MockNgbModalService },
                 { provide: Router, useValue: router },
@@ -39,26 +30,18 @@ describe('UserSettingsContainerComponent', () => {
                 { provide: AccountService, useClass: MockAccountService },
             ],
         }).compileComponents();
+
         fixture = TestBed.createComponent(UserSettingsContainerComponent);
         comp = fixture.componentInstance;
         translateService = TestBed.inject(TranslateService);
+        accountService = TestBed.inject(AccountService);
         translateService.currentLang = 'en';
     });
-
-    beforeEach(() => {
-        profileServiceMock.getProfileInfo.mockReturnValue(of({ activeProfiles: [PROFILE_LOCALVC] }));
-    });
-
-    it('should initialize with localVC profile', async () => {
-        comp.ngOnInit();
-        expect(profileServiceMock.getProfileInfo).toHaveBeenCalled();
-        expect(comp.localVCEnabled).toBeTrue();
-    });
-
-    it('should initialize with no localVC profile set', async () => {
-        profileServiceMock.getProfileInfo.mockReturnValue(of({ activeProfiles: [] }));
-        comp.ngOnInit();
-        expect(profileServiceMock.getProfileInfo).toHaveBeenCalled();
-        expect(comp.localVCEnabled).toBeFalse();
+    it('should initialize with loaded user', () => {
+        const getAuthenticationSpy = jest.spyOn(accountService, 'getAuthenticationState');
+        fixture.detectChanges();
+        expect(getAuthenticationSpy).toHaveBeenCalled();
+        expect(comp.currentUser?.id).toEqual(99);
+        expect(comp.isAtLeastTutor).toEqual(false);
     });
 });

--- a/src/test/javascript/spec/component/detail-overview-list.component.spec.ts
+++ b/src/test/javascript/spec/component/detail-overview-list.component.spec.ts
@@ -8,8 +8,6 @@ import { HttpResponse } from '@angular/common/http';
 import { UMLModel } from '@ls1intum/apollon';
 import { Detail } from 'app/shared/detail-overview-list/detail.model';
 import { Router } from '@angular/router';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
-import { MockProfileService } from '../helpers/mocks/service/mock-profile.service';
 import { MockRouter } from '../helpers/mocks/mock-router';
 import { TranslateService } from '@ngx-translate/core';
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
@@ -39,7 +37,6 @@ describe('DetailOverviewList', () => {
             providers: [
                 { provide: AlertService, useClass: MockAlertService },
                 { provide: Router, useClass: MockRouter },
-                { provide: ProfileService, useClass: MockProfileService },
                 { provide: ModelingExerciseService, useValue: { convertToPdf: jest.fn() } },
                 { provide: TranslateService, useClass: MockTranslateService },
             ],

--- a/src/test/javascript/spec/component/detail-overview-list.component.spec.ts
+++ b/src/test/javascript/spec/component/detail-overview-list.component.spec.ts
@@ -51,15 +51,12 @@ describe('DetailOverviewList', () => {
         component = fixture.componentInstance;
     });
 
-    it('should initialize and destroy', () => {
+    it('should initialize', () => {
         fixture.componentRef.setInput('sections', sections);
         fixture.detectChanges();
         expect(component.headlines).toStrictEqual([{ id: 'headline-1', translationKey: 'headline.1' }]);
         expect(component.headlinesRecord).toStrictEqual({ 'headline.1': 'headline-1' });
         expect(DetailOverviewListComponent).not.toBeNull();
-
-        component.ngOnDestroy();
-        expect(component.profileSubscription?.closed).toBeTruthy();
     });
 
     it('should escape all falsy values', () => {

--- a/src/test/javascript/spec/component/exam/manage/exercise-groups/programming-exercise-group-cell.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exercise-groups/programming-exercise-group-cell.component.spec.ts
@@ -15,6 +15,7 @@ import { MockProvider } from 'ng-mocks';
 import { RepositoryType } from '../../../../../../../main/webapp/app/programming/shared/code-editor/model/code-editor.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../../../helpers/mocks/service/mock-account.service';
+import { ActivatedRoute } from '@angular/router';
 
 describe('Programming Exercise Group Cell Component', () => {
     let comp: ProgrammingExerciseGroupCellComponent;
@@ -58,6 +59,12 @@ describe('Programming Exercise Group Cell Component', () => {
                 { provide: AccountService, useClass: MockAccountService },
                 MockProvider(AlertService),
                 provideHttpClient(),
+                {
+                    provide: ActivatedRoute,
+                    useValue: {
+                        params: of({ examId: '3' }),
+                    },
+                },
             ],
         })
             .compileComponents()
@@ -89,8 +96,8 @@ describe('Programming Exercise Group Cell Component', () => {
         fixture.detectChanges();
         const span = fixture.debugElement.query(By.css('a'));
         expect(span).toBeDefined();
-        expect(span.nativeElement.textContent).toBe('Template');
-        expect(span.nativeElement.href).toBe(exercise.templateParticipation!.repositoryUri);
+        expect(span.nativeElement.textContent).toBe(' Template ');
+        expect(span.nativeElement.href).toBe(''); // empty, as LocalVC directly downloads the repository without forwarding
     });
 
     it('should display editor mode flags', () => {

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exams.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exams.component.spec.ts
@@ -25,7 +25,6 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { MockTranslateService } from '../../../../helpers/mocks/service/mock-translate.service';
 import { WebsocketService } from 'app/shared/service/websocket.service';
 import { MockWebsocketService } from '../../../../helpers/mocks/service/mock-websocket.service';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { MockNgbModalService } from '../../../../helpers/mocks/service/mock-ngb-modal.service';
 
 describe('StudentExamsComponent', () => {
@@ -150,7 +149,6 @@ describe('StudentExamsComponent', () => {
         { provide: TranslateService, useClass: MockTranslateService },
         { provide: WebsocketService, useClass: MockWebsocketService },
         { provide: NgbModal, useClass: MockNgbModalService },
-        MockProvider(ProfileService, { getProfileInfo: () => of({ activeProfiles: [] }) }, 'useValue'),
     ];
 
     beforeEach(() => {

--- a/src/test/javascript/spec/component/exercises/shared/exercise-scores/exercise-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/exercise-scores/exercise-scores.component.spec.ts
@@ -17,14 +17,12 @@ import { ExerciseScoresComponent, FilterProp } from 'app/exercise/exercise-score
 import { ExerciseService } from 'app/exercise/exercise.service';
 import { ParticipationService } from 'app/exercise/participation/participation.service';
 import { ResultService } from 'app/exercise/result/result.service';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { Range } from 'app/shared/util/utils';
 import dayjs from 'dayjs/esm';
 import { Subscription, of } from 'rxjs';
 import { MockCourseManagementService } from '../../../../helpers/mocks/service/mock-course-management.service';
 import { MockExerciseService } from '../../../../helpers/mocks/service/mock-exercise.service';
 import { MockParticipationService } from '../../../../helpers/mocks/service/mock-participation.service';
-import { MockProfileService } from '../../../../helpers/mocks/service/mock-profile.service';
 import { MockProgrammingSubmissionService } from '../../../../helpers/mocks/service/mock-programming-submission.service';
 import { MockResultService } from '../../../../helpers/mocks/service/mock-result.service';
 
@@ -110,7 +108,6 @@ describe('Exercise Scores Component', () => {
                 { provide: ExerciseService, useClass: MockExerciseService },
                 { provide: ActivatedRoute, useValue: route },
                 { provide: ResultService, useClass: MockResultService },
-                { provide: ProfileService, useClass: MockProfileService },
                 { provide: CourseManagementService, useClass: MockCourseManagementService },
                 { provide: ProgrammingSubmissionService, useClass: MockProgrammingSubmissionService },
                 { provide: ParticipationService, useClass: MockParticipationService },

--- a/src/test/javascript/spec/component/localvc/repository-view.component.spec.ts
+++ b/src/test/javascript/spec/component/localvc/repository-view.component.spec.ts
@@ -14,8 +14,6 @@ import { Observable, of } from 'rxjs';
 import { HttpResponse } from '@angular/common/http';
 import { DueDateStat } from 'app/assessment/shared/assessment-dashboard/due-date-stat.model';
 import { ProgrammingExerciseStudentParticipation } from 'app/exercise/shared/entities/participation/programming-exercise-student-participation.model';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
-import { MockProfileService } from '../../helpers/mocks/service/mock-profile.service';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { AuxiliaryRepository } from 'app/programming/shared/entities/programming-exercise-auxiliary-repository-model';
 
@@ -39,7 +37,6 @@ describe('RepositoryViewComponent', () => {
                 { provide: ActivatedRoute, useValue: new MockActivatedRoute({ key: 'ABC123' }) },
                 { provide: ProgrammingExerciseParticipationService, useClass: MockProgrammingExerciseParticipationService },
                 { provide: ProgrammingExerciseService, useClass: MockProgrammingExerciseService },
-                { provide: ProfileService, useClass: MockProfileService },
             ],
         })
             .compileComponents()

--- a/src/test/javascript/spec/component/programming-assessment/code-editor-tutor-assessment-container.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/code-editor-tutor-assessment-container.component.spec.ts
@@ -10,7 +10,7 @@ import { User } from 'app/core/user/user.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { By } from '@angular/platform-browser';
-import { MockComponent, MockProvider } from 'ng-mocks';
+import { MockComponent } from 'ng-mocks';
 import { RepositoryFileService } from 'app/exercise/result/repository.service';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { ProgrammingSubmission } from 'app/programming/shared/entities/programming-submission.model';
@@ -42,7 +42,6 @@ import { AssessmentAfterComplaint } from 'app/assessment/manage/complaints-for-t
 import { TreeViewItem } from 'app/programming/shared/code-editor/treeview/models/tree-view-item';
 import { AlertService } from 'app/shared/service/alert.service';
 import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
-import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { MockAthenaService } from '../../helpers/mocks/service/mock-athena.service';
 import { AthenaService } from 'app/assessment/shared/athena.service';
 import { MockResizeObserver } from '../../helpers/mocks/service/mock-resize-observer';
@@ -166,7 +165,6 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
                 { provide: AthenaService, useClass: MockAthenaService },
                 { provide: ActivatedRoute, useValue: route() },
                 { provide: Router, useClass: MockRouter },
-                MockProvider(ProfileService, { getProfileInfo: () => of({ activeProfiles: [] }) }, 'useValue'),
                 provideHttpClient(),
                 provideHttpClientTesting(),
             ],


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In the client are still remnants of the gitlab setup.
As the localVCenabled flag is always true now, the client code depending on it can be removed.

### Description
<!-- Describe your changes in detail -->
- Removes the localVCenabled variable, and removes releted HTML

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
1. Navigate through programming exercise components, and verify nothing is broken


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
no UI change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined several views and action prompts by removing conditional toggles for repository access and deletion confirmations. Interface elements now consistently display unified download options and messaging across exams, programming exercises, and assessments.
	- Updated user settings to always show SSH configuration links for easier access.
- **Tests**
	- Revised test suites to align with the simplified logic and consistent interface behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->