### PR TITLE
`Communication`: Fix post paddings

### DIFF
--- a/src/main/webapp/app/communication/posting-footer/posting-footer.component.html
+++ b/src/main/webapp/app/communication/posting-footer/posting-footer.component.html
@@ -11,7 +11,7 @@
             <hr class="m-0" />
         </div>
     </div>
-    <div class="list-answer-post ms-4">
+    <div class="list-answer-post" [ngClass]="{ 'ms-4': !isThreadSidebar() }">
         @for (group of groupedAnswerPosts; track trackGroupByFn($index, group)) {
             @for (answerPost of group.posts; track trackPostByFn($index, answerPost)) {
                 <jhi-answer-post
@@ -31,7 +31,7 @@
         }
     </div>
 }
-<div class="new-reply-inline-input ms-4 my-3">
+<div class="new-reply-inline-input" [ngClass]="{ 'ms-4 my-3': !isCommunicationPage() && showAnswers() }">
     <!-- rendered during the first reply to a post -->
     <ng-container #createEditAnswerPostContainer />
     <jhi-answer-post-create-edit-modal

--- a/src/main/webapp/app/communication/posting-footer/posting-footer.component.ts
+++ b/src/main/webapp/app/communication/posting-footer/posting-footer.component.ts
@@ -9,6 +9,7 @@ import { User } from 'app/core/user/user.model';
 import { Posting } from 'app/communication/shared/entities/posting.model';
 import { AnswerPostComponent } from '../answer-post/answer-post.component';
 import { ArtemisTranslatePipe } from '../../shared/pipes/artemis-translate.pipe';
+import { NgClass } from '@angular/common';
 
 interface PostGroup {
     author: User | undefined;
@@ -18,7 +19,7 @@ interface PostGroup {
 @Component({
     selector: 'jhi-posting-footer',
     templateUrl: './posting-footer.component.html',
-    imports: [AnswerPostComponent, AnswerPostCreateEditModalComponent, ArtemisTranslatePipe],
+    imports: [AnswerPostComponent, AnswerPostCreateEditModalComponent, ArtemisTranslatePipe, NgClass],
 })
 export class PostingFooterComponent implements OnInit, OnDestroy, AfterContentChecked, OnChanges {
     lastReadDate = input<dayjs.Dayjs | undefined>();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/ls1intum/Artemis/pull/10682 introduce unwanted padding to posts in the communication module and to answers in the communication's thread view.

![image](https://github.com/user-attachments/assets/2f6501c8-10b9-4c3e-9422-555edc5512d5)


### Description
<!-- Describe your changes in detail -->
Do not apply the padding for the communication views.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student

1. Log in to Artemis
2. Go to lecture / exercise communication side bar -> see that introduced padding of #10682 introduced is still there
3. Go the to communication module and see that there is no unwanted padding between posts.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout spacing in the posting footer by applying margin classes dynamically based on the component's state, resulting in a more context-aware interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->