### PR TITLE
`Communication`: Fix an issue with editing messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7872,6 +7872,12 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.14",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+            "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+            "license": "MIT"
+        },
         "node_modules/@types/qs": {
             "version": "6.9.18",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
@@ -7889,11 +7895,12 @@
             "peer": true
         },
         "node_modules/@types/react": {
-            "version": "19.1.2",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
-            "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
+            "version": "18.3.20",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
+            "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
             "license": "MIT",
             "dependencies": {
+                "@types/prop-types": "*",
                 "csstype": "^3.0.2"
             }
         },

--- a/src/main/java/de/tum/cit/aet/artemis/communication/dto/UpdatePostingDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/dto/UpdatePostingDTO.java
@@ -1,10 +1,12 @@
 package de.tum.cit.aet.artemis.communication.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * DTO for updating a Posting with only the necessary fields.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record UpdatePostingDTO(Long id, String content, String title, Boolean resolvesPost) {
 

--- a/src/main/java/de/tum/cit/aet/artemis/communication/dto/UpdatePostingDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/dto/UpdatePostingDTO.java
@@ -8,21 +8,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record UpdatePostingDTO(Long id, String content, String title, Boolean resolvesPost) {
+public record UpdatePostingDTO(long id, String content, String title, boolean resolvesPost) {
 
-    public String getContent() {
-        return content;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public Boolean doesResolvePost() {
-        return resolvesPost;
-    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/communication/dto/UpdatePostingDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/dto/UpdatePostingDTO.java
@@ -1,0 +1,26 @@
+package de.tum.cit.aet.artemis.communication.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * DTO for updating a Posting with only the necessary fields.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UpdatePostingDTO(Long id, String content, String title, Boolean resolvesPost) {
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Boolean doesResolvePost() {
+        return resolvesPost;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/AnswerMessageService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/AnswerMessageService.java
@@ -22,6 +22,7 @@ import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewAnswe
 import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewMentionNotification;
 import de.tum.cit.aet.artemis.communication.dto.MetisCrudAction;
 import de.tum.cit.aet.artemis.communication.dto.PostDTO;
+import de.tum.cit.aet.artemis.communication.dto.UpdatePostingDTO;
 import de.tum.cit.aet.artemis.communication.repository.AnswerPostRepository;
 import de.tum.cit.aet.artemis.communication.repository.ConversationMessageRepository;
 import de.tum.cit.aet.artemis.communication.repository.ConversationParticipantRepository;
@@ -163,7 +164,7 @@ public class AnswerMessageService extends PostingService {
      * @param answerMessage   answer message to update
      * @return updated answer message that was persisted
      */
-    public AnswerPost updateAnswerMessage(Long courseId, Long answerMessageId, AnswerPost answerMessage) {
+    public AnswerPost updateAnswerMessage(Long courseId, Long answerMessageId, UpdatePostingDTO answerMessage) {
         final User user = userRepository.getUserWithGroupsAndAuthorities();
 
         // checks

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/AnswerMessageService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/AnswerMessageService.java
@@ -168,7 +168,7 @@ public class AnswerMessageService extends PostingService {
         final User user = userRepository.getUserWithGroupsAndAuthorities();
 
         // checks
-        if (answerMessage.getId() == null || !Objects.equals(answerMessage.getId(), answerMessageId)) {
+        if (!Objects.equals(answerMessage.id(), answerMessageId)) {
             throw new BadRequestAlertException("Invalid id", METIS_ANSWER_POST_ENTITY_NAME, "idnull");
         }
         AnswerPost existingAnswerMessage = this.findById(answerMessageId);
@@ -177,15 +177,15 @@ public class AnswerMessageService extends PostingService {
 
         Conversation conversation = conversationService.getConversationById(existingAnswerMessage.getPost().getConversation().getId());
         var course = preCheckUserAndCourseForMessaging(user, courseId);
-        parseUserMentions(course, answerMessage.getContent());
+        parseUserMentions(course, answerMessage.content());
         // only the content of the message can be updated
-        existingAnswerMessage.setContent(answerMessage.getContent());
+        existingAnswerMessage.setContent(answerMessage.content());
 
         // determine if the update operation is to mark the answer message as resolving the original post
-        if (existingAnswerMessage.doesResolvePost() != answerMessage.doesResolvePost()) {
+        if (existingAnswerMessage.doesResolvePost() != answerMessage.resolvesPost()) {
             // check if requesting user is allowed to mark this answer message as resolving, i.e. if user is author or original message or at least tutor
             mayMarkAnswerMessageAsResolvingElseThrow(existingAnswerMessage, user, course);
-            existingAnswerMessage.setResolvesPost(answerMessage.doesResolvePost());
+            existingAnswerMessage.setResolvesPost(answerMessage.resolvesPost());
             // sets the message as resolved if there exists any resolving answer
             existingAnswerMessage.getPost().setResolved(existingAnswerMessage.getPost().getAnswers().stream().anyMatch(AnswerPost::doesResolvePost));
             postRepository.save(existingAnswerMessage.getPost());
@@ -193,7 +193,7 @@ public class AnswerMessageService extends PostingService {
         else {
             // check if requesting user is allowed to update the content, i.e. if user is author of answer message or at least tutor
             mayUpdateOrDeleteAnswerMessageElseThrow(existingAnswerMessage, user);
-            existingAnswerMessage.setContent(answerMessage.getContent());
+            existingAnswerMessage.setContent(answerMessage.content());
             existingAnswerMessage.setUpdatedDate(ZonedDateTime.now());
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
@@ -38,6 +38,7 @@ import de.tum.cit.aet.artemis.communication.domain.course_notifications.NewPostN
 import de.tum.cit.aet.artemis.communication.dto.MetisCrudAction;
 import de.tum.cit.aet.artemis.communication.dto.PostContextFilterDTO;
 import de.tum.cit.aet.artemis.communication.dto.PostDTO;
+import de.tum.cit.aet.artemis.communication.dto.UpdatePostingDTO;
 import de.tum.cit.aet.artemis.communication.repository.ConversationMessageRepository;
 import de.tum.cit.aet.artemis.communication.repository.ConversationParticipantRepository;
 import de.tum.cit.aet.artemis.communication.repository.PostRepository;
@@ -303,7 +304,7 @@ public class ConversationMessagingService extends PostingService {
      * @param messagePost post to update
      * @return updated post that was persisted
      */
-    public Post updateMessage(Long courseId, Long postId, Post messagePost) {
+    public Post updateMessage(Long courseId, Long postId, UpdatePostingDTO messagePost) {
         final User user = userRepository.getUserWithGroupsAndAuthorities();
         // check
         if (messagePost.getId() == null || !Objects.equals(messagePost.getId(), postId)) {

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
@@ -307,7 +307,7 @@ public class ConversationMessagingService extends PostingService {
     public Post updateMessage(Long courseId, Long postId, UpdatePostingDTO messagePost) {
         final User user = userRepository.getUserWithGroupsAndAuthorities();
         // check
-        if (messagePost.getId() == null || !Objects.equals(messagePost.getId(), postId)) {
+        if (!Objects.equals(messagePost.id(), postId)) {
             throw new BadRequestAlertException("Invalid id", METIS_POST_ENTITY_NAME, "idnull");
         }
 
@@ -315,11 +315,11 @@ public class ConversationMessagingService extends PostingService {
         Conversation conversation = mayUpdateOrDeleteMessageElseThrow(existingMessage, user);
         var course = preCheckUserAndCourseForMessaging(user, courseId);
 
-        parseUserMentions(course, messagePost.getContent());
+        parseUserMentions(course, messagePost.content());
 
         // update: allow overwriting of values only for depicted fields
-        existingMessage.setContent(messagePost.getContent());
-        existingMessage.setTitle(messagePost.getTitle());
+        existingMessage.setContent(messagePost.content());
+        existingMessage.setTitle(messagePost.title());
         existingMessage.setUpdatedDate(ZonedDateTime.now());
 
         Post updatedPost = conversationMessageRepository.save(existingMessage);

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/AnswerMessageResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/AnswerMessageResource.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.artemis.communication.domain.AnswerPost;
+import de.tum.cit.aet.artemis.communication.dto.UpdatePostingDTO;
 import de.tum.cit.aet.artemis.communication.service.AnswerMessageService;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
@@ -65,16 +66,16 @@ public class AnswerMessageResource {
      *
      * @param courseId        id of the course the answer post belongs to
      * @param answerMessageId id of the answer post to update
-     * @param answerMessage   answer post to update
+     * @param updatedAnswer   answer post to update
      * @return ResponseEntity with status 200 (OK) containing the updated answer message in the response body,
      *         or with status 400 (Bad Request) if the checks on user, course or associated post validity fail
      */
     @PutMapping("courses/{courseId}/answer-messages/{answerMessageId}")
     @EnforceAtLeastStudent
-    public ResponseEntity<AnswerPost> updateAnswerMessage(@PathVariable Long courseId, @PathVariable Long answerMessageId, @RequestBody AnswerPost answerMessage) {
-        log.debug("PUT updateAnswerMessage invoked for course {} with message {}", courseId, answerMessage.getContent());
+    public ResponseEntity<AnswerPost> updateAnswerMessage(@PathVariable Long courseId, @PathVariable Long answerMessageId, @RequestBody UpdatePostingDTO updatedAnswer) {
+        log.debug("PUT updateAnswerMessage invoked for course {} with message {}", courseId, updatedAnswer.getContent());
         long start = System.nanoTime();
-        AnswerPost updatedAnswerMessage = answerMessageService.updateAnswerMessage(courseId, answerMessageId, answerMessage);
+        AnswerPost updatedAnswerMessage = answerMessageService.updateAnswerMessage(courseId, answerMessageId, updatedAnswer);
         log.debug("updateAnswerMessage took {}", TimeLogUtil.formatDurationFrom(start));
         return new ResponseEntity<>(updatedAnswerMessage, null, HttpStatus.OK);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/AnswerMessageResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/AnswerMessageResource.java
@@ -73,7 +73,7 @@ public class AnswerMessageResource {
     @PutMapping("courses/{courseId}/answer-messages/{answerMessageId}")
     @EnforceAtLeastStudent
     public ResponseEntity<AnswerPost> updateAnswerMessage(@PathVariable Long courseId, @PathVariable Long answerMessageId, @RequestBody UpdatePostingDTO updatedAnswer) {
-        log.debug("PUT updateAnswerMessage invoked for course {} with message {}", courseId, updatedAnswer.getContent());
+        log.debug("PUT updateAnswerMessage invoked for course {} with message {}", courseId, updatedAnswer.content());
         long start = System.nanoTime();
         AnswerPost updatedAnswerMessage = answerMessageService.updateAnswerMessage(courseId, answerMessageId, updatedAnswer);
         log.debug("updateAnswerMessage took {}", TimeLogUtil.formatDurationFrom(start));

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/ConversationMessageResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/ConversationMessageResource.java
@@ -169,7 +169,7 @@ public class ConversationMessageResource {
     @PutMapping("courses/{courseId}/messages/{messageId}")
     @EnforceAtLeastStudent
     public ResponseEntity<Post> updateMessage(@PathVariable Long courseId, @PathVariable Long messageId, @RequestBody UpdatePostingDTO updatedPost) {
-        log.debug("PUT updateMessage invoked for course {} with post {}", courseId, updatedPost.getContent());
+        log.debug("PUT updateMessage invoked for course {} with post {}", courseId, updatedPost.content());
         long start = System.nanoTime();
         // Note: authorization is checked in the service method
         Post updatedMessagePost = conversationMessagingService.updateMessage(courseId, messageId, updatedPost);

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/ConversationMessageResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/ConversationMessageResource.java
@@ -32,6 +32,7 @@ import de.tum.cit.aet.artemis.communication.domain.CreatedConversationMessage;
 import de.tum.cit.aet.artemis.communication.domain.DisplayPriority;
 import de.tum.cit.aet.artemis.communication.domain.Post;
 import de.tum.cit.aet.artemis.communication.dto.PostContextFilterDTO;
+import de.tum.cit.aet.artemis.communication.dto.UpdatePostingDTO;
 import de.tum.cit.aet.artemis.communication.service.ConversationMessagingService;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.repository.CourseRepository;
@@ -161,17 +162,17 @@ public class ConversationMessageResource {
      *
      * @param courseId    id of the course the message post belongs to
      * @param messageId   id of the message post to update
-     * @param messagePost message post to update
+     * @param updatedPost message post to update
      * @return ResponseEntity with status 200 (OK) containing the updated message post in the response body,
      *         or with status 400 (Bad Request) if the checks on user, course or post validity fail
      */
     @PutMapping("courses/{courseId}/messages/{messageId}")
     @EnforceAtLeastStudent
-    public ResponseEntity<Post> updateMessage(@PathVariable Long courseId, @PathVariable Long messageId, @RequestBody Post messagePost) {
-        log.debug("PUT updateMessage invoked for course {} with post {}", courseId, messagePost.getContent());
+    public ResponseEntity<Post> updateMessage(@PathVariable Long courseId, @PathVariable Long messageId, @RequestBody UpdatePostingDTO updatedPost) {
+        log.debug("PUT updateMessage invoked for course {} with post {}", courseId, updatedPost.getContent());
         long start = System.nanoTime();
         // Note: authorization is checked in the service method
-        Post updatedMessagePost = conversationMessagingService.updateMessage(courseId, messageId, messagePost);
+        Post updatedMessagePost = conversationMessagingService.updateMessage(courseId, messageId, updatedPost);
         log.debug("updateMessage took {}", TimeLogUtil.formatDurationFrom(start));
         return new ResponseEntity<>(updatedMessagePost, null, HttpStatus.OK);
     }

--- a/src/main/webapp/app/communication/service/answer-post.service.ts
+++ b/src/main/webapp/app/communication/service/answer-post.service.ts
@@ -33,7 +33,14 @@ export class AnswerPostService extends PostingService<AnswerPost> {
      * @return {Observable<EntityResponseType>}
      */
     update(courseId: number, answerPost: AnswerPost): Observable<EntityResponseType> {
-        const copy = this.convertPostingDateFromClient(answerPost);
+        const updatedAnswer = {
+            id: answerPost.id,
+            content: answerPost.content,
+            resolvesPost: answerPost.resolvesPost,
+            creationDate: answerPost.creationDate,
+            updatedDate: answerPost.updatedDate,
+        };
+        const copy = this.convertPostingDateFromClient(updatedAnswer);
         return this.http
             .put<AnswerPost>(`${this.getResourceEndpoint(courseId, answerPost)}/${answerPost.id}`, copy, { observe: 'response' })
             .pipe(map(this.convertPostingResponseDateFromServer));

--- a/src/main/webapp/app/communication/service/post.service.ts
+++ b/src/main/webapp/app/communication/service/post.service.ts
@@ -94,7 +94,14 @@ export class PostService extends PostingService<Post> {
      * @return the updated post
      */
     update<T extends Posting>(courseId: number, post: T): Observable<EntityResponseType> {
-        const copy = this.convertPostingDateFromClient(post);
+        const updatedPost = {
+            id: post.id,
+            content: post.content,
+            title: (post as Post).title,
+            creationDate: post.creationDate,
+            updatedDate: post.updatedDate,
+        };
+        const copy = this.convertPostingDateFromClient(updatedPost);
         return this.http
             .put<Post>(`${this.getResourceEndpoint(courseId, undefined, post)}/${post.id}`, copy, { observe: 'response' })
             .pipe(map(this.convertPostingResponseDateFromServer));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Updating messages and replies as a tutor sometimes results in a bad request error. (Closes #10778)


### Description
<!-- Describe your changes in detail -->
`UpdatePostingDTO` has been added to use a minimal DTO and fix the valueDeserializer error.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Tutor
- 1 Course with Communication enabled

1. Log in to Artemis.
2. Navigate to Communication section of a course.
3. Send a message to a private channel and reply to it.
4. Try editing both messages and verify that the update works as before (without any bad request error)



### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a streamlined update format for postings, improving how messages and answers are updated.

- **Refactor**
  - Updated message and answer update endpoints and services to use the new update format.
  - Modified client-side update methods to send only essential posting fields during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->