### PR TITLE
`Development`: Fix client test branch coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -94,7 +94,7 @@ module.exports = {
         global: {
             // TODO: in the future, the following values should increase to at least 90%
             statements: 89.18,
-            branches: 75.34,
+            branches: 75.33,
             functions: 83.08,
             lines: 89.25,
         },


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
I bumped the coverage in [General: Ask users to setup passkeys after login #10766](https://github.com/ls1intum/Artemis/pull/10766), where the client test pipeline also passed on the latest test run https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS8122-TSTEST-23 of that branch.

Unfortunately, #10807 and #10800 had not been merged into develop and my branch before, which appears to lower the coverage.
So the currently expected branch coverage on develop is **75.33** and not 75.34 - which causes the client test pipeline to fail since my commit.

### Description
Reduces the expected client branch coverage to the currently present value on develop.

### Steps for Testing
Verify the client test pipeline is passing and not failing due to coverage conditions.

https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS8163-TSTEST-1

### Review Progress

#### Code Review
- [x] Code Review 1
