### PR TITLE
`Development`: LTI Angular Decoratorless API Migration

### DIFF
--- a/src/main/webapp/app/lti/overview/lti13-select-content/lti13-select-content.component.ts
+++ b/src/main/webapp/app/lti/overview/lti13-select-content/lti13-select-content.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, NgZone, OnInit, SecurityContext, ViewChild, inject } from '@angular/core';
+import { Component, ElementRef, NgZone, OnInit, SecurityContext, inject, viewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { DomSanitizer } from '@angular/platform-browser';
 import { TranslateDirective } from '../../../shared/language/translate.directive';
@@ -27,8 +27,7 @@ export class Lti13SelectContentComponent implements OnInit {
     actionLink: string;
     isLinking = true;
 
-    @ViewChild('deepLinkingForm', { static: false })
-    deepLinkingForm?: ElementRef;
+    readonly deepLinkingForm = viewChild<ElementRef>('deepLinkingForm');
 
     /**
      * Initializes the component.
@@ -71,7 +70,7 @@ export class Lti13SelectContentComponent implements OnInit {
      * - Submits the form.
      */
     autoSubmitForm(): void {
-        const form = this.deepLinkingForm?.nativeElement;
+        const form = this.deepLinkingForm()?.nativeElement;
         if (form) {
             form.action = this.actionLink;
             form.submit();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).




#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Use Angular Decoratorless API for LTI components


### Description
<!-- Describe your changes in detail -->
Changed @ViewChild() → viewChild()


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Access to Moodle
- Testserver 3

1. Make sure you are logged in to Artemis with Test User 16

2. Navigate to [Moodle](https://moodle.ase.in.tum.de) and login with the same test user (Test User 16}, same PW as for the Artemis Test Server)

3. Go to My Courses and open the lti test course

4. Activate Edit mode in top right corner

5. Add a learning activity by clicking on the blue + in "Test Topic"
![image](https://github.com/user-attachments/assets/a20ac2df-f219-4530-8fd4-e5775d583dd6)

6. Select TS3 New
![image](https://github.com/user-attachments/assets/1c6fa52e-6b8d-47be-bf90-1598d22d032a)
![image](https://github.com/user-attachments/assets/805c7d8a-51b3-4e59-bd76-6d32f02520f8)

7. Click on "Select content"
![image](https://github.com/user-attachments/assets/9c6a81ce-ada8-4444-ab81-afe863779964)

8. Select the LTI test course
![image](https://github.com/user-attachments/assets/1b8995cb-1b99-488f-8d6d-139f2c635193)

9. Select a content type and click "link" in the bottom right corner
![image](https://github.com/user-attachments/assets/6e6812b7-30e3-497f-b7d6-0cb0c8c52d84)

10. If the content was selected successfully, scroll down and hit "Save and display"
![image](https://github.com/user-attachments/assets/5e0bf8c0-770e-4216-9341-3b086d614958)
(If you get an error after linking, this may be due to server sync, just try again by pressing the back button in your browser)

11. If anything is displayed and there is no "Linking failed" error, everything works as expected


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal handling of form element references for improved maintainability. No changes to visible features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->