### PR TITLE
`Development`: Optimize a slow method in the notification system

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/GeneralInstantNotificationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/GeneralInstantNotificationService.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import jakarta.validation.constraints.NotNull;
 
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import de.tum.cit.aet.artemis.communication.domain.NotificationType;
@@ -73,13 +74,15 @@ public class GeneralInstantNotificationService implements InstantNotificationSer
 
     /**
      * Checks for each user if the notification should be sent as an email or/and as a push notification.
-     * Then delegates the actual sending to the corresponding {@link InstantNotificationService}s
+     * Then delegates the actual sending to the corresponding {@link InstantNotificationService}s.
+     * It is. {@link Async} to ensure that the sending of notifications does not block requests.
      *
      * @param notification        to be sent via the channel the implementing service is responsible for
      * @param users               who should be contacted
      * @param notificationSubject that is used to provide further information (e.g. exercise, attachment, post, etc.)
      */
     @Override
+    @Async
     public void sendNotification(Notification notification, Set<User> users, Object notificationSubject) {
         var emailRecipients = filterRecipients(notification, users, EMAIL);
         var pushRecipients = filterRecipients(notification, users, PUSH);

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/GeneralInstantNotificationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/GeneralInstantNotificationService.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import jakarta.validation.constraints.NotNull;
 
 import org.springframework.context.annotation.Profile;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import de.tum.cit.aet.artemis.communication.domain.NotificationType;
@@ -74,15 +73,13 @@ public class GeneralInstantNotificationService implements InstantNotificationSer
 
     /**
      * Checks for each user if the notification should be sent as an email or/and as a push notification.
-     * Then delegates the actual sending to the corresponding {@link InstantNotificationService}s.
-     * It is. {@link Async} to ensure that the sending of notifications does not block requests.
+     * Then delegates the actual sending to the corresponding {@link InstantNotificationService}s
      *
      * @param notification        to be sent via the channel the implementing service is responsible for
      * @param users               who should be contacted
      * @param notificationSubject that is used to provide further information (e.g. exercise, attachment, post, etc.)
      */
     @Override
-    @Async
     public void sendNotification(Notification notification, Set<User> users, Object notificationSubject) {
         var emailRecipients = filterRecipients(notification, users, EMAIL);
         var pushRecipients = filterRecipients(notification, users, PUSH);

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/NotificationSettingsService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/NotificationSettingsService.java
@@ -306,12 +306,12 @@ public class NotificationSettingsService {
 
         Set<NotificationSetting> decidedNotificationSettings = notificationSettingRepository
                 .findAllNotificationSettingsForRecipientsWithId(users.stream().map(DomainObject::getId).toList());
-        Set<NotificationSetting> notificationSettings = new HashSet<>(decidedNotificationSettings);
 
         return users.stream().filter(user -> {
+            Set<NotificationSetting> notificationSettings = decidedNotificationSettings.stream()
+                    .filter(notificationSetting -> notificationSetting.getUser().getId().equals(user.getId())).collect(Collectors.toSet());
             // for those notification types that are not explicitly set by the user, we use the default settings
-            Set<String> decidedIds = decidedNotificationSettings.stream().filter(notificationSetting -> notificationSetting.getUser().getId().equals(user.getId()))
-                    .map(NotificationSetting::getSettingId).collect(Collectors.toSet());
+            Set<String> decidedIds = notificationSettings.stream().map(NotificationSetting::getSettingId).collect(Collectors.toSet());
             for (NotificationSetting defaultSetting : DEFAULT_NOTIFICATION_SETTINGS) {
                 if (!decidedIds.contains(defaultSetting.getSettingId())) {
                     notificationSettings


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We encountered an issue on the test servers that when one tried to release a quiz for practice it took over a minute to do so.
After some investigation it turned out to be a very slow method in the notification system with quadratic complexity.


### Description
<!-- Describe your changes in detail -->
I rewrote the problematic method to no longer have a quadratic complexity with regards to the number of users. 2 changes accomplished this:
1. Fix a bug where a Set was not cleared for each new user
2. Move a loop over the users outside of the main loop over the users

I also had to fix a race condition in the tests, as they expected the method to be slower than it is now.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Quiz exercise

1. Log in to Artemis
2. Go to the Quiz management detail page
3. Start the quiz
4. End the quiz
5. Release the quiz for practice
    - This should take, at most, a few seconds
    - It is still not instant, as we iterate over >2000 users on a fairly limited VM

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
Virtually unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced asynchronous execution for sending notifications, allowing for non-blocking request handling.
  
- **Refactor**
  - Streamlined how user notification settings are processed, improving performance and efficiency.

- **Tests**
  - Enhanced notification tests with dynamic wait conditions to reliably verify alerts for upcoming and expired SSH keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->