### PR TITLE
`Development`: Fix telemetry service test urls

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/core/service/TelemetryServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/TelemetryServiceTest.java
@@ -59,7 +59,7 @@ class TelemetryServiceTest extends AbstractSpringIntegrationIndependentTest {
     void testSendTelemetry_TelemetryEnabled() throws Exception {
         TelemetryService telemetryService = new TelemetryService(profileService, telemetrySendingService, true, true);
         telemetryServiceSpy = spy(telemetryService);
-        mockServer.expect(ExpectedCount.once(), requestTo(new URI(destination + "/api/core/telemetry"))).andExpect(method(HttpMethod.POST))
+        mockServer.expect(ExpectedCount.once(), requestTo(new URI(destination + "/api/telemetry"))).andExpect(method(HttpMethod.POST))
                 .andExpect(request -> assertThat(request.getBody().toString()).contains("adminName"))
                 .andRespond(withSuccess().contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString("Success!")));
         telemetryServiceSpy.sendTelemetry();
@@ -71,7 +71,7 @@ class TelemetryServiceTest extends AbstractSpringIntegrationIndependentTest {
     void testSendTelemetry_TelemetryEnabledWithoutPersonalData() throws Exception {
         TelemetryService telemetryService = new TelemetryService(profileService, telemetrySendingService, true, false);
         telemetryServiceSpy = spy(telemetryService);
-        mockServer.expect(ExpectedCount.once(), requestTo(new URI(destination + "/api/core/telemetry"))).andExpect(method(HttpMethod.POST))
+        mockServer.expect(ExpectedCount.once(), requestTo(new URI(destination + "/api/telemetry"))).andExpect(method(HttpMethod.POST))
                 .andExpect(request -> assertThat(request.getBody().toString()).doesNotContain("adminName"))
                 .andRespond(withSuccess().contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString("Success!")));
         telemetryServiceSpy.sendTelemetry();
@@ -84,7 +84,7 @@ class TelemetryServiceTest extends AbstractSpringIntegrationIndependentTest {
         TelemetryService telemetryService = new TelemetryService(profileService, telemetrySendingService, false, true);
         telemetryServiceSpy = spy(telemetryService);
 
-        mockServer.expect(ExpectedCount.never(), requestTo(new URI(destination + "/api/core/telemetry"))).andExpect(method(HttpMethod.POST))
+        mockServer.expect(ExpectedCount.never(), requestTo(new URI(destination + "/api/telemetry"))).andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess().contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString("Success!")));
         telemetryServiceSpy.sendTelemetry();
         await().atMost(2, SECONDS).untilAsserted(() -> mockServer.verify());
@@ -95,7 +95,7 @@ class TelemetryServiceTest extends AbstractSpringIntegrationIndependentTest {
         TelemetryService telemetryService = new TelemetryService(profileService, telemetrySendingService, true, true);
         telemetryServiceSpy = spy(telemetryService);
 
-        mockServer.expect(ExpectedCount.once(), requestTo(new URI(destination + "/api/core/telemetry"))).andExpect(method(HttpMethod.POST))
+        mockServer.expect(ExpectedCount.once(), requestTo(new URI(destination + "/api/telemetry"))).andExpect(method(HttpMethod.POST))
                 .andRespond(withServerError().body(mapper.writeValueAsString("Failure!")));
 
         telemetryServiceSpy.sendTelemetry();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes the urls used in the telemetry test service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated telemetry service tests to validate the current endpoint configuration, ensuring consistent and reliable behavior during telemetry data submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->