### PR TITLE
`Lectures`: Fix alignment of lecture unit cards

### DIFF
--- a/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.html
@@ -1,12 +1,12 @@
 <div class="lecture-unit-card col clickable">
     <div class="lecture-unit-header row px-4 m-0" id="lecture-unit-toggle-button" (click)="toggleCollapse()">
         <div class="d-flex p-0 justify-content-between align-items-center">
-            <div class="d-flex">
+            <div class="d-flex align-items-center">
                 <fa-icon class="me-3" size="lg" [icon]="icon()" />
                 <h5 class="m-0">{{ lectureUnit().name ?? '' }}</h5>
                 @if (!isVisibleToStudents()) {
                     <span
-                        class="badge bg-warning ms-2"
+                        class="badge bg-warning ms-2 me-2"
                         ngbTooltip="{{ 'artemisApp.textUnit.notReleasedTooltip' | artemisTranslate }} {{ lectureUnit().releaseDate | artemisDate }}"
                         jhiTranslate="artemisApp.courseOverview.exerciseList.notReleased"
                     ></span>

--- a/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.scss
+++ b/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.scss
@@ -4,7 +4,7 @@
 
     .lecture-unit-header {
         background: var(--overview-light-background-color);
-        height: 50px;
+        min-height: 50px;
 
         &:hover {
             background: var(--hover-slightly-darker-body-bg);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes a UI bug described in [Artemis issue #10743](https://github.com/ls1intum/Artemis/issues/10743).
When a lecture unit title spans two or more lines, the “Not Released” badge would stretch vertically to the height of the text, leading to a visually broken layout.
We want to ensure that the badge always remains small and properly aligned, regardless of the title length.

### Description
<!-- Describe your changes in detail -->
To solve the problem, we slightly adjusted the layout inside the lecture unit card:
	•	Added align-items-center to vertically center the icon, title, and badge inside the row.
	•	Added me-2 (margin-end) to the “Not Released” badge to ensure a small consistent space between the badge and the “View Isolated” button.
	•	Replaced the fixed height: 50px of .lecture-unit-header with a flexible min-height: 50px, allowing the card header to grow dynamically depending on the content size.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Course with a Lecture Unit

1. Go to Course Management into one course
2. Create a Lecture
3. Create a Lecture Unit and give it a very long naming
4. Verify that the not released badge is showed properly

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
<img width="1481" alt="image" src="https://github.com/user-attachments/assets/4fb4d5d6-9097-4b78-bb7c-51c3dcd48698" />

After:
<img width="1481" alt="image" src="https://github.com/user-attachments/assets/d968fad7-1ecf-4620-a3b0-e60f82847669" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved vertical alignment and spacing of icons, lecture unit names, and badges in lecture unit headers.
  - Updated header styling to use a flexible minimum height for better layout adaptability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->