### PR TITLE
`Development`: Fix an issue with missing libraries when eureka is active

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,7 @@ configurations.configureEach {
     // JPlag depends on those, but they are not really needed
     exclude group: "org.jgrapht", module: "jgrapht-core"
     exclude group: "org.apfloat", module: "apfloat"
+    exclude group: "xom", module: "xom"
 
     exclude group: "commons-configuration", module: "commons-configuration"
 
@@ -285,6 +286,9 @@ dependencies {
     // Required for several dependencies
     implementation "org.apache.commons:commons-text:1.13.1"
     implementation "org.apache.commons:commons-math3:3.6.1"
+    implementation "org.apache.commons:commons-lang3:3.17.0"
+    // required by eureka, but actually superseded by commons-lang3 above
+    implementation "commons-lang:commons-lang:2.6"
 
     implementation("org.liquibase:liquibase-core:${liquibase_version}") {
         exclude group: 'com.opencsv', module: 'opencsv'

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/localvc/LocalVCGitBranchService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/localvc/LocalVCGitBranchService.java
@@ -2,8 +2,8 @@ package de.tum.cit.aet.artemis.programming.service.localvc;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.RepositoryBuilder;
@@ -74,7 +74,7 @@ public class LocalVCGitBranchService {
      */
     @Deprecated(forRemoval = true, since = "8.0")
     public static String getDefaultBranch(String repositoryPath) {
-        try (Repository repository = new RepositoryBuilder().setGitDir(new File(repositoryPath)).build()) {
+        try (Repository repository = new RepositoryBuilder().setGitDir(Path.of(repositoryPath).toFile()).build()) {
 
             String defaultBranchName = repository.getBranch();
             if (defaultBranchName == null) {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/icl/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/icl/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.Optional;
@@ -394,7 +393,7 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractProgrammi
 
         String repoClonePath = System.getProperty("artemis.repo-clone-path", "repos");
         String projectKey = importResult.parsedExercise().getProjectKey();
-        Path exercisePath = Paths.get(repoClonePath, projectKey);
+        Path exercisePath = Path.of(repoClonePath, projectKey);
         int newTitleCount = programmingExerciseImportTestService.countOccurrencesInDirectory(exercisePath, newTitle);
         int oldTitleCount = programmingExerciseImportTestService.countOccurrencesInDirectory(exercisePath, oldTitle);
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseImportTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseImportTestService.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static tech.jhipster.config.JHipsterConstants.SPRING_PROFILE_TEST;
 
 import java.io.ByteArrayOutputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -117,7 +116,7 @@ public class ProgrammingExerciseImportTestService {
      */
     public int countOccurrencesInZip(ClassPathResource resource, String searchString) throws Exception {
         int occurrenceCount = 0;
-        try (ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(resource.getFile()))) {
+        try (ZipInputStream zipInputStream = new ZipInputStream(Files.newInputStream(resource.getFile().toPath()))) {
             ZipEntry zipEntry;
             while ((zipEntry = zipInputStream.getNextEntry()) != null) {
                 if (!zipEntry.isDirectory() && zipEntry.getName().endsWith(".zip")) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The server didn't start locally when eureka client was enabled with the change in ee0a6fe due to a missing class in the classpath from `apache-commons lang`
This also caused all e2e-tests to fail

### Description
<!-- Describe your changes in detail -->
Added `apache-commons lang` to the classpath.




### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

- Make sure the e2e-tests run again
- Start the server locally (make sure eureka.client.enabled is **not** set to false (in application-local.yml) and check that the server start succeeds

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency exclusions and added new Apache Commons libraries to improve compatibility.
- **Refactor**
  - Modernized file and path handling in various components and tests for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->