### PR TITLE
`Programming exercises`: Enable character deletion via backspace in manual assessment

### DIFF
--- a/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback.component.html
+++ b/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback.component.html
@@ -45,6 +45,7 @@
                                 ? ('artemisApp.assessment.additionalFeedbackCommentPlaceholder' | artemisTranslate)
                                 : ('artemisApp.assessment.feedbackCommentPlaceholder' | artemisTranslate)
                         "
+                        (keydown)="handleKeydown($event)"
                     ></textarea>
                 </div>
                 <div class="form-group col-3 p-2 m-0">
@@ -55,6 +56,7 @@
                         step="0.5"
                         [(ngModel)]="feedback.credits"
                         [readOnly]="viewOnly || feedback.gradingInstruction"
+                        (keydown)="handleKeydown($event)"
                     />
                 </div>
             </div>

--- a/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback.component.ts
+++ b/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback.component.ts
@@ -37,6 +37,19 @@ import { QuotePipe } from 'app/shared/pipes/quote.pipe';
     ],
 })
 export class CodeEditorTutorAssessmentInlineFeedbackComponent {
+    protected readonly faSave = faSave;
+    protected readonly faBan = faBan;
+    protected readonly faQuestionCircle = faQuestionCircle;
+    protected readonly faPencilAlt = faPencilAlt;
+    protected readonly faTrashAlt = faTrashAlt;
+    protected readonly faExclamationTriangle = faExclamationTriangle;
+    protected readonly Feedback = Feedback;
+    protected readonly ButtonSize = ButtonSize;
+    protected readonly MANUAL = FeedbackType.MANUAL;
+
+    // Expose the function to the template
+    protected readonly roundScoreSpecifiedByCourseSettings = roundValueSpecifiedByCourseSettings;
+
     private structuredGradingCriterionService = inject(StructuredGradingCriterionService);
     // Needed for the outer editor to access the DOM node of this component
     public elementRef = inject(ElementRef);
@@ -63,24 +76,10 @@ export class CodeEditorTutorAssessmentInlineFeedbackComponent {
     @Output() onDeleteFeedback = new EventEmitter<Feedback>();
     @Output() onEditFeedback = new EventEmitter<number>();
 
-    // Expose the function to the template
-    readonly roundScoreSpecifiedByCourseSettings = roundValueSpecifiedByCourseSettings;
-    protected readonly Feedback = Feedback;
-    readonly ButtonSize = ButtonSize;
-    readonly MANUAL = FeedbackType.MANUAL;
-
     viewOnly: boolean;
     oldFeedback: Feedback;
     private dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
-
-    // Icons
-    faSave = faSave;
-    faBan = faBan;
-    faQuestionCircle = faQuestionCircle;
-    faPencilAlt = faPencilAlt;
-    faTrashAlt = faTrashAlt;
-    faExclamationTriangle = faExclamationTriangle;
 
     /**
      * Updates the current feedback and sets props and emits the feedback to parent component
@@ -102,7 +101,7 @@ export class CodeEditorTutorAssessmentInlineFeedbackComponent {
 
     /**
      * When an inline feedback already exists, we set it back and display it the viewOnly mode.
-     * Otherwise the component is not displayed anymore in the parent component
+     * Otherwise, the component is not displayed anymore in the parent component
      */
     cancelFeedback() {
         this.feedback = this.oldFeedback;

--- a/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback.component.ts
+++ b/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback.component.ts
@@ -57,11 +57,13 @@ export class CodeEditorTutorAssessmentInlineFeedbackComponent {
     @Input() get feedback(): Feedback {
         return this._feedback;
     }
+
     set feedback(feedback: Feedback | undefined) {
         this._feedback = feedback || new Feedback();
         this.oldFeedback = cloneDeep(this.feedback);
         this.viewOnly = !!feedback;
     }
+
     private _feedback: Feedback;
 
     @Input() selectedFile: string;
@@ -148,5 +150,18 @@ export class CodeEditorTutorAssessmentInlineFeedbackComponent {
      */
     public buildFeedbackTextForCodeEditor(feedback: Feedback): string {
         return buildFeedbackTextForReview(feedback, false);
+    }
+
+    /**
+     * This method prevents the propagation to global event listeners (especially the monaco event listener), so the backspace key can be used.
+     *
+     * As this component is rendered within the monaco code editor, the monaco keydown event listener is attached to input fields
+     * in this component.
+     * In the assessment the code editor is readonly, so it will prevent the default behavior of the backspace key.
+     */
+    protected handleKeydown(event: KeyboardEvent) {
+        if (event.key === 'Backspace') {
+            event.stopPropagation();
+        }
     }
 }


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] I an e2e test that would detect if the bug was reintroduced
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
Fixes https://github.com/ls1intum/Artemis/issues/10475


### Description
As this the feedback component is rendered within the monaco code editor, the monaco keydown event listener is attached to input fields in the feedback component.
In the assessment the monaco code editor is readonly, so it will prevent the default behavior of the backspace key.

* Preventing change the event to be handled by the monaco editor (which will be in readonly mode in the assessment)
* Added an e2e test that detects if the backspace deletion works properly

### Steps for Testing
You need a programming exercise with manual assessment enabled and a submission. After the deadline, go to the assessment dashboard.

1. Go to the 'Assessment Dashboard' of this exercise
2. Click on 'Assess'
3. Add new inline feedback by clicking the plus icon next to the line number
4. Enter some feedback text
5. Try to remove it with the backspace key, which should now work
6. Same for the score field

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots

