### PR TITLE
`Development`: Fix flaky server integration test

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/assessment/ResultListenerIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/ResultListenerIntegrationTest.java
@@ -119,12 +119,14 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
         participantScoreScheduleService.executeScheduledTasks();
         await().until(() -> participantScoreScheduleService.isIdle());
 
-        List<ParticipantScore> savedParticipantScores = participantScoreRepository.findAllByExercise(exercise);
-        assertThat(savedParticipantScores).isNotEmpty().hasSize(1);
+        await().untilAsserted(() -> {
+            List<ParticipantScore> savedParticipantScores = participantScoreRepository.findAllByExercise(exercise);
+            assertThat(savedParticipantScores).isNotEmpty().hasSize(1);
 
-        ParticipantScore savedParticipantScore = savedParticipantScores.getFirst();
-        assertThat(savedParticipantScore.getLastPoints()).isEqualTo(200.0);
-        assertThat(savedParticipantScore.getLastRatedPoints()).isEqualTo(200.0);
+            ParticipantScore savedParticipantScore = savedParticipantScores.getFirst();
+            assertThat(savedParticipantScore.getLastPoints()).isEqualTo(200.0);
+            assertThat(savedParticipantScore.getLastRatedPoints()).isEqualTo(200.0);
+        });
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`ResultListenerIntegrationTest#updateExercisePoints_ShouldUpdatePointsInParticipantScores()` is currently flaky.

`ExerciseService#updatePointsInRelatedParticipantScores()` is annotated with `@Async`. This method is not waited for.

### Description
<!-- Describe your changes in detail -->
Part of the test is awaited with Awaitility.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] Manual Test 1
- [x] Manual Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced the score verification tests by introducing a robust asynchronous waiting mechanism. This improvement ensures that score updates are consistently verified after scheduled tasks, contributing to a more stable and reliable system overall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->