### PR TITLE
'Assessment': Fix Grading Key Rounding Errors

### DIFF
--- a/src/main/webapp/app/assessment/manage/grading-system/interval-grading-system/interval-grading-system.component.ts
+++ b/src/main/webapp/app/assessment/manage/grading-system/interval-grading-system/interval-grading-system.component.ts
@@ -145,7 +145,9 @@ export class IntervalGradingSystemComponent extends BaseGradingSystemComponent {
         if (gradeStep.upperBoundPoints == undefined || gradeStep.lowerBoundPoints == undefined) {
             return undefined;
         }
-        return gradeStep.upperBoundPoints - gradeStep.lowerBoundPoints;
+        const raw = gradeStep.upperBoundPoints - gradeStep.lowerBoundPoints;
+        // round to at most 6 decimals
+        return Math.round(raw * 1_000_000) / 1_000_000;
     }
 
     deleteGradeStep(index: number): void {


### PR DESCRIPTION

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
When converting percentage intervals to point‐based intervals, the underlying floating‐point arithmetic can produce long, confusing artifacts (e.g. 0.9999999999999999) in the grading key UI. By rounding the computed intervals to a fixed precision (6 decimals), we ensure that instructors always see clean, human‐readable boundaries (e.g. “1” or “1.5”) without altering the actual grade logic or calculations. 
Fix issue [https://github.com/ls1intum/Artemis/issues/10680](url)


### Description
<!-- Describe your changes in detail -->
Updated `getPercentageInterval(…)` to round its computed value to 6 decimal places.

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

