### PR TITLE
`Development`: Revert FK constraint name in existing migration

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20250328114200_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20250328114200_changelog.xml
@@ -7,7 +7,7 @@
         <!-- Connection to quiz group -->
         <dropForeignKeyConstraint baseTableName="quiz_question" constraintName="FKkYIc8NStrPM5ULjNkq417ssEc"/>
         <!-- Connection to quiz pool -->
-        <dropForeignKeyConstraint baseTableName="quiz_question" constraintName="FKfIH1sii1GTGlX7wfMoVrr8AAb"/>
+        <dropForeignKeyConstraint baseTableName="quiz_question" constraintName="FKFIH1SII1GTGLX7WFMOVRR8AAB"/>
         <dropColumn tableName="quiz_question" columnName="quiz_group_id"/>
         <dropColumn tableName="quiz_question" columnName="quiz_pool_id"/>
         <dropTable tableName="quiz_pool"/>


### PR DESCRIPTION
### Motivation and Context
#10603 changed the FK name of an existing migration. This causes some TS to not start since the migration has already been executed as part of the main branch.

Also, FK names in Postgres are case-sensitive (unlike in MySQL).

### Description
Revert the changes in `20250328114200_changelog.xml`.