### PR TITLE
`Development`: Fix Athena server test

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSuggestionsServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSuggestionsServiceTest.java
@@ -82,7 +82,7 @@ class AthenaFeedbackSuggestionsServiceTest extends AbstractAthenaTest {
         athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("programming", jsonPath("$.exercise.id").value(programmingExercise.getId()),
                 jsonPath("$.exercise.title").value(programmingExercise.getTitle()), jsonPath("$.submission.id").value(programmingSubmission.getId()),
                 jsonPath("$.submission.repositoryUri")
-                        .value("https://artemislocal.ase.in.tum.de/api/athena/public/programming-exercises/" + programmingExercise.getId() + "/submissions/3/repository"));
+                        .value("https://artemislocal.cit.tum.de/api/athena/public/programming-exercises/" + programmingExercise.getId() + "/submissions/3/repository"));
         List<ProgrammingFeedbackDTO> suggestions = athenaFeedbackSuggestionsService.getProgrammingFeedbackSuggestions(programmingExercise, programmingSubmission, true);
         assertThat(suggestions.getFirst().title()).isEqualTo("Not so good");
         assertThat(suggestions.getFirst().lineStart()).isEqualTo(3);


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
The test failed on develop.


### Description
The test fails since https://github.com/ls1intum/Artemis/commit/22bd2ce38cea5a3741487c81291931b151d3fa9e#diff due to the adjustment of the URL.

### Steps for Testing
1. Run the test locally `AthenaFeedbackSuggestionsServiceTest#testFeedbackSuggestionsProgramming`
2. (Verify the test passes in the pipeline)

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
#### Manual Tests
- [x] Test 1

### Screenshots
![image](https://github.com/user-attachments/assets/be17505f-c9df-4b43-b7b2-2822311e0b29)

