### PR TITLE
`Development`: Improve client code quality for conversations

### DIFF
--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.ts
@@ -21,7 +21,7 @@ import {
 } from '@angular/core';
 import { faCircleNotch, faEnvelope, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { Conversation, ConversationDTO } from 'app/communication/shared/entities/conversation/conversation.model';
-import { Subject, forkJoin, map, takeUntil } from 'rxjs';
+import { Observable, Subject, forkJoin, map, takeUntil } from 'rxjs';
 import { Post } from 'app/communication/shared/entities/post.model';
 import { Course } from 'app/core/course/shared/entities/course.model';
 import { PageType, PostContextFilter, PostSortCriterion, SortDirection } from 'app/communication/metis.util';
@@ -43,7 +43,7 @@ import { NgClass } from '@angular/common';
 import { PostCreateEditModalComponent } from 'app/communication/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component';
 import { MessageInlineInputComponent } from 'app/communication/message/message-inline-input/message-inline-input.component';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
-import { ForwardedMessageDTO } from 'app/communication/shared/entities/forwarded-message.model';
+import { ForwardedMessageDTO, ForwardedMessagesGroupDTO } from 'app/communication/shared/entities/forwarded-message.model';
 import { AnswerPost } from 'app/communication/shared/entities/answer-post.model';
 import { Posting, PostingType } from 'app/communication/shared/entities/posting.model';
 import { canCreateNewMessageInConversation } from 'app/communication/conversations/conversation-permissions.utils';
@@ -357,107 +357,160 @@ export class ConversationMessagesComponent implements OnInit, AfterViewInit, OnD
         return groupA.author.id === groupB.author.id;
     }
 
+    /**
+     * Sets and prepares the list of posts for display.
+     * Applies pinned message filters, loads forwarded messages and their sources, and groups posts for rendering.
+     */
     setPosts(): void {
+        // Saves the current scroll position relative to the bottom.
         if (this.content) {
             this.previousScrollDistanceFromTop = this.content.nativeElement.scrollHeight - this.content.nativeElement.scrollTop;
         }
-
         this.applyPinnedMessageFilter();
+        this.reversePosts();
 
+        const postIds = this.getPostIdsWithForwardedMessages();
+
+        if (postIds.length === 0) {
+            this.groupPosts();
+            return;
+        }
+        // only fetch forwarded messages if there are any
+        this.fetchForwardedMessages(postIds);
+    }
+
+    private fetchForwardedMessages = (postIds: number[]) => {
+        this.metisService.getForwardedMessagesByIds(postIds, PostingType.POST)?.subscribe((response) => {
+            const forwardedMessagesGroups = response.body;
+
+            if (!forwardedMessagesGroups) {
+                this.groupPosts();
+                return;
+            }
+
+            const forwardedMessagesMap = this.mapForwardedMessages(forwardedMessagesGroups);
+            // collect post and answer post ids from the forwarded messages to be fetched
+            const { sourcePostIds, sourceAnswerIds } = this.collectSourceIds(forwardedMessagesMap);
+
+            const requests = this.buildSourceRequests(sourcePostIds, sourceAnswerIds);
+
+            if (requests.length === 0) {
+                this.groupPosts();
+                return;
+            }
+
+            // fetch the actual information and wait until all responses are received before grouping the posts
+            forkJoin(requests).subscribe((responses) => {
+                const { fetchedPosts, fetchedAnswerPosts } = this.extractFetchedSources(responses);
+
+                this.posts = this.attachForwardedMessages(this.posts, forwardedMessagesMap, fetchedPosts, fetchedAnswerPosts);
+
+                this.groupPosts();
+                this.cdr.markForCheck();
+            });
+        });
+    };
+
+    /**
+     * Reverses the posts array to maintain chronological order.
+     */
+    private reversePosts(): void {
         this.posts = this.posts.slice().reverse();
+    }
 
-        const postIdsWithForwardedMessages = this.posts.filter((post) => post.hasForwardedMessages && post.id !== undefined).map((post) => post.id) as number[];
+    /**
+     * Filters posts that contain forwarded messages and have a valid ID.
+     */
+    private getPostIdsWithForwardedMessages(): number[] {
+        return this.posts.filter((post) => post.hasForwardedMessages && post.id !== undefined).map((post) => post.id!) as number[];
+    }
 
-        if (postIdsWithForwardedMessages.length > 0) {
-            this.metisService.getForwardedMessagesByIds(postIdsWithForwardedMessages, PostingType.POST)?.subscribe((response) => {
-                const forwardedMessagesGroups = response.body;
+    /**
+     * Converts list of forwarded message groups to a map from post ID to message list.
+     */
+    private mapForwardedMessages(groups: ForwardedMessagesGroupDTO[]): Map<number, ForwardedMessageDTO[]> {
+        return new Map(groups.map((group) => [group.id!, group.messages!]));
+    }
 
-                if (forwardedMessagesGroups) {
-                    const map = new Map<number, ForwardedMessageDTO[]>(forwardedMessagesGroups.map((group) => [group.id, group.messages]));
+    /**
+     * Extracts all source post and answer post IDs from forwarded messages.
+     */
+    private collectSourceIds(map: Map<number, ForwardedMessageDTO[]>): { sourcePostIds: number[]; sourceAnswerIds: number[] } {
+        const sourcePostIds: number[] = [];
+        const sourceAnswerIds: number[] = [];
 
-                    const sourcePostIds: number[] = [];
-                    const sourceAnswerIds: number[] = [];
-
-                    map.forEach((messages) => {
-                        messages.forEach((message) => {
-                            if (message.sourceType?.toString() === 'POST' && message.sourceId) {
-                                sourcePostIds.push(message.sourceId);
-                            } else if (message.sourceType?.toString() === 'ANSWER' && message.sourceId) {
-                                sourceAnswerIds.push(message.sourceId);
-                            }
-                        });
-                    });
-
-                    const sourceRequests = [];
-                    if (sourcePostIds.length > 0) {
-                        sourceRequests.push(this.metisService.getSourcePostsByIds(sourcePostIds));
-                    }
-                    if (sourceAnswerIds.length > 0) {
-                        sourceRequests.push(this.metisService.getSourceAnswerPostsByIds(sourceAnswerIds));
-                    }
-
-                    if (sourceRequests.length > 0) {
-                        forkJoin(sourceRequests).subscribe((responses) => {
-                            let fetchedPosts: Post[] = [];
-                            let fetchedAnswerPosts: AnswerPost[] = [];
-
-                            responses.forEach((response) => {
-                                if (Array.isArray(response)) {
-                                    if (response.length > 0) {
-                                        if ((response[0] as Post).conversation !== undefined) {
-                                            fetchedPosts = response as Post[];
-                                        } else if ((response[0] as AnswerPost).resolvesPost !== undefined) {
-                                            fetchedAnswerPosts = response as AnswerPost[];
-                                        }
-                                    }
-                                }
-                            });
-
-                            const fetchedPostIds = new Set(fetchedPosts.map((post) => post.id));
-                            const fetchedAnswerPostIds = new Set(fetchedAnswerPosts.map((answerPost) => answerPost.id));
-
-                            this.posts = this.posts.map((post) => {
-                                const forwardedMessages = map.get(post.id!) || [];
-                                post.forwardedPosts = forwardedMessages
-                                    .filter((message) => message.sourceType?.toString() === 'POST')
-                                    .map((message) => {
-                                        if (message.sourceId && !fetchedPostIds.has(message.sourceId)) {
-                                            // A source post has not been found so it was most likely deleted.
-                                            // We return undefined to indicate a missing post and handle it later (see forwarded-message.component)
-                                            return undefined;
-                                        }
-                                        return fetchedPosts.find((fetchedPost) => fetchedPost.id === message.sourceId);
-                                    });
-
-                                post.forwardedAnswerPosts = forwardedMessages
-                                    .filter((message) => message.sourceType?.toString() === 'ANSWER')
-                                    .map((message) => {
-                                        if (message.sourceId && !fetchedAnswerPostIds.has(message.sourceId)) {
-                                            // A source post has not been found so it was most likely deleted.
-                                            // We return undefined to indicate a missing post and handle it later (see forwarded-message.component)
-                                            return undefined;
-                                        }
-                                        return fetchedAnswerPosts.find((fetchedAnswerPost) => fetchedAnswerPost.id === message.sourceId);
-                                    });
-                                return post;
-                            });
-
-                            this.groupPosts();
-                            this.cdr.markForCheck();
-                        });
-                    } else {
-                        // No source posts or answer posts to fetch
-                        this.groupPosts();
-                    }
-                } else {
-                    // No forwarded messages found
-                    this.groupPosts();
+        map.forEach((messages) => {
+            messages.forEach((message) => {
+                if (message.sourceType?.toString() === 'POST' && message.sourceId) {
+                    sourcePostIds.push(message.sourceId);
+                } else if (message.sourceType?.toString() === 'ANSWER' && message.sourceId) {
+                    sourceAnswerIds.push(message.sourceId);
                 }
             });
-        } else {
-            // No posts with forwarded messages
-            this.groupPosts();
+        });
+
+        return { sourcePostIds, sourceAnswerIds };
+    }
+
+    /**
+     * Builds requests to fetch the source posts and answer posts based on their IDs.
+     * Wraps observables to emit nothing if inputs are invalid or expected to return undefined.
+     */
+    private buildSourceRequests(sourcePostIds: number[], sourceAnswerIds: number[]): Observable<Posting[] | undefined>[] {
+        const requests: Observable<Posting[] | undefined>[] = [];
+
+        if (sourcePostIds.length > 0) {
+            requests.push(this.metisService.getSourcePostsByIds(sourcePostIds));
         }
+
+        if (sourceAnswerIds.length > 0) {
+            requests.push(this.metisService.getSourceAnswerPostsByIds(sourceAnswerIds));
+        }
+
+        return requests;
+    }
+
+    /**
+     * Extracts fetched post and answer post arrays from forkJoin responses.
+     */
+    private extractFetchedSources(responses: (Posting[] | undefined)[]): { fetchedPosts: Post[]; fetchedAnswerPosts: AnswerPost[] } {
+        let fetchedPosts: Post[] = [];
+        let fetchedAnswerPosts: AnswerPost[] = [];
+
+        responses.forEach((response) => {
+            if (Array.isArray(response) && response.length > 0) {
+                const first = response[0];
+                if ((first as Post).conversation !== undefined) {
+                    fetchedPosts = response as Post[];
+                } else if ((first as AnswerPost).resolvesPost !== undefined) {
+                    fetchedAnswerPosts = response as AnswerPost[];
+                }
+            }
+        });
+
+        return { fetchedPosts, fetchedAnswerPosts };
+    }
+
+    /**
+     * Attaches forwarded posts and forwarded answer posts to their corresponding post.
+     */
+    private attachForwardedMessages(posts: Post[], messageMap: Map<number, ForwardedMessageDTO[]>, fetchedPosts: Post[], fetchedAnswerPosts: AnswerPost[]): Post[] {
+        const fetchedPostIds = new Set(fetchedPosts.map((post) => post.id));
+        const fetchedAnswerPostIds = new Set(fetchedAnswerPosts.map((answerPost) => answerPost.id));
+
+        return posts.map((post) => {
+            const forwardedMessages = messageMap.get(post.id!) || [];
+
+            post.forwardedPosts = forwardedMessages
+                .filter((m) => m.sourceType?.toString() === 'POST')
+                .map((m) => (m.sourceId && fetchedPostIds.has(m.sourceId) ? fetchedPosts.find((p) => p.id === m.sourceId) : undefined));
+
+            post.forwardedAnswerPosts = forwardedMessages
+                .filter((m) => m.sourceType?.toString() === 'ANSWER')
+                .map((m) => (m.sourceId && fetchedAnswerPostIds.has(m.sourceId) ? fetchedAnswerPosts.find((a) => a.id === m.sourceId) : undefined));
+
+            return post;
+        });
     }
 
     fetchNextPage() {

--- a/src/main/webapp/app/communication/service/forwarded-message.service.ts
+++ b/src/main/webapp/app/communication/service/forwarded-message.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { Observable, catchError, throwError } from 'rxjs';
-import { ForwardedMessage, ForwardedMessageDTO } from 'app/communication/shared/entities/forwarded-message.model';
+import { ForwardedMessage, ForwardedMessageDTO, ForwardedMessagesGroupDTO } from 'app/communication/shared/entities/forwarded-message.model';
 import { PostingType } from 'app/communication/shared/entities/posting.model';
 
 type EntityResponseType = HttpResponse<ForwardedMessageDTO>;
@@ -35,21 +35,16 @@ export class ForwardedMessageService {
      * @param type - The type of messages to retrieve (PostingType.POST or PostingType.ANSWER).
      * @returns An observable containing a list of objects where each object includes an ID and its corresponding messages (as DTOs), wrapped in an HttpResponse.
      */
-    getForwardedMessages(postingIds: number[], type: PostingType): Observable<HttpResponse<{ id: number; messages: ForwardedMessageDTO[] }[]>> {
+    getForwardedMessages(postingIds: number[], type: PostingType): Observable<HttpResponse<ForwardedMessagesGroupDTO[]>> {
         if (!postingIds || postingIds.length === 0) {
             return throwError(() => new Error('IDs cannot be empty'));
         }
         const params = new HttpParams().set('postingIds', postingIds.join(',')).set('type', type.toString());
 
-        return this.http
-            .get<{ id: number; messages: ForwardedMessageDTO[] }[]>(this.resourceUrl, {
-                params,
-                observe: 'response',
-            })
-            .pipe(
-                catchError(() => {
-                    return throwError(() => new Error('Failed to retrieve forwarded messages'));
-                }),
-            );
+        return this.http.get<{ id: number; messages: ForwardedMessageDTO[] }[]>(this.resourceUrl, { params, observe: 'response' }).pipe(
+            catchError(() => {
+                return throwError(() => new Error('Failed to retrieve forwarded messages'));
+            }),
+        );
     }
 }

--- a/src/main/webapp/app/communication/service/forwarded-message.service.ts
+++ b/src/main/webapp/app/communication/service/forwarded-message.service.ts
@@ -41,7 +41,7 @@ export class ForwardedMessageService {
         }
         const params = new HttpParams().set('postingIds', postingIds.join(',')).set('type', type.toString());
 
-        return this.http.get<{ id: number; messages: ForwardedMessageDTO[] }[]>(this.resourceUrl, { params, observe: 'response' }).pipe(
+        return this.http.get<ForwardedMessagesGroupDTO[]>(this.resourceUrl, { params, observe: 'response' }).pipe(
             catchError(() => {
                 return throwError(() => new Error('Failed to retrieve forwarded messages'));
             }),

--- a/src/main/webapp/app/communication/service/metis.service.ts
+++ b/src/main/webapp/app/communication/service/metis.service.ts
@@ -23,7 +23,7 @@ import { ChannelDTO, ChannelSubType, getAsChannelDTO } from 'app/communication/s
 import { Conversation, ConversationDTO } from 'app/communication/shared/entities/conversation/conversation.model';
 import { getAsGroupChatDTO } from 'app/communication/shared/entities/conversation/group-chat.model';
 import { getAsOneToOneChatDTO } from 'app/communication/shared/entities/conversation/one-to-one-chat.model';
-import { ForwardedMessage, ForwardedMessageDTO } from 'app/communication/shared/entities/forwarded-message.model';
+import { ForwardedMessage, ForwardedMessagesGroupDTO } from 'app/communication/shared/entities/forwarded-message.model';
 import { MetisPostDTO } from 'app/communication/shared/entities/metis-post-dto.model';
 import { Post } from 'app/communication/shared/entities/post.model';
 import { Posting, PostingType, SavedPostStatus } from 'app/communication/shared/entities/posting.model';
@@ -831,7 +831,7 @@ export class MetisService implements OnDestroy {
      * @param type - The type of messages to retrieve ('post' or 'answer').
      * @returns An observable containing a list of objects where each object includes an ID and its corresponding messages (as DTOs), wrapped in an HttpResponse, or undefined if the IDs are invalid.
      */
-    getForwardedMessagesByIds(postingIds: number[], type: PostingType): Observable<HttpResponse<{ id: number; messages: ForwardedMessageDTO[] }[]>> | undefined {
+    getForwardedMessagesByIds(postingIds: number[], type: PostingType): Observable<HttpResponse<ForwardedMessagesGroupDTO[]>> | undefined {
         if (postingIds && postingIds.length > 0) {
             return this.forwardedMessageService.getForwardedMessages(postingIds, type);
         } else {

--- a/src/main/webapp/app/communication/shared/entities/forwarded-message.model.ts
+++ b/src/main/webapp/app/communication/shared/entities/forwarded-message.model.ts
@@ -12,6 +12,11 @@ export interface ForwardedMessageDTO {
     content?: string;
 }
 
+export interface ForwardedMessagesGroupDTO {
+    id?: number;
+    messages: ForwardedMessageDTO[];
+}
+
 export class ForwardedMessage implements BaseEntity {
     public id?: number;
     public sourceId?: number;


### PR DESCRIPTION
### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
There was a big method `setPosts()` without documentation which was hard to understand


### Description
I refactored this method into smaller ones and tried to improve typings and documentation


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 2 Students
- Communication enabled

1. Write a few messages and answers in the same channel. Forward messages, save posts 
2. Now reload the page, navigate again into the channel and make sure everything is displayed properly
3. Delete messages and make sure this works (also when the message has been forwarded or saved)


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the structure and readability of conversation message handling, especially for messages with forwarded content. No changes to existing features or user experience.
  - Updated data handling for forwarded message groups to streamline message retrieval and display.

- **Style**
  - Enhanced code clarity and maintainability behind the scenes, ensuring more reliable processing of forwarded messages. No visible impact for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->