### PR TITLE
`Development`: Make passkey setup optional after login for users

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/UserDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/UserDTO.java
@@ -72,9 +72,14 @@ public class UserDTO extends AuditingEntityDTO {
     private ZonedDateTime vcsAccessTokenExpiryDate;
 
     /**
-     * True if at least one passkey has been registered for this user.
+     * True if
+     * <ul>
+     * <li>No passkey has been registered for this user yet</li>
+     * <li>and the passkey feature is enabled</li>
+     * <li>and <code>artemis.user-settings.passkey.ask-to-setup</code> is set to true</li>
+     * </ul>
      */
-    private boolean hasRegisteredAPasskey = false;
+    private boolean askToSetupPasskey = false;
 
     private ZonedDateTime externalLLMUsageAccepted;
 
@@ -240,12 +245,12 @@ public class UserDTO extends AuditingEntityDTO {
         return vcsAccessTokenExpiryDate;
     }
 
-    public void setHasRegisteredAPasskey(boolean hasCreatedPasskeys) {
-        this.hasRegisteredAPasskey = hasCreatedPasskeys;
+    public void setAskToSetupPasskey(boolean hasCreatedPasskeys) {
+        this.askToSetupPasskey = hasCreatedPasskeys;
     }
 
-    public boolean getHasRegisteredAPasskey() {
-        return hasRegisteredAPasskey;
+    public boolean getAskToSetupPasskey() {
+        return askToSetupPasskey;
     }
 
     @Override

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/UserDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/UserDTO.java
@@ -76,7 +76,7 @@ public class UserDTO extends AuditingEntityDTO {
      * <ul>
      * <li>No passkey has been registered for this user yet</li>
      * <li>and the passkey feature is enabled</li>
-     * <li>and <code>artemis.user-settings.passkey.ask-to-setup</code> is set to true</li>
+     * <li>and <code>artemis.user-management.passkey.ask-users-to-setup</code> is set to true</li>
      * </ul>
      */
     private boolean askToSetupPasskey = false;

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/UserDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/UserDTO.java
@@ -245,8 +245,8 @@ public class UserDTO extends AuditingEntityDTO {
         return vcsAccessTokenExpiryDate;
     }
 
-    public void setAskToSetupPasskey(boolean hasCreatedPasskeys) {
-        this.askToSetupPasskey = hasCreatedPasskeys;
+    public void setAskToSetupPasskey(boolean askToSetupPasskey) {
+        this.askToSetupPasskey = askToSetupPasskey;
     }
 
     public boolean getAskToSetupPasskey() {

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicAccountResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicAccountResource.java
@@ -171,7 +171,7 @@ public class PublicAccountResource {
         User user = userOptional.get();
         boolean askToSetupPasskey = false;
         if (askUsersToSetupPasskey) {
-            askToSetupPasskey = this.passkeyCredentialsRepository.existsByUserId(user.getId());
+            askToSetupPasskey = !this.passkeyCredentialsRepository.existsByUserId(user.getId());
         }
         user.setVisibleRegistrationNumber();
         UserDTO userDTO = new UserDTO(user);

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicAccountResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicAccountResource.java
@@ -57,7 +57,7 @@ public class PublicAccountResource {
     @Value("${artemis.user-management.registration.allowed-email-pattern:#{null}}")
     private Optional<Pattern> allowedEmailPattern;
 
-    @Value("${artemis.user-management.passkey.ask-users-to-setup:false}")
+    @Value("${artemis.user-management.passkey.ask-users-to-setup:true}")
     private boolean askUsersToSetupPasskey;
 
     private final AccountService accountService;

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicAccountResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicAccountResource.java
@@ -169,16 +169,16 @@ public class PublicAccountResource {
         }
 
         User user = userOptional.get();
-        boolean askToSetupPasskey = false;
+        boolean shouldPromptUserToSetupPasskey = false;
         if (askUsersToSetupPasskey) {
-            askToSetupPasskey = !this.passkeyCredentialsRepository.existsByUserId(user.getId());
+            shouldPromptUserToSetupPasskey = !this.passkeyCredentialsRepository.existsByUserId(user.getId());
         }
         user.setVisibleRegistrationNumber();
         UserDTO userDTO = new UserDTO(user);
         // we set this value on purpose here: the user can only fetch their own information, make the token available for constructing the token-based clone-URL
         userDTO.setVcsAccessToken(user.getVcsAccessToken());
         userDTO.setVcsAccessTokenExpiryDate(user.getVcsAccessTokenExpiryDate());
-        userDTO.setAskToSetupPasskey(askToSetupPasskey);
+        userDTO.setAskToSetupPasskey(shouldPromptUserToSetupPasskey);
         log.debug("GET /account {} took {}ms", user.getLogin(), System.currentTimeMillis() - start);
         return ResponseEntity.ok(userDTO);
     }

--- a/src/main/resources/config/application-core.yml
+++ b/src/main/resources/config/application-core.yml
@@ -12,6 +12,7 @@ artemis:
     user-management:
         passkey:
             enabled: false # used by Constants.PASSKEY_ENABLED_PROPERTY_NAME
+            ask-users-to-setup: true # if true, users who have not set up a passkey will be asked to do so
 
 spring:
     liquibase:

--- a/src/main/webapp/app/core/home/home.component.spec.ts
+++ b/src/main/webapp/app/core/home/home.component.spec.ts
@@ -154,7 +154,7 @@ describe('HomeComponent', () => {
         it('should not open the modal if the user has already registered a passkey', () => {
             component.isPasskeyEnabled = true;
             const openModalSpy = jest.spyOn(modalService, 'open');
-            accountService.userIdentity = { hasRegisteredAPasskey: true } as any;
+            accountService.userIdentity = { askToSetupPasskey: true } as any;
 
             component.openSetupPasskeyModal();
 

--- a/src/main/webapp/app/core/home/home.component.spec.ts
+++ b/src/main/webapp/app/core/home/home.component.spec.ts
@@ -144,7 +144,7 @@ describe('HomeComponent', () => {
         it('should not open the modal if passkey feature is disabled', () => {
             component.isPasskeyEnabled = false;
             const openModalSpy = jest.spyOn(modalService, 'open');
-            accountService.userIdentity = { hasRegisteredAPasskey: false } as any;
+            accountService.userIdentity = { askToSetupPasskey: true } as any;
 
             component.openSetupPasskeyModal();
 
@@ -154,7 +154,7 @@ describe('HomeComponent', () => {
         it('should not open the modal if the user has already registered a passkey', () => {
             component.isPasskeyEnabled = true;
             const openModalSpy = jest.spyOn(modalService, 'open');
-            accountService.userIdentity = { askToSetupPasskey: true } as any;
+            accountService.userIdentity = { askToSetupPasskey: false } as any;
 
             component.openSetupPasskeyModal();
 
@@ -165,7 +165,7 @@ describe('HomeComponent', () => {
             component.isPasskeyEnabled = true;
             const openModalSpy = jest.spyOn(modalService, 'open');
 
-            accountService.userIdentity = { hasRegisteredAPasskey: false } as any;
+            accountService.userIdentity = { askToSetupPasskey: true } as any;
 
             component.openSetupPasskeyModal();
 
@@ -178,7 +178,7 @@ describe('HomeComponent', () => {
             futureDate.setDate(futureDate.getDate() + 1);
             localStorage.setItem(EARLIEST_SETUP_PASSKEY_REMINDER_DATE_LOCAL_STORAGE_KEY, futureDate.toISOString());
 
-            accountService.userIdentity = { hasRegisteredAPasskey: false } as any;
+            accountService.userIdentity = { askToSetupPasskey: true } as any;
             const openModalSpy = jest.spyOn(modalService, 'open');
 
             component.openSetupPasskeyModal();
@@ -192,7 +192,7 @@ describe('HomeComponent', () => {
             dateInPast.setDate(dateInPast.getDate() - 10);
             localStorage.setItem(EARLIEST_SETUP_PASSKEY_REMINDER_DATE_LOCAL_STORAGE_KEY, dateInPast.toISOString());
 
-            accountService.userIdentity = { hasRegisteredAPasskey: false } as any;
+            accountService.userIdentity = { askToSetupPasskey: true } as any;
             const openModalSpy = jest.spyOn(modalService, 'open');
 
             component.openSetupPasskeyModal();

--- a/src/main/webapp/app/core/home/home.component.spec.ts
+++ b/src/main/webapp/app/core/home/home.component.spec.ts
@@ -23,6 +23,7 @@ import { of } from 'rxjs';
 import { MockRouter } from 'test/helpers/mocks/mock-router';
 import { EARLIEST_SETUP_PASSKEY_REMINDER_DATE_LOCAL_STORAGE_KEY, SetupPasskeyModalComponent } from 'app/core/course/overview/setup-passkey-modal/setup-passkey-modal.component';
 import { MockNgbModalService } from 'test/helpers/mocks/service/mock-ngb-modal.service';
+import { User } from 'app/core/user/user.model';
 
 describe('HomeComponent', () => {
     let component: HomeComponent;
@@ -144,7 +145,7 @@ describe('HomeComponent', () => {
         it('should not open the modal if passkey feature is disabled', () => {
             component.isPasskeyEnabled = false;
             const openModalSpy = jest.spyOn(modalService, 'open');
-            accountService.userIdentity = { askToSetupPasskey: true } as any;
+            accountService.userIdentity = { askToSetupPasskey: true } as User;
 
             component.openSetupPasskeyModal();
 
@@ -154,7 +155,7 @@ describe('HomeComponent', () => {
         it('should not open the modal if the user has already registered a passkey', () => {
             component.isPasskeyEnabled = true;
             const openModalSpy = jest.spyOn(modalService, 'open');
-            accountService.userIdentity = { askToSetupPasskey: false } as any;
+            accountService.userIdentity = { askToSetupPasskey: false } as User;
 
             component.openSetupPasskeyModal();
 
@@ -165,7 +166,7 @@ describe('HomeComponent', () => {
             component.isPasskeyEnabled = true;
             const openModalSpy = jest.spyOn(modalService, 'open');
 
-            accountService.userIdentity = { askToSetupPasskey: true } as any;
+            accountService.userIdentity = { askToSetupPasskey: true } as User;
 
             component.openSetupPasskeyModal();
 
@@ -178,7 +179,7 @@ describe('HomeComponent', () => {
             futureDate.setDate(futureDate.getDate() + 1);
             localStorage.setItem(EARLIEST_SETUP_PASSKEY_REMINDER_DATE_LOCAL_STORAGE_KEY, futureDate.toISOString());
 
-            accountService.userIdentity = { askToSetupPasskey: true } as any;
+            accountService.userIdentity = { askToSetupPasskey: true } as User;
             const openModalSpy = jest.spyOn(modalService, 'open');
 
             component.openSetupPasskeyModal();
@@ -192,7 +193,7 @@ describe('HomeComponent', () => {
             dateInPast.setDate(dateInPast.getDate() - 10);
             localStorage.setItem(EARLIEST_SETUP_PASSKEY_REMINDER_DATE_LOCAL_STORAGE_KEY, dateInPast.toISOString());
 
-            accountService.userIdentity = { askToSetupPasskey: true } as any;
+            accountService.userIdentity = { askToSetupPasskey: true } as User;
             const openModalSpy = jest.spyOn(modalService, 'open');
 
             component.openSetupPasskeyModal();

--- a/src/main/webapp/app/core/home/home.component.ts
+++ b/src/main/webapp/app/core/home/home.component.ts
@@ -105,7 +105,7 @@ export class HomeComponent implements OnInit, AfterViewChecked {
             return;
         }
 
-        if (this.accountService.userIdentity?.askToSetupPasskey) {
+        if (!this.accountService.userIdentity?.askToSetupPasskey) {
             return;
         }
 

--- a/src/main/webapp/app/core/home/home.component.ts
+++ b/src/main/webapp/app/core/home/home.component.ts
@@ -105,7 +105,7 @@ export class HomeComponent implements OnInit, AfterViewChecked {
             return;
         }
 
-        if (this.accountService.userIdentity?.hasRegisteredAPasskey) {
+        if (this.accountService.userIdentity?.askToSetupPasskey) {
             return;
         }
 

--- a/src/main/webapp/app/core/user/user.model.ts
+++ b/src/main/webapp/app/core/user/user.model.ts
@@ -20,7 +20,7 @@ export class User extends Account {
      * <ul>
      * <li>No passkey has been registered for this user yet</li>
      * <li>and the passkey feature is enabled</li>
-     * <li>and <code>artemis.user-settings.passkey.ask-to-setup</code> is set to true</li>
+     * <li>and <code>artemis.user-management.passkey.ask-users-to-setup</code> is set to true</li>
      * </ul>
      */
     public askToSetupPasskey?: boolean;

--- a/src/main/webapp/app/core/user/user.model.ts
+++ b/src/main/webapp/app/core/user/user.model.ts
@@ -16,9 +16,14 @@ export class User extends Account {
     public vcsAccessTokenExpiryDate?: string;
     public externalLLMUsageAccepted?: dayjs.Dayjs;
     /**
-     * true if at least one passkey is registered for this user
+     * True if
+     * <ul>
+     * <li>No passkey has been registered for this user yet</li>
+     * <li>and the passkey feature is enabled</li>
+     * <li>and <code>artemis.user-settings.passkey.ask-to-setup</code> is set to true</li>
+     * </ul>
      */
-    public hasRegisteredAPasskey?: boolean;
+    public askToSetupPasskey?: boolean;
 
     constructor(
         id?: number,
@@ -39,7 +44,7 @@ export class User extends Account {
         vcsAccessToken?: string,
         vcsAccessTokenExpiryDate?: string,
         externalLLMUsageAccepted?: dayjs.Dayjs,
-        hasRegisteredAPasskey?: boolean,
+        askToSetupPasskey?: boolean,
     ) {
         super(activated, authorities, email, firstName, langKey, lastName, login, imageUrl);
         this.id = id;
@@ -52,7 +57,7 @@ export class User extends Account {
         this.vcsAccessToken = vcsAccessToken;
         this.vcsAccessTokenExpiryDate = vcsAccessTokenExpiryDate;
         this.externalLLMUsageAccepted = externalLLMUsageAccepted;
-        this.hasRegisteredAPasskey = hasRegisteredAPasskey;
+        this.askToSetupPasskey = askToSetupPasskey;
     }
 }
 /**

--- a/src/test/java/de/tum/cit/aet/artemis/core/user/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/user/AccountResourceIntegrationTest.java
@@ -230,7 +230,7 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
         userUtilService.createAndSaveUser(AUTHENTICATEDUSER);
         UserDTO account = request.get("/api/core/public/account", HttpStatus.OK, UserDTO.class);
         assertThat(account).isNotNull();
-        assertThat(account.getHasRegisteredAPasskey()).isFalse();
+        assertThat(account.getAskToSetupPasskey()).isFalse();
     }
 
     @Test
@@ -242,7 +242,7 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
         UserDTO account = request.get("/api/core/public/account", HttpStatus.OK, UserDTO.class);
 
         assertThat(account).isNotNull();
-        assertThat(account.getHasRegisteredAPasskey()).isTrue();
+        assertThat(account.getAskToSetupPasskey()).isTrue();
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/core/user/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/user/AccountResourceIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.cit.aet.artemis.core.config.Constants;
@@ -243,6 +244,32 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
 
         assertThat(account).isNotNull();
         assertThat(account.getAskToSetupPasskey()).isTrue();
+    }
+
+    /**
+     * <p>
+     * Reflects the case when the configuration property
+     * <code>artemis.user-management.passkey.ask-to-setup</code> is set to <strong>false</strong>.
+     * </p>
+     *
+     * <p>
+     * If it were set to <strong>true</strong>, the value of <code>askUserToSetupPasskey</code>
+     * would be <strong>true</strong>. However, since the configuration does not display the modal,
+     * the value is always returned as <strong>false</strong>.
+     * </p>
+     */
+    @Test
+    @WithMockUser(username = AUTHENTICATEDUSER)
+    void testGetAccountWhenAskUsersToSetupPasskeyIsFalse() throws Exception {
+        User user = userUtilService.createAndSaveUser(AUTHENTICATEDUSER);
+        passkeyCredentialUtilService.createAndSavePasskeyCredential(user);
+
+        ReflectionTestUtils.setField(publicAccountResource, "askUsersToSetupPasskey", false);
+
+        UserDTO account = request.get("/api/core/public/account", HttpStatus.OK, UserDTO.class);
+
+        assertThat(account).isNotNull();
+        assertThat(account.getAskToSetupPasskey()).isFalse();
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/core/user/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/user/AccountResourceIntegrationTest.java
@@ -249,7 +249,7 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
     /**
      * <p>
      * Reflects the case when the configuration property
-     * <code>artemis.user-management.passkey.ask-to-setup</code> is set to <strong>false</strong>.
+     * <code>artemis.user-management.passkey.ask-users-to-setup</code> is set to <strong>false</strong>.
      * </p>
      *
      * <p>

--- a/src/test/java/de/tum/cit/aet/artemis/core/user/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/user/AccountResourceIntegrationTest.java
@@ -231,7 +231,7 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
         userUtilService.createAndSaveUser(AUTHENTICATEDUSER);
         UserDTO account = request.get("/api/core/public/account", HttpStatus.OK, UserDTO.class);
         assertThat(account).isNotNull();
-        assertThat(account.getAskToSetupPasskey()).isFalse();
+        assertThat(account.getAskToSetupPasskey()).isTrue();
     }
 
     @Test
@@ -243,7 +243,7 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
         UserDTO account = request.get("/api/core/public/account", HttpStatus.OK, UserDTO.class);
 
         assertThat(account).isNotNull();
-        assertThat(account.getAskToSetupPasskey()).isTrue();
+        assertThat(account.getAskToSetupPasskey()).isFalse();
     }
 
     /**


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added an integration test (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I adjusted integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
We want to give admins the option not to prompt all their users to setup a passkey once they enable the feature.

### Description
- Added the variable `artemis.user-management.passkey.ask-users-to-setup` to the `application-core.yml`, which by default will be set to true and prompt users to setup a passkey once the feature is enabled.
- Adjusted client, server and tests accordingly

### Steps for Testing
To be tested locally:

1. Set `artemis.user-management.passkey.enabled` to true (default value is false in `application-core.yml`)
2. Set `artemis.user-management.passkey.ask-users-to-setup` to true (default in `application-core.yml`)
3. Start the server & client
4. See that you are prompted with a modal once you login that asks you to setup a passkey (if you have not setup a passkey yet)
5. Delete your passkey again
6. Set `artemis.user-management.passkey.ask-users-to-setup` to false
7. Restart the server & client
8. See that you are NOT prompted with a modal once you login (even if you have not setup a passkey yet)

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
#### Manual Tests
- [x] Test 1

### Test Coverage
#### Client

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|---------------------:|
| home.component.ts | 75% | ✅ |

### Screenshots
#### Does not show modal if configuration is false
![doesNotShowModalifConfigurationValueIsFalse](https://github.com/user-attachments/assets/0d4538c3-28f9-4b40-9613-fadeaa0c5306)

#### Shows modal if configuration is true
![showsModalWithDefaultConfiguration](https://github.com/user-attachments/assets/2eb0c7e6-6477-49cc-85ac-1e2307f101fd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to control whether users are prompted to set up a passkey.
- **Bug Fixes**
  - Updated user account logic to more accurately determine when to prompt users for passkey setup.
- **Refactor**
  - Renamed user properties related to passkey setup for improved clarity and consistency across the app.
- **Tests**
  - Updated and expanded tests to cover new passkey prompt logic and configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->