### PR TITLE
`Development`: Adjust assetlinks.json for Android passkeys

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
@@ -26,8 +26,11 @@ public class AndroidAppSiteAssociationResource {
     @Value("${artemis.androidAppPackage: #{null}}")
     private String androidAppPackage;
 
-    @Value("${artemis.androidSha256CertFingerprints: #{null}}")
-    private String sha256CertFingerprints;
+    @Value("${artemis.androidSha256CertFingerprints.release: #{null}}")
+    private String sha256CertFingerprintRelease;
+
+    @Value("${artemis.androidSha256CertFingerprints.debug: #{null}}")
+    private String sha256CertFingerprintDebug;
 
     private static final Logger log = LoggerFactory.getLogger(AndroidAppSiteAssociationResource.class);
 
@@ -40,18 +43,18 @@ public class AndroidAppSiteAssociationResource {
     @GetMapping(value = "assetlinks.json", produces = "application/json")
     @ManualConfig
     public ResponseEntity<List<AndroidAssetLinksEntry>> getAndroidAssetLinks() {
-        if (androidAppPackage == null || androidAppPackage.length() < 4 || sha256CertFingerprints == null || sha256CertFingerprints.length() < 20) {
+        if (androidAppPackage == null || androidAppPackage.length() < 4 || sha256CertFingerprintRelease == null || sha256CertFingerprintRelease.length() < 20) {
             log.debug("Android Assetlinks information is not configured!");
             return ResponseEntity.notFound().build();
         }
 
-        final AndroidAssetLinksEntry.AndroidTarget appTarget = new AndroidAssetLinksEntry.AndroidTarget("android_app", androidAppPackage, List.of(sha256CertFingerprints));
+        final AndroidAssetLinksEntry.AndroidTarget appTarget = new AndroidAssetLinksEntry.AndroidTarget("android_app", androidAppPackage,
+                List.of(sha256CertFingerprintRelease, sha256CertFingerprintDebug));
 
-        final AndroidAssetLinksEntry handleAllUrls = new AndroidAssetLinksEntry(List.of("delegate_permission/common.handle_all_urls"), appTarget);
+        final AndroidAssetLinksEntry handleAllUrlsAndCreds = new AndroidAssetLinksEntry(
+                List.of("delegate_permission/common.handle_all_urls", "delegate_permission/common.get_login_creds"), appTarget);
 
-        final AndroidAssetLinksEntry getLoginCredentials = new AndroidAssetLinksEntry(List.of("delegate_permission/common.get_login_creds"), appTarget);
-
-        return ResponseEntity.ok(List.of(handleAllUrls, getLoginCredentials));
+        return ResponseEntity.ok(List.of(handleAllUrlsAndCreds));
     }
 
     public record AndroidAssetLinksEntry(List<String> relation, AndroidTarget target) {

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.communication.web;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -46,13 +47,18 @@ public class AndroidAppSiteAssociationResource {
     @GetMapping(value = "assetlinks.json", produces = "application/json")
     @ManualConfig
     public ResponseEntity<List<AndroidAssetLinksStatement>> getAndroidAssetLinks() {
-        if (androidAppPackage == null || androidAppPackage.length() < 4 || sha256CertFingerprintRelease == null || sha256CertFingerprintRelease.length() < 20) {
+        if (androidAppPackage == null || androidAppPackage.length() < 4 || sha256CertFingerprintRelease == null || sha256CertFingerprintRelease.length() < 20
+        // The debug fingerprint is optional, so we don't check it
+        ) {
             log.debug("Android Assetlinks information is not configured!");
             return ResponseEntity.notFound().build();
         }
 
-        final AndroidAssetLinksStatement.AndroidTarget appTarget = new AndroidAssetLinksStatement.AndroidTarget("android_app", androidAppPackage,
-                List.of(sha256CertFingerprintRelease, sha256CertFingerprintDebug));
+        List<String> fingerprints = new ArrayList<>(List.of(sha256CertFingerprintRelease));
+        if (sha256CertFingerprintDebug != null) {
+            fingerprints.add(sha256CertFingerprintDebug);
+        }
+        final AndroidAssetLinksStatement.AndroidTarget appTarget = new AndroidAssetLinksStatement.AndroidTarget("android_app", androidAppPackage, fingerprints);
 
         final AndroidAssetLinksStatement.WebTarget webTarget = new AndroidAssetLinksStatement.WebTarget("web", artemisServerUrl);
 

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
@@ -23,6 +23,9 @@ import de.tum.cit.aet.artemis.core.security.annotations.ManualConfig;
 @RequestMapping(".well-known/") // Intentionally not prefixed with "communication"
 public class AndroidAppSiteAssociationResource {
 
+    @Value("${server.url}")
+    private String artemisServerUrl;
+
     @Value("${artemis.androidAppPackage: #{null}}")
     private String androidAppPackage;
 
@@ -51,7 +54,7 @@ public class AndroidAppSiteAssociationResource {
         final AndroidAssetLinksStatement.AndroidTarget appTarget = new AndroidAssetLinksStatement.AndroidTarget("android_app", androidAppPackage,
                 List.of(sha256CertFingerprintRelease, sha256CertFingerprintDebug));
 
-        final AndroidAssetLinksStatement.WebTarget webTarget = new AndroidAssetLinksStatement.WebTarget("web", "https://artemis.tum.de");
+        final AndroidAssetLinksStatement.WebTarget webTarget = new AndroidAssetLinksStatement.WebTarget("web", artemisServerUrl);
 
         final List<String> relations = List.of("delegate_permission/common.handle_all_urls", "delegate_permission/common.get_login_creds");
 

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -316,7 +316,7 @@ public class SecurityConfiguration {
                 publicKeyCredentialCreationOptionsRepository,
                 publicKeyCredentialRequestOptionsRepository
             );
-            var androidAppRelease = "android:apk-key-hash:fqGKBkDrSPLF-n_CrKmrhX7EdfQx8jzBWtWwE4f-NDE";
+            var androidAppRelease = "android:apk-key-hash:0uGmb4wAVZefMC89ealdeIUfxSFaf4Gzv2Aice9vYCQ";
             var androidAppDebug = "android:apk-key-hash:f8uZdBkwFUuGS4pzsAmUUhn2vZBqfBaxdjevdLFIO2w";
             http.with(webAuthnConfigurer, configurer -> {
                 configurer

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -6,8 +6,10 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import jakarta.annotation.PostConstruct;
 
@@ -56,6 +58,7 @@ import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
 import de.tum.cit.aet.artemis.core.security.passkey.ArtemisWebAuthnConfigurer;
 import de.tum.cit.aet.artemis.core.service.ProfileService;
 import de.tum.cit.aet.artemis.core.service.user.PasswordService;
+import de.tum.cit.aet.artemis.core.util.AndroidApkKeyHashUtil;
 import de.tum.cit.aet.artemis.lti.config.CustomLti13Configurer;
 
 @Configuration
@@ -102,6 +105,12 @@ public class SecurityConfiguration {
 
     @Value("${client.port:${server.port}}")
     private String port;
+
+    @Value("${artemis.androidSha256CertFingerprints.release: #{null}}")
+    private String androidSha256CertFingerprintRelease;
+
+    @Value("${artemis.androidSha256CertFingerprints.debug: #{null}}")
+    private String androidSha256CertFingerprintDebug;
 
     private URL clientUrlToRegisterPasskey;
 
@@ -316,11 +325,16 @@ public class SecurityConfiguration {
                 publicKeyCredentialCreationOptionsRepository,
                 publicKeyCredentialRequestOptionsRepository
             );
-            var androidAppRelease = "android:apk-key-hash:0uGmb4wAVZefMC89ealdeIUfxSFaf4Gzv2Aice9vYCQ";
-            var androidAppDebug = "android:apk-key-hash:f8uZdBkwFUuGS4pzsAmUUhn2vZBqfBaxdjevdLFIO2w";
+            Set<String> allowedOrigins = new HashSet<>(Set.of(clientUrlToRegisterPasskey.toString(), clientUrlToAuthenticateWithPasskey.toString()));
+            if (androidSha256CertFingerprintRelease != null) {
+                allowedOrigins.add(AndroidApkKeyHashUtil.getHashFromFingerprint(androidSha256CertFingerprintRelease));
+            }
+            if (androidSha256CertFingerprintDebug != null) {
+                allowedOrigins.add(AndroidApkKeyHashUtil.getHashFromFingerprint(androidSha256CertFingerprintDebug));
+            }
             http.with(webAuthnConfigurer, configurer -> {
                 configurer
-                    .allowedOrigins(clientUrlToRegisterPasskey.toString(), clientUrlToAuthenticateWithPasskey.toString(), androidAppRelease, androidAppDebug)
+                    .allowedOrigins(allowedOrigins)
                     .rpId(clientUrlToRegisterPasskey.getHost())
                     .rpName("Artemis");
             });

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -316,9 +316,11 @@ public class SecurityConfiguration {
                 publicKeyCredentialCreationOptionsRepository,
                 publicKeyCredentialRequestOptionsRepository
             );
+            var androidAppRelease = "android:apk-key-hash:fqGKBkDrSPLF-n_CrKmrhX7EdfQx8jzBWtWwE4f-NDE";
+            var androidAppDebug = "android:apk-key-hash:f8uZdBkwFUuGS4pzsAmUUhn2vZBqfBaxdjevdLFIO2w";
             http.with(webAuthnConfigurer, configurer -> {
                 configurer
-                    .allowedOrigins(clientUrlToRegisterPasskey.toString(), clientUrlToAuthenticateWithPasskey.toString())
+                    .allowedOrigins(clientUrlToRegisterPasskey.toString(), clientUrlToAuthenticateWithPasskey.toString(), androidAppRelease, androidAppDebug)
                     .rpId(clientUrlToRegisterPasskey.getHost())
                     .rpName("Artemis");
             });

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/AndroidApkKeyHashUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/AndroidApkKeyHashUtil.java
@@ -1,0 +1,26 @@
+package de.tum.cit.aet.artemis.core.util;
+
+public class AndroidApkKeyHashUtil {
+
+    /**
+     * Generates the Android APK key hash from the provided SHA-256 certificate fingerprint.
+     * See <a href="https://developer.android.com/identity/sign-in/credential-manager#verify-origin">this section in the Android passkey documentation</a>
+     *
+     * @param fingerprint The SHA-256 certificate fingerprint in hexadecimal format.
+     * @return The Android APK key hash in the format "android:apk-key-hash:<base64-encoded-hash>".
+     */
+    public static String getHashFromFingerprint(String fingerprint) {
+        // Remove all colons from the fingerprint
+        String noColon = fingerprint.replace(":", "");
+        int len = noColon.length();
+        byte[] bytes = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            bytes[i / 2] = (byte) ((Character.digit(noColon.charAt(i), 16) << 4) + Character.digit(noColon.charAt(i + 1), 16));
+        }
+
+        // Use the URL-safe Base64 encoder without padding
+        String encoded = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        return "android:apk-key-hash:" + encoded;
+    }
+
+}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -39,7 +39,9 @@ artemis:
         batch-waiting-time: 30000   # in ms = 30s
     iosAppId: "T7PP2KY2B6.de.tum.cit.ase.artemis"
     androidAppPackage: "de.tum.cit.aet.artemis"
-    androidSha256CertFingerprints: "D2:E1:A6:6F:8C:00:55:97:9F:30:2F:3D:79:A9:5D:78:85:1F:C5:21:5A:7F:81:B3:BF:60:22:71:EF:6F:60:24"
+    androidSha256CertFingerprints:
+      release: "D2:E1:A6:6F:8C:00:55:97:9F:30:2F:3D:79:A9:5D:78:85:1F:C5:21:5A:7F:81:B3:BF:60:22:71:EF:6F:60:24"
+      debug: "7F:CB:99:74:19:30:15:4B:86:4B:8A:73:B0:09:94:52:19:F6:BD:90:6A:7C:16:B1:76:37:AF:74:B1:48:3B:6C"
 
     # activate the following line if you want to support push notifications for the mobile clients.
     # More information about the TUM hosted hermes service can be found here: https://github.com/ls1intum/Hermes

--- a/src/test/java/de/tum/cit/aet/artemis/core/AndroidAppSiteAssociationResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/AndroidAppSiteAssociationResourceTest.java
@@ -17,13 +17,13 @@ class AndroidAppSiteAssociationResourceTest extends AbstractSpringIntegrationInd
 
     @Test
     void testGetAndroidAssetLinks() {
-        List<AndroidAppSiteAssociationResource.AndroidAssetLinksEntry> androidAssetLinksEntry = androidAppSiteAssociationResource.getAndroidAssetLinks().getBody();
+        List<AndroidAppSiteAssociationResource.AndroidAssetLinksStatement> androidAssetLinksStatement = androidAppSiteAssociationResource.getAndroidAssetLinks().getBody();
 
-        assertThat(androidAssetLinksEntry).hasSize(2);
-        assertThat(androidAssetLinksEntry.getFirst().relation().getFirst()).isEqualTo("delegate_permission/common.handle_all_urls");
-        assertThat(androidAssetLinksEntry.getFirst().target().package_name()).isEqualTo("de.tum.cit.aet.artemis");
-        assertThat(androidAssetLinksEntry.get(1).relation().getFirst()).isEqualTo("delegate_permission/common.get_login_creds");
-        assertThat(androidAssetLinksEntry.get(1).target().package_name()).isEqualTo("de.tum.cit.aet.artemis");
+        assertThat(androidAssetLinksStatement).hasSize(2);
+        assertThat(androidAssetLinksStatement.getFirst().relation().getFirst()).isEqualTo("delegate_permission/common.handle_all_urls");
+        assertThat(androidAssetLinksStatement.getFirst().target().package_name()).isEqualTo("de.tum.cit.aet.artemis");
+        assertThat(androidAssetLinksStatement.get(1).relation().getFirst()).isEqualTo("delegate_permission/common.get_login_creds");
+        assertThat(androidAssetLinksStatement.get(1).target().package_name()).isEqualTo("de.tum.cit.aet.artemis");
     }
 
 }

--- a/src/test/java/de/tum/cit/aet/artemis/core/AndroidAppSiteAssociationResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/AndroidAppSiteAssociationResourceTest.java
@@ -20,10 +20,18 @@ class AndroidAppSiteAssociationResourceTest extends AbstractSpringIntegrationInd
         List<AndroidAppSiteAssociationResource.AndroidAssetLinksStatement> androidAssetLinksStatement = androidAppSiteAssociationResource.getAndroidAssetLinks().getBody();
 
         assertThat(androidAssetLinksStatement).hasSize(2);
-        assertThat(androidAssetLinksStatement.getFirst().relation().getFirst()).isEqualTo("delegate_permission/common.handle_all_urls");
-        assertThat(androidAssetLinksStatement.getFirst().target().package_name()).isEqualTo("de.tum.cit.aet.artemis");
-        assertThat(androidAssetLinksStatement.get(1).relation().getFirst()).isEqualTo("delegate_permission/common.get_login_creds");
-        assertThat(androidAssetLinksStatement.get(1).target().package_name()).isEqualTo("de.tum.cit.aet.artemis");
+        var androidStatement = androidAssetLinksStatement.getFirst();
+        assertThat(androidStatement.relation().getFirst()).isEqualTo("delegate_permission/common.handle_all_urls");
+        assertThat(androidStatement.relation().get(1)).isEqualTo("delegate_permission/common.get_login_creds");
+        var androidTarget = androidStatement.target();
+        assertThat(androidTarget).isInstanceOf(AndroidAppSiteAssociationResource.AndroidAssetLinksStatement.AndroidTarget.class);
+        assertThat(((AndroidAppSiteAssociationResource.AndroidAssetLinksStatement.AndroidTarget) androidTarget).package_name()).isEqualTo("de.tum.cit.aet.artemis");
+
+        var webStatement = androidAssetLinksStatement.get(1);
+        assertThat(webStatement.relation().getFirst()).isEqualTo("delegate_permission/common.handle_all_urls");
+        assertThat(webStatement.relation().get(1)).isEqualTo("delegate_permission/common.get_login_creds");
+        var webTarget = webStatement.target();
+        assertThat(webTarget).isInstanceOf(AndroidAppSiteAssociationResource.AndroidAssetLinksStatement.WebTarget.class);
     }
 
 }

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/AndroidApkKeyHashUtilTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/AndroidApkKeyHashUtilTest.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.artemis.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class AndroidApkKeyHashUtilTest {
+
+    @Test
+    void getHashFromFingerprint() {
+        String fingerprint = "D2:E1:A6:6F:8C:00:55:97:9F:30:2F:3D:79:A9:5D:78:85:1F:C5:21:5A:7F:81:B3:BF:60:22:71:EF:6F:60:24";
+        String expectedHash = "android:apk-key-hash:0uGmb4wAVZefMC89ealdeIUfxSFaf4Gzv2Aice9vYCQ";
+
+        String actualHash = AndroidApkKeyHashUtil.getHashFromFingerprint(fingerprint);
+        assertEquals(expectedHash, actualHash);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/AndroidApkKeyHashUtilTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/AndroidApkKeyHashUtilTest.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.artemis.core.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +12,6 @@ class AndroidApkKeyHashUtilTest {
         String expectedHash = "android:apk-key-hash:0uGmb4wAVZefMC89ealdeIUfxSFaf4Gzv2Aice9vYCQ";
 
         String actualHash = AndroidApkKeyHashUtil.getHashFromFingerprint(fingerprint);
-        assertEquals(expectedHash, actualHash);
+        assertThat(actualHash).isEqualTo(expectedHash);
     }
 }

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -25,7 +25,9 @@ artemis:
         batch-waiting-time: 5   # 5ms (make the tests faster)
     iosAppId: "2J3C6P6X3N.de.tum.cit.artemis"
     androidAppPackage: "de.tum.cit.aet.artemis"
-    androidSha256CertFingerprints: "D2:E1:A6:6F:8C:00:55:97:9F:30:2F:3D:79:A9:5D:78:85:1F:C5:21:5A:7F:81:B3:BF:60:22:71:EF:6F:60:24"
+    androidSha256CertFingerprints:
+        release: "D2:E1:A6:6F:8C:00:55:97:9F:30:2F:3D:79:A9:5D:78:85:1F:C5:21:5A:7F:81:B3:BF:60:22:71:EF:6F:60:24"
+        debug: "7F:CB:99:74:19:30:15:4B:86:4B:8A:73:B0:09:94:52:19:F6:BD:90:6A:7C:16:B1:76:37:AF:74:B1:48:3B:6C"
 
     push-notification-relay: https://hermes-sandbox.artemis.cit.tum.de
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
For adding passkey support for Android, we need to adjust the assetlinks.json file and add the apkKeyHash to the allowed origins for the passkey operations. 
To make the passkey creation work the with the debug build of the Android application (needed to test the app in development), I additionally added the fingerprint of the debug keystore. 

### Description
<!-- Describe your changes in detail -->
Adjusted the `assetlinks.json` file and the allowedOrigins.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
1. Deploy this PR to a test server
2. Go to https://developers.google.com/digital-asset-links/tools/generator and fill in the following information:
- Relation type: Credential Sharing
- Hosting site domain: `artemis-test<x>.artemis.cit.tum.de`
- App package name: `de.tum.cit.aet.artemis`
- App package fingerprint: `D2:E1:A6:6F:8C:00:55:97:9F:30:2F:3D:79:A9:5D:78:85:1F:C5:21:5A:7F:81:B3:BF:60:22:71:EF:6F:60:24`
3. Click "Test statement"
4. The result should look like the following: (the first entry should be success, the second one is still error, because we need to make an android release for that)
![Image](https://github.com/user-attachments/assets/c3ca2e12-bf8a-4e10-90b4-2f5f8879694e)
5. Also check with this fingerprint: `7F:CB:99:74:19:30:15:4B:86:4B:8A:73:B0:09:94:52:19:F6:BD:90:6A:7C:16:B1:76:37:AF:74:B1:48:3B:6C`

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.
#### Code Tests
- [x] Test 1
- [x] Test 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Support for separate Android certificate fingerprints for release and debug builds.
	- Android app association response now includes both app and web targets with enhanced relation support.
- **Improvements**
	- Enhanced configuration options for Android certificate fingerprints.
	- Expanded allowed origins for authentication to include Android APK key hashes.
- **Bug Fixes**
	- Improved validation and handling of certificate fingerprints in Android app association.
- **Tests**
	- Added and updated tests to cover new utility methods and updated Android app association response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->