### PR TITLE
`Develop`: Add authorization tests for deleting programming assessments

### DIFF
--- a/linting.sh
+++ b/linting.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./gradlew spotlessApply -PratchetFrom='develop'
+./gradlew spotlessApply -PratchetFrom=develop

--- a/linting.sh
+++ b/linting.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./gradlew spotlessApply -PratchetFrom=develop
+./gradlew spotlessApply -PratchetFrom='develop'

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
@@ -1,10 +1,19 @@
 package de.tum.cit.aet.artemis.programming;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.notNull;
+import static org.mockito.Mockito.verify;
+
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 import org.assertj.core.data.Offset;
 import org.eclipse.jgit.lib.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +24,7 @@ import org.mockito.ArgumentMatchers;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
+
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentNote;
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.assessment.domain.Complaint;
@@ -41,13 +51,6 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParti
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
 import de.tum.cit.aet.artemis.programming.dto.ResultDTO;
 import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseFactory;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isA;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.notNull;
-import static org.mockito.Mockito.verify;
 
 class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegrationIndependentTest {
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
@@ -1080,10 +1080,11 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
     private void deleteAssessmentAsForbiddenUser() throws Exception {
         ProgrammingSubmission submission = programmingExerciseUtilService.createProgrammingSubmission(null, false);
         submission = programmingExerciseUtilService.addProgrammingSubmissionWithResultAndAssessor(programmingExercise, submission, TEST_PREFIX + "student1", TEST_PREFIX + "tutor1",
-            AssessmentType.AUTOMATIC, true);
+                AssessmentType.AUTOMATIC, true);
+        assertThat(submission.getResults()).hasSize(1);
 
-        request.delete("/api/programming/participations/" + submission.getParticipation().getId() + "/programming-submissions/" + submission.getId() + "/results/" + submission.getFirstResult().getId(),
-            HttpStatus.FORBIDDEN);
+        request.delete("/api/programming/participations/" + submission.getParticipation().getId() + "/programming-submissions/" + submission.getId() + "/results/"
+                + submission.getFirstResult().getId(), HttpStatus.FORBIDDEN);
 
         assertThat(submission.getResults()).hasSize(1);
     }
@@ -1105,8 +1106,8 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         Result thirdResult = submission.getResults().get(2);
         assertThat(submission.getResults()).hasSize(3);
 
-        request.delete("/api/programming/participations/" + submission.getParticipation().getId() + "/programming-submissions/" + submission.getId() + "/results/" + resultToDelete.getId(),
-            HttpStatus.OK);
+        request.delete("/api/programming/participations/" + submission.getParticipation().getId() + "/programming-submissions/" + submission.getId() + "/results/"
+                + resultToDelete.getId(), HttpStatus.OK);
 
         submission = submissionRepository.findOneWithEagerResultAndFeedbackAndAssessmentNote(submission.getId());
         assertThat(submission.getResults()).hasSize(2);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
@@ -1,19 +1,10 @@
 package de.tum.cit.aet.artemis.programming;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isA;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.notNull;
-import static org.mockito.Mockito.verify;
-
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.assertj.core.data.Offset;
 import org.eclipse.jgit.lib.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +15,6 @@ import org.mockito.ArgumentMatchers;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
-
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentNote;
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.assessment.domain.Complaint;
@@ -51,6 +41,13 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParti
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
 import de.tum.cit.aet.artemis.programming.dto.ResultDTO;
 import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.notNull;
+import static org.mockito.Mockito.verify;
 
 class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegrationIndependentTest {
 
@@ -1060,5 +1057,60 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         assertThat(submission.getResults().getFirst()).isEqualTo(firstResult);
         assertThat(submission.getResults().get(2)).isEqualTo(firstSemiAutomaticResult);
         assertThat(submission.getResults().get(3)).isEqualTo(submission.getLatestResult()).isEqualTo(lastResult);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor2", roles = "TUTOR")
+    void deleteAssessmentOfOtherTutorAsTutor() throws Exception {
+        deleteAssessmentAsForbiddenUser();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TUTOR")
+    void deleteAssessmentAsTutor() throws Exception {
+        deleteAssessmentAsForbiddenUser();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "STUDENT")
+    void deleteOwnAssessmentAsStudent() throws Exception {
+        deleteAssessmentAsForbiddenUser();
+    }
+
+    private void deleteAssessmentAsForbiddenUser() throws Exception {
+        ProgrammingSubmission submission = programmingExerciseUtilService.createProgrammingSubmission(null, false);
+        submission = programmingExerciseUtilService.addProgrammingSubmissionWithResultAndAssessor(programmingExercise, submission, TEST_PREFIX + "student1", TEST_PREFIX + "tutor1",
+            AssessmentType.AUTOMATIC, true);
+
+        request.delete("/api/programming/participations/" + submission.getParticipation().getId() + "/programming-submissions/" + submission.getId() + "/results/" + submission.getFirstResult().getId(),
+            HttpStatus.FORBIDDEN);
+
+        assertThat(submission.getResults()).hasSize(1);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void deleteAssessmentAsInstructor() throws Exception {
+        Course course = exerciseUtilService.addCourseWithOneExerciseAndSubmissions(TEST_PREFIX, "programming", 1, Optional.empty());
+        Exercise exercise = exerciseRepository.findAllExercisesByCourseId(course.getId()).stream().findFirst().orElseThrow();
+
+        exerciseUtilService.addAutomaticAssessmentToExercise(exercise);
+        exerciseUtilService.addAutomaticAssessmentToExercise(exercise);
+        exerciseUtilService.addAssessmentToExercise(exercise, userUtilService.getUserByLogin(TEST_PREFIX + "tutor1"));
+
+        var submissions = participationUtilService.getAllSubmissionsOfExercise(exercise);
+        Submission submission = submissions.getFirst();
+        Result resultToDelete = submission.getResults().get(0);
+        Result secondResult = submission.getResults().get(1);
+        Result thirdResult = submission.getResults().get(2);
+        assertThat(submission.getResults()).hasSize(3);
+
+        request.delete("/api/programming/participations/" + submission.getParticipation().getId() + "/programming-submissions/" + submission.getId() + "/results/" + resultToDelete.getId(),
+            HttpStatus.OK);
+
+        submission = submissionRepository.findOneWithEagerResultAndFeedbackAndAssessmentNote(submission.getId());
+        assertThat(submission.getResults()).hasSize(2);
+        assertThat(submission.getResults().get(0)).isEqualTo(secondResult);
+        assertThat(submission.getResults().get(1)).isEqualTo(thirdResult);
     }
 }


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context

This PR adds missing authorization tests for the DELETE /participations/{participationId}/programming-submissions/{submissionId}/results/{resultId} endpoint.

Previously, only access for Admin users was tested.
However, the endpoint enforces that only users with at least Instructor permissions (i.e., Instructor or Admin) can delete an assessment.

### Description

Added negative tests to verify that:
A Tutor cannot delete another tutor’s or their own assessment, and a Student cannot delete their own assessment (403 FORBIDDEN)

Added a positive test to verify that:
An Instructor can successfully delete an assessment (200 OK).

Each test validates both the HTTP response status and that the results on the submission are correctly updated (or remain unchanged) after the delete request.