### PR TITLE
`Development`: Remove spring jpa database type configuration for postgres in docker

### DIFF
--- a/docker/artemis/config/postgres.env
+++ b/docker/artemis/config/postgres.env
@@ -4,6 +4,3 @@
 
 SPRING_DATASOURCE_URL="jdbc:postgresql://artemis-postgres:5432/Artemis?sslmode=disable"
 SPRING_DATASOURCE_USERNAME="Artemis"
-
-SPRING_JPA_DATABASE_PLATFORM="org.hibernate.dialect.PostgreSQLDialect"
-SPRING_JPA_DATABASE="POSTGRESQL"


### PR DESCRIPTION

### Checklist
#### General

- [x] This is a small issue that I tested on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context

When starting Artemis, the following deprecation warning is printed: 

```
PostgreSQLDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
```


### Description

The database type is usually set implicitly via spring.datasource.url (e.g. `jdbc:postgresql://artemis-postgres:5432/Artemis`).

We have removed the unnecessary configuration options.


### Steps for Testing

1. Deploy to TS3, TS4 or TS6
2. Check that the server is starting and the login is still working

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
- [ ] 
