### PR TITLE
`Development`: Remove imprint value from ProfileInfo class

### DIFF
--- a/src/main/webapp/app/core/layouts/profiles/profile-info.model.ts
+++ b/src/main/webapp/app/core/layouts/profiles/profile-info.model.ts
@@ -146,7 +146,6 @@ export class ProfileInfo {
     public externalPasswordResetLinkMap: { [key: string]: string };
     public features: ActiveFeatureToggles;
     public git: Git;
-    public imprint: string;
     public java: Java;
     public needsToAcceptTerms?: boolean;
     public operatorAdminName: string;


### PR DESCRIPTION
Commit 419dffc899c5b9b91ba9f10d128cd234a4b83ba1 removed the imprint value from the profile info test, but did not remove it from the class itself. This currently causes the client build to fail, preventing successful tests. This PR removes the value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the "imprint" property from user profile information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->