### PR TITLE
`Development`: Update saml2 config properties

### DIFF
--- a/docker/saml-test/application-saml2.yml
+++ b/docker/saml-test/application-saml2.yml
@@ -13,13 +13,13 @@ saml2:
 
 info.saml2:
     # The name of the SAML2 identity provider shown on the login page (optional)
-    identity-provider-name:
+    identityProviderName:
     # The label for the SAML2 login button (e.g., 'Shibboleth Login')
-    button-label: 'SAML2 Login'
+    buttonLabel: 'SAML2 Login'
     # Disables the password-based login user interface, but leaves the API enabled.
     # Use the URL query parameter '?showLoginForm' to display the login form nevertheless.
-    password-login-disabled: false
+    passwordLoginDisabled: false
     # Sends an e-mail to the new user with a link to set the Artemis password. This password allows login to Artemis and its
     # services such as Jenkins. This allows the users to use password-based Git workflows.
     # Enables the password reset function in Artemis.
-    enable-password: true
+    enablePassword: true

--- a/docs/admin/saml2-shibboleth.rst
+++ b/docs/admin/saml2-shibboleth.rst
@@ -33,7 +33,7 @@ The new (and old) security filter chain is presented in the following figure:
 
 The feature is configured by the application-saml2.yml file.
 You can configure multiple identity providers.
-In addition, the SAML2 feature allows to decide whether a user can obtain a password (see "info.saml2.enable-password").
+In addition, the SAML2 feature allows to decide whether a user can obtain a password (see "info.saml2.enablePassword").
 This app password allows to use the connected services as VCS and CI as usual with the local user credentials.
 
 You can see the structure of the saml2 configuration in the following:
@@ -81,15 +81,15 @@ You can see the structure of the saml2 configuration in the following:
     info:
         saml2:
             # Name of the button to login with SAML2
-            button-label: 'SAML2 Login'
+            buttonLabel: 'SAML2 Login'
             # Name of the identity provider (e.g., University X Account). Only used for the text at login page
-            identity-provider-name: 'Shibboleth Account'
+            identityProviderName: 'Shibboleth Account'
             # Hide the password login form. If true, the password login form is hidden and only the SAML2 login button is shown.
-            password-login-disabled: false
+            passwordLoginDisabled: false
             # Sends a e-mail to the new user with a link to set the Artemis password. This password allows login to Artemis and its
             # services such as Jenkins. It also allows the users to use password-based Git workflow.
             # It also enables the password reset function in Artemis.
-            enable-password: true
+            enablePassword: true
 
 Example configuration
 ^^^^^^^^^^^^^^^^^^^^^
@@ -107,10 +107,10 @@ The SAML2 configuration of Artemis could look like this:
         lang-key-pattern: 'de'
     info:
         saml2:
-            button-label: 'Shibboleth Login'
-            enable-password: false
-            password-login-disabled: true
-            identity-provider-name: 'Shibboleth Account'
+            buttonLabel: 'Shibboleth Login'
+            enablePassword: false
+            passwordLoginDisabled: true
+            identityProviderName: 'Shibboleth Account'
     spring:
         security:
             saml2:

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SAML2Properties.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SAML2Properties.java
@@ -14,7 +14,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /**
- * This class describes SAML2 properties.
+ * This class describes SAML2 properties. Those values are specified in application-saml2.yml and automatically mapped to the below Java attributes. Admins can override the values
+ * in application-prod.yml
  */
 @Profile(PROFILE_CORE)
 @Component

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/connectors/SAML2Service.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/connectors/SAML2Service.java
@@ -57,7 +57,7 @@ public class SAML2Service {
 
     private final AuditEventRepository auditEventRepository;
 
-    @Value("${info.saml2.enable-password:#{null}}")
+    @Value("${info.saml2.enablePassword:#{null}}")
     private Optional<Boolean> saml2EnablePassword;
 
     private static final Logger log = LoggerFactory.getLogger(SAML2Service.class);

--- a/src/main/resources/config/application-saml2.yml
+++ b/src/main/resources/config/application-saml2.yml
@@ -12,6 +12,7 @@
 # Proxy Environment
 # Forward /login and /saml2 to the Artemis Server.
 
+# NOTE: the following values are used in SAML2Properties and are automatically mapped to Java during server startup
 saml2:
     # Define the patterns used when generating users. SAML2 Attributes can be substituted by surrounding them with
     # curly brackets. E.g. username: '{user_attribute}'. Missing attributes get replaced with an empty string.
@@ -49,15 +50,16 @@ spring:
                     #     assertingparty:
                     #         metadata-uri: URL_TO_METADATA_HERE # If your IdP does not publish its metadata you can generate it here: https://www.samltool.com/idp_metadata.php
 
+# NOTE: the following values are exposed over the REST endpoint `management/info` to the client and automatically mapped in profile.service.ts so they are available right after the client app start
 info.saml2:
     # The name of the SAML2 identity provider shown on the login page (optional)
-    identity-provider-name:
+    identityProviderName:
     # The label for the SAML2 login button (e.g., 'Shibboleth Login')
-    button-label: 'SAML2 Login'
+    buttonLabel: 'SAML2 Login'
     # Disables the password-based login user interface, but leaves the API enabled.
     # Use the URL query parameter '?showLoginForm' to display the login form nevertheless.
-    password-login-disabled: false
+    passwordLoginDisabled: false
     # Sends an e-mail to the new user with a link to set the Artemis password. This password allows login to Artemis and its
     # external services (e.g. Jenkins). This allows the users to use password-based Git workflows.
     # Enables the password reset function in Artemis.
-    enable-password: true
+    enablePassword: true

--- a/src/main/webapp/app/core/home/home.component.html
+++ b/src/main/webapp/app/core/home/home.component.html
@@ -117,23 +117,23 @@
                 </div>
             </div>
         }
-        @if (!isPasswordLoginDisabled && !!profileInfo?.saml2Config) {
+        @if (!isPasswordLoginDisabled && !!profileInfo?.saml2) {
             <div class="col-12 col-xl-2 py-5 h-100">
                 <div class="d-none d-xl-block vertical-divider" jhiTranslate="login.divider"></div>
                 <div class="d-xl-none horizontal-divider" jhiTranslate="login.divider"></div>
             </div>
         }
-        @if (!!profileInfo?.saml2Config) {
+        @if (!!profileInfo?.saml2) {
             <div class="login-col col-12 col-xl-5">
                 <!-- SAML2 Authentication -->
                 <div class="h-100 d-flex flex-column align-items-center justify-content-center">
-                    @if (!profileInfo!.saml2Config!.identityProviderName) {
+                    @if (!profileInfo!.saml2!.identityProviderName) {
                         <div [jhiTranslate]="'home.login.saml2.pleaseSignIn'" class="lead text-center">Please sign in via Single Sign-on.</div>
                     }
-                    @if (profileInfo!.saml2Config!.identityProviderName) {
+                    @if (profileInfo!.saml2!.identityProviderName) {
                         <div
                             [jhiTranslate]="'home.login.saml2.pleaseSignInProvider'"
-                            [translateValues]="{ provider: profileInfo!.saml2Config!.identityProviderName }"
+                            [translateValues]="{ provider: profileInfo!.saml2!.identityProviderName }"
                             class="lead text-center"
                         >
                             Please sign in.
@@ -153,7 +153,7 @@
                         <jhi-saml2-login
                             [acceptedTerms]="!needsToAcceptTerms || userAcceptedTerms"
                             [rememberMe]="rememberMe"
-                            [saml2Profile]="profileInfo!.saml2Config!"
+                            [saml2Profile]="profileInfo!.saml2!"
                             class="d-block text-center"
                         />
                     </div>

--- a/src/main/webapp/app/core/home/home.component.ts
+++ b/src/main/webapp/app/core/home/home.component.ts
@@ -117,7 +117,7 @@ export class HomeComponent implements OnInit, AfterViewChecked {
         this.needsToAcceptTerms = !!this.profileInfo.needsToAcceptTerms;
         this.activatedRoute.queryParams.subscribe((params) => {
             const loginFormOverride = params.hasOwnProperty('showLoginForm');
-            this.isPasswordLoginDisabled = !!this.profileInfo?.saml2Config && this.profileInfo.saml2Config.passwordLoginDisabled && !loginFormOverride;
+            this.isPasswordLoginDisabled = !!this.profileInfo?.saml2 && this.profileInfo.saml2.passwordLoginDisabled && !loginFormOverride;
         });
     }
 

--- a/src/main/webapp/app/core/home/saml2-login/saml2.config.ts
+++ b/src/main/webapp/app/core/home/saml2-login/saml2.config.ts
@@ -1,3 +1,4 @@
+// NOTE: Those values are specified in application-saml2.yml and automatically mapped to the below Typescript attributes when the saml2 profile is active. Admins can override the values in application-prod.yml
 export class Saml2Config {
     public identityProviderName?: string;
     public buttonLabel?: string;

--- a/src/main/webapp/app/core/layouts/profiles/profile-info.model.ts
+++ b/src/main/webapp/app/core/layouts/profiles/profile-info.model.ts
@@ -154,7 +154,7 @@ export class ProfileInfo {
     public programmingLanguageFeatures: ProgrammingLanguageFeature[] = [];
     public registrationEnabled?: boolean;
     public repositoryAuthenticationMechanisms: string[];
-    public saml2Config?: Saml2Config;
+    public saml2?: Saml2Config;
     public sentry: SentryConfig;
     public sshCloneURLTemplate: string;
     public studentExamStoreSessionData: boolean;

--- a/src/test/resources/config/application-saml2.yml
+++ b/src/test/resources/config/application-saml2.yml
@@ -44,8 +44,8 @@ spring:
 
 
 # String used for the SAML2 login button. E.g. 'Shibboleth Login'
-info.saml2.button-label: 'SAML2 Login'
+info.saml2.buttonLabel: 'SAML2 Login'
 # Sends an e-mail to the new user with a link to set the Artemis password. This password allows login to Artemis and its
 # services such as Jenkins. This allows the users to use password-based Git workflows.
 # Enabled the password reset function in Artemis.
-info.saml2.enable-password: true
+info.saml2.enablePassword: true


### PR DESCRIPTION
## Breaking changes !!
* The payload of https://`artemis-base-url`/management/info slightly changed for saml2 properties
* Some options in the `application.yml` have changed
    * `info.saml2.identity-provider-name` --> `info.identityProviderName`
    * `info.saml2.button-label` --> `info.buttonLabel`
    * `info.saml2.password-login-disabled` --> `info.passwordLoginDisabled`
    * `info.saml2.enable-password` --> `info.enablePassword`

This PR fixes an issue introduced in https://github.com/ls1intum/Artemis/pull/10663 when the variables was renamed in the client, but not in the correspoing yml files.