### PR TITLE
`Communication`: Add channel management notifications

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/course_notifications/AddedToChannelNotification.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/course_notifications/AddedToChannelNotification.java
@@ -1,0 +1,59 @@
+package de.tum.cit.aet.artemis.communication.domain.course_notifications;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+import de.tum.cit.aet.artemis.communication.annotations.CourseNotificationType;
+import de.tum.cit.aet.artemis.communication.domain.NotificationChannelOption;
+
+/**
+ * Notification that tells the user they were added to a channel.
+ */
+@CourseNotificationType(19)
+public class AddedToChannelNotification extends CourseNotification {
+
+    protected String channelModerator;
+
+    protected String channelName;
+
+    protected Long channelId;
+
+    /**
+     * Default constructor used when creating the notification.
+     */
+    public AddedToChannelNotification(Long courseId, String courseTitle, String courseImageUrl, String channelModerator, String channelName, Long channelId) {
+        super(null, courseId, courseTitle, courseImageUrl, ZonedDateTime.now());
+        this.channelModerator = channelModerator;
+        this.channelName = channelName;
+        this.channelId = channelId;
+    }
+
+    /**
+     * Constructor used when loading the existing notification from the database.
+     */
+    public AddedToChannelNotification(Long notificationId, Long courseId, ZonedDateTime creationDate, Map<String, String> parameters) {
+        super(notificationId, courseId, creationDate, parameters);
+    }
+
+    @Override
+    public CourseNotificationCategory getCourseNotificationCategory() {
+        return CourseNotificationCategory.COMMUNICATION;
+    }
+
+    @Override
+    public Duration getCleanupDuration() {
+        return Duration.ofDays(7);
+    }
+
+    @Override
+    public List<NotificationChannelOption> getSupportedChannels() {
+        return List.of(NotificationChannelOption.WEBAPP, NotificationChannelOption.PUSH);
+    }
+
+    @Override
+    public String getRelativeWebAppUrl() {
+        return "/courses/" + courseId + "/communication?conversationId=" + channelId;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/course_notifications/ChannelDeletedNotification.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/course_notifications/ChannelDeletedNotification.java
@@ -1,0 +1,56 @@
+package de.tum.cit.aet.artemis.communication.domain.course_notifications;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+import de.tum.cit.aet.artemis.communication.annotations.CourseNotificationType;
+import de.tum.cit.aet.artemis.communication.domain.NotificationChannelOption;
+
+/**
+ * Notification that tells the user that a channel they are in was deleted.
+ */
+@CourseNotificationType(18)
+public class ChannelDeletedNotification extends CourseNotification {
+
+    protected String deletingUser;
+
+    protected String channelName;
+
+    /**
+     * Default constructor used when creating the notification.
+     */
+    public ChannelDeletedNotification(Long courseId, String courseTitle, String courseImageUrl, String deletingUser, String channelName) {
+        super(null, courseId, courseTitle, courseImageUrl, ZonedDateTime.now());
+        this.deletingUser = deletingUser;
+        this.channelName = channelName;
+    }
+
+    /**
+     * Constructor used when loading the existing notification from the database.
+     */
+    public ChannelDeletedNotification(Long notificationId, Long courseId, ZonedDateTime creationDate, Map<String, String> parameters) {
+        super(notificationId, courseId, creationDate, parameters);
+    }
+
+    @Override
+    public CourseNotificationCategory getCourseNotificationCategory() {
+        return CourseNotificationCategory.COMMUNICATION;
+    }
+
+    @Override
+    public Duration getCleanupDuration() {
+        return Duration.ofDays(7);
+    }
+
+    @Override
+    public List<NotificationChannelOption> getSupportedChannels() {
+        return List.of(NotificationChannelOption.WEBAPP, NotificationChannelOption.PUSH);
+    }
+
+    @Override
+    public String getRelativeWebAppUrl() {
+        return "/courses/" + courseId;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/course_notifications/RemovedFromChannelNotification.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/course_notifications/RemovedFromChannelNotification.java
@@ -1,0 +1,60 @@
+package de.tum.cit.aet.artemis.communication.domain.course_notifications;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import de.tum.cit.aet.artemis.communication.annotations.CourseNotificationType;
+import de.tum.cit.aet.artemis.communication.domain.NotificationChannelOption;
+
+/**
+ * Notification that tells the user they were removed from a channel.
+ */
+@CourseNotificationType(20)
+public class RemovedFromChannelNotification extends CourseNotification {
+
+    protected String channelModerator;
+
+    protected String channelName;
+
+    protected Long channelId;
+
+    /**
+     * Default constructor used when creating the notification.
+     */
+    public RemovedFromChannelNotification(Long courseId, String courseTitle, String courseImageUrl, String channelModerator, String channelName, Long channelId) {
+        super(null, courseId, courseTitle, courseImageUrl, ZonedDateTime.now());
+        this.channelModerator = channelModerator;
+        this.channelName = Objects.requireNonNullElse(channelName, "Group Chat");
+        this.channelId = channelId;
+    }
+
+    /**
+     * Constructor used when loading the existing notification from the database.
+     */
+    public RemovedFromChannelNotification(Long notificationId, Long courseId, ZonedDateTime creationDate, Map<String, String> parameters) {
+        super(notificationId, courseId, creationDate, parameters);
+    }
+
+    @Override
+    public CourseNotificationCategory getCourseNotificationCategory() {
+        return CourseNotificationCategory.COMMUNICATION;
+    }
+
+    @Override
+    public Duration getCleanupDuration() {
+        return Duration.ofDays(7);
+    }
+
+    @Override
+    public List<NotificationChannelOption> getSupportedChannels() {
+        return List.of(NotificationChannelOption.WEBAPP, NotificationChannelOption.PUSH);
+    }
+
+    @Override
+    public String getRelativeWebAppUrl() {
+        return "/courses/" + courseId;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/setting_presets/AllActivityUserCourseNotificationSettingPreset.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/setting_presets/AllActivityUserCourseNotificationSettingPreset.java
@@ -4,7 +4,9 @@ import java.util.Map;
 
 import de.tum.cit.aet.artemis.communication.annotations.CourseNotificationSettingPreset;
 import de.tum.cit.aet.artemis.communication.domain.NotificationChannelOption;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.AddedToChannelNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.AttachmentChangedNotification;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.ChannelDeletedNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.ExerciseAssessedNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.ExerciseOpenForPracticeNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.ExerciseUpdatedNotification;
@@ -15,6 +17,7 @@ import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewManua
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewMentionNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewPostNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.QuizExerciseStartedNotification;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.RemovedFromChannelNotification;
 
 @CourseNotificationSettingPreset(2)
 public class AllActivityUserCourseNotificationSettingPreset extends UserCourseNotificationSettingPreset {
@@ -41,6 +44,12 @@ public class AllActivityUserCourseNotificationSettingPreset extends UserCourseNo
                 Map.entry(AttachmentChangedNotification.class,
                         Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)),
                 Map.entry(NewManualFeedbackRequestNotification.class,
+                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)),
+                Map.entry(ChannelDeletedNotification.class,
+                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)),
+                Map.entry(AddedToChannelNotification.class,
+                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)),
+                Map.entry(RemovedFromChannelNotification.class,
                         Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/setting_presets/DefaultUserCourseNotificationSettingPreset.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/setting_presets/DefaultUserCourseNotificationSettingPreset.java
@@ -4,7 +4,9 @@ import java.util.Map;
 
 import de.tum.cit.aet.artemis.communication.annotations.CourseNotificationSettingPreset;
 import de.tum.cit.aet.artemis.communication.domain.NotificationChannelOption;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.AddedToChannelNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.AttachmentChangedNotification;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.ChannelDeletedNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.ExerciseAssessedNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.ExerciseOpenForPracticeNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.ExerciseUpdatedNotification;
@@ -15,6 +17,7 @@ import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewManua
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewMentionNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewPostNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.QuizExerciseStartedNotification;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.RemovedFromChannelNotification;
 
 @CourseNotificationSettingPreset(1)
 public class DefaultUserCourseNotificationSettingPreset extends UserCourseNotificationSettingPreset {
@@ -42,6 +45,12 @@ public class DefaultUserCourseNotificationSettingPreset extends UserCourseNotifi
                 Map.entry(AttachmentChangedNotification.class,
                         Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)),
                 Map.entry(NewManualFeedbackRequestNotification.class,
+                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)),
+                Map.entry(ChannelDeletedNotification.class,
+                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)),
+                Map.entry(AddedToChannelNotification.class,
+                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)),
+                Map.entry(RemovedFromChannelNotification.class,
                         Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/setting_presets/IgnoreUserCourseNotificationSettingPreset.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/setting_presets/IgnoreUserCourseNotificationSettingPreset.java
@@ -4,7 +4,9 @@ import java.util.Map;
 
 import de.tum.cit.aet.artemis.communication.annotations.CourseNotificationSettingPreset;
 import de.tum.cit.aet.artemis.communication.domain.NotificationChannelOption;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.AddedToChannelNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.AttachmentChangedNotification;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.ChannelDeletedNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.ExerciseAssessedNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.ExerciseOpenForPracticeNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.ExerciseUpdatedNotification;
@@ -15,6 +17,7 @@ import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewManua
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewMentionNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewPostNotification;
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.QuizExerciseStartedNotification;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.RemovedFromChannelNotification;
 
 @CourseNotificationSettingPreset(3)
 public class IgnoreUserCourseNotificationSettingPreset extends UserCourseNotificationSettingPreset {
@@ -42,6 +45,12 @@ public class IgnoreUserCourseNotificationSettingPreset extends UserCourseNotific
                 Map.entry(AttachmentChangedNotification.class,
                         Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, false, NotificationChannelOption.PUSH, false)),
                 Map.entry(NewManualFeedbackRequestNotification.class,
+                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, false, NotificationChannelOption.PUSH, false)),
+                Map.entry(ChannelDeletedNotification.class,
+                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, false, NotificationChannelOption.PUSH, false)),
+                Map.entry(AddedToChannelNotification.class,
+                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, false, NotificationChannelOption.PUSH, false)),
+                Map.entry(RemovedFromChannelNotification.class,
                         Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, false, NotificationChannelOption.PUSH, false)));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/CourseNotificationPushProxyService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/CourseNotificationPushProxyService.java
@@ -1,8 +1,11 @@
 package de.tum.cit.aet.artemis.communication.service;
 
 import static de.tum.cit.aet.artemis.communication.domain.NotificationType.ATTACHMENT_CHANGE;
+import static de.tum.cit.aet.artemis.communication.domain.NotificationType.CONVERSATION_ADD_USER_CHANNEL;
+import static de.tum.cit.aet.artemis.communication.domain.NotificationType.CONVERSATION_DELETE_CHANNEL;
 import static de.tum.cit.aet.artemis.communication.domain.NotificationType.CONVERSATION_NEW_MESSAGE;
 import static de.tum.cit.aet.artemis.communication.domain.NotificationType.CONVERSATION_NEW_REPLY_MESSAGE;
+import static de.tum.cit.aet.artemis.communication.domain.NotificationType.CONVERSATION_REMOVE_USER_CHANNEL;
 import static de.tum.cit.aet.artemis.communication.domain.NotificationType.CONVERSATION_USER_MENTIONED;
 import static de.tum.cit.aet.artemis.communication.domain.NotificationType.EXERCISE_PRACTICE;
 import static de.tum.cit.aet.artemis.communication.domain.NotificationType.EXERCISE_RELEASED;
@@ -143,6 +146,24 @@ public class CourseNotificationPushProxyService {
                         NotificationTargetFactory.COURSES_TEXT);
                 target = notificationTarget.toJsonString();
                 type = ATTACHMENT_CHANGE.toString();
+                break;
+            case "channelDeletedNotification":
+                notificationPlaceholders = new String[] { parameters.get("courseTitle"), parameters.get("channelName"), parameters.get("deletingUser"), };
+
+                notificationTarget = new NotificationTarget(NotificationTargetFactory.CONVERSATION_DELETION_TEXT, Long.parseLong(parameters.get("courseId")),
+                        NotificationTargetFactory.CONVERSATION_DELETION_TEXT, courseNotificationDTO.courseId(), NotificationTargetFactory.COURSES_TEXT);
+                target = notificationTarget.toJsonString();
+                type = CONVERSATION_DELETE_CHANNEL.toString();
+                break;
+            case "addedToChannelNotification":
+            case "removedFromChannelNotification":
+                notificationPlaceholders = new String[] { parameters.get("courseTitle"), parameters.get("channelName"), parameters.get("channelModerator"), };
+
+                notificationTarget = new NotificationTarget(NotificationTargetFactory.COURSE_MANAGEMENT_TEXT, Long.parseLong(parameters.get("channelId")),
+                        NotificationTargetFactory.COURSE_MANAGEMENT_TEXT, courseNotificationDTO.courseId(), NotificationTargetFactory.COURSES_TEXT);
+                target = notificationTarget.toJsonString();
+                type = courseNotificationDTO.notificationType().equals("addedToChannelNotification") ? CONVERSATION_ADD_USER_CHANNEL.toString()
+                        : CONVERSATION_REMOVE_USER_CHANNEL.toString();
                 break;
             default:
                 return new PushNotificationDataDTO(new CourseNotificationSerializedDTO(courseNotificationDTO));

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/conversation/ChannelResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/conversation/ChannelResource.java
@@ -33,11 +33,15 @@ import org.springframework.web.bind.annotation.RestController;
 import de.tum.cit.aet.artemis.communication.domain.ConversationParticipant;
 import de.tum.cit.aet.artemis.communication.domain.NotificationType;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Channel;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.AddedToChannelNotification;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.ChannelDeletedNotification;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.RemovedFromChannelNotification;
 import de.tum.cit.aet.artemis.communication.dto.ChannelDTO;
 import de.tum.cit.aet.artemis.communication.dto.ChannelIdAndNameDTO;
 import de.tum.cit.aet.artemis.communication.dto.FeedbackChannelRequestDTO;
 import de.tum.cit.aet.artemis.communication.repository.ConversationParticipantRepository;
 import de.tum.cit.aet.artemis.communication.repository.conversation.ChannelRepository;
+import de.tum.cit.aet.artemis.communication.service.CourseNotificationService;
 import de.tum.cit.aet.artemis.communication.service.conversation.ChannelService;
 import de.tum.cit.aet.artemis.communication.service.conversation.ConversationDTOService;
 import de.tum.cit.aet.artemis.communication.service.conversation.ConversationService;
@@ -55,6 +59,8 @@ import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
 import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInCourse.EnforceAtLeastEditorInCourse;
 import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInCourse.EnforceAtLeastTutorInCourse;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
+import de.tum.cit.aet.artemis.core.service.feature.Feature;
+import de.tum.cit.aet.artemis.core.service.feature.FeatureToggleService;
 import de.tum.cit.aet.artemis.tutorialgroup.api.TutorialGroupChannelManagementApi;
 
 @Profile(PROFILE_CORE)
@@ -84,10 +90,15 @@ public class ChannelResource extends ConversationManagementResource {
 
     private final ConversationParticipantRepository conversationParticipantRepository;
 
+    private final FeatureToggleService featureToggleService;
+
+    private final CourseNotificationService courseNotificationService;
+
     public ChannelResource(ConversationParticipantRepository conversationParticipantRepository, SingleUserNotificationService singleUserNotificationService,
             ChannelService channelService, ChannelRepository channelRepository, ChannelAuthorizationService channelAuthorizationService,
             AuthorizationCheckService authorizationCheckService, ConversationDTOService conversationDTOService, CourseRepository courseRepository, UserRepository userRepository,
-            ConversationService conversationService, Optional<TutorialGroupChannelManagementApi> tutorialGroupChannelManagementApi) {
+            ConversationService conversationService, Optional<TutorialGroupChannelManagementApi> tutorialGroupChannelManagementApi, FeatureToggleService featureToggleService,
+            CourseNotificationService courseNotificationService) {
         super(courseRepository);
         this.channelService = channelService;
         this.channelRepository = channelRepository;
@@ -99,6 +110,8 @@ public class ChannelResource extends ConversationManagementResource {
         this.tutorialGroupChannelManagementApi = tutorialGroupChannelManagementApi;
         this.singleUserNotificationService = singleUserNotificationService;
         this.conversationParticipantRepository = conversationParticipantRepository;
+        this.featureToggleService = featureToggleService;
+        this.courseNotificationService = courseNotificationService;
     }
 
     /**
@@ -293,8 +306,18 @@ public class ChannelResource extends ConversationManagementResource {
         var usersToNotify = conversationParticipantRepository.findConversationParticipantsByConversationId(channel.getId()).stream().map(ConversationParticipant::getUser)
                 .collect(Collectors.toSet());
         conversationService.deleteConversation(channel);
-        usersToNotify.forEach(
-                user -> singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(channel, user, requestingUser, NotificationType.CONVERSATION_DELETE_CHANNEL));
+
+        if (featureToggleService.isFeatureEnabled(Feature.CourseSpecificNotifications)) {
+            var course = channel.getCourse();
+            var channelDeletedNotification = new ChannelDeletedNotification(courseId, course.getTitle(), course.getCourseIcon(), requestingUser.getName(), channel.getName());
+
+            courseNotificationService.sendCourseNotification(channelDeletedNotification,
+                    usersToNotify.stream().filter((user) -> !Objects.equals(user.getId(), requestingUser.getId())).toList());
+        }
+        else {
+            usersToNotify.forEach(user -> singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(channel, user, requestingUser,
+                    NotificationType.CONVERSATION_DELETE_CHANNEL));
+        }
         return ResponseEntity.ok().build();
     }
 
@@ -422,8 +445,18 @@ public class ChannelResource extends ConversationManagementResource {
         var requestingUser = userRepository.getUserWithGroupsAndAuthorities();
         channelAuthorizationService.isAllowedToRegisterUsersToChannel(channelFromDatabase, usersLoginsToRegister, requestingUser);
         Set<User> registeredUsers = channelService.registerUsersToChannel(addAllStudents, addAllTutors, addAllInstructors, usersLoginsToRegister, course, channelFromDatabase);
-        registeredUsers.forEach(user -> singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(channelFromDatabase, user, requestingUser,
-                NotificationType.CONVERSATION_ADD_USER_CHANNEL));
+
+        if (featureToggleService.isFeatureEnabled(Feature.CourseSpecificNotifications)) {
+            var addedToChannelNotification = new AddedToChannelNotification(courseId, course.getTitle(), course.getCourseIcon(), requestingUser.getName(),
+                    channelFromDatabase.getName(), channelFromDatabase.getId());
+
+            courseNotificationService.sendCourseNotification(addedToChannelNotification, registeredUsers.stream().toList());
+        }
+        else {
+            registeredUsers.forEach(user -> singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(channelFromDatabase, user, requestingUser,
+                    NotificationType.CONVERSATION_ADD_USER_CHANNEL));
+        }
+
         return ResponseEntity.ok().build();
     }
 
@@ -460,8 +493,17 @@ public class ChannelResource extends ConversationManagementResource {
         }
 
         conversationService.deregisterUsersFromAConversation(course, usersToDeRegister, channelFromDatabase);
-        usersToDeRegister.forEach(user -> singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(channelFromDatabase, user, requestingUser,
-                NotificationType.CONVERSATION_REMOVE_USER_CHANNEL));
+
+        if (featureToggleService.isFeatureEnabled(Feature.CourseSpecificNotifications)) {
+            var removedFromChannelNotification = new RemovedFromChannelNotification(courseId, course.getTitle(), course.getCourseIcon(), requestingUser.getName(),
+                    channelFromDatabase.getName(), channelFromDatabase.getId());
+
+            courseNotificationService.sendCourseNotification(removedFromChannelNotification, usersToDeRegister.stream().toList());
+        }
+        else {
+            usersToDeRegister.forEach(user -> singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(channelFromDatabase, user, requestingUser,
+                    NotificationType.CONVERSATION_REMOVE_USER_CHANNEL));
+        }
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/conversation/GroupChatResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/conversation/GroupChatResource.java
@@ -23,9 +23,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.artemis.communication.domain.NotificationType;
 import de.tum.cit.aet.artemis.communication.domain.conversation.GroupChat;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.AddedToChannelNotification;
+import de.tum.cit.aet.artemis.communication.domain.course_notifications.RemovedFromChannelNotification;
 import de.tum.cit.aet.artemis.communication.dto.GroupChatDTO;
 import de.tum.cit.aet.artemis.communication.dto.MetisCrudAction;
 import de.tum.cit.aet.artemis.communication.repository.conversation.GroupChatRepository;
+import de.tum.cit.aet.artemis.communication.service.CourseNotificationService;
 import de.tum.cit.aet.artemis.communication.service.conversation.ConversationDTOService;
 import de.tum.cit.aet.artemis.communication.service.conversation.ConversationService;
 import de.tum.cit.aet.artemis.communication.service.conversation.GroupChatService;
@@ -35,6 +38,8 @@ import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.repository.CourseRepository;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
+import de.tum.cit.aet.artemis.core.service.feature.Feature;
+import de.tum.cit.aet.artemis.core.service.feature.FeatureToggleService;
 
 @Profile(PROFILE_CORE)
 @RestController
@@ -57,9 +62,14 @@ public class GroupChatResource extends ConversationManagementResource {
 
     private final SingleUserNotificationService singleUserNotificationService;
 
+    private final FeatureToggleService featureToggleService;
+
+    private final CourseNotificationService courseNotificationService;
+
     public GroupChatResource(SingleUserNotificationService singleUserNotificationService, UserRepository userRepository, CourseRepository courseRepository,
             GroupChatAuthorizationService groupChatAuthorizationService, ConversationService conversationService, GroupChatService groupChatService,
-            GroupChatRepository groupChatRepository, ConversationDTOService conversationDTOService) {
+            GroupChatRepository groupChatRepository, ConversationDTOService conversationDTOService, FeatureToggleService featureToggleService,
+            CourseNotificationService courseNotificationService) {
         super(courseRepository);
         this.userRepository = userRepository;
         this.groupChatAuthorizationService = groupChatAuthorizationService;
@@ -68,6 +78,8 @@ public class GroupChatResource extends ConversationManagementResource {
         this.groupChatRepository = groupChatRepository;
         this.conversationDTOService = conversationDTOService;
         this.singleUserNotificationService = singleUserNotificationService;
+        this.featureToggleService = featureToggleService;
+        this.courseNotificationService = courseNotificationService;
     }
 
     /**
@@ -151,8 +163,18 @@ public class GroupChatResource extends ConversationManagementResource {
         groupChatAuthorizationService.isAllowedToAddUsersToGroupChat(groupChatFromDatabase, requestingUser);
         var usersToRegister = conversationService.findUsersInDatabase(userLogins);
         conversationService.registerUsersToConversation(course, usersToRegister, groupChatFromDatabase, Optional.of(MAX_GROUP_CHAT_PARTICIPANTS));
-        usersToRegister.forEach(user -> singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(groupChatFromDatabase, user, requestingUser,
-                NotificationType.CONVERSATION_ADD_USER_GROUP_CHAT));
+
+        if (featureToggleService.isFeatureEnabled(Feature.CourseSpecificNotifications)) {
+            var addedToChannelNotification = new AddedToChannelNotification(courseId, course.getTitle(), course.getCourseIcon(), requestingUser.getName(),
+                    groupChatFromDatabase.getName(), groupChatFromDatabase.getId());
+
+            courseNotificationService.sendCourseNotification(addedToChannelNotification, usersToRegister.stream().toList());
+        }
+        else {
+            usersToRegister.forEach(user -> singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(groupChatFromDatabase, user, requestingUser,
+                    NotificationType.CONVERSATION_ADD_USER_GROUP_CHAT));
+        }
+
         return ResponseEntity.ok().build();
     }
 
@@ -183,8 +205,17 @@ public class GroupChatResource extends ConversationManagementResource {
         conversationService.deregisterUsersFromAConversation(course, usersToDeRegister, groupChatFromDatabase);
         // ToDo: Discuss if we should delete the group chat if it has no participants left, but maybe we want to keep it for data analysis purposes
 
-        usersToDeRegister.forEach(user -> singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(groupChatFromDatabase, user, requestingUser,
-                NotificationType.CONVERSATION_REMOVE_USER_GROUP_CHAT));
+        if (featureToggleService.isFeatureEnabled(Feature.CourseSpecificNotifications)) {
+            var removedFromChannelNotification = new RemovedFromChannelNotification(courseId, course.getTitle(), course.getCourseIcon(), requestingUser.getName(),
+                    groupChatFromDatabase.getName(), groupChatFromDatabase.getId());
+
+            courseNotificationService.sendCourseNotification(removedFromChannelNotification, usersToDeRegister.stream().toList());
+        }
+        else {
+            usersToDeRegister.forEach(user -> singleUserNotificationService.notifyClientAboutConversationCreationOrDeletion(groupChatFromDatabase, user, requestingUser,
+                    NotificationType.CONVERSATION_REMOVE_USER_GROUP_CHAT));
+        }
+
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/webapp/app/communication/course-notification/course-notification.service.ts
+++ b/src/main/webapp/app/communication/course-notification/course-notification.service.ts
@@ -32,6 +32,9 @@ export class CourseNotificationService {
         quizExerciseStartedNotification: faRectangleList,
         attachmentChangedNotification: faRectangleList,
         newManualFeedbackRequestNotification: faRectangleList,
+        channelDeletedNotification: faComments,
+        addedToChannelNotification: faComments,
+        removedFromChannelNotification: faComments,
     };
 
     public static readonly DISABLE_NOTIFICATION_CHANNEL_TYPES: Record<string, Array<CourseNotificationChannel>> = {
@@ -46,6 +49,9 @@ export class CourseNotificationService {
         quizExerciseStartedNotification: [CourseNotificationChannel.EMAIL],
         attachmentChangedNotification: [CourseNotificationChannel.EMAIL],
         newManualFeedbackRequestNotification: [CourseNotificationChannel.EMAIL],
+        channelDeletedNotification: [CourseNotificationChannel.EMAIL],
+        addedToChannelNotification: [CourseNotificationChannel.EMAIL],
+        removedFromChannelNotification: [CourseNotificationChannel.EMAIL],
     };
 
     // Parameter keys that should be rendered as markdown

--- a/src/main/webapp/app/communication/course-notification/course-notification/course-notification.component.scss
+++ b/src/main/webapp/app/communication/course-notification/course-notification/course-notification.component.scss
@@ -85,9 +85,17 @@ $notification-padding-x: 1.2rem;
 
 .course-notification-date {
     position: absolute;
-    top: $notification-padding-y + 0.2rem;
+    top: $notification-padding-y - 0.4rem;
     right: $notification-padding-y;
     text-align: right;
+    color: var(--secondary);
+    font-size: 80%;
+
+    transition: right 0.2s ease-in-out;
+}
+
+.course-notification:hover .course-notification-date {
+    right: $notification-padding-y + 0.5rem;
 }
 
 .course-notification-content {
@@ -97,11 +105,6 @@ $notification-padding-x: 1.2rem;
     line-clamp: 2;
     -webkit-box-orient: vertical;
     font-size: 90%;
-}
-
-.course-notification-date {
-    color: var(--secondary);
-    font-size: 80%;
 }
 
 .course-notification-loading-indicator {

--- a/src/main/webapp/i18n/de/notification.json
+++ b/src/main/webapp/i18n/de/notification.json
@@ -243,6 +243,21 @@
                 "content": "In {{exerciseTitle}} wird Feedback benötigt.",
                 "settingsTitle": "Feedback benötigt"
             },
+            "channelDeletedNotification": {
+                "title": "Kanal gelöscht",
+                "content": "{{channelName}} wurde in {{courseTitle}} gelöscht.",
+                "settingsTitle": "Kanal gelöscht"
+            },
+            "addedToChannelNotification": {
+                "title": "Kanal beigetreten",
+                "content": "Du bist {{channelName}} in {{courseTitle}} beigetreten.",
+                "settingsTitle": "Kanal beigetreten"
+            },
+            "removedFromChannelNotification": {
+                "title": "Aus Kanal entfernt",
+                "content": "Du wurdest aus {{channelName}} in {{courseTitle}} entfernt.",
+                "settingsTitle": "Aus Kanal entfernt"
+            },
             "temporal": {
                 "now": "Jetzt",
                 "oneHourAgo": "Vor 1 Stunde.",

--- a/src/main/webapp/i18n/en/notification.json
+++ b/src/main/webapp/i18n/en/notification.json
@@ -243,6 +243,21 @@
                 "content": "Feedback was requested in {{exerciseTitle}}.",
                 "settingsTitle": "Feedback requested"
             },
+            "channelDeletedNotification": {
+                "title": "Channel deleted",
+                "content": "{{channelName}} was deleted in {{courseTitle}}.",
+                "settingsTitle": "Feedback requested"
+            },
+            "addedToChannelNotification": {
+                "title": "Added to channel",
+                "content": "You were added to {{channelName}} in {{courseTitle}}.",
+                "settingsTitle": "Added to channel"
+            },
+            "removedFromChannelNotification": {
+                "title": "Removed from channel",
+                "content": "You were removed from {{channelName}} in {{courseTitle}}.",
+                "settingsTitle": "Removed from channel"
+            },
             "temporal": {
                 "now": "Now",
                 "oneHourAgo": "1 hour ago.",

--- a/src/test/java/de/tum/cit/aet/artemis/communication/ChannelIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/ChannelIntegrationTest.java
@@ -25,17 +25,21 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import de.tum.cit.aet.artemis.communication.domain.ConversationParticipant;
+import de.tum.cit.aet.artemis.communication.domain.CourseNotification;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Channel;
 import de.tum.cit.aet.artemis.communication.dto.ChannelDTO;
 import de.tum.cit.aet.artemis.communication.dto.ChannelIdAndNameDTO;
 import de.tum.cit.aet.artemis.communication.dto.FeedbackChannelRequestDTO;
 import de.tum.cit.aet.artemis.communication.dto.MetisCrudAction;
 import de.tum.cit.aet.artemis.communication.service.conversation.ConversationService;
+import de.tum.cit.aet.artemis.communication.test_repository.CourseNotificationTestRepository;
 import de.tum.cit.aet.artemis.communication.util.ConversationUtilService;
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.domain.CourseInformationSharingConfiguration;
 import de.tum.cit.aet.artemis.core.domain.Language;
 import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.core.service.feature.Feature;
+import de.tum.cit.aet.artemis.core.service.feature.FeatureToggleService;
 import de.tum.cit.aet.artemis.core.user.util.UserFactory;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
@@ -78,6 +82,12 @@ class ChannelIntegrationTest extends AbstractConversationTest {
 
     @Autowired
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
+
+    @Autowired
+    private FeatureToggleService featureToggleService;
+
+    @Autowired
+    private CourseNotificationTestRepository courseNotificationRepository;
 
     @BeforeEach
     @Override
@@ -1032,6 +1042,77 @@ class ChannelIntegrationTest extends AbstractConversationTest {
 
         // cleanup
         conversationRepository.deleteById(initialChannel.getId());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void shouldSendNotificationWhenUserIsRegisteredAndFeatureEnabled() throws Exception {
+        featureToggleService.enableFeature(Feature.CourseSpecificNotifications);
+
+        var channel = createChannel(true, TEST_PREFIX + "notification");
+
+        userUtilService.changeUser(testPrefix + "instructor1");
+        request.postWithoutResponseBody("/api/communication/courses/" + exampleCourseId + "/channels/" + channel.getId() + "/register",
+                List.of(testPrefix + "student1", testPrefix + "student2"), HttpStatus.OK);
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            List<CourseNotification> notifications = courseNotificationRepository.findAll();
+
+            boolean hasAddedToChannelNotification = notifications.stream().filter(notification -> notification.getCourse().getId().equals(exampleCourseId))
+                    .anyMatch(notification -> notification.getType() == 19);
+
+            assertThat(hasAddedToChannelNotification).isTrue();
+        });
+
+        conversationRepository.deleteById(channel.getId());
+        featureToggleService.disableFeature(Feature.CourseSpecificNotifications);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void shouldSendNotificationWhenUserIsRemovedAndFeatureEnabled() throws Exception {
+        featureToggleService.enableFeature(Feature.CourseSpecificNotifications);
+
+        var channel = createChannel(true, TEST_PREFIX + "notification");
+        addUsersToConversation(channel.getId(), "student1", "student2");
+
+        userUtilService.changeUser(testPrefix + "instructor1");
+        request.postWithoutResponseBody("/api/communication/courses/" + exampleCourseId + "/channels/" + channel.getId() + "/deregister",
+                List.of(testPrefix + "student1", testPrefix + "student2"), HttpStatus.OK);
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            List<CourseNotification> notifications = courseNotificationRepository.findAll();
+
+            boolean hasRemovedFromChannelNotification = notifications.stream().filter(notification -> notification.getCourse().getId().equals(exampleCourseId))
+                    .anyMatch(notification -> notification.getType() == 20);
+
+            assertThat(hasRemovedFromChannelNotification).isTrue();
+        });
+
+        conversationRepository.deleteById(channel.getId());
+        featureToggleService.disableFeature(Feature.CourseSpecificNotifications);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void shouldSentNotificationWhenChannelIsAndFeatureEnabled() throws Exception {
+        featureToggleService.enableFeature(Feature.CourseSpecificNotifications);
+
+        var channel = createChannel(true, TEST_PREFIX + "notification");
+        addUsersToConversation(channel.getId(), "student1", "student2");
+
+        request.delete("/api/communication/courses/" + exampleCourseId + "/channels/" + channel.getId(), HttpStatus.OK);
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            List<CourseNotification> notifications = courseNotificationRepository.findAll();
+
+            boolean hasChannelDeletedNotification = notifications.stream().filter(notification -> notification.getCourse().getId().equals(exampleCourseId))
+                    .anyMatch(notification -> notification.getType() == 18);
+
+            assertThat(hasChannelDeletedNotification).isTrue();
+        });
+
+        featureToggleService.disableFeature(Feature.CourseSpecificNotifications);
     }
 
     private void testArchivalChangeWorks(ChannelDTO channel, boolean isPublicChannel, boolean shouldArchive) throws Exception {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the notifications for channel management do not exist in the new notification system. This PR aims to implement them.

### Description
<!-- Describe your changes in detail -->
I added notifications for channel deletion and when users are added/removed from group chats or course wide channels.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Course with communication enabled
- 1 Student/Tutor/Instructor with notification settings on "All Activity" for the course (to change go to the course, click the notification bell on the top right, and select the "All Activity" preset)

1. Log in to Artemis with the instructor
2. Navigate to the communication tab
3. Create a new course wide or group channels, add users and verify if the other student gets notifications when they are added to the channel
4. Remove users from the channels and verify that users get notified
5. Delete a non-group-chat channel and verify if participating users get notified

**One note for course-wide channels**: Users that did not view the channel at least once will not get notified when the course wide channel is deleted.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="395" alt="Bildschirmfoto 2025-04-08 um 12 27 01" src="https://github.com/user-attachments/assets/f5771255-ca4b-45b4-b4ac-f26d29399730" />