### PR TITLE
`General`: Fix filename for downloaded files

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/FilePathType.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/FilePathType.java
@@ -46,5 +46,6 @@ public enum FilePathType {
     FILE_UPLOAD_SUBMISSION,
 
     /** <strong> Other file paths </strong> **/
-    TEMPORARY
+    TEMPORARY,
+    MARKDOWN,
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/FilePathService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/FilePathService.java
@@ -168,6 +168,7 @@ public class FilePathService {
         String filename = path.getFileName().toString();
 
         return switch (filePathType) {
+            case MARKDOWN -> getMarkdownFilePath().resolve(filename);
             case TEMPORARY -> getTempFilePath().resolve(filename);
             case DRAG_AND_DROP_BACKGROUND -> getDragAndDropBackgroundFilePath().resolve(filename);
             case DRAG_ITEM -> getDragItemFilePath().resolve(filename);
@@ -326,6 +327,7 @@ public class FilePathService {
 
         return switch (filePathType) {
             case TEMPORARY -> URI.create(FileService.DEFAULT_FILE_SUBPATH + filename);
+            case MARKDOWN -> URI.create("markdown/" + filename);
             case DRAG_AND_DROP_BACKGROUND -> URI.create("drag-and-drop/backgrounds/" + id + "/" + filename);
             case DRAG_ITEM -> URI.create("drag-and-drop/drag-items/" + id + "/" + filename);
             case COURSE_ICON -> URI.create("course/icons/" + id + "/" + filename);

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/FileService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/FileService.java
@@ -362,6 +362,7 @@ public class FileService implements DisposableBean {
             case DRAG_ITEM -> "DragItem_";
             case COURSE_ICON -> "CourseIcon_";
             case PROFILE_PICTURE -> "ProfilePicture_";
+            case MARKDOWN -> "Markdown_";
             case EXAM_USER_SIGNATURE -> "ExamUserSignature_";
             case EXAM_USER_IMAGE -> "ExamUserImage_";
             case LECTURE_ATTACHMENT -> "LectureAttachment_";

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/FileResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/FileResource.java
@@ -226,10 +226,10 @@ public class FileResource {
         var fileUpload = fileUploadService.findByPath(publicPath);
 
         if (fileUpload.isPresent()) {
-            return buildFileResponse(serverFilePath, filename, Optional.ofNullable(fileUpload.get().getFilename()), true);
+            return buildFileResponse(serverFilePath, filename, Optional.ofNullable(fileUpload.get().getFilename()), FilePathType.MARKDOWN, true);
         }
 
-        return buildFileResponse(serverFilePath, filename, true);
+        return buildFileResponse(serverFilePath, filename, FilePathType.MARKDOWN, true);
     }
 
     /**
@@ -243,7 +243,7 @@ public class FileResource {
     public ResponseEntity<byte[]> getMarkdownFile(@PathVariable String filename) {
         log.debug("REST request to get file : {}", filename);
         sanitizeFilenameElseThrow(filename);
-        return buildFileResponse(FilePathService.getMarkdownFilePath(), filename, false);
+        return buildFileResponse(FilePathService.getMarkdownFilePath(), filename, FilePathType.MARKDOWN, false);
     }
 
     /**
@@ -352,8 +352,9 @@ public class FileResource {
         if (!usersOfTheSubmission.contains(requestingUser) && !authCheckService.isAtLeastTeachingAssistantForExercise(exercise)) {
             throw new AccessForbiddenException();
         }
+        FilePathType type = FilePathType.FILE_UPLOAD_SUBMISSION;
 
-        return buildFileResponse(getActualPathFromPublicPathString(submission.getFilePath(), FilePathType.FILE_UPLOAD_SUBMISSION), false);
+        return buildFileResponse(getActualPathFromPublicPathString(submission.getFilePath(), type), type, false);
     }
 
     /**
@@ -414,7 +415,8 @@ public class FileResource {
         ExamUser examUser = api.findWithExamById(examUserId).orElseThrow();
         authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, examUser.getExam().getCourse(), null);
 
-        return buildFileResponse(getActualPathFromPublicPathString(examUser.getSigningImagePath(), FilePathType.EXAM_USER_SIGNATURE), false);
+        FilePathType type = FilePathType.EXAM_USER_SIGNATURE;
+        return buildFileResponse(getActualPathFromPublicPathString(examUser.getSigningImagePath(), type), type, false);
     }
 
     /**
@@ -432,7 +434,8 @@ public class FileResource {
         ExamUser examUser = api.findWithExamById(examUserId).orElseThrow();
         authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, examUser.getExam().getCourse(), null);
 
-        return buildFileResponse(getActualPathFromPublicPathString(examUser.getStudentImagePath(), FilePathType.EXAM_USER_IMAGE), true);
+        FilePathType type = FilePathType.EXAM_USER_IMAGE;
+        return buildFileResponse(getActualPathFromPublicPathString(examUser.getStudentImagePath(), type), type, true);
     }
 
     /**
@@ -459,7 +462,8 @@ public class FileResource {
         // check if the user is authorized to access the requested attachment unit
         checkAttachmentAuthorizationOrThrow(course, attachment);
 
-        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink(), FilePathType.LECTURE_ATTACHMENT), Optional.of(attachmentName));
+        FilePathType type = FilePathType.LECTURE_ATTACHMENT;
+        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink(), type), Optional.of(attachmentName), type);
     }
 
     /**
@@ -527,8 +531,8 @@ public class FileResource {
 
         // check if the user is authorized to access the requested attachment unit
         checkAttachmentAuthorizationOrThrow(course, attachment);
-        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink(), FilePathType.ATTACHMENT_UNIT),
-                Optional.of(attachment.getName() + "." + getExtension(attachment.getLink())));
+        FilePathType type = FilePathType.ATTACHMENT_UNIT;
+        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink(), type), Optional.of(attachment.getName() + "." + getExtension(attachment.getLink())), type);
     }
 
     /**
@@ -549,7 +553,8 @@ public class FileResource {
         Attachment attachment = attachmentUnit.getAttachment();
         checkAttachmentUnitExistsInCourseOrThrow(course, attachmentUnit);
 
-        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink(), FilePathType.ATTACHMENT_UNIT), false);
+        FilePathType type = FilePathType.ATTACHMENT_UNIT;
+        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink(), type), type, false);
     }
 
     /**
@@ -569,7 +574,8 @@ public class FileResource {
         Course course = courseRepository.findByIdElseThrow(courseId);
         checkAttachmentExistsInCourseOrThrow(course, attachment);
 
-        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink(), FilePathType.LECTURE_ATTACHMENT), false);
+        FilePathType type = FilePathType.LECTURE_ATTACHMENT;
+        return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink(), type), type, false);
     }
 
     /**
@@ -605,7 +611,8 @@ public class FileResource {
         Matcher matcher = pattern.matcher(directoryPath);
 
         if (matcher.matches()) {
-            return buildFileResponse(getActualPathFromPublicPathString(slide.getSlideImagePath(), FilePathType.SLIDE), false);
+            FilePathType type = FilePathType.SLIDE;
+            return buildFileResponse(getActualPathFromPublicPathString(slide.getSlideImagePath(), type), type, false);
         }
         else {
             throw new EntityNotFoundException("Slide", slideNumber);
@@ -637,7 +644,8 @@ public class FileResource {
         Matcher matcher = pattern.matcher(directoryPath);
 
         if (matcher.matches()) {
-            return buildFileResponse(getActualPathFromPublicPathString(slide.getSlideImagePath(), FilePathType.SLIDE), false);
+            FilePathType type = FilePathType.SLIDE;
+            return buildFileResponse(getActualPathFromPublicPathString(slide.getSlideImagePath(), type), type, false);
         }
         else {
             throw new EntityNotFoundException("Slide", slideId);
@@ -664,23 +672,26 @@ public class FileResource {
         // check if hidden link is available in the attachment
         String studentVersion = attachment.getStudentVersion();
         if (studentVersion == null) {
-            return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink(), FilePathType.ATTACHMENT_UNIT), false);
+            FilePathType type = FilePathType.ATTACHMENT_UNIT;
+            return buildFileResponse(getActualPathFromPublicPathString(attachment.getLink(), type), type, false);
         }
 
         String fileName = studentVersion.substring(studentVersion.lastIndexOf("/") + 1);
 
-        return buildFileResponse(FilePathService.getAttachmentUnitFileSystemPath().resolve(Path.of(attachmentUnit.getId().toString(), "student")), fileName, false);
+        return buildFileResponse(FilePathService.getAttachmentUnitFileSystemPath().resolve(Path.of(attachmentUnit.getId().toString(), "student")), fileName,
+                FilePathType.STUDENT_VERSION_SLIDES, false);
     }
 
     /**
      * Builds the response with headers, body and content type for specified path containing the file name
      *
      * @param path  to the file including the file name
+     * @param type  the type of the file path
      * @param cache true if the response should contain a header that allows caching; false otherwise
      * @return response entity
      */
-    private ResponseEntity<byte[]> buildFileResponse(Path path, boolean cache) {
-        return buildFileResponse(path.getParent(), path.getFileName().toString(), Optional.empty(), cache);
+    private ResponseEntity<byte[]> buildFileResponse(Path path, FilePathType type, boolean cache) {
+        return buildFileResponse(path.getParent(), path.getFileName().toString(), Optional.empty(), type, cache);
     }
 
     /**
@@ -688,11 +699,12 @@ public class FileResource {
      *
      * @param path     to the file including the file name
      * @param filename the name of the file
+     * @param type     the type of the file path
      * @param cache    true if the response should contain a header that allows caching; false otherwise
      * @return response entity
      */
-    private ResponseEntity<byte[]> buildFileResponse(Path path, String filename, boolean cache) {
-        return buildFileResponse(path, filename, Optional.empty(), cache);
+    private ResponseEntity<byte[]> buildFileResponse(Path path, String filename, FilePathType type, boolean cache) {
+        return buildFileResponse(path, filename, Optional.empty(), type, cache);
     }
 
     /**
@@ -700,10 +712,11 @@ public class FileResource {
      *
      * @param path            to the file
      * @param replaceFilename replaces the downloaded file's name, if provided
+     * @param type            the type of the file path
      * @return response entity
      */
-    private ResponseEntity<byte[]> buildFileResponse(Path path, Optional<String> replaceFilename) {
-        return buildFileResponse(path.getParent(), path.getFileName().toString(), replaceFilename, false);
+    private ResponseEntity<byte[]> buildFileResponse(Path path, Optional<String> replaceFilename, FilePathType type) {
+        return buildFileResponse(path.getParent(), path.getFileName().toString(), replaceFilename, type, false);
     }
 
     /**
@@ -712,10 +725,11 @@ public class FileResource {
      * @param path            to the file
      * @param filename        the name of the file
      * @param replaceFilename replaces the downloaded file's name, if provided
+     * @param type            the type of the file path
      * @param cache           true if the response should contain a header that allows caching; false otherwise
      * @return response entity
      */
-    private ResponseEntity<byte[]> buildFileResponse(Path path, String filename, Optional<String> replaceFilename, boolean cache) {
+    private ResponseEntity<byte[]> buildFileResponse(Path path, String filename, Optional<String> replaceFilename, FilePathType type, boolean cache) {
         try {
             Path actualPath = path.resolve(filename);
             byte[] file = fileService.getFileForPath(actualPath);
@@ -731,6 +745,11 @@ public class FileResource {
                     ? "attachment"
                     : "inline";
             String headerFilename = FileService.sanitizeFilename(replaceFilename.orElse(filename));
+            String prefix = fileService.generateTargetFilenameBase(type);
+            // the stored filename contains potentially a prefix and a timestamp. The user doesn't need that and it should be removed
+            headerFilename = headerFilename.replace(prefix, "");
+            headerFilename = headerFilename.replaceFirst("^[^_]*_", "");
+
             headers.setContentDisposition(ContentDisposition.builder(contentType).filename(headerFilename).build());
 
             var response = ResponseEntity.ok().headers(headers).contentType(getMediaTypeFromFilename(filename)).header("filename", filename);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When downloading a file, we set as filename to download the filename that we store in our filesystem.
This disturbs the user flow as they do not get 

### Description
<!-- Describe your changes in detail -->


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 

1. Log in to Artemis
2. Navigate to Course Administration
3. Create an attachment unit and download it.
4. Check that the filename is the same as you uploaded without some prefix or a timestamp.

#### Exam Mode Testing

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->