### PR TITLE
`Development`: Move passkey security config to own file

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
@@ -25,6 +25,9 @@ import de.tum.cit.aet.artemis.core.service.ProfileService;
 @RequestMapping(".well-known/") // Intentionally not prefixed with "communication"
 public class AndroidAppSiteAssociationResource {
 
+    @Value("${info.testServer:false}")
+    private boolean isTestServer;
+
     @Value("${server.url}")
     private String artemisServerUrl;
 
@@ -62,7 +65,8 @@ public class AndroidAppSiteAssociationResource {
         }
 
         List<String> fingerprints = new ArrayList<>(List.of(sha256CertFingerprintRelease));
-        if (sha256CertFingerprintDebug != null && !profileService.isProductionActive()) {
+        boolean isDebugFingerprintAllowed = !profileService.isProductionActive() || isTestServer;
+        if (sha256CertFingerprintDebug != null && isDebugFingerprintAllowed) {
             fingerprints.add(sha256CertFingerprintDebug);
         }
         final AndroidAssetLinksStatement.AndroidTarget appTarget = new AndroidAssetLinksStatement.AndroidTarget("android_app", androidAppPackage, fingerprints);

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.artemis.core.security.annotations.ManualConfig;
+import de.tum.cit.aet.artemis.core.service.ProfileService;
 
 /**
  * REST controller for the android assetlink.json
@@ -38,6 +39,12 @@ public class AndroidAppSiteAssociationResource {
 
     private static final Logger log = LoggerFactory.getLogger(AndroidAppSiteAssociationResource.class);
 
+    private final ProfileService profileService;
+
+    public AndroidAppSiteAssociationResource(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
     /**
      * Provides the assetlinks json content for the Android client deeplink link feature.
      * More information on the json content can be found <a href="https://developer.android.com/training/app-links/verify-android-applinks">here</a>
@@ -55,7 +62,7 @@ public class AndroidAppSiteAssociationResource {
         }
 
         List<String> fingerprints = new ArrayList<>(List.of(sha256CertFingerprintRelease));
-        if (sha256CertFingerprintDebug != null) {
+        if (sha256CertFingerprintDebug != null && !profileService.isProductionActive()) {
             fingerprints.add(sha256CertFingerprintDebug);
         }
         final AndroidAssetLinksStatement.AndroidTarget appTarget = new AndroidAssetLinksStatement.AndroidTarget("android_app", androidAppPackage, fingerprints);

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/AndroidAppSiteAssociationResource.java
@@ -2,7 +2,6 @@ package de.tum.cit.aet.artemis.communication.web;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -15,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.artemis.core.security.annotations.ManualConfig;
-import de.tum.cit.aet.artemis.core.service.ProfileService;
+import de.tum.cit.aet.artemis.core.service.AndroidFingerprintService;
 
 /**
  * REST controller for the android assetlink.json
@@ -25,27 +24,18 @@ import de.tum.cit.aet.artemis.core.service.ProfileService;
 @RequestMapping(".well-known/") // Intentionally not prefixed with "communication"
 public class AndroidAppSiteAssociationResource {
 
-    @Value("${info.testServer:false}")
-    private boolean isTestServer;
-
     @Value("${server.url}")
     private String artemisServerUrl;
 
     @Value("${artemis.androidAppPackage: #{null}}")
     private String androidAppPackage;
 
-    @Value("${artemis.androidSha256CertFingerprints.release: #{null}}")
-    private String sha256CertFingerprintRelease;
-
-    @Value("${artemis.androidSha256CertFingerprints.debug: #{null}}")
-    private String sha256CertFingerprintDebug;
-
     private static final Logger log = LoggerFactory.getLogger(AndroidAppSiteAssociationResource.class);
 
-    private final ProfileService profileService;
+    private final AndroidFingerprintService androidFingerprintService;
 
-    public AndroidAppSiteAssociationResource(ProfileService profileService) {
-        this.profileService = profileService;
+    public AndroidAppSiteAssociationResource(AndroidFingerprintService androidFingerprintService) {
+        this.androidFingerprintService = androidFingerprintService;
     }
 
     /**
@@ -57,18 +47,13 @@ public class AndroidAppSiteAssociationResource {
     @GetMapping(value = "assetlinks.json", produces = "application/json")
     @ManualConfig
     public ResponseEntity<List<AndroidAssetLinksStatement>> getAndroidAssetLinks() {
-        if (androidAppPackage == null || androidAppPackage.length() < 4 || sha256CertFingerprintRelease == null || sha256CertFingerprintRelease.length() < 20
-        // The debug fingerprint is optional, so we don't check it
-        ) {
+        List<String> fingerprints = androidFingerprintService.getFingerprints();
+
+        if (androidAppPackage == null || androidAppPackage.length() < 4 || fingerprints.isEmpty()) {
             log.debug("Android Assetlinks information is not configured!");
             return ResponseEntity.notFound().build();
         }
 
-        List<String> fingerprints = new ArrayList<>(List.of(sha256CertFingerprintRelease));
-        boolean isDebugFingerprintAllowed = !profileService.isProductionActive() || isTestServer;
-        if (sha256CertFingerprintDebug != null && isDebugFingerprintAllowed) {
-            fingerprints.add(sha256CertFingerprintDebug);
-        }
         final AndroidAssetLinksStatement.AndroidTarget appTarget = new AndroidAssetLinksStatement.AndroidTarget("android_app", androidAppPackage, fingerprints);
 
         final AndroidAssetLinksStatement.WebTarget webTarget = new AndroidAssetLinksStatement.WebTarget("web", artemisServerUrl);

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -10,8 +10,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
@@ -39,7 +37,6 @@ import de.tum.cit.aet.artemis.core.security.DomainUserDetailsService;
 import de.tum.cit.aet.artemis.core.security.Role;
 import de.tum.cit.aet.artemis.core.security.filter.SpaWebFilter;
 import de.tum.cit.aet.artemis.core.security.jwt.JWTConfigurer;
-import de.tum.cit.aet.artemis.core.security.jwt.JWTCookieService;
 import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
 import de.tum.cit.aet.artemis.core.security.passkey.ArtemisPasskeyWebAuthnConfigurer;
 import de.tum.cit.aet.artemis.core.service.ProfileService;
@@ -54,13 +51,9 @@ public class SecurityConfiguration {
 
     private final CorsFilter corsFilter;
 
-    private final HttpMessageConverter<Object> converter;
-
     private final Optional<CustomLti13Configurer> customLti13Configurer;
 
     private final ArtemisPasskeyWebAuthnConfigurer passkeyWebAuthnConfigurer;
-
-    private final JWTCookieService jwtCookieService;
 
     private final PasswordService passwordService;
 
@@ -71,14 +64,11 @@ public class SecurityConfiguration {
     @Value("#{'${spring.prometheus.monitoringIp:127.0.0.1}'.split(',')}")
     private List<String> monitoringIpAddresses;
 
-    public SecurityConfiguration(CorsFilter corsFilter, MappingJackson2HttpMessageConverter converter, Optional<CustomLti13Configurer> customLti13Configurer,
-            ArtemisPasskeyWebAuthnConfigurer passkeyWebAuthnConfigurer, JWTCookieService jwtCookieService, PasswordService passwordService, ProfileService profileService,
-            TokenProvider tokenProvider) {
-        this.converter = converter;
+    public SecurityConfiguration(CorsFilter corsFilter, Optional<CustomLti13Configurer> customLti13Configurer, ArtemisPasskeyWebAuthnConfigurer passkeyWebAuthnConfigurer,
+            PasswordService passwordService, ProfileService profileService, TokenProvider tokenProvider) {
         this.corsFilter = corsFilter;
         this.customLti13Configurer = customLti13Configurer;
         this.passkeyWebAuthnConfigurer = passkeyWebAuthnConfigurer;
-        this.jwtCookieService = jwtCookieService;
         this.passwordService = passwordService;
         this.profileService = profileService;
         this.tokenProvider = tokenProvider;

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisPasskeyWebAuthnConfigurer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisPasskeyWebAuthnConfigurer.java
@@ -109,11 +109,9 @@ public class ArtemisPasskeyWebAuthnConfigurer {
 
             relyingPartyId = clientUrlToRegisterPasskey.getHost();
 
-            // Configure allowed origins
             allowedOrigins.add(clientUrlToRegisterPasskey.toString());
             allowedOrigins.add(clientUrlToAuthenticateWithPasskey.toString());
 
-            // Add Android APK key hashes if configured
             addAndroidApkKeyHashes();
 
             log.info("WebAuthn passkey authentication enabled with RP ID: {}", relyingPartyId);

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisPasskeyWebAuthnConfigurer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisPasskeyWebAuthnConfigurer.java
@@ -1,0 +1,165 @@
+package de.tum.cit.aet.artemis.core.security.passkey;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.WebAuthnConfigurer;
+import org.springframework.security.web.webauthn.authentication.PublicKeyCredentialRequestOptionsRepository;
+import org.springframework.security.web.webauthn.management.PublicKeyCredentialUserEntityRepository;
+import org.springframework.security.web.webauthn.management.UserCredentialRepository;
+import org.springframework.security.web.webauthn.registration.PublicKeyCredentialCreationOptionsRepository;
+import org.springframework.stereotype.Component;
+
+import de.tum.cit.aet.artemis.core.config.Constants;
+import de.tum.cit.aet.artemis.core.repository.UserRepository;
+import de.tum.cit.aet.artemis.core.security.jwt.JWTCookieService;
+import de.tum.cit.aet.artemis.core.util.AndroidApkKeyHashUtil;
+
+/**
+ * Configurer for WebAuthn passkey authentication in Artemis.
+ * This component encapsulates the passkey functionality and configuration.
+ */
+@Component
+@Profile(Constants.PROFILE_CORE)
+public class ArtemisPasskeyWebAuthnConfigurer {
+
+    private static final Logger log = LoggerFactory.getLogger(ArtemisPasskeyWebAuthnConfigurer.class);
+
+    private final HttpMessageConverter<Object> converter;
+
+    private final JWTCookieService jwtCookieService;
+
+    private final UserRepository userRepository;
+
+    private final PublicKeyCredentialUserEntityRepository publicKeyCredentialUserEntityRepository;
+
+    private final UserCredentialRepository userCredentialRepository;
+
+    private final PublicKeyCredentialCreationOptionsRepository publicKeyCredentialCreationOptionsRepository;
+
+    private final PublicKeyCredentialRequestOptionsRepository publicKeyCredentialRequestOptionsRepository;
+
+    @Value("${" + Constants.PASSKEY_ENABLED_PROPERTY_NAME + ":false}")
+    private boolean passkeyEnabled;
+
+    /**
+     * We expect the server URL to equal the client URL
+     */
+    @Value("${server.url}")
+    private String serverUrl;
+
+    @Value("${client.port:${server.port}}")
+    private String port;
+
+    @Value("${artemis.androidSha256CertFingerprints.release: #{null}}")
+    private String androidSha256CertFingerprintRelease;
+
+    @Value("${artemis.androidSha256CertFingerprints.debug: #{null}}")
+    private String androidSha256CertFingerprintDebug;
+
+    private final Set<String> allowedOrigins = new HashSet<>();
+
+    private String relyingPartyId;
+
+    private final String relyingPartyName = "Artemis";
+
+    public ArtemisPasskeyWebAuthnConfigurer(MappingJackson2HttpMessageConverter converter, JWTCookieService jwtCookieService, UserRepository userRepository,
+            PublicKeyCredentialUserEntityRepository publicKeyCredentialUserEntityRepository, UserCredentialRepository userCredentialRepository,
+            PublicKeyCredentialCreationOptionsRepository publicKeyCredentialCreationOptionsRepository,
+            PublicKeyCredentialRequestOptionsRepository publicKeyCredentialRequestOptionsRepository) {
+        this.converter = converter;
+        this.jwtCookieService = jwtCookieService;
+        this.userRepository = userRepository;
+        this.publicKeyCredentialUserEntityRepository = publicKeyCredentialUserEntityRepository;
+        this.userCredentialRepository = userCredentialRepository;
+        this.publicKeyCredentialCreationOptionsRepository = publicKeyCredentialCreationOptionsRepository;
+        this.publicKeyCredentialRequestOptionsRepository = publicKeyCredentialRequestOptionsRepository;
+    }
+
+    /**
+     * Validates the configuration for allowed origins when passkey authentication is enabled.
+     * <p>
+     * This method ensures that the server URL and port are correctly configured for WebAuthn
+     * when passkey authentication is enabled. If the configuration is invalid, an exception is thrown.
+     * </p>
+     *
+     * @throws IllegalStateException if the server URL configuration is invalid
+     */
+    @PostConstruct
+    public void validatePasskeyAllowedOriginConfiguration() {
+        if (!passkeyEnabled) {
+            return;
+        }
+
+        try {
+            URL clientUrlToRegisterPasskey = new URI(serverUrl).toURL();
+            URL clientUrlToAuthenticateWithPasskey = new URI(serverUrl + ":" + port).toURL();
+
+            relyingPartyId = clientUrlToRegisterPasskey.getHost();
+
+            // Configure allowed origins
+            allowedOrigins.add(clientUrlToRegisterPasskey.toString());
+            allowedOrigins.add(clientUrlToAuthenticateWithPasskey.toString());
+
+            // Add Android APK key hashes if configured
+            addAndroidApkKeyHashes();
+
+            log.info("WebAuthn passkey authentication enabled with RP ID: {}", relyingPartyId);
+            log.info("Allowed origins: {}", allowedOrigins);
+        }
+        catch (URISyntaxException | MalformedURLException e) {
+            throw new IllegalStateException("Invalid server URL configuration for WebAuthn: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Adds Android APK key hashes to allowed origins if configured.
+     */
+    private void addAndroidApkKeyHashes() {
+        if (androidSha256CertFingerprintRelease != null) {
+            String hash = AndroidApkKeyHashUtil.getHashFromFingerprint(androidSha256CertFingerprintRelease);
+            allowedOrigins.add(hash);
+            log.info("Added Android release APK key hash: {}", hash);
+        }
+
+        if (androidSha256CertFingerprintDebug != null) {
+            String hash = AndroidApkKeyHashUtil.getHashFromFingerprint(androidSha256CertFingerprintDebug);
+            allowedOrigins.add(hash);
+            log.info("Added Android debug APK key hash: {}", hash);
+        }
+    }
+
+    /**
+     * Configures HttpSecurity with WebAuthn if passkey authentication is enabled.
+     *
+     * @param http The HttpSecurity to configure
+     * @return true if passkey authentication was configured, false otherwise
+     */
+    public boolean configure(HttpSecurity http) throws Exception {
+        if (!passkeyEnabled) {
+            return false;
+        }
+
+        WebAuthnConfigurer<HttpSecurity> webAuthnConfigurer = new ArtemisWebAuthnConfigurer<>(converter, jwtCookieService, userRepository, publicKeyCredentialUserEntityRepository,
+                userCredentialRepository, publicKeyCredentialCreationOptionsRepository, publicKeyCredentialRequestOptionsRepository);
+
+        http.with(webAuthnConfigurer, configurer -> {
+            configurer.allowedOrigins(allowedOrigins).rpId(relyingPartyId).rpName(relyingPartyName);
+        });
+
+        return true;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisPasskeyWebAuthnConfigurer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisPasskeyWebAuthnConfigurer.java
@@ -30,7 +30,6 @@ import de.tum.cit.aet.artemis.core.util.AndroidApkKeyHashUtil;
 
 /**
  * Configurer for WebAuthn passkey authentication in Artemis.
- * This component encapsulates the passkey functionality and configuration.
  */
 @Component
 @Profile(Constants.PROFILE_CORE)

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisPasskeyWebAuthnConfigurer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisPasskeyWebAuthnConfigurer.java
@@ -55,6 +55,9 @@ public class ArtemisPasskeyWebAuthnConfigurer {
     @Value("${" + Constants.PASSKEY_ENABLED_PROPERTY_NAME + ":false}")
     private boolean passkeyEnabled;
 
+    @Value("${info.testServer:false}")
+    private boolean isTestServer;
+
     /**
      * We expect the server URL to equal the client URL
      */
@@ -136,7 +139,8 @@ public class ArtemisPasskeyWebAuthnConfigurer {
             log.info("Added Android release APK key hash: {}", hash);
         }
 
-        if (androidSha256CertFingerprintDebug != null && !profileService.isProductionActive()) {
+        boolean isDebugFingerprintAllowed = !profileService.isProductionActive() || isTestServer;
+        if (androidSha256CertFingerprintDebug != null && isDebugFingerprintAllowed) {
             String hash = AndroidApkKeyHashUtil.getHashFromFingerprint(androidSha256CertFingerprintDebug);
             allowedOrigins.add(hash);
             log.warn("Added Android debug APK key hash: {}", hash);

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/AndroidFingerprintService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/AndroidFingerprintService.java
@@ -1,0 +1,72 @@
+package de.tum.cit.aet.artemis.core.service;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * Helper service for getting the fingerprints for the Android app.
+ */
+@Profile(PROFILE_CORE)
+@Service
+public class AndroidFingerprintService {
+
+    private static final Logger log = LoggerFactory.getLogger(AndroidFingerprintService.class);
+
+    @Value("${info.testServer:false}")
+    private boolean isTestServer;
+
+    @Value("${artemis.androidSha256CertFingerprints.release: #{null}}")
+    private String androidSha256CertFingerprintRelease;
+
+    @Value("${artemis.androidSha256CertFingerprints.debug: #{null}}")
+    private String androidSha256CertFingerprintDebug;
+
+    private final ProfileService profileService;
+
+    public AndroidFingerprintService(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    /**
+     * Returns the fingerprints for the Android app.
+     * The release fingerprint is always included.
+     * The debug fingerprint is only included if the production profile is not active or if the test server is used.
+     *
+     * @return a list of fingerprints
+     */
+    public List<String> getFingerprints() {
+        List<String> fingerprints = new ArrayList<>();
+        if (isFingerprintValid(androidSha256CertFingerprintRelease)) {
+            fingerprints.add(androidSha256CertFingerprintRelease);
+        }
+        else {
+            log.warn("The Android release fingerprint is not valid: {}", androidSha256CertFingerprintRelease);
+        }
+
+        boolean isDebugFingerprintAllowed = !profileService.isProductionActive() || isTestServer;
+        if (isFingerprintValid(androidSha256CertFingerprintDebug) && isDebugFingerprintAllowed) {
+            fingerprints.add(androidSha256CertFingerprintDebug);
+            log.warn("Added the Android debug fingerprint: {}", androidSha256CertFingerprintDebug);
+        }
+
+        return fingerprints;
+    }
+
+    /**
+     * Checks if the given fingerprint is valid.
+     *
+     * @param fingerprint the fingerprint to check
+     * @return true if the fingerprint is valid, false otherwise
+     */
+    public static boolean isFingerprintValid(String fingerprint) {
+        return fingerprint != null && fingerprint.length() > 20;
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.


### Motivation
With #10820 the `SecurityConfig` grew even larger, so we decided to move the passkey specific logic to its own file, as a follow-up. 
### Description
<!-- Describe your changes in detail -->
- Moved the security config to a own file.
- Exclude the debug fingerprints for prod (except for testservers)

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student

To ensure the refactoring did not break anything:
1. Create a new passkey for your user
2. Login with that passkey

Ensure that the debug fingerprint is also enabled on the test servers:
1. Go to https://artemis-test5.artemis.cit.tum.de/.well-known/assetlinks.json (replace `5` with the deployed testserver)
2. See that two sha fingerprints are returned:
![image](https://github.com/user-attachments/assets/8fecdcbb-ed0b-4ab8-a732-97b193df2ba1)


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the security configuration by moving all passkey (WebAuthn) authentication setup into a dedicated component, reducing complexity and dependencies in the main security settings.
  - Updated Android app site association handling to use a centralized service for managing certificate fingerprints.

- **New Features**
  - Introduced a new component to manage passkey (WebAuthn) authentication configuration, improving modularity and maintainability. This includes enhanced validation and logging for passkey-related settings.
  - Added a service to manage Android app certificate fingerprints with environment-aware logic for including debug fingerprints.

- **Bug Fixes**
  - Restricted inclusion of debug Android app fingerprint data to non-production environments or test servers, enhancing security of Android asset links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->