### PR TITLE
`Lectures`: Fix file upload when file name contains 'slide'

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/service/FilePathService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/FilePathService.java
@@ -150,7 +150,7 @@ public class FilePathService {
             String attachmentUnitId = path.getName(2).toString();
             return getAttachmentUnitFilePath().resolve(Path.of(attachmentUnitId, "student", filename));
         }
-        if (!publicPath.toString().contains("slide")) {
+        if (!publicPath.toString().contains("slide/")) {
             String attachmentUnitId = path.getName(2).toString();
             return getAttachmentUnitFilePath().resolve(Path.of(attachmentUnitId, filename));
         }

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/FilePathService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/FilePathService.java
@@ -251,7 +251,7 @@ public class FilePathService {
         if (path.toString().contains("student")) {
             return URI.create("attachments/attachment-unit/" + id + "/student/" + filename);
         }
-        if (!path.toString().contains("slide")) {
+        if (!path.toString().contains("slide/")) {
             return URI.create("attachments/attachment-unit/" + id + "/" + filename);
         }
         try {

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/FilePathService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/FilePathService.java
@@ -251,7 +251,7 @@ public class FilePathService {
         if (path.toString().contains("student")) {
             return URI.create("attachments/attachment-unit/" + id + "/student/" + filename);
         }
-        if (!path.toString().contains("slide/")) {
+        if (!path.toString().contains("slide" + path.getFileSystem().getSeparator())) {
             return URI.create("attachments/attachment-unit/" + id + "/" + filename);
         }
         try {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
File units for lectures could not be uploaded if the file name contains the string 'slide'. This PR fixes that.
This has been haunting me for a week.


### Description
<!-- Describe your changes in detail -->
I changed the methods returning the public path for an attachment unit's actual path and the other method that does this vice versa. The previous version also matched paths where the file name contained the string 'slide'. In both methods, I appended the respective separator to the string that the path is compared against. Since a filename cannot contain the separator, this prevents the false positives that caused the issue. 


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Lecture

1. Log in to Artemis
2. Navigate to Course Administration
3. Add a File Lecture unit
4. Upload any file whose name contains the string 'slide'
5. Click submit

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
*Note*: I am not certain whether this change constitutes as trivial. If it does not, I will provide the coverage report for the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy when identifying slide-related files, reducing false matches for file paths containing the word "slide" but not referring to actual slide directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->