### PR TITLE
`Communication`: Add button to clear all notifications

### DIFF
--- a/src/main/webapp/app/communication/course-notification/course-notification-popup-overlay/course-notification-popup-overlay.component.html
+++ b/src/main/webapp/app/communication/course-notification/course-notification-popup-overlay/course-notification-popup-overlay.component.html
@@ -22,8 +22,12 @@
     }
 
     <div class="course-notification-popup-overlay-collapse">
-        <button class="btn btn-outline-primary rounded-circle btn-sm" (click)="collapseOverlayClicked()">
+        <button class="btn btn-outline-primary rounded-circle btn-sm me-2" (click)="collapseOverlayClicked()">
             <fa-icon [icon]="faTimes" />
+        </button>
+
+        <button class="btn btn-outline-primary rounded-circle btn-sm" (click)="clearAllNotifications()">
+            <fa-icon [icon]="faTrash" />
         </button>
     </div>
 </div>

--- a/src/main/webapp/app/communication/course-notification/course-notification-popup-overlay/course-notification-popup-overlay.component.spec.ts
+++ b/src/main/webapp/app/communication/course-notification/course-notification-popup-overlay/course-notification-popup-overlay.component.spec.ts
@@ -222,4 +222,70 @@ describe('CourseNotificationPopupOverlayComponent', () => {
 
         expect(collapseOverlayClickedSpy).toHaveBeenCalledOnce();
     });
+
+    it('should clear all notifications when clearAllNotifications is called', fakeAsync(() => {
+        const mockNotification1 = createMockNotification(1, 101);
+        const mockNotification2 = createMockNotification(2, 102);
+        componentAsAny.notifications = [mockNotification1, mockNotification2];
+        componentAsAny.isExpanded = true;
+        fixture.detectChanges();
+
+        component.clearAllNotifications();
+        tick(0); // Process the setTimeout
+
+        expect(componentAsAny.notifications).toHaveLength(0);
+        expect(componentAsAny.isExpanded).toBeFalse();
+    }));
+
+    it('should do nothing when clearAllNotifications is called and isExpanded is false', () => {
+        const mockNotification = createMockNotification(1, 101);
+        componentAsAny.notifications = [mockNotification];
+        componentAsAny.isExpanded = false;
+        fixture.detectChanges();
+
+        const setNotificationStatusSpy = jest.spyOn(courseNotificationService, 'setNotificationStatus');
+        const setNotificationStatusInMapSpy = jest.spyOn(courseNotificationService, 'setNotificationStatusInMap');
+        const decreaseNotificationCountBySpy = jest.spyOn(courseNotificationService, 'decreaseNotificationCountBy');
+
+        component.clearAllNotifications();
+
+        expect(setNotificationStatusSpy).not.toHaveBeenCalled();
+        expect(setNotificationStatusInMapSpy).not.toHaveBeenCalled();
+        expect(decreaseNotificationCountBySpy).not.toHaveBeenCalled();
+        expect(componentAsAny.notifications).toHaveLength(1);
+    });
+
+    it('should mark all notifications as seen on server when clearAllNotifications is called', fakeAsync(() => {
+        const mockNotification1 = createMockNotification(1, 101);
+        const mockNotification2 = createMockNotification(2, 101);
+        const mockNotification3 = createMockNotification(3, 102);
+        componentAsAny.notifications = [mockNotification1, mockNotification2, mockNotification3];
+        componentAsAny.isExpanded = true;
+        fixture.detectChanges();
+
+        component.clearAllNotifications();
+        tick(0);
+
+        expect(courseNotificationService.setNotificationStatus).toHaveBeenCalledWith(101, [1, 2], CourseNotificationViewingStatus.SEEN);
+        expect(courseNotificationService.setNotificationStatusInMap).toHaveBeenCalledWith(101, [1, 2], CourseNotificationViewingStatus.SEEN);
+        expect(courseNotificationService.decreaseNotificationCountBy).toHaveBeenCalledWith(101, 2);
+
+        expect(courseNotificationService.setNotificationStatus).toHaveBeenCalledWith(102, [3], CourseNotificationViewingStatus.SEEN);
+        expect(courseNotificationService.setNotificationStatusInMap).toHaveBeenCalledWith(102, [3], CourseNotificationViewingStatus.SEEN);
+        expect(courseNotificationService.decreaseNotificationCountBy).toHaveBeenCalledWith(102, 1);
+    }));
+
+    it('should trigger clearAllNotifications when clicking the clear button', () => {
+        const mockNotification = createMockNotification(1, 101);
+        componentAsAny.notifications = [mockNotification];
+        componentAsAny.isExpanded = true;
+        fixture.detectChanges();
+
+        const clearAllNotificationsSpy = jest.spyOn(component, 'clearAllNotifications');
+
+        const clearButton = fixture.debugElement.queryAll(By.css('.btn-outline-primary'))[1];
+        clearButton.nativeElement.click();
+
+        expect(clearAllNotificationsSpy).toHaveBeenCalledOnce();
+    });
 });

--- a/src/main/webapp/app/communication/course-notification/course-notification-popup-overlay/course-notification-popup-overlay.component.ts
+++ b/src/main/webapp/app/communication/course-notification/course-notification-popup-overlay/course-notification-popup-overlay.component.ts
@@ -8,7 +8,7 @@ import { CourseNotificationService } from 'app/communication/course-notification
 import { CourseNotificationViewingStatus } from 'app/communication/shared/entities/course-notification/course-notification-viewing-status';
 import { CommonModule } from '@angular/common';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faTimes, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 /**
  * Component that displays real-time notification popups.
@@ -40,6 +40,7 @@ export class CourseNotificationPopupOverlayComponent implements OnInit, OnDestro
 
     // Icons
     protected readonly faTimes = faTimes;
+    protected readonly faTrash = faTrash;
 
     ngOnInit(): void {
         this.courseNotificationWebsocketSubscription = this.courseNotificationWebsocketService.websocketNotification$.subscribe((notification) => {
@@ -115,6 +116,46 @@ export class CourseNotificationPopupOverlayComponent implements OnInit, OnDestro
 
         // To avoid overlap with the overlayClicked function, we do this on the next tick
         setTimeout(() => {
+            this.isExpanded = false;
+        });
+    }
+
+    /**
+     * Clears all currently visible notifications and marks them as seen.
+     */
+    clearAllNotifications() {
+        if (!this.isExpanded) {
+            return;
+        }
+
+        const notificationCourseMap: Record<string, Array<CourseNotification>> = {};
+
+        this.notifications.forEach((notification) => {
+            if (!notificationCourseMap[notification.courseId!]) {
+                notificationCourseMap[notification.courseId!] = [notification];
+            } else {
+                notificationCourseMap[notification.courseId!].push(notification);
+            }
+        });
+
+        for (const courseId of Object.keys(notificationCourseMap)) {
+            const courseIdNumber = Number(courseId);
+            this.courseNotificationService.setNotificationStatus(
+                courseIdNumber,
+                notificationCourseMap[courseId].map((notification) => notification.notificationId!),
+                CourseNotificationViewingStatus.SEEN,
+            );
+            this.courseNotificationService.setNotificationStatusInMap(
+                courseIdNumber,
+                notificationCourseMap[courseId].map((notification) => notification.notificationId!),
+                CourseNotificationViewingStatus.SEEN,
+            );
+            this.courseNotificationService.decreaseNotificationCountBy(courseIdNumber, notificationCourseMap[courseId].length);
+        }
+
+        // To avoid overlap with the overlayClicked function, we do this on the next tick
+        setTimeout(() => {
+            this.notifications = [];
             this.isExpanded = false;
         });
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, to hide all notifications in the popup window, users need to click the "discard" icon one-by-one. This is tiring if there are many notifications.

### Description
<!-- Describe your changes in detail -->
I added a button to hide all currently seen notifications and mark them as seen.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 2 Students/Tutors/Instructors

1. Log in to Artemis with both users (for example by using the incognito window on one of them or 2 different browsers)
2. Navigate to course 
3. On one user, go to settings and enable the "All Activity" preset
4. Navigate to the communication tab on the other user
5. Write more than 2 messages in a channel that is not muted by the user with "All Activity" enabled
6. On the user that gets the notifications, click them at the bottom right to expand them
7. The "Trash" Icon should show, allowing you to hide all notifications
8. Click it and observe that all notifications are removed from the popup

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="464" alt="Bildschirmfoto 2025-05-08 um 10 30 51" src="https://github.com/user-attachments/assets/0f71ebf3-362c-49db-8398-cbff1903c772" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Clear All Notifications" button to the course notification popup overlay, allowing users to clear all notifications at once.

- **Bug Fixes**
  - Improved spacing between the collapse and clear buttons for better visual clarity.

- **Tests**
  - Added comprehensive tests to verify the new "Clear All Notifications" functionality and its interaction with the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->