### PR TITLE
`General`: Fix edit message e2e test

### DIFF
--- a/src/main/webapp/app/communication/message/message-inline-input/message-inline-input.component.ts
+++ b/src/main/webapp/app/communication/message/message-inline-input/message-inline-input.component.ts
@@ -62,10 +62,10 @@ export class MessageInlineInputComponent extends PostingCreateEditDirective<Post
      */
     updatePosting(): void {
         this.posting.content = this.formGroup.get('content')?.value;
+        this.isModalOpen.emit();
         this.metisService.updatePost(this.posting).subscribe({
             next: () => {
                 this.isLoading = false;
-                this.isModalOpen.emit();
             },
             error: () => {
                 this.isLoading = false;

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -275,11 +275,8 @@ export class CourseMessagesPage {
         await postLocator.locator('#save').click();
         await responsePromise;
 
-        await this.page.waitForTimeout(10000);
-
         await this.page.waitForSelector(`#item-${messageId} .markdown-preview:has-text("${message}")`, {
             state: 'visible',
-            timeout: 60000,
         });
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently there is a failing e2e test in the CourseMessages.spec.ts file for when users are editing messages.

### Description
<!-- Describe your changes in detail -->
I added a longer timeout to check whether the message was edited and the edited message actually appears on screen.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1