### PR TITLE
`Communication`: Enable push notifications for new messages by default

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/setting_presets/DefaultUserCourseNotificationSettingPreset.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/setting_presets/DefaultUserCourseNotificationSettingPreset.java
@@ -35,8 +35,7 @@ public class DefaultUserCourseNotificationSettingPreset extends UserCourseNotifi
 
     public DefaultUserCourseNotificationSettingPreset() {
         presetMap = Map.ofEntries(
-                Map.entry(NewPostNotification.class,
-                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, false, NotificationChannelOption.PUSH, true)),
+                Map.entry(NewPostNotification.class, Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, false, NotificationChannelOption.PUSH, true)),
                 Map.entry(NewAnswerNotification.class,
                         Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)),
                 Map.entry(NewMentionNotification.class,

--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/setting_presets/DefaultUserCourseNotificationSettingPreset.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/setting_presets/DefaultUserCourseNotificationSettingPreset.java
@@ -36,7 +36,7 @@ public class DefaultUserCourseNotificationSettingPreset extends UserCourseNotifi
     public DefaultUserCourseNotificationSettingPreset() {
         presetMap = Map.ofEntries(
                 Map.entry(NewPostNotification.class,
-                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, false, NotificationChannelOption.PUSH, false)),
+                        Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, false, NotificationChannelOption.PUSH, true)),
                 Map.entry(NewAnswerNotification.class,
                         Map.of(NotificationChannelOption.EMAIL, false, NotificationChannelOption.WEBAPP, true, NotificationChannelOption.PUSH, true)),
                 Map.entry(NewMentionNotification.class,


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
By default, push notifications for new messages are disabled. This has lead to many users thinking notifications don't work correctly, as this default behavior deviates from the old default behavior and is counter-intuitive. By enabling them by default, we hope to reduce the number of questions regarding notifications.

### Description
<!-- Describe your changes in detail -->
In the default notification settings preset, we set "Push" for the New Message Notification type to enabled by default.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 2 Users in the same course, at least one with default notification settings

1. Log in to Artemis with one user on any platform, e.g. web app.
2. Log in with the other user (default notification settings) on iOS or Android.
3. Send a message from the first user (step 1) to the second user (step 2) in a channel or private chat and ensure the user is notified via push notification on iOS/Android.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Push notifications for new posts are now enabled by default for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->