### PR TITLE
`General`: Fix missing translations in student view

### DIFF
--- a/src/main/webapp/app/core/course/overview/courses.route.ts
+++ b/src/main/webapp/app/core/course/overview/courses.route.ts
@@ -103,7 +103,6 @@ export const routes: Routes = [
                 path: 'exercises/text-exercises/:exerciseId',
                 data: {
                     authorities: [Authority.USER],
-                    pageTitle: 'overview.textExercise',
                 },
                 loadChildren: () => import('app/text/overview/text-editor.route').then((m) => m.textEditorRoute),
             },
@@ -113,7 +112,7 @@ export const routes: Routes = [
                     import('app/programming/overview/code-editor-student-container/code-editor-student-container.component').then((m) => m.CodeEditorStudentContainerComponent),
                 data: {
                     authorities: [Authority.USER],
-                    pageTitle: 'overview.programmingExercise',
+                    pageTitle: 'artemisApp.programmingExercise.home.title',
                 },
                 canActivate: [UserRouteAccessService],
             },
@@ -121,7 +120,6 @@ export const routes: Routes = [
                 path: 'exercises/:exerciseId/repository',
                 data: {
                     authorities: [Authority.USER],
-                    pageTitle: 'overview.repository',
                 },
                 loadChildren: () => import('app/programming/overview/programming-repository.route').then((m) => m.routes),
             },
@@ -129,7 +127,6 @@ export const routes: Routes = [
                 path: 'exercises/modeling-exercises/:exerciseId',
                 data: {
                     authorities: [Authority.USER],
-                    pageTitle: 'overview.modelingExercise',
                 },
                 loadChildren: () => import('app/modeling/overview/modeling-participation.route').then((m) => m.routes),
             },
@@ -137,7 +134,6 @@ export const routes: Routes = [
                 path: 'exercises/quiz-exercises/:exerciseId',
                 data: {
                     authorities: [Authority.USER],
-                    pageTitle: 'overview.quizExercise',
                 },
                 loadChildren: () => import('app/quiz/overview/quiz-participation.route').then((m) => m.routes),
             },
@@ -146,7 +142,7 @@ export const routes: Routes = [
                 loadComponent: () => import('app/fileupload/overview/file-upload-submission/file-upload-submission.component').then((m) => m.FileUploadSubmissionComponent),
                 data: {
                     authorities: [Authority.USER],
-                    pageTitle: 'overview.fileUploadExercise',
+                    pageTitle: 'artemisApp.fileUploadExercise.home.title',
                 },
                 canActivate: [UserRouteAccessService],
                 canDeactivate: [PendingChangesGuard],

--- a/src/main/webapp/i18n/de/fileUploadExercise.json
+++ b/src/main/webapp/i18n/de/fileUploadExercise.json
@@ -2,7 +2,7 @@
     "artemisApp": {
         "fileUploadExercise": {
             "home": {
-                "title": "Datei-Upload-Aufgaben",
+                "title": "Datei-Upload-Aufgabe",
                 "createLabel": "Datei-Upload-Aufgabe erstellen",
                 "editLabel": "Datei-Upload-Aufgabe bearbeiten",
                 "importLabel": "Datei-Upload-Aufgabe importieren"

--- a/src/main/webapp/i18n/de/modelingExercise.json
+++ b/src/main/webapp/i18n/de/modelingExercise.json
@@ -2,7 +2,7 @@
     "artemisApp": {
         "modelingExercise": {
             "home": {
-                "title": "Modellierungsaufgaben",
+                "title": "Modellierungsaufgabe",
                 "createLabel": "Modellierungsaufgabe erstellen",
                 "editLabel": "Modellierungsaufgabe bearbeiten",
                 "importLabel": "Modellierungsaufgabe importieren"

--- a/src/main/webapp/i18n/de/programmingExercise.json
+++ b/src/main/webapp/i18n/de/programmingExercise.json
@@ -2,7 +2,7 @@
     "artemisApp": {
         "programmingExercise": {
             "home": {
-                "title": "Programmieraufgaben",
+                "title": "Programmieraufgabe",
                 "createLabel": "Programmieraufgabe erstellen",
                 "editLabel": "Programmieraufgabe bearbeiten",
                 "importLabel": "Programmieraufgabe importieren",

--- a/src/main/webapp/i18n/de/textExercise.json
+++ b/src/main/webapp/i18n/de/textExercise.json
@@ -2,7 +2,7 @@
     "artemisApp": {
         "textExercise": {
             "home": {
-                "title": "Textaufgaben",
+                "title": "Textaufgabe",
                 "createLabel": "Textaufgabe erstellen",
                 "editLabel": "Textaufgabe bearbeiten",
                 "importLabel": "Textaufgabe importieren"

--- a/src/main/webapp/i18n/en/fileUploadExercise.json
+++ b/src/main/webapp/i18n/en/fileUploadExercise.json
@@ -2,7 +2,7 @@
     "artemisApp": {
         "fileUploadExercise": {
             "home": {
-                "title": "File Upload Exercises",
+                "title": "File Upload Exercise",
                 "createLabel": "Create File Upload Exercise",
                 "editLabel": "Edit File Upload Exercise",
                 "importLabel": "Import File Upload Exercise"

--- a/src/main/webapp/i18n/en/modelingExercise.json
+++ b/src/main/webapp/i18n/en/modelingExercise.json
@@ -2,7 +2,7 @@
     "artemisApp": {
         "modelingExercise": {
             "home": {
-                "title": "Modeling Exercises",
+                "title": "Modeling Exercise",
                 "createLabel": "Create Modeling Exercise",
                 "editLabel": "Edit Modeling Exercise",
                 "importLabel": "Import Modeling Exercise"

--- a/src/main/webapp/i18n/en/programmingExercise.json
+++ b/src/main/webapp/i18n/en/programmingExercise.json
@@ -2,7 +2,7 @@
     "artemisApp": {
         "programmingExercise": {
             "home": {
-                "title": "Programming Exercises",
+                "title": "Programming Exercise",
                 "createLabel": "Create Programming Exercise",
                 "editLabel": "Edit Programming Exercise",
                 "importLabel": "Import Programming Exercise",

--- a/src/main/webapp/i18n/en/quizExercise.json
+++ b/src/main/webapp/i18n/en/quizExercise.json
@@ -8,7 +8,7 @@
         },
         "quizExercise": {
             "home": {
-                "title": "Quiz Exercises",
+                "title": "Quiz Exercise",
                 "createLabel": "Create Quiz",
                 "editLabel": "Edit Quiz",
                 "importLabel": "Import Quiz",

--- a/src/main/webapp/i18n/en/textExercise.json
+++ b/src/main/webapp/i18n/en/textExercise.json
@@ -2,7 +2,7 @@
     "artemisApp": {
         "textExercise": {
             "home": {
-                "title": "Text Exercises",
+                "title": "Text Exercise",
                 "createLabel": "Create Text Exercise",
                 "editLabel": "Edit Text Exercise",
                 "importLabel": "Import Text Exercise"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #10668
Some headers in the student view are missing translations because they use a key that doesn't exist.


### Description
<!-- Describe your changes in detail -->
I made three changes:
1. Made sure that the affected routes use an existing translation key
2. Unified the translations to consistently use singular in components that target a single exercise.
3. Deleted pageTitles that are not defined and are never used because child components define the pageTitles.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student

1. Log in to Artemis
2.  Navigate to a course
3. For a programming exercise, check that a translation is shown in the code editor that is singular in both English and German
4. For a modeling exercise check that a translation is shown that is singular when opening the submission view in both English and German
5. For a text exercise check that a translation is shown that is singular when opening the submission view in both English and German
6. For a file upload exercise check that a translation is shown that is singular when opening the submission view in both English and German
7. For a quiz exercise check that the English translation is singular when opening  a quiz

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged, only edited JSON and route files.
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/user-attachments/assets/912c0d09-88a3-4922-8e70-2f2e4dda88c5)
![image](https://github.com/user-attachments/assets/d42fe8fc-f972-44e7-8483-7a83ed87e899)
![image](https://github.com/user-attachments/assets/bf9b63d3-41c9-4409-98ac-a053cbcab58f)
![image](https://github.com/user-attachments/assets/5edf6dee-d339-4e54-a6cb-d1bd59a6b32c)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated page titles for exercise-related routes to use consistent singular forms in both English and German.
	- Improved localization by changing exercise home page titles from plural to singular for all exercise types.
- **Chores**
	- Refined route configurations to use updated localization keys for page titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->