### PR TITLE
`Programming exercises`: Fix resetting and editing practice repository

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationAuthorizationCheckService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationAuthorizationCheckService.java
@@ -165,7 +165,7 @@ public class ParticipationAuthorizationCheckService {
      * Determines whether a given programming exercise participation is locked.
      * A participation is considered locked if:
      * <ul>
-     * <li>The due date of the exercise has passed.</li>
+     * <li>The due date of the exercise has passed and the participation is not in practice mode.</li>
      * <li>The exercise is an exam exercise, and:
      * <ul>
      * <li>The associated student exam has already been submitted.</li>
@@ -181,7 +181,7 @@ public class ParticipationAuthorizationCheckService {
      * @return {@code true} if the participation is locked based on the conditions above; {@code false} otherwise.
      */
     public boolean isLocked(ProgrammingExerciseStudentParticipation participation, ProgrammingExercise exercise) {
-        if (exerciseDateService.isAfterDueDate(participation, exercise)) {
+        if (exerciseDateService.isAfterDueDate(participation, exercise) && !participation.isPracticeMode()) {
             return true;
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationAuthorizationCheckService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationAuthorizationCheckService.java
@@ -163,7 +163,8 @@ public class ParticipationAuthorizationCheckService {
 
     /**
      * Determines whether a given programming exercise participation is locked.
-     * A participation is considered locked if:
+     * A practice mode participation is never locked.
+     * Otherwise, a participation is considered locked if:
      * <ul>
      * <li>The due date of the exercise has passed and the participation is not in practice mode.</li>
      * <li>The exercise is an exam exercise, and:
@@ -181,7 +182,11 @@ public class ParticipationAuthorizationCheckService {
      * @return {@code true} if the participation is locked based on the conditions above; {@code false} otherwise.
      */
     public boolean isLocked(ProgrammingExerciseStudentParticipation participation, ProgrammingExercise exercise) {
-        if (exerciseDateService.isAfterDueDate(participation, exercise) && !participation.isPracticeMode()) {
+        if (participation.isPracticeMode()) {
+            return false;
+        }
+
+        if (exerciseDateService.isAfterDueDate(participation, exercise)) {
             return true;
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationAuthorizationCheckService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationAuthorizationCheckService.java
@@ -166,7 +166,7 @@ public class ParticipationAuthorizationCheckService {
      * A practice mode participation is never locked.
      * Otherwise, a participation is considered locked if:
      * <ul>
-     * <li>The due date of the exercise has passed and the participation is not in practice mode.</li>
+     * <li>The due date of the exercise has passed.</li>
      * <li>The exercise is an exam exercise, and:
      * <ul>
      * <li>The associated student exam has already been submitted.</li>

--- a/src/main/webapp/app/core/course/overview/exercise-details/reset-repo-button/reset-repo-button.component.html
+++ b/src/main/webapp/app/core/course/overview/exercise-details/reset-repo-button/reset-repo-button.component.html
@@ -13,6 +13,7 @@
             [smallButton]="smallButtons"
             [hideLabelMobile]="false"
             [ngbPopover]="popContent"
+            #popover="ngbPopover"
             [autoClose]="'outside'"
             placement="top-left"
             container="body"

--- a/src/main/webapp/app/core/course/overview/exercise-details/reset-repo-button/reset-repo-button.component.ts
+++ b/src/main/webapp/app/core/course/overview/exercise-details/reset-repo-button/reset-repo-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, inject } from '@angular/core';
+import { Component, Input, OnInit, ViewChild, inject } from '@angular/core';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 import { faBackward } from '@fortawesome/free-solid-svg-icons';
 import { ParticipationService } from 'app/exercise/participation/participation.service';
@@ -36,6 +36,8 @@ export class ResetRepoButtonComponent implements OnInit {
     @Input() participations: StudentParticipation[];
     @Input() smallButtons: boolean;
 
+    @ViewChild('popover') popover: NgbPopover;
+
     gradedParticipation?: StudentParticipation;
     practiceParticipation?: StudentParticipation;
 
@@ -59,6 +61,7 @@ export class ResetRepoButtonComponent implements OnInit {
             .pipe(
                 finalize(() => {
                     this.exercise.loading = false;
+                    this.popover.close();
                 }),
             )
             .subscribe({

--- a/src/main/webapp/app/core/course/overview/exercise-details/reset-repo-button/reset-repo-button.component.ts
+++ b/src/main/webapp/app/core/course/overview/exercise-details/reset-repo-button/reset-repo-button.component.ts
@@ -59,10 +59,13 @@ export class ResetRepoButtonComponent implements OnInit {
             .pipe(
                 finalize(() => {
                     this.exercise.loading = false;
-                    this.alertService.success('artemisApp.exerciseActions.resetRepository.success');
-                    window.scrollTo(0, 0);
                 }),
             )
-            .subscribe();
+            .subscribe({
+                next: () => {
+                    this.alertService.success('artemisApp.exerciseActions.resetRepository.success');
+                    window.scrollTo(0, 0);
+                },
+            });
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

1. Fixing the success alert being displayed on error: https://github.com/ls1intum/Artemis/issues/10514
2. While investigating above issue I realized the request to reset practice repository after deadline of the programming exercise (the reset-repository request in practice mode always fails with AccessForbiddenException because [`participationAuthCheckService.isLocked(participation, exercise)` ](https://github.com/ls1intum/Artemis/blob/65964e5551b6e51a5536056d40b6fe499a50e11a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseParticipationResource.java#L297-L299) is always true for exercises which are past due date. To my understanding the due date should not matter for practice mode. (as it is always past due date)
3. For the same reason, also submitting changes in the online editor failed because `RepositoryAccessService->hasAccessToOwnStudentParticipation` will return false when the participation is locked too 
4. the reset repository popover does not close on submitting

### Description

1. Previously the success alert was displayed, no matter what the programming-exercise-participations/{participationId}/reset-repository request response was. Moved the alert trigger the next callback to fix.
2. adding check to to always returning false for practice mode participation in ParticipationAuthorizationCheckService->isLocked 
5. closing the popover when resetting the repository
### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Programming exercise with past due date, enabled online editor
- 1 Student
1. Navigate to the programming exercise and start practice mode.
6. Make some changes in online editor and save them.
7. Click Reset Repository.
8. Observe the notification pop-ups.
9. Check if the repository really reseted


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| reset-repo-button.component.ts | 97.14% | ✅  |

#### Server

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| ParticipationAuthorizationCheckService.java | 73% | ✅  |


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the criteria for locking programming exercise participations so that only those not in practice mode are locked once the due date has passed.

- **New Features**
  - Enhanced the repository reset process by displaying a success notification and scrolling the view to the top after a reset completes.
  - Introduced a new popover interaction for the reset repository button to improve user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->