### PR TITLE
`Development`: Fix passkey commonjs import and prevent such imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -125,6 +125,10 @@ export default tseslint.config(
                         {
                             name: 'dayjs',
                             message: "Please import from 'dayjs/esm' instead."
+                        },
+                        {
+                            name: 'lodash',
+                            message: "Please import from 'lodash-es' instead."
                         }
                     ]
                 }

--- a/src/main/webapp/app/core/user/settings/passkey-settings/util/bitwarden.util.ts
+++ b/src/main/webapp/app/core/user/settings/passkey-settings/util/bitwarden.util.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import { MalformedBitwardenCredential } from 'app/core/user/settings/passkey-settings/entities/malformed-bitwarden-credential';
 import { encodeAsBase64Url } from 'app/shared/util/base64.util';
 

--- a/src/main/webapp/app/core/user/settings/passkey-settings/util/bitwarden.util.ts
+++ b/src/main/webapp/app/core/user/settings/passkey-settings/util/bitwarden.util.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash-es';
 import { MalformedBitwardenCredential } from 'app/core/user/settings/passkey-settings/entities/malformed-bitwarden-credential';
 import { encodeAsBase64Url } from 'app/shared/util/base64.util';
 
@@ -37,27 +36,24 @@ export function getCredentialFromMalformedBitwardenObject(malformedBitwardenCred
         return null;
     }
 
-    const clonedCredential: Credential = cloneDeep(malformedBitwardenCredential) as unknown as Credential;
-    const credential = JSON.parse(JSON.stringify(clonedCredential));
-
     return {
         //@ts-expect-error authenticatorAttachment is a method in the (getAuthenticatorAttachment) object, but we return it as property here for simplicity, assuming that we only want to stringify it afterward anyway
-        authenticatorAttachment: credential.authenticatorAttachment,
+        authenticatorAttachment: malformedBitwardenCredential.authenticatorAttachment,
         clientExtensionResults: malformedBitwardenCredential.getClientExtensionResults(),
-        id: credential.id,
-        rawId: convertToBase64(credential.rawId),
+        id: malformedBitwardenCredential.id,
+        rawId: convertToBase64(malformedBitwardenCredential.rawId),
         response: {
-            attestationObject: convertToBase64(credential.response.attestationObject),
+            attestationObject: convertToBase64(malformedBitwardenCredential.response.attestationObject),
             authenticatorData: convertToBase64(
                 malformedBitwardenCredential.response.authenticatorData ?? malformedBitwardenCredential.response.getAuthenticatorData?.() ?? undefined,
             ),
-            clientDataJSON: convertToBase64(credential.response.clientDataJSON),
+            clientDataJSON: convertToBase64(malformedBitwardenCredential.response.clientDataJSON),
             publicKey: convertToBase64(malformedBitwardenCredential.response.getPublicKey?.() ?? undefined),
             publicKeyAlgorithm: malformedBitwardenCredential.response.getPublicKeyAlgorithm?.() ?? undefined,
             transports: malformedBitwardenCredential.response.getTransports?.() ?? undefined,
             signature: convertToBase64(malformedBitwardenCredential.response.signature),
             userHandle: convertToBase64(malformedBitwardenCredential.response.userHandle),
         },
-        type: credential.type,
+        type: malformedBitwardenCredential.type,
     };
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).





### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When you build our client for production, the following warning is shown.
![image](https://github.com/user-attachments/assets/6efc699b-ba7f-486d-af9e-5915b3dfacb3)


### Description
<!-- Describe your changes in detail -->
Removed the import as it's cloneDeep method was not necessary and added an eslint rule that prevents such imports in the future.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

- Code Review
- Make sure the build job succeeds
- Test that creating  a passkey with bitwarden still works
- Test that the login with the bitwarden passkey does still work

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2

#### Manual Test
- [x] Manual Test 1
- [ ] Manual Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated import restrictions to enforce using ES module variants for certain libraries.
  - Adjusted imports to use the ES module version of lodash for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->