### PR TITLE
`Development`: Upload Client JUnit test report as artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,12 @@ jobs:
           with:
               name: Coverage Report Client Tests
               path: build/test-results/lcov-report/
+        - name: Upload JUnit Test Results
+          if: success() || failure()
+          uses: actions/upload-artifact@v4
+          with:
+            name: Client JUnit Test Results
+            path: junit.xml
 
   client-tests-selected:
       runs-on: ubuntu-latest


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
We want to parse both `server` and `client` JUnit test results to [Helios](https://github.com/ls1intum/Helios) in order to monitor and potentially detect flaky tests across the entire `Artemis` codebase. Currently, Helios can parse artifacts named `JUnit Test Results` for **server** tests. This PR adds a new artifact named `Client JUnit Test Results` for the **client** tests.

Although Helios still requires the artifact name `JUnit Test Results` to parse data automatically, flexible artifact parsing is already in progress and will be implemented in the current sprint. Once it’s available, Helios will be able to handle customized artifact names and parse both server and client tests seamlessly.


### Description
- Add artifact upload for client JUnit test results
This ensures client-side test results are also available as a separate artifact named "Client JUnit Test Results".


### Steps for Testing
1. Trigger the Workflow
  - You can either create a new pull request based on this branch to trigger the GitHub Actions test workflow or use the existing workflow run provided by this PR.
  - The workflow run URL is: [Workflow Run](https://github.com/ls1intum/Artemis/actions/runs/#artifacts)
2. Verify Artifact Upload
  - After the workflow completes, scroll down to the Artifacts section.
  - Confirm that:
    - An artifact named `Client JUnit Test Results` (client tests) is present.

