### PR TITLE
`Iris`: Fix multiple iris settings calls in communication channels

### DIFF
--- a/src/main/webapp/app/communication/shared/redirect-to-iris-button/redirect-to-iris-button.component.spec.ts
+++ b/src/main/webapp/app/communication/shared/redirect-to-iris-button/redirect-to-iris-button.component.spec.ts
@@ -270,4 +270,42 @@ describe('RedirectToIrisButtonComponent', () => {
 
         jest.spyOn(component.metisConversationService, 'activeConversation$', 'get').mockReturnValue(of(mockChannelDTO));
     }
+
+    it('should ignore undefined conversations', fakeAsync(() => {
+        jest.spyOn(profileService, 'isProfileActive').mockReturnValue(true);
+        const spyCheckIrisSettings = jest.spyOn(component as any, 'checkIrisSettings');
+        jest.spyOn(component.metisConversationService, 'activeConversation$', 'get').mockReturnValue(of(undefined));
+
+        component.ngOnInit();
+        tick();
+
+        expect(spyCheckIrisSettings).not.toHaveBeenCalled();
+    }));
+
+    it('should call checkIrisSettings on new conversation with different id', fakeAsync(() => {
+        jest.spyOn(profileService, 'isProfileActive').mockReturnValue(true);
+        const spyCheckIrisSettings = jest.spyOn(component as any, 'checkIrisSettings');
+
+        const firstConversation = { id: 1, type: ConversationType.CHANNEL, subType: ChannelSubType.EXERCISE } as ConversationDTO;
+        const secondConversation = { id: 2, type: ConversationType.CHANNEL, subType: ChannelSubType.EXERCISE } as ConversationDTO;
+        jest.spyOn(component.metisConversationService, 'activeConversation$', 'get').mockReturnValue(of(firstConversation, secondConversation));
+
+        component.ngOnInit();
+        tick();
+
+        expect(spyCheckIrisSettings).toHaveBeenCalledTimes(2);
+    }));
+
+    it('should not call checkIrisSettings if conversation id stays the same', fakeAsync(() => {
+        jest.spyOn(profileService, 'isProfileActive').mockReturnValue(true);
+        const spyCheckIrisSettings = jest.spyOn(component as any, 'checkIrisSettings');
+
+        const sameConversation = { id: 1, type: ConversationType.CHANNEL, subType: ChannelSubType.EXERCISE } as ConversationDTO;
+        jest.spyOn(component.metisConversationService, 'activeConversation$', 'get').mockReturnValue(of(sameConversation, sameConversation));
+
+        component.ngOnInit();
+        tick();
+
+        expect(spyCheckIrisSettings).toHaveBeenCalledOnce();
+    }));
 });

--- a/src/main/webapp/app/communication/shared/redirect-to-iris-button/redirect-to-iris-button.component.ts
+++ b/src/main/webapp/app/communication/shared/redirect-to-iris-button/redirect-to-iris-button.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit, inject, input, signal } from '@angular/co
 import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
 import { ChannelDTO, ChannelSubType, getAsChannelDTO } from 'app/communication/shared/entities/conversation/channel.model';
 import { IrisCourseSettings, IrisExerciseSettings } from 'app/iris/shared/entities/settings/iris-settings.model';
-import { Subscription, catchError, of } from 'rxjs';
+import { Subscription, catchError, distinctUntilKeyChanged, filter, of } from 'rxjs';
 import { Course } from 'app/core/course/shared/entities/course.model';
 import { Router } from '@angular/router';
 import { NgClass } from '@angular/common';
@@ -33,6 +33,7 @@ export class RedirectToIrisButtonComponent implements OnInit, OnDestroy {
     router = inject(Router);
 
     private conversationServiceSubscription: Subscription;
+    private settingsSubscription: Subscription | undefined;
     private irisCombinedExerciseSettings: IrisExerciseSettings | undefined;
     private irisCombinedCourseSettings: IrisCourseSettings | undefined;
     channelSubTypeReferenceRouterLink = '';
@@ -48,13 +49,19 @@ export class RedirectToIrisButtonComponent implements OnInit, OnDestroy {
         if (!isIrisActive) {
             return;
         }
-        this.conversationServiceSubscription = this.metisConversationService.activeConversation$.subscribe((conversation) => {
-            this.checkIrisSettings(getAsChannelDTO(conversation));
-        });
+        this.conversationServiceSubscription = this.metisConversationService.activeConversation$
+            .pipe(
+                filter((conversation) => !!conversation),
+                distinctUntilKeyChanged('id'),
+            )
+            .subscribe((conversation) => {
+                this.checkIrisSettings(getAsChannelDTO(conversation));
+            });
     }
 
     ngOnDestroy(): void {
         this.conversationServiceSubscription?.unsubscribe();
+        this.settingsSubscription?.unsubscribe();
     }
 
     /**
@@ -76,7 +83,7 @@ export class RedirectToIrisButtonComponent implements OnInit, OnDestroy {
         if (cachedSettings) {
             this.setIrisStatus(extractEnabled(cachedSettings), channelDTO);
         } else {
-            fetchSettings()
+            this.settingsSubscription = fetchSettings()
                 .pipe(
                     catchError(() => {
                         this.setIrisStatus(false, channelDTO);

--- a/src/main/webapp/app/iris/manage/settings/shared/iris-settings.service.spec.ts
+++ b/src/main/webapp/app/iris/manage/settings/shared/iris-settings.service.spec.ts
@@ -61,6 +61,35 @@ describe('Iris Settings Service', () => {
         tick();
     }));
 
+    it('should reuse pending request when getting combined course settings', fakeAsync(() => {
+        const mockedSettings = mockSettings();
+        service
+            .getCombinedCourseSettings(1)
+            .pipe(take(1))
+            .subscribe((resp) => expect(resp).toEqual(mockedSettings));
+        service
+            .getCombinedCourseSettings(1)
+            .pipe(take(1))
+            .subscribe((resp) => expect(resp).toEqual(mockedSettings));
+        const req = httpMock.expectOne({ method: 'GET' });
+        req.flush(mockedSettings, { status: 200, statusText: 'Ok' });
+        tick();
+    }));
+
+    it('should reuse cached result after getting combined course settings', fakeAsync(() => {
+        const mockedSettings = mockSettings();
+        service.getCombinedCourseSettings(1).pipe(take(1)).subscribe();
+        const req = httpMock.expectOne({ method: 'GET' });
+        req.flush(mockedSettings, { status: 200, statusText: 'Ok' });
+        tick();
+        service
+            .getCombinedCourseSettings(1)
+            .pipe(take(1))
+            .subscribe((resp) => expect(resp).toEqual(mockedSettings));
+        httpMock.expectNone({ method: 'GET' });
+        tick();
+    }));
+
     it('should set course settings', fakeAsync(() => {
         const mockedSettings = mockSettings();
         service
@@ -94,6 +123,67 @@ describe('Iris Settings Service', () => {
         tick();
     }));
 
+    it('should reuse pending request when getting combined programming exercise settings', fakeAsync(() => {
+        const mockedSettings = mockSettings();
+        service
+            .getCombinedExerciseSettings(1)
+            .pipe(take(1))
+            .subscribe((resp) => expect(resp).toEqual(mockedSettings));
+        service
+            .getCombinedExerciseSettings(1)
+            .pipe(take(1))
+            .subscribe((resp) => expect(resp).toEqual(mockedSettings));
+        const req = httpMock.expectOne({ method: 'GET' });
+        req.flush(mockedSettings, { status: 200, statusText: 'Ok' });
+        tick();
+    }));
+
+    it('should reuse cached result after getting combined programming exercise settings', fakeAsync(() => {
+        const mockedSettings = mockSettings();
+        service.getCombinedExerciseSettings(1).pipe(take(1)).subscribe();
+        const req = httpMock.expectOne({ method: 'GET' });
+        req.flush(mockedSettings, { status: 200, statusText: 'Ok' });
+        tick();
+        service
+            .getCombinedExerciseSettings(1)
+            .pipe(take(1))
+            .subscribe((resp) => expect(resp).toEqual(mockedSettings));
+        httpMock.expectNone({ method: 'GET' });
+        tick();
+    }));
+
+    it('should trigger new request after cache duration for course settings', fakeAsync(() => {
+        const mockedSettings = mockSettings();
+        service.getCombinedCourseSettings(1).pipe(take(1)).subscribe();
+        const req = httpMock.expectOne({ method: 'GET' });
+        req.flush(mockedSettings, { status: 200, statusText: 'Ok' });
+        tick();
+
+        // Advance time by more than CACHE_DURATION
+        tick((IrisSettingsService as any).CACHE_DURATION + 1);
+
+        service.getCombinedCourseSettings(1).pipe(take(1)).subscribe();
+        const newReq = httpMock.expectOne({ method: 'GET' });
+        newReq.flush(mockedSettings, { status: 200, statusText: 'Ok' });
+        tick();
+    }));
+
+    it('should trigger new request after cache duration for exercise settings', fakeAsync(() => {
+        const mockedSettings = mockSettings();
+        service.getCombinedExerciseSettings(1).pipe(take(1)).subscribe();
+        const req = httpMock.expectOne({ method: 'GET' });
+        req.flush(mockedSettings, { status: 200, statusText: 'Ok' });
+        tick();
+
+        // Advance time by more than CACHE_DURATION
+        tick((IrisSettingsService as any).CACHE_DURATION + 1);
+
+        service.getCombinedExerciseSettings(1).pipe(take(1)).subscribe();
+        const newReq = httpMock.expectOne({ method: 'GET' });
+        newReq.flush(mockedSettings, { status: 200, statusText: 'Ok' });
+        tick();
+    }));
+
     it('should set programming exercise settings', fakeAsync(() => {
         const mockedSettings = mockSettings();
         service
@@ -108,4 +198,48 @@ describe('Iris Settings Service', () => {
     afterEach(() => {
         httpMock.verify();
     });
+
+    it('should clear pending request and allow retry after failure for course settings', fakeAsync(() => {
+        service
+            .getCombinedCourseSettings(1)
+            .pipe(take(1))
+            .subscribe({
+                error: (err) => expect(err.status).toBe(500),
+            });
+        const req = httpMock.expectOne({ method: 'GET' });
+        req.flush({}, { status: 500, statusText: 'Internal Server Error' });
+        tick();
+
+        // Retry should trigger a new request
+        const mockedSettings = mockSettings();
+        service
+            .getCombinedCourseSettings(1)
+            .pipe(take(1))
+            .subscribe((resp) => expect(resp).toEqual(mockedSettings));
+        const retryReq = httpMock.expectOne({ method: 'GET' });
+        retryReq.flush(mockedSettings, { status: 200, statusText: 'Ok' });
+        tick();
+    }));
+
+    it('should clear pending request and allow retry after failure for exercise settings', fakeAsync(() => {
+        service
+            .getCombinedExerciseSettings(1)
+            .pipe(take(1))
+            .subscribe({
+                error: (err) => expect(err.status).toBe(500),
+            });
+        const req = httpMock.expectOne({ method: 'GET' });
+        req.flush({}, { status: 500, statusText: 'Internal Server Error' });
+        tick();
+
+        // Retry should trigger a new request
+        const mockedSettings = mockSettings();
+        service
+            .getCombinedExerciseSettings(1)
+            .pipe(take(1))
+            .subscribe((resp) => expect(resp).toEqual(mockedSettings));
+        const retryReq = httpMock.expectOne({ method: 'GET' });
+        retryReq.flush(mockedSettings, { status: 200, statusText: 'Ok' });
+        tick();
+    }));
 });

--- a/src/main/webapp/app/iris/manage/settings/shared/iris-settings.service.ts
+++ b/src/main/webapp/app/iris/manage/settings/shared/iris-settings.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { finalize, map, shareReplay, tap } from 'rxjs/operators';
 import { IrisCourseSettings, IrisExerciseSettings, IrisGlobalSettings } from 'app/iris/shared/entities/settings/iris-settings.model';
 import { IrisVariant } from 'app/iris/shared/entities/settings/iris-variant';
 import { IrisSubSettingsType } from 'app/iris/shared/entities/settings/iris-sub-settings.model';
@@ -14,6 +14,14 @@ export class IrisSettingsService {
     private http = inject(HttpClient);
 
     public resourceUrl = 'api/iris';
+
+    private courseSettingsCache = new Map<number, IrisCourseSettings>();
+    private exerciseSettingsCache = new Map<number, IrisExerciseSettings>();
+    private pendingCourseRequests = new Map<number, Observable<IrisCourseSettings | undefined>>();
+    private pendingExerciseRequests = new Map<number, Observable<IrisExerciseSettings | undefined>>();
+    private courseCacheTimestamps = new Map<number, number>();
+    private exerciseCacheTimestamps = new Map<number, number>();
+    private static readonly CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 
     /**
      * Get the global Iris settings
@@ -35,13 +43,40 @@ export class IrisSettingsService {
     }
 
     /**
-     * Get the combined Iris settings for a course
+     * Get the combined Iris settings for a course.
+     * Uses caching to avoid unnecessary API calls for 5 minutes and ensures
+     * that simultaneous requests for the same course ID reuse the same pending request.
+     *
      * @param courseId the id of the course
      */
     getCombinedCourseSettings(courseId: number): Observable<IrisCourseSettings | undefined> {
-        return this.http
-            .get<IrisCourseSettings>(`${this.resourceUrl}/courses/${courseId}/iris-settings`, { observe: 'response' })
-            .pipe(map((res: HttpResponse<IrisCourseSettings>) => res.body ?? undefined));
+        const now = Date.now();
+        const cached = this.courseSettingsCache.get(courseId);
+        const timestamp = this.courseCacheTimestamps.get(courseId);
+
+        if (cached && timestamp && now - timestamp < IrisSettingsService.CACHE_DURATION) {
+            return of(cached);
+        }
+
+        const pending = this.pendingCourseRequests.get(courseId);
+        if (pending) {
+            return pending;
+        }
+
+        const request$ = this.http.get<IrisCourseSettings>(`${this.resourceUrl}/courses/${courseId}/iris-settings`, { observe: 'response' }).pipe(
+            map((res: HttpResponse<IrisCourseSettings>) => res.body ?? undefined),
+            tap((settings) => {
+                if (settings) {
+                    this.courseSettingsCache.set(courseId, settings);
+                    this.courseCacheTimestamps.set(courseId, Date.now());
+                }
+            }),
+            finalize(() => this.pendingCourseRequests.delete(courseId)),
+            shareReplay(1),
+        );
+
+        this.pendingCourseRequests.set(courseId, request$);
+        return request$;
     }
 
     /**
@@ -55,13 +90,40 @@ export class IrisSettingsService {
     }
 
     /**
-     * Get the combined Iris settings for an exercise
+     * Get the combined Iris settings for an exercise.
+     * Uses caching to avoid unnecessary API calls for 5 minutes and ensures
+     * that simultaneous requests for the same exercise ID reuse the same pending request.
+     *
      * @param exerciseId the id of the exercise
      */
     getCombinedExerciseSettings(exerciseId: number): Observable<IrisExerciseSettings | undefined> {
-        return this.http
-            .get<IrisExerciseSettings>(`${this.resourceUrl}/exercises/${exerciseId}/iris-settings`, { observe: 'response' })
-            .pipe(map((res: HttpResponse<IrisExerciseSettings>) => res.body ?? undefined));
+        const now = Date.now();
+        const cached = this.exerciseSettingsCache.get(exerciseId);
+        const timestamp = this.exerciseCacheTimestamps.get(exerciseId);
+
+        if (cached && timestamp && now - timestamp < IrisSettingsService.CACHE_DURATION) {
+            return of(cached);
+        }
+
+        const pending = this.pendingExerciseRequests.get(exerciseId);
+        if (pending) {
+            return pending;
+        }
+
+        const request$ = this.http.get<IrisExerciseSettings>(`${this.resourceUrl}/exercises/${exerciseId}/iris-settings`, { observe: 'response' }).pipe(
+            map((res: HttpResponse<IrisExerciseSettings>) => res.body ?? undefined),
+            tap((settings) => {
+                if (settings) {
+                    this.exerciseSettingsCache.set(exerciseId, settings);
+                    this.exerciseCacheTimestamps.set(exerciseId, Date.now());
+                }
+            }),
+            finalize(() => this.pendingExerciseRequests.delete(exerciseId)),
+            shareReplay(1),
+        );
+
+        this.pendingExerciseRequests.set(exerciseId, request$);
+        return request$;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As mentioned in [PR#10748](https://github.com/ls1intum/Artemis/pull/10748#issue-3020061105) the redirect-to-iris-component fetches the same iris-settings multiple times. This should not happen as it fetches the exact same data from the same REST endpoint. Only one call should be made.

### Description
<!-- Describe your changes in detail -->
This PR adds two changes. 
The first change reduces the calls in the `iris-settings.service.ts` by caching all the calls. This is done by first caching pending requests and the caching the fetched settings. The cache save them for 5 minutes to prevent updated settings to not take affect.
The second change is in the `redirect-to-iris-button.component.ts` by fetching the iris-settings only if the conversation id changes. This fixes multiple requests if metadata changes for the conversations which triggers a new request.
With this changes the component now only fetches the settings once.
Disclaimer: If you first test the exercise and then the lecture channels a second request is triggered, because those are different settings that need to be fetched separately.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:

- 1 Student in a course with comms enabled and a lecture with communication channel
-  iris activated for the course and exercises

1. Log in to Artemis
2. Navigate to Communication
3. Open a channel of a lecture or exercise
4. Verify that only one iris-settings call is made

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| redirect-to-iris-button.component.ts | 93.5% | ✅ ❌ |
| iris-settings.service.ts | 98.21% | ✅ ❌ |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved performance and reliability of Iris settings retrieval by introducing caching and request deduplication for course and exercise settings.
- **Bug Fixes**
  - Enhanced handling of active conversations to ensure settings are only checked when necessary, reducing unnecessary operations.
- **Tests**
  - Added comprehensive tests for caching, request reuse, cache expiration, and error recovery in Iris settings services.
  - Extended tests for conversation handling in the redirect button component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->