### PR TITLE
`Development`: Improve development docker multinode setup documentation

### DIFF
--- a/docker/artemis/config/node1.env
+++ b/docker/artemis/config/node1.env
@@ -3,4 +3,4 @@ EUREKA_INSTANCE_INSTANCEID='Artemis:1'
 EUREKA_INSTANCE_HOSTNAME='artemis-app-node-1'
 SPRING_HAZELCAST_INTERFACE='artemis-app-node-1'
 
-#INFO_OPERATORNAME='Some Artemis Dev' # uncomment for dev multinode setup
+#INFO_OPERATORNAME='Some Artemis Dev' # uncomment for local dev multinode setup

--- a/docker/artemis/config/node1.env
+++ b/docker/artemis/config/node1.env
@@ -2,3 +2,5 @@ SPRING_PROFILES_ACTIVE='prod,localvc,localci,core,scheduling,docker'
 EUREKA_INSTANCE_INSTANCEID='Artemis:1'
 EUREKA_INSTANCE_HOSTNAME='artemis-app-node-1'
 SPRING_HAZELCAST_INTERFACE='artemis-app-node-1'
+
+#INFO_OPERATORNAME='Some Artemis Dev' # uncomment for dev multinode setup

--- a/docs/admin/setup/distributed.rst
+++ b/docs/admin/setup/distributed.rst
@@ -769,6 +769,8 @@ MacOS setup
 #. Make sure to enable "Allow the default Docker socket to be used (requires password)" in the Docker Desktop settings.
    This can be found under Settings > Advanced in Docker Desktop.
 
+#. Define the operator name ``INFO_OPERATORNAME='Some Artemis Dev'`` in the file ``docker/artemis/config/node1.env``.
+
 #. Start the docker containers by running the following command:
 
     .. code:: bash


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
I need the multinode setup for local development for debugging purposes, the current description https://docs.artemis.cit.tum.de/admin/setup/distributed.html#macos-setup unfortunately lacks some details, therefore the server will not start.

### Description
Added a step on where to add a variable that was not defined before, but required for starting the server.

### Steps for Testing
1. From your root directory, execute `docker compose -f docker/test-server-multi-node-mysql-localci.yml up` and see that the server does not start (node 1 will restart over and over again)
2. Add `INFO_OPERATORNAME='Some Artemis Dev'` in your `node1.env`, see that the server does now start properly (all 3 nodes up and running)
3. Verify the documentation is rendered properly https://artemis-platform--10685.org.readthedocs.build/en/10685/admin/setup/distributed.html#macos-setup

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
#### Manual Tests
- [ ] Test 1

### Screenshots

Without setting the variable, you find the following logs in node1
```
2025-04-15 14:43:03 org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'propertiesConfigurationGuard' defined in URL [jar:nested:/opt/artemis/Artemis.war/!WEB-INF/classes/!/de/tum/cit/aet/artemis/core/config/PropertiesConfigurationGuard.class]: The name of the operator (university) must be configured, but is not!
2025-04-15 14:43:03     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1812)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:601)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:523)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:339)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:347)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:337)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.DefaultListableBeanFactory.instantiateSingleton(DefaultListableBeanFactory.java:1155)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingleton(DefaultListableBeanFactory.java:1121)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:1056)
2025-04-15 14:43:03     at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:987)
2025-04-15 14:43:03     at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:627)
2025-04-15 14:43:03     at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146)
2025-04-15 14:43:03     at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752)
2025-04-15 14:43:03     at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:439)
2025-04-15 14:43:03     at org.springframework.boot.SpringApplication.run(SpringApplication.java:318)
2025-04-15 14:43:03     at de.tum.cit.aet.artemis.ArtemisApp.main(ArtemisApp.java:67)
2025-04-15 14:43:03     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
2025-04-15 14:43:03     at java.base/java.lang.reflect.Method.invoke(Method.java:580)
2025-04-15 14:43:03     at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:102)
2025-04-15 14:43:03     at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:64)
2025-04-15 14:43:03     at org.springframework.boot.loader.launch.WarLauncher.main(WarLauncher.java:53)
2025-04-15 14:43:03 Caused by: java.lang.IllegalArgumentException: The name of the operator (university) must be configured, but is not!
2025-04-15 14:43:03     at de.tum.cit.aet.artemis.core.config.PropertiesConfigurationGuard.afterPropertiesSet(PropertiesConfigurationGuard.java:28)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1859)
2025-04-15 14:43:03     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1808)
2025-04-15 14:43:03     ... 21 common frames omitted
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the distributed setup guide for MacOS to include instructions for defining the operator name environment variable in the configuration file.

- **Chores**
  - Added a commented-out example of the operator name environment variable in the configuration file for development setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->