### PR TITLE
`Development`: Store triggering workflow info and add workflow notices for E2E tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -40,6 +40,27 @@ jobs:
       TEST_TIMEOUT_SECONDS: ${{ vars.TEST_TIMEOUT_SECONDS }}
       TEST_WORKER_PROCESSES: ${{ vars.TEST_WORKER_PROCESSES }}
     steps:
+      # Save the triggering workflow information as an artifact for later reference
+      - name: Save triggering workflow info
+        run: |
+          echo "TRIGGERING_WORKFLOW_RUN_ID=${{ github.event.workflow_run.id }}" > workflow-context.txt
+          echo "TRIGGERING_WORKFLOW_HEAD_BRANCH=${{ github.event.workflow_run.head_branch }}" >> workflow-context.txt
+          echo "TRIGGERING_WORKFLOW_HEAD_SHA=${{ github.event.workflow_run.head_sha }}" >> workflow-context.txt
+          cat workflow-context.txt
+
+      - name: Upload workflow context
+        uses: actions/upload-artifact@v4
+        with:
+          name: workflow-context
+          path: workflow-context.txt
+
+      # Add a notice in this workflow run's timeline showing which Build workflow triggered it
+      # This helps developers navigate between related workflow runs
+      - name: Add link to triggering workflow
+        run: |
+          echo "::notice title=Triggered by workflow run::This E2E test was triggered by workflow run #${{ github.event.workflow_run.id }} - View it at https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
+
+
       # Since this workflow is triggered by a workflow_run event, we are not able to see the workflow status in check-runs.
       # So we need to set the status to pending manually by calling the GitHub API.
       - name: Create pending status


### PR DESCRIPTION

### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
When using GitHub's `workflow_run` trigger (as our E2E Tests workflow does), GitHub always runs the workflow file from the `default` branch:
> **Important:** The `workflow_run` event always runs the workflow file from the `default` branch, not from the branch that triggered the original workflow.

[GitHub Documentation Reference](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run)

This creates two issues:

- **Visibility issue:** There's no clear visual connection between the original `Build` workflow and the `E2E Tests` workflow that was triggered by it. GitHub doesn't provide a UI element showing which workflow triggered another.
- **API/Webhook limitation:** The relationship between workflows (which `Build` workflow triggered which `E2E` workflow) is not accessible via GitHub's API or webhook events. This makes it impossible for our [Helios](https://github.com/ls1intum/Helios) system to know the original triggering workflow when processing the E2E test results. Currently, all E2E tests appear to be running only on the default branch in Helios, regardless of which feature branch they're actually testing, since there's no way to get the information about the original triggering branch.

### Solution
This PR adds:
- **Workflow Context Artifact:**
  - Saves the triggering workflow run ID and branch information as an artifact
  - Allows our webhook handler to download this information and establish the relationship between workflows
- **Workflow Notice in `E2E` Timeline:**
  - Adds a notice showing which `Build` workflow triggered this E2E run
  - Uses GitHub's `::notice` [workflow command](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-notice-message) which appears directly in the workflow timeline
  - Makes it easy to navigate from `E2E` workflow to its triggering `Build` workflow
Here's how the workflow notice (which opens the `Build` workflow run) appears in GitHub's UI:
![image](https://github.com/user-attachments/assets/aa5b0d82-c68e-4ab4-9271-885670a853fe)


### Steps for Testing
Since the `workflow_run` trigger always runs the workflow file from the `default` branch (not the PR branch), testing can only be done after merging to the `default` branch. I've tested this implementation in a dummy repository and added screenshots showing how the workflow notice appears in the GitHub UI.
