### PR TITLE
`Development`: Fix delete test run e2e test

### DIFF
--- a/src/test/playwright/e2e/exam/test-exam/TestExamTestRun.spec.ts
+++ b/src/test/playwright/e2e/exam/test-exam/TestExamTestRun.spec.ts
@@ -99,7 +99,8 @@ test.describe('Test exam test run', { tag: '@slow' }, () => {
             await examTestRun.openTestRunPage(course, exam);
             await examTestRun.getTestRun(testRun.id!).waitFor({ state: 'visible' });
             await expect(examTestRun.getTestRunIdElement(testRun.id!)).toBeVisible();
-            await examTestRun.deleteTestExamTestRun();
+            await examTestRun.deleteTestRun(testRun.id!);
+            await expect(examTestRun.getTestRun(testRun.id!)).not.toBeVisible();
         });
     });
 

--- a/src/test/playwright/support/pageobjects/exam/ExamTestRunPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamTestRunPage.ts
@@ -100,12 +100,4 @@ export class ExamTestRunPage {
         await this.page.locator('#delete').click();
         await responsePromise;
     }
-
-    async deleteTestExamTestRun() {
-        await this.page.locator('svg.svg-inline--fa.fa-xmark').nth(1).click();
-        await this.page.locator('#confirm-entity-name').fill('Test Run');
-        const responsePromise = this.page.waitForResponse(`api/exam/courses/*/exams/*/test-run/*`);
-        await this.page.locator('#delete').click();
-        await responsePromise;
-    }
 }


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
The test `ts [Test exam test run › Delete a test run › Deletes a test run](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AEPTMA1863-DA-3/test/case/801787429)` currently fails on develop 
```
FAILURE: TestExamTestRun.spec.ts:97:13 Deletes a test run

  [slow-tests] › e2e/exam/test-exam/TestExamTestRun.spec.ts:97:13 › Test exam test run › Delete a test run › Deletes a test run @slow 

    Test timeout of 180000ms exceeded.

    Error: locator.click: Test timeout of 180000ms exceeded.
    Call log:
(72 more lines...)
```

### Description
In [Development: Fix and re-enable exam mode e2e tests #8946](https://github.com/ls1intum/Artemis/pull/8946) a fix was introduced for the E2E tests. It seems that for the test run deletion, a workaround was required.

This workaround (`deleteTestExamTestRun`) is no longer required and we can use a more robust implementation (`deleteTestRun`) instead (which is also used in the fast version of the tests in `ExamTestRun.spec.ts`.

### Steps for Testing

1. Execute the E2E tests of `TestExamTestRun.spec.ts` locally
2. See that all tests are passing

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
![image](https://github.com/user-attachments/assets/77924d4e-9cda-47ee-8d95-86e8a4040635)
