### PR TITLE
`Communication`: Fix an issue in search for content and author 

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationMessageRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationMessageRepository.java
@@ -1,11 +1,10 @@
 package de.tum.cit.aet.artemis.communication.repository;
 
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getAnsweredOrReactedSpecification;
-import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getAuthorSpecification;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getConversationsSpecification;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getCourseWideChannelsSpecification;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getPinnedSpecification;
-import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getSearchTextSpecification;
+import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getSearchTextAndAuthorSpecification;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getSortSpecification;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getUnresolvedSpecification;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
@@ -53,9 +52,8 @@ public interface ConversationMessageRepository extends ArtemisJpaRepository<Post
     private Specification<Post> configureSearchSpecification(Specification<Post> specification, PostContextFilterDTO postContextFilter, long userId) {
         return specification
         // @formatter:off
-            .and(getSearchTextSpecification(postContextFilter.searchText()))
+            .and(getSearchTextAndAuthorSpecification(postContextFilter.searchText(), postContextFilter.authorIds()))
             .and(getCourseWideChannelsSpecification(Boolean.TRUE.equals(postContextFilter.filterToCourseWide()), postContextFilter.courseId()))
-            .and(getAuthorSpecification(postContextFilter.authorIds()))
             .and(getAnsweredOrReactedSpecification(Boolean.TRUE.equals(postContextFilter.filterToAnsweredOrReacted()), userId))
             .and(getUnresolvedSpecification(Boolean.TRUE.equals(postContextFilter.filterToUnresolved())))
             .and(getPinnedSpecification(Boolean.TRUE.equals(postContextFilter.pinnedOnly())))

--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/MessageSpecs.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/MessageSpecs.java
@@ -30,13 +30,41 @@ import de.tum.cit.aet.artemis.core.dto.SortingOrder;
 public class MessageSpecs {
 
     /**
-     * Specification to fetch Posts belonging to a Conversation
+     * Specification which filters Messages and answer posts according to a search string and a list of authors
+     * message and answer post are only kept if the search string (which is not a #id pattern) is included in the message content (all strings lowercased)
+     * and the author of the message or answer post is in the list of authors
      *
-     * @param conversationId id of the conversation the Posts belong to
+     * @param searchText Text to be searched within messages
+     * @param authorIds  ids of the authors
      * @return specification used to chain DB operations
      */
-    public static Specification<Post> getConversationSpecification(Long conversationId) {
-        return ((root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get(Post_.CONVERSATION).get(Conversation_.ID), conversationId));
+    public static Specification<Post> getSearchTextAndAuthorSpecification(String searchText, long[] authorIds) {
+        return (root, query, criteriaBuilder) -> {
+            boolean hasText = searchText != null && !searchText.isBlank();
+            boolean hasAuthors = authorIds != null && authorIds.length > 0;
+            if (!hasText && !hasAuthors) {
+                return null;
+            }
+            if (hasText && !hasAuthors) {
+                return getSearchTextSpecification(searchText).toPredicate(root, query, criteriaBuilder);
+            }
+            if (!hasText && hasAuthors) {
+                return getAuthorSpecification(authorIds).toPredicate(root, query, criteriaBuilder);
+            }
+
+            List<Long> authorIdList = Arrays.stream(authorIds).boxed().toList();
+            Expression<String> searchTextLiteral = criteriaBuilder.literal("%" + searchText.toLowerCase() + "%");
+            Predicate baseTextPredicate = criteriaBuilder.like(criteriaBuilder.lower(root.get(Post_.CONTENT)), searchTextLiteral);
+            Predicate baseAuthorPredicate = root.get(Post_.AUTHOR).get(User_.ID).in(authorIdList);
+            Predicate baseCombined = criteriaBuilder.and(baseTextPredicate, baseAuthorPredicate);
+
+            Join<Post, AnswerPost> answerJoin = root.join(Post_.ANSWERS, JoinType.LEFT);
+            Predicate answerTextPredicate = criteriaBuilder.like(criteriaBuilder.lower(answerJoin.get(AnswerPost_.CONTENT)), searchTextLiteral);
+            Predicate answerAuthorPredicate = answerJoin.get(AnswerPost_.AUTHOR).get(User_.ID).in(authorIdList);
+            Predicate answerCombined = criteriaBuilder.and(answerTextPredicate, answerAuthorPredicate);
+
+            return criteriaBuilder.or(baseCombined, answerCombined);
+        };
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -869,6 +869,47 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         assertThat(resultPosts).extracting(Post::getContent).contains("SearchTestGroup");
     }
 
+    @ParameterizedTest
+    @MethodSource("searchQueryAndAuthorProvider")
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testWhetherShouldIncludeBasePostWhenSearchingMessagesByContentAndAuthor(String searchQuery, String authorLogin, boolean shouldBeIncluded) throws Exception {
+        // Create base post by student1 with content "base"
+        Post basePost = createPostWithOneToOneChat(TEST_PREFIX);
+        basePost.setContent("base");
+        basePost = createPostAndAwaitAsyncCode(basePost);
+
+        // Add an answer from student2 with content "answer" to the base post
+        userUtilService.changeUser(TEST_PREFIX + "student2");
+        AnswerPost answer = new AnswerPost();
+        answer.setContent("answer");
+        answer.setPost(basePost);
+        createAnswerPostAndAwaitAsyncCode(answer);
+
+        // Use PostContextFilterDTO and conversationMessageRepository.findMessages
+        long conversationId = basePost.getConversation().getId();
+        long authorId = userTestRepository.findOneByLogin(authorLogin).orElseThrow().getId();
+        PostContextFilterDTO filter = new PostContextFilterDTO(courseId, null, new long[] { conversationId }, new long[] { authorId }, searchQuery, false, false, false,
+                PostSortCriterion.CREATION_DATE, SortingOrder.DESCENDING);
+        Page<Post> returnedPage = conversationMessageRepository.findMessages(filter, Pageable.unpaged(), 0L /* Not used here */);
+        List<Post> returnedPosts = returnedPage.getContent();
+
+        if (shouldBeIncluded) {
+            assertThat(returnedPosts).isNotEmpty();
+            assertThat(returnedPosts).extracting(Post::getContent).contains("base");
+        }
+        else {
+            assertThat(returnedPosts).isEmpty();
+        }
+    }
+
+    private static Stream<Arguments> searchQueryAndAuthorProvider() {
+        String baseAuthor = TEST_PREFIX + "student1";
+        String answerAuthor = TEST_PREFIX + "student2";
+
+        return Stream.of(Arguments.of("base", baseAuthor, true), Arguments.of("answer", answerAuthor, true), Arguments.of("base", answerAuthor, false),
+                Arguments.of("answer", baseAuthor, false));
+    }
+
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void shouldSendCourseNotificationForNewPostWhenFeatureIsEnabled() throws Exception {
@@ -1001,6 +1042,16 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
      */
     private Post createPostAndAwaitAsyncCode(Post postToSave) throws Exception {
         return request.postWithResponseBody("/api/communication/courses/" + courseId + "/messages", postToSave, Post.class, HttpStatus.CREATED);
+    }
+
+    /**
+     * Calls the POST /answer-messages endpoint to create a new answer post
+     *
+     * @param answerPostToSave answer post to save in the database
+     * @return saved answer post
+     */
+    private AnswerPost createAnswerPostAndAwaitAsyncCode(AnswerPost answerPostToSave) throws Exception {
+        return request.postWithResponseBody("/api/communication/courses/" + courseId + "/answer-messages", answerPostToSave, AnswerPost.class, HttpStatus.CREATED);
     }
 
     private static List<CourseInformationSharingConfiguration> courseInformationSharingConfigurationProvider() {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With the newly introduced author search, there was a bug discovered when search for both an author and a searchText query.

This PR fixes #10796.

### Description
<!-- Describe your changes in detail -->
- Fix the bug
- Add integration tests

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student

1. Log in to Artemis
2. Go to any chat with a post by another user (PostA) and write a answer to that post (PostB)
3. In the search bar type "from:me" and search for PostA content -> see PostA is not in search results
4. Search for the author or PostA "from:test_user_...." and search PostB -> PostB is not in search results
5. Verify that the rest of the search still works as expected

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message search functionality to support filtering by both message content and author.
- **Tests**
	- Added comprehensive tests to verify correct inclusion of messages when searching by content and author.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->