### PR TITLE
`Development`: Do not load iris settings in exam mode

### DIFF
--- a/src/main/webapp/app/text/overview/text-editor.component.ts
+++ b/src/main/webapp/app/text/overview/text-editor.component.ts
@@ -201,7 +201,7 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
     /**
      * Loads Iris settings for the current exercise if Iris is available and the exercise is not in exam mode.
      *
-     * This method retrieves the user profile information and checks if the `PROFILE_IRIS` is active.
+     * This method retrieves the application profile settings and checks if `PROFILE_IRIS` is active.
      * If active and the exercise is not in exam mode, it fetches the Iris settings for the given exercise ID.
      */
     private loadIrisSettings(): void {

--- a/src/main/webapp/app/text/overview/text-editor.component.ts
+++ b/src/main/webapp/app/text/overview/text-editor.component.ts
@@ -198,6 +198,12 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
             });
     }
 
+    /**
+     * Loads Iris settings for the current exercise if Iris is available and the exercise is not in exam mode.
+     *
+     * This method retrieves the user profile information and checks if the `PROFILE_IRIS` is active.
+     * If active and the exercise is not in exam mode, it fetches the Iris settings for the given exercise ID.
+     */
     private loadIrisSettings(): void {
         this.profileService.getProfileInfo().subscribe((profileInfo) => {
             // only load the settings if Iris is available and this is not an exam exercise

--- a/src/main/webapp/app/text/overview/text-editor.component.ts
+++ b/src/main/webapp/app/text/overview/text-editor.component.ts
@@ -194,7 +194,11 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
                     }
                 }
                 this.updateParticipation(this.participation);
+                this.loadIrisSettings();
             });
+    }
+
+    private loadIrisSettings(): void {
         this.profileService.getProfileInfo().subscribe((profileInfo) => {
             // only load the settings if Iris is available and this is not an exam exercise
             if (profileInfo?.activeProfiles?.includes(PROFILE_IRIS) && !this.examMode) {

--- a/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
@@ -6,10 +6,10 @@ import { AlertService } from 'app/shared/service/alert.service';
 import { TranslateService } from '@ngx-translate/core';
 import { MockTextEditorService } from '../../helpers/mocks/service/mock-text-editor.service';
 import { TextEditorService } from 'app/text/overview/text-editor.service';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
-import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
+import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { TextResultComponent } from 'app/text/overview/text-result/text-result.component';
 import { SubmissionResultStatusComponent } from 'app/course/overview/submission-result-status.component';
 import { TextEditorComponent } from 'app/text/overview/text-editor.component';
@@ -44,6 +44,12 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
+import { PROFILE_IRIS } from 'app/app.constants';
+import { IrisSettings } from 'app/entities/iris/settings/iris-settings.model';
+import { IrisSettingsService } from 'app/iris/manage/settings/shared/iris-settings.service';
+import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
+import { MockProfileService } from '../../helpers/mocks/service/mock-profile.service';
+import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
 
 describe('TextEditorComponent', () => {
     let comp: TextEditorComponent;
@@ -52,6 +58,8 @@ describe('TextEditorComponent', () => {
     let textService: TextEditorService;
     let textSubmissionService: TextSubmissionService;
     let getTextForParticipationStub: jest.SpyInstance;
+    let profileService: ProfileService;
+    let irisSettingsService: IrisSettingsService;
 
     const route = { snapshot: { paramMap: convertToParamMap({ participationId: 42 }) } } as ActivatedRoute;
     const textExercise = { id: 1 } as TextExercise;
@@ -94,6 +102,8 @@ describe('TextEditorComponent', () => {
                 { provide: TextSubmissionService, useClass: MockTextSubmissionService },
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: AccountService, useClass: MockAccountService },
+                { provide: ProfileService, useClass: MockProfileService },
+                MockProvider(IrisSettingsService),
                 provideHttpClient(),
                 provideHttpClientTesting(),
             ],
@@ -105,6 +115,8 @@ describe('TextEditorComponent', () => {
                 debugElement = fixture.debugElement;
                 textService = debugElement.injector.get(TextEditorService);
                 textSubmissionService = TestBed.inject(TextSubmissionService);
+                profileService = TestBed.inject(ProfileService);
+                irisSettingsService = TestBed.inject(IrisSettingsService);
                 getTextForParticipationStub = jest.spyOn(textService, 'get');
             });
     });
@@ -459,4 +471,65 @@ describe('TextEditorComponent', () => {
         comp.ngOnDestroy();
         expect(textSubmissionService.update).toHaveBeenCalled();
     });
+
+    it('should load Iris settings when Iris profile is active and not in exam mode', fakeAsync(() => {
+        const profileInfo = { activeProfiles: [PROFILE_IRIS] } as ProfileInfo;
+        jest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of(profileInfo));
+
+        const mockIrisSettings = { id: 123 } as IrisSettings;
+        jest.spyOn(irisSettingsService, 'getCombinedExerciseSettings').mockReturnValue(of(mockIrisSettings));
+
+        route.params = of({ exerciseId: '456' });
+
+        comp.examMode = false;
+
+        comp['loadIrisSettings']();
+        tick();
+
+        expect(profileService.getProfileInfo).toHaveBeenCalled();
+        expect(irisSettingsService.getCombinedExerciseSettings).toHaveBeenCalledWith('456');
+        expect(comp.irisSettings).toEqual(mockIrisSettings);
+
+        flush();
+    }));
+
+    it('should not load Iris settings when in exam mode', fakeAsync(() => {
+        const profileInfo = { activeProfiles: [PROFILE_IRIS] } as ProfileInfo;
+        jest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of(profileInfo));
+
+        jest.spyOn(irisSettingsService, 'getCombinedExerciseSettings');
+
+        route.params = of({ exerciseId: '456' });
+
+        comp.examMode = true;
+
+        comp['loadIrisSettings']();
+        tick();
+
+        expect(profileService.getProfileInfo).toHaveBeenCalled();
+        expect(irisSettingsService.getCombinedExerciseSettings).not.toHaveBeenCalled();
+        expect(comp.irisSettings).toBeUndefined();
+
+        flush();
+    }));
+
+    it('should not load Iris settings when Iris profile is not active', fakeAsync(() => {
+        const profileInfo = { activeProfiles: ['no-iris'] } as ProfileInfo;
+        jest.spyOn(profileService, 'getProfileInfo').mockReturnValue(of(profileInfo));
+
+        jest.spyOn(irisSettingsService, 'getCombinedExerciseSettings');
+
+        route.params = of({ exerciseId: '456' });
+
+        comp.examMode = false;
+
+        comp['loadIrisSettings']();
+        tick();
+
+        expect(profileService.getProfileInfo).toHaveBeenCalled();
+        expect(irisSettingsService.getCombinedExerciseSettings).not.toHaveBeenCalled();
+        expect(comp.irisSettings).toBeUndefined();
+
+        flush();
+    }));
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
During yesterday's testing session for the 8.0.0 release, issues #10503 and #10515 were discovered. This PR resolves #10503 and resolves #10515.

### Description
<!-- Describe your changes in detail -->
The issue was that Artemis attempted to load Iris settings for the text editor in exam mode, even though it shouldn't, since Iris is disabled in exam mode. This happened because the call to load Iris settings was executed before the participation state was updated.

As a result, the `examMode` boolean variable was not determined yet, since it depends on participation.

To fix this issue, I created a separate function called `loadIrisSettings`, which is now called after participation is updated.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
**Please test this pull request on the test servers where Iris is enabled: TS1, TS3, and TS5.**

Prerequisites:
- 1 Instructor
- 1 Students
- 1 Exam with text exercise

1. Log in to Artemis.
2. Participate in an exam with a text exercise and view the exam summary (a test run is also fine and faster to configure).
3. Verify that there are no errors on the summary page.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - The text editor now automatically applies Iris configuration settings during initialization when supported. This enhancement ensures that users benefit from tailored settings during their exercise sessions, provided that Iris integration is active and exam mode is not enabled.

- **Tests**
  - Enhanced test coverage for the TextEditorComponent with new test cases verifying the loading of Iris settings under various conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->