### PR TITLE
`Development`: Improve Codeowners to be more detailed

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,3 +69,8 @@
 /src/test/javascript/spec/component/quiz-statistic              @ls1intum/quiz-maintainers
 /src/test/javascript/spec/component/short-answer-question       @ls1intum/quiz-maintainers
 
+# Other
+/docker     @ls1intum/operations-maintainers
+/.github    @ls1intum/operations-maintainers
+/.ci        @ls1intum/operations-maintainers
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,65 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-# Unless a later match takes precedence, @krusche and @jpbernius will be
+# Unless a later match takes precedence, @krusche will be
 # requested for review when someone opens a pull request.
 
-*    @ls1intum/artemis-maintainers
+* @krusche
+
+# Server code
+/src/main/java/de/tum/cit/aet/artemis/athena         @ls1intum/athena-maintainers
+/src/main/java/de/tum/cit/aet/artemis/atlas          @ls1intum/atlas-maintainers
+/src/main/java/de/tum/cit/aet/artemis/buildagent     @ls1intum/programming-maintainers
+/src/main/java/de/tum/cit/aet/artemis/communication  @ls1intum/communication-maintainers
+/src/main/java/de/tum/cit/aet/artemis/iris           @ls1intum/iris-maintainers
+/src/main/java/de/tum/cit/aet/artemis/lecture        @ls1intum/lectures-maintainers
+/src/main/java/de/tum/cit/aet/artemis/lti            @ls1intum/lti-maintainers
+/src/main/java/de/tum/cit/aet/artemis/modeling       @ls1intum/apollon-maintainers
+/src/main/java/de/tum/cit/aet/artemis/plagiarism     @ls1intum/plagiarism-maintainers
+/src/main/java/de/tum/cit/aet/artemis/programming    @ls1intum/programming-maintainers
+/src/main/java/de/tum/cit/aet/artemis/quiz           @ls1intum/quiz-maintainers
+
+# Client code
+/src/main/webapp/app/atlas          @ls1intum/atlas-maintainers
+/src/main/webapp/app/buildagent     @ls1intum/programming-maintainers
+/src/main/webapp/app/communication  @ls1intum/communication-maintainers
+/src/main/webapp/app/iris           @ls1intum/iris-maintainers
+/src/main/webapp/app/lecture        @ls1intum/lectures-maintainers
+/src/main/webapp/app/lti            @ls1intum/lti-maintainers
+/src/main/webapp/app/modeling       @ls1intum/apollon-maintainers
+/src/main/webapp/app/plagiarism     @ls1intum/plagiarism-maintainers
+/src/main/webapp/app/programming    @ls1intum/programming-maintainers
+/src/main/webapp/app/quiz           @ls1intum/quiz-maintainers
+
+# Server tests
+/src/test/java/de/tum/cit/aet/artemis/athena         @ls1intum/athena-maintainers
+/src/test/java/de/tum/cit/aet/artemis/atlas          @ls1intum/atlas-maintainers
+/src/test/java/de/tum/cit/aet/artemis/buildagent     @ls1intum/programming-maintainers
+/src/test/java/de/tum/cit/aet/artemis/communication  @ls1intum/communication-maintainers
+/src/test/java/de/tum/cit/aet/artemis/iris           @ls1intum/iris-maintainers
+/src/test/java/de/tum/cit/aet/artemis/lecture        @ls1intum/lectures-maintainers
+/src/test/java/de/tum/cit/aet/artemis/lti            @ls1intum/lti-maintainers
+/src/test/java/de/tum/cit/aet/artemis/modeling       @ls1intum/apollon-maintainers
+/src/test/java/de/tum/cit/aet/artemis/plagiarism     @ls1intum/plagiarism-maintainers
+/src/test/java/de/tum/cit/aet/artemis/programming    @ls1intum/programming-maintainers
+/src/test/java/de/tum/cit/aet/artemis/quiz           @ls1intum/quiz-maintainers
+
+# Client tests
+/src/test/javascript/spec/component/exercises/programming       @ls1intum/programming-maintainers
+/src/test/javascript/spec/component/exercises/quiz              @ls1intum/quiz-maintainers
+/src/test/javascript/spec/component/iris                        @ls1intum/iris-maintainers
+/src/test/javascript/spec/component/lecture                     @ls1intum/lectures-maintainers
+/src/test/javascript/spec/component/lecture-unit                @ls1intum/lectures-maintainers
+/src/test/javascript/spec/component/modeling-assessment         @ls1intum/apollon-maintainers
+/src/test/javascript/spec/component/modeling-assessment-editor  @ls1intum/apollon-maintainers
+/src/test/javascript/spec/component/modeling-editor             @ls1intum/apollon-maintainers
+/src/test/javascript/spec/component/modeling-exercise           @ls1intum/apollon-maintainers
+/src/test/javascript/spec/component/modeling-explanation-editor @ls1intum/apollon-maintainers
+/src/test/javascript/spec/component/modeling-submission         @ls1intum/apollon-maintainers
+/src/test/javascript/spec/component/plagiarism                  @ls1intum/plagiarism-maintainers
+/src/test/javascript/spec/component/programming-assessment      @ls1intum/programming-maintainers
+/src/test/javascript/spec/component/programming-exercise        @ls1intum/programming-maintainers
+/src/test/javascript/spec/component/quiz-exercise               @ls1intum/quiz-maintainers
+/src/test/javascript/spec/component/quiz-statistic              @ls1intum/quiz-maintainers
+/src/test/javascript/spec/component/short-answer-question       @ls1intum/quiz-maintainers
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We want to improve the CODEOWNERS file with the new maintainer teams

### Description
<!-- Describe your changes in detail -->
I adjusted it to the best of my ability. Client tests are still pretty unstructured and therefore the mapping is spotty.

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Revised internal responsibility assignments to streamline team coordination across different project areas including backend, frontend, and testing. This update improves internal collaboration and maintenance without affecting the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->