### PR TITLE
`Development`: Exclude spec files from coverage table

### DIFF
--- a/supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py
+++ b/supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py
@@ -256,6 +256,8 @@ def coverage_to_table(covs):
 
     for cov in covs:
         class_file = cov[0].rsplit("/", 1)[1]
+        if class_file.endswith(".spec.ts"):  # Exclude .spec.ts files
+            continue
         line_coverage = cov[1]
         confirmation = "✅ ❌"
         if line_coverage.startswith("100"):


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
When creating the coverage table for [General: Display modal to setup passkeys after login #10766](https://github.com/ls1intum/Artemis/pull/10766) I had to manually delete `.spec.ts` entries from the coverage table. 
This is manual work that should not be required.

This PR makes sure to exclude `.spec.ts` files from the coverage report (we wont write tests for tests)

```
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| app.component.spec.ts | not found (modified) | ❌ |
| app.component.ts | 75% | ✅ ❌ |
| system-notification-detail.component.spec.ts | not found (modified) | ❌ |
| account.service.ts | 87.71% | ✅ ❌ |
| courses.component.ts | 93.05% | ✅ ❌ |
| setup-passkey-modal.component.spec.ts | not found (added) | ❌ |
| setup-passkey-modal.component.ts | 100% | ✅ |
| home.component.spec.ts | not found (added) | ❌ |
| home.component.ts | 77.37% | ✅ ❌ |
| navbar.component.ts | 87.28% | ✅ ❌ |
| user.model.ts | 100% | ✅ |
| delete-dialog.component.ts | 93.18% | ✅ ❌ |
| exercise-filter-modal.component.ts | 89.28% | ✅ ❌ |

#### Server

Coverage artifact not found, tests probably failed.
```

### Description
- Filtering out `.spec.ts` files when the coverage table is created

### Steps for Testing
1. Check out a branch with changes to client tests (`.spec.ts` files) (e.g. [General: Display modal to setup passkeys after login #10766](https://github.com/ls1intum/Artemis/pull/10766))
2. Adjust the coverage script according to changes in this PR
3. See that the coverage table is created without `.spec.ts` entries

Should not contain `.spec.ts` files
```
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| app.component.ts | 75% | ✅ ❌ |
| account.service.ts | 87.71% | ✅ ❌ |
| courses.component.ts | 93.05% | ✅ ❌ |
| setup-passkey-modal.component.ts | 100% | ✅ |
| home.component.ts | 77.37% | ✅ ❌ |
| navbar.component.ts | 87.28% | ✅ ❌ |
| user.model.ts | 100% | ✅ |
| delete-dialog.component.ts | 93.18% | ✅ ❌ |
| exercise-filter-modal.component.ts | 89.28% | ✅ ❌ |

#### Server

Coverage artifact not found, tests probably failed.
```


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
#### Manual Tests
- [x] Test 1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Test specification files are now excluded from the code coverage summary table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->