### PR TITLE
`Development`: Fix E2E tests condition to run single-node for PRs

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -91,14 +91,14 @@ jobs:
 
       # If the workflow is triggered by a pull request, we need to run the tests on single node Artemis instance.
       - name: Run E2E Playwright tests (MySQL, Local)
-        if: ${{ github.event.workflow_run.pull_requests != null && github.event.workflow_run.pull_requests.length > 0 }}
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
         run: .ci/E2E-tests/execute.sh mysql-localci playwright
         env:
           FAST_TEST_TIMEOUT_SECONDS: 60
 
-      # If the workflow is triggered by a push to a branch (e.g. develop, main), we need to run the tests on multi-node Artemis instance.
+      # If the workflow is triggered other events (by a push to a branch e.g. develop, main, or release), we need to run the tests on multi-node Artemis instance.
       - name: Run E2E Playwright tests (MySQL, Local, Multi-Node)
-        if: ${{ github.event.workflow_run.pull_requests == null || github.event.workflow_run.pull_requests.length == 0 }}
+        if: ${{ github.event.workflow_run.event != 'pull_request' }}
         run: .ci/E2E-tests/execute.sh multi-node playwright
         env:
           FAST_TEST_TIMEOUT_SECONDS: 75


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
Previously, all E2E tests were running as multi-node due to incorrect `if` conditions in the workflow. The conditions were incorrectly checking `github.event.workflow_run.pull_requests`, causing the single-node test case to never run.

This PR fixes the logic by correctly checking `github.event.workflow_run.event == 'pull_request'` to determine if the triggering workflow was caused by a PR. Now:
- Tests will run on **Single-node** artemis if the `workflow_run` event was triggered by a PR.
- Tests will run on  **Multi-node** artemis if the `workflow_run` event was triggered by other events (e.g., push to `develop`, `main`, `release` branches, or `release`).

### Description
- `if` condition in `test-e2e.yml` fixed.

