### PR TITLE
`Communication`: Fix null title in announcement email

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/MailService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/MailService.java
@@ -207,18 +207,13 @@ public class MailService implements InstantNotificationService {
      * @return the modified subject of the email
      */
     private String createAnnouncementText(Object notificationSubject, Locale locale) {
-        // Fallback course title
-        String unknownCourseEn = "(Unknown Course)";
-        String unknownCourseDe = "(Unbekannter Kurs)";
-        String unknownCourseText = locale.toString().equals("en") ? unknownCourseEn : unknownCourseDe;
-
         // Translation that can not be done via i18n Resource Bundle (for Thymeleaf) but has to be set in this service via Java
         String newAnnouncementString = locale.toString().equals("en") ? "New announcement \"%s\" in course \"%s\"" : "Neue Ankündigung \"%s\" im Kurs \"%s\"";
 
         Post post = (Post) notificationSubject;
 
         String postTitle = post.getTitle() != null ? post.getTitle() : "";
-        String courseTitle = post.getConversation().getCourse().getTitle() != null ? post.getConversation().getCourse().getTitle() : unknownCourseText;
+        String courseTitle = post.getConversation().getCourse().getTitle();
 
         return String.format(newAnnouncementString, postTitle, courseTitle);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).(https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There has been an issue that caused the announcement email to be sent with a null title. Currently, the post title is pasted into the email subject without checking if it is null.

### Description

This PR adds a small check to verify the post and course title are not null falls back to a default value if necessary. 


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of null values in email announcements to ensure that the post title is always a valid string, enhancing the clarity and reliability of notifications sent to recipients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->