### PR TITLE
`Tutorial groups`: Fix tutorial group buttons display strings twice

### DIFF
--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups/tutorial-groups-management/tutorial-group-row-buttons/tutorial-group-row-buttons.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups/tutorial-groups-management/tutorial-group-row-buttons/tutorial-group-row-buttons.component.html
@@ -5,7 +5,6 @@
             <button type="button" [id]="'sessions-' + tutorialGroup.id" (click)="openSessionDialog($event)" class="btn btn-primary btn-sm me-1">
                 <fa-icon [icon]="faCalendar" />
                 <span class="d-none d-md-inline">{{ 'artemisApp.pages.tutorialGroupsManagement.rowButtons.sessions' | artemisTranslate }}</span>
-                <span class="d-none d-md-inline" jhiTranslate="artemisApp.pages.tutorialGroupsManagement.rowButtons.sessions"></span>
             </button>
         }
         <!-- Registered Students -->
@@ -13,7 +12,6 @@
             <button [id]="'registrations-' + tutorialGroup.id" class="btn btn-primary btn-sm me-1" (click)="openRegistrationDialog($event)">
                 <fa-icon [icon]="faUsers" />
                 <span class="d-none d-md-inline">{{ 'artemisApp.pages.registeredStudents.title' | artemisTranslate }}</span>
-                <span class="d-none d-md-inline" jhiTranslate="artemisApp.pages.registeredStudents.title"></span>
             </button>
         }
         <!-- Edit -->
@@ -21,7 +19,6 @@
             <a [id]="'edit-' + tutorialGroup.id" [routerLink]="['/course-management', course.id!, 'tutorial-groups', tutorialGroup.id, 'edit']" class="btn btn-warning btn-sm me-1">
                 <fa-icon [icon]="faWrench" />
                 <span class="d-none d-md-inline">{{ 'entity.action.edit' | artemisTranslate }}</span>
-                <span class="d-none d-md-inline" jhiTranslate="entity.action.edit"></span>
             </a>
         }
         <!-- Delete -->


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixing https://github.com/ls1intum/Artemis/issues/10501 

### Description
Removing duplicate spans from the buttons. 


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Course
- 1 Tutor assigned to course
- 1 Tutorial group 

1. Navigate to course management
2. Select a course
3. Navigate to Tutorials
(-  if no tutorial group is set up create one by with the _+Create new tutorial group_ button
(if you did not set a tutor for this course assign one so you can create the tutorial group by going to course management and clicking on the tutors of the course)
5. See the tutorial group in the list, check for the button texts (not duplicated anymore)

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
just removed duplicate spans

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1235" alt="image" src="https://github.com/user-attachments/assets/8c4ef4ce-5a2c-4c0c-b03a-5ebae97eb350" />
