### PR TITLE
`Development`: Fix failing learning path integration test

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/atlas/learningpath/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/learningpath/LearningPathIntegrationTest.java
@@ -196,7 +196,7 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         assertThat(updatedCourse.getLearningPaths()).isNotNull();
         assertThat(updatedCourse.getLearningPaths().size()).as("should create LearningPath for each student").isEqualTo(NUMBER_OF_STUDENTS);
         updatedCourse.getLearningPaths().forEach(
-                lp -> assertThat(lp.getCompetencies().size()).as("LearningPath (id={}) should have be linked to all " + "Competencies", lp.getId()).isEqualTo(competencies.length));
+                lp -> assertThat(lp.getCompetencies().size()).as("LearningPath (id={}) should have be linked to all Competencies", lp.getId()).isEqualTo(competencies.length));
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/learningpath/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/learningpath/LearningPathIntegrationTest.java
@@ -208,7 +208,7 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         assertThat(updatedCourse.getLearningPathsEnabled()).as("should enable LearningPaths").isTrue();
         assertThat(updatedCourse.getLearningPaths()).isNotNull();
         assertThat(updatedCourse.getLearningPaths().size()).as("should create LearningPath for each student").isEqualTo(NUMBER_OF_STUDENTS);
-        updatedCourse.getLearningPaths().forEach(lp -> assertThat(lp.getProgress()).as("LearningPath (id={}) should " + "have no progress", lp.getId()).isEqualTo(0));
+        updatedCourse.getLearningPaths().forEach(lp -> assertThat(lp.getProgress()).as("LearningPath (id={}) should have no progress", lp.getId()).isEqualTo(0));
     }
 
     @Test
@@ -317,7 +317,7 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         await().untilAsserted(() -> {
             final var learningPathOptional = learningPathRepository.findWithEagerCompetenciesByCourseIdAndUserId(course.getId(), student.getId());
             assertThat(learningPathOptional).isPresent();
-            assertThat(learningPathOptional.get().getCompetencies()).as("should contain new " + "competency").contains(newCompetency);
+            assertThat(learningPathOptional.get().getCompetencies()).as("should contain new competency").contains(newCompetency);
             assertThat(learningPathOptional.get().getCompetencies().size()).as("should not remove old competencies").isEqualTo(competencies.length + 1);
             final var oldCompetencies = Set.of(competencies[0], competencies[1], competencies[2], competencies[3], competencies[4]);
             assertThat(learningPathOptional.get().getCompetencies()).as("should not remove old competencies").containsAll(oldCompetencies);
@@ -356,8 +356,8 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         assertThat(learningPathOptional).isPresent();
         assertThat(learningPathOptional.get().getCompetencies()).as("should not contain deleted competency").doesNotContain(competencies[0]);
         final var nonDeletedCompetencies = Set.of(competencies[1], competencies[2], competencies[3], competencies[4]);
-        assertThat(learningPathOptional.get().getCompetencies().size()).as("should contain competencies that have not" + " been deleted").isEqualTo(nonDeletedCompetencies.size());
-        assertThat(learningPathOptional.get().getCompetencies()).as("should contain competencies that have not been " + "deleted").containsAll(nonDeletedCompetencies);
+        assertThat(learningPathOptional.get().getCompetencies().size()).as("should contain competencies that have not been deleted").isEqualTo(nonDeletedCompetencies.size());
+        assertThat(learningPathOptional.get().getCompetencies()).as("should contain competencies that have not been deleted").containsAll(nonDeletedCompetencies);
     }
 
     @Test
@@ -374,8 +374,7 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
     }
 
     /**
-     * This only tests if the end point successfully retrieves the health status. The correctness of the health
-     * status is tested in LearningPathServiceTest.
+     * This only tests if the end point successfully retrieves the health status. The correctness of the health status is tested in LearningPathServiceTest.
      *
      * @throws Exception the request failed
      * @see de.tum.cit.aet.artemis.atlas.service.LearningPathServiceTest
@@ -484,7 +483,7 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         void shouldGenerateLearningPath() throws Exception {
             course.setLearningPathsEnabled(true);
             course = courseRepository.save(course);
-            final var response = request.postWithResponseBody("/api/atlas/courses/" + course.getId() + "/learning" + "-path", null, LearningPathDTO.class, HttpStatus.CREATED);
+            final var response = request.postWithResponseBody("/api/atlas/courses/" + course.getId() + "/learning-path", null, LearningPathDTO.class, HttpStatus.CREATED);
             assertThat(response).isNotNull();
             final var student = userTestRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
             final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
@@ -710,9 +709,8 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
         final var student = userTestRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
-        final var result = request.get("/api/atlas/learning-path/" + learningPath.getId() + "/relative-navigation" + "?learningObjectId=" + textUnit.getId()
-                + "&learningObjectType=" + LearningPathNavigationObjectDTO.LearningObjectType.LECTURE + "&competencyId=" + competencies[0].getId(), HttpStatus.OK,
-                LearningPathNavigationDTO.class);
+        final var result = request.get("/api/atlas/learning-path/" + learningPath.getId() + "/relative-navigation?learningObjectId=" + textUnit.getId() + "&learningObjectType="
+                + LearningPathNavigationObjectDTO.LearningObjectType.LECTURE + "&competencyId=" + competencies[0].getId(), HttpStatus.OK, LearningPathNavigationDTO.class);
 
         verifyNavigationResult(result, null, textUnit, textExercise);
 
@@ -736,8 +734,7 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         final var result = request.get("/api/atlas/learning-path/" + learningPath.getId() + "/navigation-overview", HttpStatus.OK, LearningPathNavigationOverviewDTO.class);
 
-        // TODO: currently learning objects connected to more than one competency are provided twice in the learning
-        // path
+        // TODO: currently learning objects connected to more than one competency are provided twice in the learning path
         // TODO: this is not a problem for the navigation overview as the duplicates are filtered out
 
         assertThat(result.learningObjects()).hasSize(2);

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/learningpath/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/learningpath/LearningPathIntegrationTest.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.atlas.learningpath;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -195,7 +196,7 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         assertThat(updatedCourse.getLearningPaths()).isNotNull();
         assertThat(updatedCourse.getLearningPaths().size()).as("should create LearningPath for each student").isEqualTo(NUMBER_OF_STUDENTS);
         updatedCourse.getLearningPaths().forEach(
-                lp -> assertThat(lp.getCompetencies().size()).as("LearningPath (id={}) should have be linked to all Competencies", lp.getId()).isEqualTo(competencies.length));
+                lp -> assertThat(lp.getCompetencies().size()).as("LearningPath (id={}) should have be linked to all " + "Competencies", lp.getId()).isEqualTo(competencies.length));
     }
 
     @Test
@@ -207,7 +208,7 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         assertThat(updatedCourse.getLearningPathsEnabled()).as("should enable LearningPaths").isTrue();
         assertThat(updatedCourse.getLearningPaths()).isNotNull();
         assertThat(updatedCourse.getLearningPaths().size()).as("should create LearningPath for each student").isEqualTo(NUMBER_OF_STUDENTS);
-        updatedCourse.getLearningPaths().forEach(lp -> assertThat(lp.getProgress()).as("LearningPath (id={}) should have no progress", lp.getId()).isEqualTo(0));
+        updatedCourse.getLearningPaths().forEach(lp -> assertThat(lp.getProgress()).as("LearningPath (id={}) should " + "have no progress", lp.getId()).isEqualTo(0));
     }
 
     @Test
@@ -313,12 +314,14 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         final var newCompetency = restCall.apply(this);
 
         final var student = userTestRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
-        final var learningPathOptional = learningPathRepository.findWithEagerCompetenciesByCourseIdAndUserId(course.getId(), student.getId());
-        assertThat(learningPathOptional).isPresent();
-        assertThat(learningPathOptional.get().getCompetencies()).as("should contain new competency").contains(newCompetency);
-        assertThat(learningPathOptional.get().getCompetencies().size()).as("should not remove old competencies").isEqualTo(competencies.length + 1);
-        final var oldCompetencies = Set.of(competencies[0], competencies[1], competencies[2], competencies[3], competencies[4]);
-        assertThat(learningPathOptional.get().getCompetencies()).as("should not remove old competencies").containsAll(oldCompetencies);
+        await().untilAsserted(() -> {
+            final var learningPathOptional = learningPathRepository.findWithEagerCompetenciesByCourseIdAndUserId(course.getId(), student.getId());
+            assertThat(learningPathOptional).isPresent();
+            assertThat(learningPathOptional.get().getCompetencies()).as("should contain new " + "competency").contains(newCompetency);
+            assertThat(learningPathOptional.get().getCompetencies().size()).as("should not remove old competencies").isEqualTo(competencies.length + 1);
+            final var oldCompetencies = Set.of(competencies[0], competencies[1], competencies[2], competencies[3], competencies[4]);
+            assertThat(learningPathOptional.get().getCompetencies()).as("should not remove old competencies").containsAll(oldCompetencies);
+        });
     }
 
     @Test
@@ -353,8 +356,8 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         assertThat(learningPathOptional).isPresent();
         assertThat(learningPathOptional.get().getCompetencies()).as("should not contain deleted competency").doesNotContain(competencies[0]);
         final var nonDeletedCompetencies = Set.of(competencies[1], competencies[2], competencies[3], competencies[4]);
-        assertThat(learningPathOptional.get().getCompetencies().size()).as("should contain competencies that have not been deleted").isEqualTo(nonDeletedCompetencies.size());
-        assertThat(learningPathOptional.get().getCompetencies()).as("should contain competencies that have not been deleted").containsAll(nonDeletedCompetencies);
+        assertThat(learningPathOptional.get().getCompetencies().size()).as("should contain competencies that have not" + " been deleted").isEqualTo(nonDeletedCompetencies.size());
+        assertThat(learningPathOptional.get().getCompetencies()).as("should contain competencies that have not been " + "deleted").containsAll(nonDeletedCompetencies);
     }
 
     @Test
@@ -371,7 +374,8 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
     }
 
     /**
-     * This only tests if the end point successfully retrieves the health status. The correctness of the health status is tested in LearningPathServiceTest.
+     * This only tests if the end point successfully retrieves the health status. The correctness of the health
+     * status is tested in LearningPathServiceTest.
      *
      * @throws Exception the request failed
      * @see de.tum.cit.aet.artemis.atlas.service.LearningPathServiceTest
@@ -480,7 +484,7 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         void shouldGenerateLearningPath() throws Exception {
             course.setLearningPathsEnabled(true);
             course = courseRepository.save(course);
-            final var response = request.postWithResponseBody("/api/atlas/courses/" + course.getId() + "/learning-path", null, LearningPathDTO.class, HttpStatus.CREATED);
+            final var response = request.postWithResponseBody("/api/atlas/courses/" + course.getId() + "/learning" + "-path", null, LearningPathDTO.class, HttpStatus.CREATED);
             assertThat(response).isNotNull();
             final var student = userTestRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
             final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
@@ -706,8 +710,9 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         course = learningPathUtilService.enableAndGenerateLearningPathsForCourse(course);
         final var student = userTestRepository.findOneByLogin(STUDENT1_OF_COURSE).orElseThrow();
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
-        final var result = request.get("/api/atlas/learning-path/" + learningPath.getId() + "/relative-navigation?learningObjectId=" + textUnit.getId() + "&learningObjectType="
-                + LearningPathNavigationObjectDTO.LearningObjectType.LECTURE + "&competencyId=" + competencies[0].getId(), HttpStatus.OK, LearningPathNavigationDTO.class);
+        final var result = request.get("/api/atlas/learning-path/" + learningPath.getId() + "/relative-navigation" + "?learningObjectId=" + textUnit.getId()
+                + "&learningObjectType=" + LearningPathNavigationObjectDTO.LearningObjectType.LECTURE + "&competencyId=" + competencies[0].getId(), HttpStatus.OK,
+                LearningPathNavigationDTO.class);
 
         verifyNavigationResult(result, null, textUnit, textExercise);
 
@@ -731,7 +736,8 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         final var result = request.get("/api/atlas/learning-path/" + learningPath.getId() + "/navigation-overview", HttpStatus.OK, LearningPathNavigationOverviewDTO.class);
 
-        // TODO: currently learning objects connected to more than one competency are provided twice in the learning path
+        // TODO: currently learning objects connected to more than one competency are provided twice in the learning
+        // path
         // TODO: this is not a problem for the navigation overview as the duplicates are filtered out
 
         assertThat(result.learningObjects()).hasSize(2);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#10805 introduced a test failure when running the entire test class as the method is async now and therefore the learning path fetched from the db might not yet be updated when the updated content is asserted.

### Description
<!-- Describe your changes in detail -->
Wrapped the assertions in `await().untilAsserted() to account for the async execution.


### Steps for Testing
Make sure ` LearningPathIntegrationTest [addCompetencyToLearningPaths]` passes on bamboo/github actions

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test stability by ensuring that competency additions to learning paths are properly awaited before assertions, reducing flakiness in test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->