### PR TITLE
`General`: Fix LTI login when passkey is enabled

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -305,6 +305,12 @@ public class SecurityConfiguration {
             //  PROBLEM: This currently would break LocalVC cloning via http based on the LocalVCServletService
             //.httpBasic(Customizer.withDefaults());
 
+        // Conditionally adds configuration for LTI if it is active.
+        if (profileService.isLtiActive()) {
+            // Activates the LTI endpoints and filters.
+            http.with(customLti13Configurer.orElseThrow(), configurer -> configurer.configure(http));
+        }
+
         if (passkeyEnabled) {
             WebAuthnConfigurer<HttpSecurity> webAuthnConfigurer = new ArtemisWebAuthnConfigurer<>(
                 converter,
@@ -323,12 +329,6 @@ public class SecurityConfiguration {
             });
         }
         // @formatter:on
-
-        // Conditionally adds configuration for LTI if it is active.
-        if (profileService.isLtiActive()) {
-            // Activates the LTI endpoints and filters.
-            http.with(customLti13Configurer.orElseThrow(), configurer -> configurer.configure(http));
-        }
 
         // Builds and returns the SecurityFilterChain.
         return http.build();


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [ ] I **strictly** followed the principle of **data economy** for all database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.

### Motivation and Context
[General: Add passkey login option #10656](https://github.com/ls1intum/Artemis/pull/10656) appears to have broken the LTI login, reported by @raffifasaro .

### Description
Moved the Passkey filter to a later point in the chain, so LTI login works again.

TODO
* double check filter order, check LTI13LaunchFilter

### Steps for Testing
Only ts3 has LTI enabled! (testing step3)

1. Log in to Artemis with password
2. Log in to Artemis with passkey
3. Login to Moodle via LTI https://moodle.ase.in.tum.de/ (only works on ts3) 
4. Navigate to LTI Testing Course with test user 16 https://moodle.ase.in.tum.de/course/view.php?id=8
5. Interact with `Competency`, verify that it is loaded properly

Note: 
* activate edit mode 
* https://moodle.ase.in.tum.de/course/view.php?id=8
* Go to test topic => Add activity or resource => select test server => select content (should not throw 401)

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots

#### Before fix
![image](https://github.com/user-attachments/assets/69cf12e0-b30c-4f53-92fc-fcdba43c52e3)

![ltiAuthBrokenBeforeBugfix](https://github.com/user-attachments/assets/0f00e7c1-6cb5-4f88-b974-9f5e41cbcf44)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the order of security configurations to apply LTI support earlier in the setup process. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->