### PR TITLE
`Tutorial groups`: Fix creation form

### DIFF
--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups/crud/tutorial-group-form/tutorial-group-form.component.scss
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups/crud/tutorial-group-form/tutorial-group-form.component.scss
@@ -1,0 +1,11 @@
+/* This overrides monaco injected styles and makes sure that the monaco editor doesn't break the layout */
+.row,
+.col-12 {
+    flex: 1 1 auto !important;
+    position: relative !important;
+    display: flex !important;
+    flex-direction: column !important;
+}
+button#submitButton {
+    max-width: fit-content;
+}

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups/crud/tutorial-group-form/tutorial-group-form.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups/crud/tutorial-group-form/tutorial-group-form.component.ts
@@ -40,6 +40,7 @@ export const titleRegex = new RegExp('^[a-zA-Z0-9]{1}[a-zA-Z0-9- ]{0,19}$');
 @Component({
     selector: 'jhi-tutorial-group-form',
     templateUrl: './tutorial-group-form.component.html',
+    styleUrls: ['./tutorial-group-form.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [FormsModule, ReactiveFormsModule, TranslateDirective, NgbTypeahead, MarkdownEditorMonacoComponent, ScheduleFormComponent, FaIconComponent, ArtemisTranslatePipe],
 })


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #10690 


### Description
<!-- Describe your changes in detail -->
The monaco injects styles that break the layout of the form. We now make sure that the layout of the application takes precedence.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to tutorial groups in a course
4. Create a new tutorial group
5. Fill out the form
6. See that the form no longer shrinks drastically, when selecting a weekday

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged, i only adapted css



### Screenshots
https://github.com/user-attachments/assets/5a8ea9ad-903a-46fb-b334-4f14b0e7dfef



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout consistency and appearance for the tutorial group form, ensuring styles are not disrupted by the Monaco editor.
  - Adjusted button sizing for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->