### PR TITLE
`Development`: Fix e2e ssh failures by routing via docker compose nginx

### DIFF
--- a/.ci/E2E-tests/execute.sh
+++ b/.ci/E2E-tests/execute.sh
@@ -27,7 +27,7 @@ echo "Compose file:"
 echo $COMPOSE_FILE
 
 # pass current host's hostname to the docker container for server.url (see docker compose config file)
-export HOST_HOSTNAME=$(hostname)
+export HOST_HOSTNAME="nginx"
 
 cd docker
 


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
After migrating from Bamboo to GitHub for running E2E tests, three specific tests consistently fail. These are:
```
Error: ExamParticipation.spec.ts:294:17 Participates in exam by Git submission using ssh
Error: ProgrammingExerciseParticipation.spec.ts:104:21 Makes a git submission using SSH with RSA key
Error: ProgrammingExerciseParticipation.spec.ts:104:21 Makes a git submission using SSH with ED25519 key
```
All failures are SSH-related. The error logs indicate a timeout when trying to connect to the Git repository using the host machine’s name:
```
ssh: connect to host github-l-13.ase.cit.tum.de port 7921: Connection timed out  
fatal: Could not read from remote repository.  
Please make sure you have the correct access rights and the repository exists.
```
The SSH request attempts to resolve and reach the host machine directly, which fails in the containerized setup.

In order to fix it we change to use host machine's name as HOSTNAME to use compose nginx service name so that the request will not try to be made to the actual host but to resolved and redirected to the compose environment.

### Description
- Updated the E2E test environment configuration to use nginx as the hostname.
- This change allows SSH connections to be routed through the compose environment’s nginx service instead of attempting to connect to the actual host IP.


### Steps for Testing
- Set the required environment variables:
```bash
export ARTEMIS_ADMIN_USERNAME=artemis_admin
export ARTEMIS_ADMIN_PASSWORD=artemis_admin
export PLAYWRIGHT_USERNAME_TEMPLATE=artemis_test_user_
export PLAYWRIGHT_PASSWORD_TEMPLATE=artemis_test_user_password_
export PLAYWRIGHT_CREATE_USERS=true
export TEST_TIMEOUT_SECONDS=360
export TEST_RETRIES=1
export TEST_WORKER_PROCESSES=4
export SLOW_TEST_TIMEOUT_SECONDS=180
export FAST_TEST_TIMEOUT_SECONDS=75
export ARTEMIS_DOCKER_TAG=develop
```
- Run cleanup script (⚠️ Warning: removes containers and volumes):
```bash
./.ci/E2E-tests/cleanup.sh
```
- Execute E2E tests:
```bash
./.ci/E2E-tests/execute.sh mysql-localci playwright
```
OR
```bash
.ci/E2E-tests/execute.sh multi-node playwright
```
- Confirm that the SSH-related tests pass by checking `src/test/playwright/test-reports/results.xml`

Example:
```xml
  <testcase name="Exam participation › Programming exam with Git submissions › Participates in exam by Git submission using ssh" classname="e2e/exam/ExamParticipation.spec.ts" time="81.846">
    
    <system-out>
      
      <![CDATA[Could not find test cases yet, retrying... (1 / 20)
Could not find test cases yet, retrying... (2 / 20)
Could not find test cases yet, retrying... (3 / 20)
Could not find test cases yet, retrying... (4 / 20)
Could not find test cases yet, retrying... (5 / 20)
Could not find test cases yet, retrying... (6 / 20)
Could not find test cases yet, retrying... (7 / 20)
Could not find test cases yet, retrying... (8 / 20)
Setting up SSH credentials with key artemis_playwright_ed25519
Cloning repository from ssh://git@nginx:7921/git/PLAYWRIGHT5B49E1328PROGRAMMING6CB4304D9/playwright5b49e1328programming6cb4304d9-artemis_test_user_2.git
Cloned repository successfully. Pushing files...]]>
      
    </system-out>
    
  </testcase>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
	- Updated the container deployment configuration to use a fixed hostname, ensuring consistent and reliable server setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->