### PR TITLE
`Iris`: Fix wrong unauthorized messages in lecture communication channels

### DIFF
--- a/src/main/webapp/app/communication/shared/redirect-to-iris-button/redirect-to-iris-button.component.spec.ts
+++ b/src/main/webapp/app/communication/shared/redirect-to-iris-button/redirect-to-iris-button.component.spec.ts
@@ -78,8 +78,10 @@ describe('RedirectToIrisButtonComponent', () => {
     }));
 
     it('should be enabled for lecture chats if Iris is activated for the lecture', fakeAsync(() => {
-        const getExerciseSettingsSpy = jest.spyOn(irisSettingsService, 'getCombinedCourseSettings').mockReturnValue(of(irisSettings));
+        const getCourseSettingsSpy = jest.spyOn(irisSettingsService, 'getCombinedCourseSettings').mockReturnValue(of(irisSettings));
         jest.spyOn(profileService, 'isProfileActive').mockReturnValue(true);
+
+        componentRef.setInput('course', { id: 56, studentCourseAnalyticsDashboardEnabled: false } as Course);
 
         const mockChannelDTO = {
             type: ConversationType.CHANNEL,
@@ -93,14 +95,14 @@ describe('RedirectToIrisButtonComponent', () => {
         tick();
 
         expect(component.irisEnabled()).toBeTrue();
-        expect(getExerciseSettingsSpy).toHaveBeenCalledOnce();
+        expect(getCourseSettingsSpy).toHaveBeenCalledExactlyOnceWith(56);
     }));
 
     it('should be enabled for general chat if Iris is activated for the course chat', fakeAsync(() => {
         const getExerciseSettingsSpy = jest.spyOn(irisSettingsService, 'getCombinedCourseSettings').mockReturnValue(of(irisSettings));
         jest.spyOn(profileService, 'isProfileActive').mockReturnValue(true);
 
-        componentRef.setInput('course', { id: 42, studentCourseAnalyticsDashboardEnabled: true } as Course);
+        componentRef.setInput('course', { id: 64, studentCourseAnalyticsDashboardEnabled: true } as Course);
 
         const mockChannelDTO = {
             type: ConversationType.CHANNEL,
@@ -114,7 +116,7 @@ describe('RedirectToIrisButtonComponent', () => {
         tick();
 
         expect(component.irisEnabled()).toBeTrue();
-        expect(getExerciseSettingsSpy).toHaveBeenCalledOnce();
+        expect(getExerciseSettingsSpy).toHaveBeenCalledExactlyOnceWith(64);
     }));
 
     it('should be disabled for exercise chats if Iris is disabled for the exercise', fakeAsync(() => {
@@ -164,8 +166,10 @@ describe('RedirectToIrisButtonComponent', () => {
     it('should be disabled for lecture chats if Iris is disabled for the lecture', fakeAsync(() => {
         const disabledIrisSettings = mockSettings();
         disabledIrisSettings.irisLectureChatSettings!.enabled = false;
-        const getLectureSettingsSpy = jest.spyOn(irisSettingsService, 'getCombinedCourseSettings').mockReturnValue(of(disabledIrisSettings));
+        const getCourseSettingsSpy = jest.spyOn(irisSettingsService, 'getCombinedCourseSettings').mockReturnValue(of(disabledIrisSettings));
         jest.spyOn(profileService, 'isProfileActive').mockReturnValue(true);
+
+        componentRef.setInput('course', { id: 56, studentCourseAnalyticsDashboardEnabled: false } as Course);
 
         const mockChannelDTO = {
             type: ConversationType.CHANNEL,
@@ -179,7 +183,7 @@ describe('RedirectToIrisButtonComponent', () => {
         tick();
 
         expect(component.irisEnabled()).toBeFalse();
-        expect(getLectureSettingsSpy).toHaveBeenCalledOnce();
+        expect(getCourseSettingsSpy).toHaveBeenCalledExactlyOnceWith(56);
     }));
 
     it('should handle errors when retrieving Iris settings', fakeAsync(() => {

--- a/src/main/webapp/app/communication/shared/redirect-to-iris-button/redirect-to-iris-button.component.ts
+++ b/src/main/webapp/app/communication/shared/redirect-to-iris-button/redirect-to-iris-button.component.ts
@@ -118,10 +118,11 @@ export class RedirectToIrisButtonComponent implements OnInit, OnDestroy {
                 break;
             }
             case ChannelSubType.LECTURE: {
-                if (channelDTO.subTypeReferenceId) {
+                const course = this.course();
+                if (course?.id) {
                     this.updateIrisStatus<IrisCourseSettings>(
                         this.irisCombinedCourseSettings,
-                        () => this.irisSettingsService.getCombinedCourseSettings(channelDTO.subTypeReferenceId!),
+                        () => this.irisSettingsService.getCombinedCourseSettings(course.id!),
                         (settings) => settings.irisLectureChatSettings?.enabled,
                         channelDTO,
                         (settings) => (this.irisCombinedCourseSettings = settings),


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

#10394 introduced a feature to forward communication messages into Iris chats. For lecture channels & chats, the client incorrectly used the lecture ID to fetch course-level Iris settings. This caused an error popup since the course with that ID does usually not exist.


### Description
<!-- Describe your changes in detail -->

Update the Iris settings fetch method to use the course ID when checking if lecture chats are active.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student in a course with comms enabled and a lecture with communication channel

1. Log in to Artemis
2. Navigate to Communication
3. Open the channel of the lecture
4. Verify that the iris-settings call in the network dev tab succeeds
5. Verify there is no error visible on screen

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy in retrieving course settings for lecture channels, ensuring the correct course ID is used.
- **Tests**
  - Enhanced test precision by verifying method calls with specific arguments and setting component inputs more explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->