### PR TITLE
`Communication`: Improve messages reply view in exercises and lectures

### DIFF
--- a/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.html
+++ b/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.html
@@ -10,19 +10,9 @@
                 [isButtonLoading]="isLoading"
                 [isFormGroupValid]="formGroup.valid"
                 [editType]="editType"
+                [showCloseButton]="true"
+                (closeEditor)="close()"
             />
-            <div class="col mt-1 text-end">
-                <button jhi-posting-button [buttonLabel]="'artemisApp.metis.cancel' | artemisTranslate" class="btn btn-sm btn-outline-secondary" (click)="close()"></button>
-                <button
-                    jhi-posting-button
-                    [buttonLoading]="isLoading"
-                    [disabled]="isLoading || !formGroup.valid"
-                    [buttonLabel]="'artemisApp.metis.savePosting' | artemisTranslate"
-                    id="save"
-                    class="btn btn-sm btn-outline-primary"
-                    type="submit"
-                ></button>
-            </div>
         </div>
     </form>
 </ng-template>

--- a/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.html
+++ b/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.html
@@ -1,6 +1,6 @@
 <ng-template #postingEditor>
     <form [formGroup]="formGroup" (ngSubmit)="confirm()">
-        <div>
+        <div class="me-2">
             <jhi-posting-markdown-editor
                 formControlName="content"
                 [editorHeight]="editorHeight"

--- a/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.scss
+++ b/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.scss
@@ -6,3 +6,7 @@
         background-color: transparent !important;
     }
 }
+
+.ng-invalid {
+    border-left: none !important;
+}

--- a/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.ts
+++ b/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.ts
@@ -1,19 +1,17 @@
 import { Component, ViewContainerRef, ViewEncapsulation, input, output } from '@angular/core';
-import { PostingButtonComponent } from 'app/communication/posting-button/posting-button.component';
 import { PostingCreateEditModalDirective } from 'app/communication/posting-create-edit-modal/posting-create-edit-modal.directive';
 import { AnswerPost } from 'app/communication/shared/entities/answer-post.model';
 import { FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { PostContentValidationPattern } from 'app/communication/metis.util';
 import { Posting } from 'app/communication/shared/entities/posting.model';
 import { PostingMarkdownEditorComponent } from 'app/communication/posting-markdown-editor/posting-markdown-editor.component';
-import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 
 @Component({
     selector: 'jhi-answer-post-create-edit-modal',
     templateUrl: './answer-post-create-edit-modal.component.html',
     styleUrls: ['answer-post-create-edit-modal.component.scss'],
     encapsulation: ViewEncapsulation.None,
-    imports: [FormsModule, ReactiveFormsModule, PostingMarkdownEditorComponent, PostingButtonComponent, ArtemisTranslatePipe],
+    imports: [FormsModule, ReactiveFormsModule, PostingMarkdownEditorComponent],
 })
 export class AnswerPostCreateEditModalComponent extends PostingCreateEditModalDirective<AnswerPost> {
     createEditAnswerPostContainerRef = input<ViewContainerRef>();

--- a/src/main/webapp/app/communication/posting-footer/posting-footer.component.html
+++ b/src/main/webapp/app/communication/posting-footer/posting-footer.component.html
@@ -11,7 +11,7 @@
             <hr class="m-0" />
         </div>
     </div>
-    <ng-container class="list-answer-post">
+    <div class="list-answer-post ms-4">
         @for (group of groupedAnswerPosts; track trackGroupByFn($index, group)) {
             @for (answerPost of group.posts; track trackPostByFn($index, answerPost)) {
                 <jhi-answer-post
@@ -29,9 +29,9 @@
                 />
             }
         }
-    </ng-container>
+    </div>
 }
-<div class="new-reply-inline-input">
+<div class="new-reply-inline-input ms-4 my-2">
     <!-- rendered during the first reply to a post -->
     <ng-container #createEditAnswerPostContainer />
     <jhi-answer-post-create-edit-modal

--- a/src/main/webapp/app/communication/posting-footer/posting-footer.component.html
+++ b/src/main/webapp/app/communication/posting-footer/posting-footer.component.html
@@ -1,4 +1,4 @@
-@if (showAnswers()) {
+@if (showAnswers() && sortedAnswerPosts().length > 0) {
     <div class="d-flex align-items-center mb-1 mx-3">
         <div class="fs-x-small fw-900 me-2">
             {{

--- a/src/main/webapp/app/communication/posting-markdown-editor/posting-markdown-editor.component.html
+++ b/src/main/webapp/app/communication/posting-markdown-editor/posting-markdown-editor.component.html
@@ -26,6 +26,8 @@
         [editType]="editType()"
         [isInCommunication]="true"
         [course]="course()"
+        [showCloseButton]="showCloseButton()"
+        (closeEditor)="closeEditor.emit()"
     >
         <ng-container id="previewMonaco">
             @if (previewMode) {

--- a/src/main/webapp/app/communication/posting-markdown-editor/posting-markdown-editor.component.ts
+++ b/src/main/webapp/app/communication/posting-markdown-editor/posting-markdown-editor.component.ts
@@ -15,6 +15,7 @@ import {
     forwardRef,
     inject,
     input,
+    output,
 } from '@angular/core';
 import monaco from 'monaco-editor';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -80,6 +81,8 @@ export class PostingMarkdownEditorComponent implements OnInit, ControlValueAcces
     @Input() isInputLengthDisplayed = true;
     @Input() suppressNewlineOnEnter = true;
 
+    showCloseButton = input<boolean>(false);
+    closeEditor = output<void>();
     isButtonLoading = input<boolean>(false);
     isFormGroupValid = input<boolean>(false);
     editType = input<PostingEditType>();

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
@@ -82,6 +82,13 @@
                     </div>
                 </ng-template>
             </ng-container>
+
+            @if (showCloseButton()) {
+                <button type="button" class="btn btn-sm close-btn p-0 ms-auto" (click)="onCloseButtonClick()">
+                    <fa-icon [icon]="faTimes" />
+                </button>
+            }
+
             @if (inEditMode) {
                 <ng-container ngbNavItem>
                     <div class="d-flex align-items-center" [style.flex-flow]="'row wrap'">

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
@@ -39,7 +39,12 @@
                                     [style.cursor]="isResizing ? 'ns-resize !important' : undefined"
                                 >
                                     <div class="row mx-0 align-items-baseline">
-                                        <span class="col upload-subtitle" jhiTranslate="artemisApp.markdownEditor.fileUpload"></span>
+                                        <span
+                                            class="col upload-subtitle"
+                                            [jhiTranslate]="
+                                                wrapper.getBoundingClientRect().width < 500 ? 'artemisApp.markdownEditor.fileUploadShort' : 'artemisApp.markdownEditor.fileUpload'
+                                            "
+                                        ></span>
                                     </div>
                                 </label>
                                 <a class="col-auto mx-1" href="https://markdown-it.github.io/">

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.ts
@@ -13,6 +13,7 @@ import {
     computed,
     inject,
     input,
+    output,
     signal,
 } from '@angular/core';
 import { MonacoEditorComponent } from 'app/shared/monaco-editor/monaco-editor.component';
@@ -41,7 +42,7 @@ import { AttachmentAction } from 'app/shared/monaco-editor/model/actions/attachm
 import { BulletedListAction } from 'app/shared/monaco-editor/model/actions/bulleted-list.action';
 import { StrikethroughAction } from 'app/shared/monaco-editor/model/actions/strikethrough.action';
 import { OrderedListAction } from 'app/shared/monaco-editor/model/actions/ordered-list.action';
-import { faAngleDown, faGripLines, faQuestionCircle, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { faAngleDown, faGripLines, faQuestionCircle, faSpinner, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { v4 as uuid } from 'uuid';
 import { AlertService, AlertType } from 'app/shared/service/alert.service';
 import { TextEditorActionGroup } from 'app/shared/monaco-editor/model/actions/text-editor-action-group.model';
@@ -254,6 +255,9 @@ export class MarkdownEditorMonacoComponent implements AfterContentInit, AfterVie
     readonly useCommunicationForFileUpload = input<boolean>(false);
     readonly fallbackConversationId = input<number>();
 
+    showCloseButton = input<boolean>(false);
+    closeEditor = output<void>();
+
     @Output()
     markdownChange = new EventEmitter<string>();
 
@@ -317,6 +321,7 @@ export class MarkdownEditorMonacoComponent implements AfterContentInit, AfterVie
     // Icons
     protected readonly faQuestionCircle = faQuestionCircle;
     protected readonly faSpinner = faSpinner;
+    protected readonly faTimes = faTimes;
     protected readonly faGripLines = faGripLines;
     protected readonly faAngleDown = faAngleDown;
     protected readonly facArtemisIntelligence = facArtemisIntelligence;
@@ -656,5 +661,12 @@ export class MarkdownEditorMonacoComponent implements AfterContentInit, AfterVie
      */
     applyOptionPreset(preset: MonacoEditorOptionPreset): void {
         this.monacoEditor.applyOptionPreset(preset);
+    }
+
+    /**
+     * Emits the closeEditor event when the close button is clicked
+     */
+    onCloseButtonClick(): void {
+        this.closeEditor.emit();
     }
 }

--- a/src/main/webapp/i18n/de/markdownEditor.json
+++ b/src/main/webapp/i18n/de/markdownEditor.json
@@ -6,6 +6,7 @@
                 "fullscreen": "Vollbild"
             },
             "fileUpload": "Füge Dateien durch Drag-and-Drop oder durch Auswählen hinzu.",
+            "fileUploadShort": "Füge Dateien hinzu",
             "guide": "Formatierungen mit Markdown sind möglich",
             "color": "Farbe",
             "preview": {

--- a/src/main/webapp/i18n/en/markdownEditor.json
+++ b/src/main/webapp/i18n/en/markdownEditor.json
@@ -6,6 +6,7 @@
                 "fullscreen": "Fullscreen"
             },
             "fileUpload": "Attach files by dragging & dropping or selecting them.",
+            "fileUploadShort": "Attach files here",
             "guide": "Styling with Markdown is possible",
             "color": "Color",
             "preview": {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/)..
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The communication sidebar in lectures and exercises had some improvement potentials:
1. There were cancel and save buttons when creating a new reply. This was confusing, because save did the same as pressing send in the editor.
2. For posts with no replies, a UI element was shown with "0 replies". This did not look very nice
3. Replies lack easy visual distinction from base posts
4. A red box was shown above the editor if no text was entered into the editor (see image below)
![image](https://github.com/user-attachments/assets/b2abc82a-cb55-4384-aecc-f4059bbd55f7)


### Description
<!-- Describe your changes in detail -->
1. Removed the cancel and save buttons. Instead of the cancel button, we added an X close icon to the top right corner of the markdown editor.
2. Hiding the reply count for no replies
3. Add indentation for replies and the reply markdown editor
4. Remove invalid form indicator to hide the red box


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student

1. Log in to Artemis
2. Go to any lecture or exercise
3. See the communication bar on the right
4. If there are no posts, create a new one
5. Create a answer post and see that everything is aligned properly
6. Verify that closing the editor with X icon in the top right works


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/user-attachments/assets/59ebef02-4d33-47dd-a7ec-21ac2abdeb0e)
