### PR TITLE
`Communication`: Fix resolve directly after sending reply

### DIFF
--- a/src/main/webapp/app/communication/service/metis.service.ts
+++ b/src/main/webapp/app/communication/service/metis.service.ts
@@ -737,6 +737,14 @@ export class MetisService implements OnDestroy {
                         if (cachedAnswer) {
                             answer.authorRole = cachedAnswer.authorRole;
                         }
+
+                        // The updates only set the post.id property of answers, so we set the author and conversation properties manually
+                        // to ensure the same answer.post structure as from the get-messages call.
+                        answer.post = {
+                            id: postDTO.post.id,
+                            author: postDTO.post.author,
+                            conversation: postDTO.post.conversation,
+                        };
                     });
                     this.cachedPosts[indexToUpdate] = postDTO.post;
                 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
There was a bug where the author of the base post could not mark a newly sent answer as resolving. Only after reloading this option was available.

### Description
<!-- Describe your changes in detail -->
Set the answer's base post conversation and author manually for websocket updates. This ensures that the resolve button is available correctly.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student

1. Log in to Artemis
2. Go to any Chat
3. Write a post
4. Reply to that post
5. Without reloading, mark your new reply as resolving (with the checkmark button)

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that answers within a post correctly reference their parent post after updates, maintaining consistency in displayed data.

- **Tests**
  - Added a test to verify that answer-post relationships are properly updated when posts are received via WebSocket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->