### PR TITLE
`Development`: Add JUnit reporter for E2E summary and fix status indicator behavior

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -194,17 +194,17 @@ jobs:
         if: always()
         id: find-pr
         continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH_NAME=${{ github.event.workflow_run.head_branch }}
           echo "Checking if PR exists for head ref: $BRANCH_NAME."
 
-          PR_DETAILS=$(gh api repos/${{ github.repository }}/pulls \
-            --paginate \
-            --jq ".[] | select(.head.ref == \"$BRANCH_NAME\") | {number: .number}")
+          PR_RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:$BRANCH_NAME")
 
-          PR_NUMBER=$(echo "$PR_DETAILS" | jq -r ".number")
+          # Extract PR number
+          # Look for "number": followed by digits
+          PR_NUMBER=$(echo "$PR_RESPONSE" | grep -o '"number":[0-9]*' | head -1 | sed 's/"number"://')
 
           if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
             echo "Found PR: $PR_NUMBER from branch: $BRANCH_NAME."

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -194,6 +194,8 @@ jobs:
         if: always()
         id: find-pr
         continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH_NAME=${{ github.event.workflow_run.head_branch }}
           echo "Checking if PR exists for head ref: $BRANCH_NAME."

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -124,51 +124,33 @@ jobs:
       - name: Run cleanup script (after E2E)
         run: .ci/E2E-tests/cleanup.sh
 
-      # Once the tests are finished, we need to parse the test results to get
-      # the total number of tests, the number of tests that passed, failed or were skipped.
-      # We need this info to display it to the Developers in the Workflow section below each pull request
-      # The next step in this workflow uses this info to update the status.
-      - name: Parse test results
+      - name: Test Report
+        uses: mikepenz/action-junit-report@v5
+        id: test-reporter
         if: always()
-        id: parse-results
-        continue-on-error: true
-        run: |
-          TOTAL=0
-          PASSED=0
-          FAILED=0
-          SKIPPED=0
-
-          # Check if test results file exists
-          XML_FILE="src/test/playwright/test-reports/results.xml"
-          if [ -f "$XML_FILE" ]; then
-            echo "Final results.xml file found, started parsing..."
-
-            # Sum the totals for all testsuites
-            TESTS_COUNT=$(grep -o 'tests="[0-9]*"' "$XML_FILE" | grep -o '[0-9]*' | awk '{sum+=$1} END {print sum}')
-            FAILURES_COUNT=$(grep -o 'failures="[0-9]*"' "$XML_FILE" | grep -o '[0-9]*' | awk '{sum+=$1} END {print sum}')
-            SKIPPED_COUNT=$(grep -o 'skipped="[0-9]*"' "$XML_FILE" | grep -o '[0-9]*' | awk '{sum+=$1} END {print sum}')
-            set -e
-
-            # Use values if counts were found
-            if [ -n "$TESTS_COUNT" ]; then TOTAL=$TESTS_COUNT; fi
-            if [ -n "$FAILURES_COUNT" ]; then FAILED=$FAILURES_COUNT; fi
-            if [ -n "$SKIPPED_COUNT" ]; then SKIPPED=$SKIPPED_COUNT; fi
-
-            # Calculate passed tests
-            PASSED=$((TOTAL - FAILED - SKIPPED))
-          fi
-
-          echo "XML Parsing Results:"
-          echo "Total: $TOTAL"
-          echo "Failed: $FAILED"
-          echo "Skipped: $SKIPPED"
-          echo "Passed: $PASSED"
-
-          # Save to outputs
-          echo "total=$TOTAL" >> $GITHUB_OUTPUT
-          echo "passed=$PASSED" >> $GITHUB_OUTPUT
-          echo "failed=$FAILED" >> $GITHUB_OUTPUT
-          echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
+        env:
+          # Increase the memory limit for the action
+          # https://github.com/mikepenz/action-junit-report?tab=readme-ov-file#common-configurations
+          NODE_OPTIONS: "--max_old_space_size=4096"
+        with:
+          # Specifies which commit SHA to associate the test report with.
+          commit: ${{ github.event.workflow_run.head_sha }}
+          # Fails the job if any test failed.
+          fail_on_failure: true
+          # Fails the job if no tests are found.
+          require_tests: true
+          # Fails the job if no passed tests are found.
+          require_passed_tests: true
+          detailed_summary: true
+          include_time_in_summary: true
+          flaky_summary: true
+          # Groups test results by suite in the detailed summary.
+          group_suite: true
+          # Adds a comment to the PR with the test summary.
+          comment: true
+          # Prevents updating previous test report comment; creates a new comment instead.
+          updateComment: false
+          report_paths: 'src/test/playwright/test-reports/results.xml'
 
       # Update the status of the workflow run with the results parsed in the previous step.
       - name: Update status with results
@@ -179,18 +161,18 @@ jobs:
           WORKFLOW_STATUS="${{ job.status }}"
 
           # Get test results
-          TOTAL="${{ steps.parse-results.outputs.total || 0 }}"
-          PASSED="${{ steps.parse-results.outputs.passed || 0 }}"
-          FAILED="${{ steps.parse-results.outputs.failed || 0 }}"
-          SKIPPED="${{ steps.parse-results.outputs.skipped || 0 }}"
+          TOTAL="${{ steps.test-reporter.outputs.total || 0 }}"
+          PASSED="${{ steps.test-reporter.outputs.passed || 0 }}"
+          FAILED="${{ steps.test-reporter.outputs.failed || 0 }}"
+          SKIPPED="${{ steps.test-reporter.outputs.skipped || 0 }}"
 
           # Determine GitHub status state based on workflow status
           if [ "$WORKFLOW_STATUS" = "success" ]; then
             STATE="success"
-            DESCRIPTION="✅ E2E tests finished: $PASSED passed, $FAILED failed, $SKIPPED skipped"
+            DESCRIPTION="E2E tests finished: $PASSED passed, $SKIPPED skipped, $FAILED failed"
           elif [ "$WORKFLOW_STATUS" = "failure" ]; then
             STATE="failure"
-            DESCRIPTION="❌ E2E tests failed: $PASSED passed, $FAILED failed, $SKIPPED skipped"
+            DESCRIPTION="E2E tests finished: $FAILED failed, $SKIPPED skipped, $PASSED passed"
           else
             STATE="error"
             DESCRIPTION="⚠️ E2E tests encountered an error"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           # Specifies which commit SHA to associate the test report with.
           commit: ${{ github.event.workflow_run.head_sha }}
+          check_name: "End-to-End (E2E) Test Report"
           # Fails the job if any test failed.
           fail_on_failure: true
           # Fails the job if no tests are found.
@@ -145,11 +146,8 @@ jobs:
           annotate_only: true
           detailed_summary: true
           include_time_in_summary: true
-          flaky_summary: true
           # Groups test results by suite in the detailed summary.
           group_suite: true
-          # Adds a comment to the PR with the test summary.
-          comment: true
           # Prevents updating previous test report comment; creates a new comment instead.
           updateComment: false
           report_paths: 'src/test/playwright/test-reports/results.xml'
@@ -190,3 +188,43 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             "${{ env.STATUSES_REQUEST_URL }}" \
             -d "$JSON_PAYLOAD"
+
+      # Find the PR number
+      - name: Find PR number
+        if: always()
+        id: find-pr
+        continue-on-error: true
+        run: |
+          BRANCH_NAME=${{ github.event.workflow_run.head_branch }}
+          echo "Checking if PR exists for head ref: $BRANCH_NAME."
+
+          PR_DETAILS=$(gh api repos/${{ github.repository }}/pulls \
+            --paginate \
+            --jq ".[] | select(.head.ref == \"$BRANCH_NAME\") | {number: .number}")
+
+          PR_NUMBER=$(echo "$PR_DETAILS" | jq -r ".number")
+
+          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+            echo "Found PR: $PR_NUMBER from branch: $BRANCH_NAME."
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          else
+            echo "No PR found from branch: $BRANCH_NAME."
+            echo "pr_head_sha=" >> $GITHUB_OUTPUT
+          fi
+
+      # Add comment to the PR with test result summary
+      - name: Add test results comment to PR
+        if: always() && steps.find-pr.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            const prNumber = ${{ steps.find-pr.outputs.pr_number }};
+            const testSummary = `${{ steps.test-reporter.outputs.summary }} ${{ steps.test-reporter.outputs.detailed_summary }}`;
+
+            github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `### End-to-End (E2E) Test Results Summary\n\n${testSummary}`
+              });

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -125,7 +125,7 @@ jobs:
         run: .ci/E2E-tests/cleanup.sh
 
       - name: Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v5.5.0
         id: test-reporter
         if: always()
         env:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -141,6 +141,8 @@ jobs:
           require_tests: true
           # Fails the job if no passed tests are found.
           require_passed_tests: true
+          # Disable status check creation.
+          annotate_only: true
           detailed_summary: true
           include_time_in_summary: true
           flaky_summary: true

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -203,15 +203,13 @@ jobs:
             "https://api.github.com/repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:$BRANCH_NAME")
 
           # Extract PR number
-          # Look for "number": followed by digits
-          PR_NUMBER=$(echo "$PR_RESPONSE" | grep -o '"number":[0-9]*' | head -1 | sed 's/"number"://')
+          PR_NUMBER=$(echo "$PR_RESPONSE" | grep -o '"number": [0-9]*,' | head -1 | sed 's/"number": //g' | sed 's/,//g' | tr -d ' \t\n\r')
 
           if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
             echo "Found PR: $PR_NUMBER from branch: $BRANCH_NAME."
             echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           else
             echo "No PR found from branch: $BRANCH_NAME."
-            echo "pr_head_sha=" >> $GITHUB_OUTPUT
           fi
 
       # Add comment to the PR with test result summary


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
Previously, we were parsing test results manually and updating GitHub status checks based on the overall workflow status. However, this approach didn’t reflect actual test failures—status was marked as `successful` as long as the workflow didn’t throw an `error`, even if some tests failed.

While experimenting with reusable JUnit reporter plugins (e.g. `mikepenz/action-junit-report`, `EnricoMi/publish-unit-test-result-action`, and `dorny/test-reporter`) to improve visibility into test results, I noticed that `annotations` (e.g., failed test methods/files) were not being shown properly.

After some research, I found this is a known issue with GitHub’s status check API: when workflows are triggered by non-standard events (like `workflow_run`), any created status checks with annotations are not correctly grouped under the originating workflow. Instead, they appear under unrelated workflows (e.g., “Build”). GitHub currently doesn’t allow status check associations to be manually defined in these cases. Several GitHub Discussions highlight this issue. 
- https://github.com/orgs/community/discussions/14891
- https://github.com/orgs/community/discussions/24616
- https://github.com/mikepenz/action-junit-report/issues/40

Because of this limitation, we’ve disabled annotations in the reporter by setting `annotate_only: true`.

### Description
- Adds a reusable JUnit reporter (`mikepenz/action-junit-report`) that generates a clean summary view for test results and posts it directly in the workflow UI.
- Enables stricter options such as fail_on_failure, require_tests, and require_passed_tests to ensure proper job failure when tests fail.
- Keeps our custom status check logic, but updates it to use the test reporter’s outputs (passed, failed, skipped, total) instead of manually parsed XML data.
- Adds a custom implementation to post test results as PR comments after each E2E test run, since we can't use the built-in PR comment feature of `mikepenz/action-junit-report` (our workflow runs in a different context rather than directly on `pull_request` events).
- Fixes the core issue where previously we considered the job "successful" even if tests failed. Now, the job will fail appropriately based on test results, aligning with expected behavior.


### Steps for Testing
This workflow is triggered by the `workflow_run` event, which means it can only be tested after merging to the `default` branch.


### Screenshots
- Status checks will now accurately reflect test results
![image](https://github.com/user-attachments/assets/0168ea4f-8307-4130-8421-7ed0d2813110)
- Detailed test summary available in the workflow UI
![image](https://github.com/user-attachments/assets/6ac6703a-50cc-4be3-aa50-4b90405e3159)
- If a pull request exists, a comment is automatically added after each E2E test run
![image](https://github.com/user-attachments/assets/a574e39e-9fbc-43e7-9189-af11819ee5e0)
- When a result is success
![image](https://github.com/user-attachments/assets/7ca54f1b-5ab8-4113-abae-f083419bb670)
![image](https://github.com/user-attachments/assets/249fe3db-b61d-4c8f-afc0-77411e53ca25)
![image](https://github.com/user-attachments/assets/70d41ff7-1f3e-4ba8-84a9-ed892e9a0eb5)
