### PR TITLE
`Development`: Fix markdown and conversation file upload

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/web/FileResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/FileResource.java
@@ -220,16 +220,15 @@ public class FileResource {
         log.debug("REST request to get file for markdown in conversation: File {} for conversation {} in course {}", filename, conversationId, courseId);
         sanitizeFilenameElseThrow(filename);
 
-        var publicPath = FilePathService.getMarkdownFilePathForConversation(courseId, conversationId);
-        Path responsePath = getResponsePathFromPublicPath(publicPath);
-
-        var fileUpload = fileUploadService.findByPath("courses/" + courseId + "/conversations/" + conversationId + "/" + filename);
+        var serverFilePath = FilePathService.getMarkdownFilePathForConversation(courseId, conversationId);
+        var publicPath = "courses/" + courseId + "/conversations/" + conversationId + "/" + filename;
+        var fileUpload = fileUploadService.findByPath(publicPath);
 
         if (fileUpload.isPresent()) {
-            return buildFileResponse(responsePath, filename, Optional.ofNullable(fileUpload.get().getFilename()), true);
+            return buildFileResponse(serverFilePath, filename, Optional.ofNullable(fileUpload.get().getFilename()), true);
         }
 
-        return buildFileResponse(responsePath, filename, true);
+        return buildFileResponse(serverFilePath, filename, true);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/FileResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/FileResource.java
@@ -167,7 +167,8 @@ public class FileResource {
     public ResponseEntity<String> saveMarkdownFile(@RequestParam(value = "file") MultipartFile file, @RequestParam(defaultValue = "false") boolean keepFileName)
             throws URISyntaxException {
         log.debug("REST request to upload file for markdown: {}", file.getOriginalFilename());
-        String responsePath = fileService.handleSaveFile(file, keepFileName, true).toString();
+        String publicPath = fileService.handleSaveFile(file, keepFileName, true).toString();
+        String responsePath = getResponsePathFromPublicPathString(publicPath);
 
         // return path for getting the file
         String responseBody = "{\"path\":\"" + responsePath + "\"}";

--- a/src/test/java/de/tum/cit/aet/artemis/core/FileIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/FileIntegrationTest.java
@@ -36,6 +36,7 @@ import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import de.tum.cit.aet.artemis.communication.util.ConversationUtilService;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.service.FilePathService;
 import de.tum.cit.aet.artemis.exam.domain.ExamUser;
@@ -78,6 +79,9 @@ class FileIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private ExamUtilService examUtilService;
+
+    @Autowired
+    private ConversationUtilService conversationUtilService;
 
     @Autowired
     private MockMvc mockMvc;
@@ -399,6 +403,24 @@ class FileIntegrationTest extends AbstractSpringIntegrationIndependentTest {
             assertThat(contentDisposition).doesNotContain("–");
             assertThat(contentDisposition).contains("filename=");
         }
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testUploadAndRetrieveFileForConversation() throws Exception {
+        userUtilService.addUsers(TEST_PREFIX, 4, 4, 4, 1);
+        var posts = conversationUtilService.createPostsWithinCourse(TEST_PREFIX);
+        var conversation = posts.getFirst().getConversation();
+        var course = conversation.getCourse();
+
+        MockMultipartFile file = new MockMultipartFile("file", "image.png", "image/png", new byte[] { 1, 2, 3, 4, 5 });
+
+        JsonNode response = request.postWithMultipartFile("/api/core/files/courses/" + course.getId() + "/conversations/" + conversation.getId(), file.getOriginalFilename(),
+                "file", file, JsonNode.class, HttpStatus.CREATED);
+        String responsePath = response.get("path").asText();
+
+        byte[] retrievedContent = request.get(responsePath, HttpStatus.OK, byte[].class);
+        assertThat(retrievedContent).isEqualTo(file.getBytes());
     }
 
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
After the 8.0 API Migrations, file uploads with the markdown editor did not work anymore.

This PR closes #10615 

### Description
<!-- Describe your changes in detail -->
- Fixed retrieving file uploads for conversations by using the internal path to fetch the file from the FileService
- Fixed uploading files using the `markdown-file-upload` API by returning the `api/core/files` path segment that was missing after the migration changes.
- Added integration test to ensure fetching an uploaded file for a conversation works.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
**Conversation Uploads**

Prerequisites:
- 1 Student

1. Log in to Artemis
2. Navigate to any chat
3. Add a file upload to your post by using the "Attach files by dragging & dropping or selecting them." label
4. Go to the post preview 
5. For uploaded images the image is shown, for other uploaded files clicking the link loads the file in a new tab

**Other uploads**

Prerequisits
- 1 Instructor

1. Log in to Artemis
2. Go to any screen with a markdown editor text area. Eg edit an FAQ, edit a text exercise, edit course details, ...
3. Upload a file to the text field
4. Go to the preview mode
5. For uploaded images the image is shown, for other uploaded files clicking the link loads the file in a new tab

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined file upload and retrieval operations to ensure accurate file path generation.
  
- **Tests**
  - Introduced an integration test verifying that file uploads and retrievals work correctly during conversation interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->