### PR TITLE
`Quiz exercises`: Fix unassessed quiz exercise check for exam instructors

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamService.java
@@ -120,12 +120,13 @@ public class ExamService {
 
     private static final int EXAM_ACTIVE_DAYS = 7;
 
-    private final QuizResultService quizResultService;
-
-    @Value("${artemis.course-archives-path}")
-    private Path examArchivesDirPath;
-
     private static final Logger log = LoggerFactory.getLogger(ExamService.class);
+
+    private static final boolean IS_TEST_RUN = false;
+
+    private static final String NOT_ALLOWED_TO_ACCESS_THE_GRADE_SUMMARY = "You are not allowed to access the grade summary of a student exam ";
+
+    private final QuizResultService quizResultService;
 
     private final UserRepository userRepository;
 
@@ -177,9 +178,8 @@ public class ExamService {
 
     private final ObjectMapper defaultObjectMapper;
 
-    private static final boolean IS_TEST_RUN = false;
-
-    private static final String NOT_ALLOWED_TO_ACCESS_THE_GRADE_SUMMARY = "You are not allowed to access the grade summary of a student exam ";
+    @Value("${artemis.course-archives-path}")
+    private Path examArchivesDirPath;
 
     public ExamService(ExamRepository examRepository, StudentExamRepository studentExamRepository, TutorLeaderboardService tutorLeaderboardService,
             StudentParticipationRepository studentParticipationRepository, ComplaintRepository complaintRepository, ComplaintResponseRepository complaintResponseRepository,
@@ -216,6 +216,70 @@ public class ExamService {
         this.courseRepository = courseRepository;
         this.defaultObjectMapper = new ObjectMapper();
         this.quizResultService = quizResultService;
+    }
+
+    private static boolean isSecondCorrectionEnabled(Exam exam) {
+        return exam.getExerciseGroups().stream().flatMap(exerciseGroup -> exerciseGroup.getExercises().stream()).anyMatch(Exercise::getSecondCorrectionEnabled);
+    }
+
+    /**
+     * Determines whether the student should see the result of the exam.
+     * This is the case if the exam is started and not ended yet or if the results are already published.
+     *
+     * @param studentExam   The student exam
+     * @param participation The participation of the student
+     * @return true if the student should see the result, false otherwise
+     */
+    public static boolean shouldStudentSeeResult(StudentExam studentExam, StudentParticipation participation) {
+        return (studentExam.getExam().isStarted() && !studentExam.isEnded() && participation instanceof ProgrammingExerciseStudentParticipation)
+                || studentExam.areResultsPublishedYet();
+    }
+
+    /**
+     * Helper method which attaches the result to its participation.
+     * For direct automatic feedback during the exam conduction for {@link ProgrammingExercise}, we need to attach the results.
+     * We also attach the result if the results are already published for the exam.
+     * If no suitable Result is found for StudentParticipation, an empty Result set is assigned to prevent LazyInitializationException on future reads.
+     * See {@link StudentExam#areResultsPublishedYet}
+     *
+     * @param studentExam         the given studentExam
+     * @param participation       the given participation of the student
+     * @param isAtLeastInstructor flag for instructor access privileges
+     */
+    private static void setResultIfNecessary(StudentExam studentExam, StudentParticipation participation, boolean isAtLeastInstructor) {
+        // Only set the result during the exam for programming exercises (for direct automatic feedback) or after publishing the results
+        boolean isStudentAllowedToSeeResult = shouldStudentSeeResult(studentExam, participation);
+        Optional<Submission> latestSubmission = participation.findLatestSubmission();
+
+        // To prevent LazyInitializationException.
+        participation.setResults(Set.of());
+        if (latestSubmission.isPresent()) {
+            var lastSubmission = latestSubmission.get();
+            if (isStudentAllowedToSeeResult || isAtLeastInstructor) {
+                // Also set the latest result into the participation as the client expects it there for programming exercises
+                Result latestResult = lastSubmission.getLatestResult();
+                if (latestResult != null) {
+                    latestResult.setParticipation(null);
+                    latestResult.setSubmission(lastSubmission);
+                    latestResult.filterSensitiveInformation();
+                    // to avoid cycles and support certain use cases on the client, only the last result + submission inside the participation are relevant, i.e. participation ->
+                    // lastResult -> lastSubmission
+                    participation.setResults(Set.of(latestResult));
+                }
+                participation.setSubmissions(Set.of(lastSubmission));
+            }
+            lastSubmission.setResults(null);
+        }
+    }
+
+    private static Set<Exercise> getAllExercisesForExam(Exam exam) {
+        return getAllExercisesForExamByType(exam, Exercise.class);
+    }
+
+    private static <T extends Exercise> Set<T> getAllExercisesForExamByType(Exam exam, Class<T> exerciseType) {
+        return exam.getExerciseGroups().stream().flatMap(exerciseGroup -> exerciseGroup.getExercises().stream())
+                // this also filters potential null values
+                .filter(exerciseType::isInstance).map(exerciseType::cast).collect(Collectors.toSet());
     }
 
     /**
@@ -315,10 +379,6 @@ public class ExamService {
         // the second correction has started if it is enabled in the exam and at least one exercise was started
         var hasSecondCorrectionAndStarted = exam.getNumberOfCorrectionRoundsInExam() > 1 && isSecondCorrectionEnabled(exam);
         return new ExamScoresDTO(exam.getId(), exam.getTitle(), exam.getExamMaxPoints(), averagePointsAchieved, hasSecondCorrectionAndStarted, exerciseGroups, studentResults);
-    }
-
-    private static boolean isSecondCorrectionEnabled(Exam exam) {
-        return exam.getExerciseGroups().stream().flatMap(exerciseGroup -> exerciseGroup.getExercises().stream()).anyMatch(Exercise::getSecondCorrectionEnabled);
     }
 
     /**
@@ -596,56 +656,6 @@ public class ExamService {
         else {
             // To prevent LazyInitializationException.
             exercise.setStudentParticipations(Set.of());
-        }
-    }
-
-    /**
-     * Determines whether the student should see the result of the exam.
-     * This is the case if the exam is started and not ended yet or if the results are already published.
-     *
-     * @param studentExam   The student exam
-     * @param participation The participation of the student
-     * @return true if the student should see the result, false otherwise
-     */
-    public static boolean shouldStudentSeeResult(StudentExam studentExam, StudentParticipation participation) {
-        return (studentExam.getExam().isStarted() && !studentExam.isEnded() && participation instanceof ProgrammingExerciseStudentParticipation)
-                || studentExam.areResultsPublishedYet();
-    }
-
-    /**
-     * Helper method which attaches the result to its participation.
-     * For direct automatic feedback during the exam conduction for {@link ProgrammingExercise}, we need to attach the results.
-     * We also attach the result if the results are already published for the exam.
-     * If no suitable Result is found for StudentParticipation, an empty Result set is assigned to prevent LazyInitializationException on future reads.
-     * See {@link StudentExam#areResultsPublishedYet}
-     *
-     * @param studentExam         the given studentExam
-     * @param participation       the given participation of the student
-     * @param isAtLeastInstructor flag for instructor access privileges
-     */
-    private static void setResultIfNecessary(StudentExam studentExam, StudentParticipation participation, boolean isAtLeastInstructor) {
-        // Only set the result during the exam for programming exercises (for direct automatic feedback) or after publishing the results
-        boolean isStudentAllowedToSeeResult = shouldStudentSeeResult(studentExam, participation);
-        Optional<Submission> latestSubmission = participation.findLatestSubmission();
-
-        // To prevent LazyInitializationException.
-        participation.setResults(Set.of());
-        if (latestSubmission.isPresent()) {
-            var lastSubmission = latestSubmission.get();
-            if (isStudentAllowedToSeeResult || isAtLeastInstructor) {
-                // Also set the latest result into the participation as the client expects it there for programming exercises
-                Result latestResult = lastSubmission.getLatestResult();
-                if (latestResult != null) {
-                    latestResult.setParticipation(null);
-                    latestResult.setSubmission(lastSubmission);
-                    latestResult.filterSensitiveInformation();
-                    // to avoid cycles and support certain use cases on the client, only the last result + submission inside the participation are relevant, i.e. participation ->
-                    // lastResult -> lastSubmission
-                    participation.setResults(Set.of(latestResult));
-                }
-                participation.setSubmissions(Set.of(lastSubmission));
-            }
-            lastSubmission.setResults(null);
         }
     }
 
@@ -1068,6 +1078,8 @@ public class ExamService {
             totalNumberOfComplaintResponse += numberOfComplaintResponse;
         }
 
+        boolean existsUnassessedQuizzes = submissionRepository.existsUnassessedQuizzesByExamId(exam.getId());
+
         if (isInstructor) {
             // set number of student exams that have been generated
             long numberOfGeneratedStudentExams = examRepository.countGeneratedStudentExamsByExamWithoutTestRuns(exam.getId());
@@ -1097,11 +1109,11 @@ public class ExamService {
             }
 
             return new ExamChecklistDTO(numberOfGeneratedStudentExams, numberOfTestRuns, totalNumberOfAssessmentsFinished, totalNumberOfParticipationsForAssessment,
-                    numberOfStudentExamsSubmitted, numberOfStudentExamsStarted, totalNumberOfComplaints, totalNumberOfComplaintResponse, exercisesPrepared, null, null);
+                    numberOfStudentExamsSubmitted, numberOfStudentExamsStarted, totalNumberOfComplaints, totalNumberOfComplaintResponse, exercisesPrepared, existsUnassessedQuizzes,
+                    null);
 
         }
 
-        boolean existsUnassessedQuizzes = submissionRepository.existsUnassessedQuizzesByExamId(exam.getId());
         boolean existsUnsubmittedExercises = submissionRepository.existsUnsubmittedExercisesByExamId(exam.getId());
 
         // For non-instructors, consider what limited information they should receive and adjust accordingly
@@ -1132,16 +1144,6 @@ public class ExamService {
     private <T extends Exercise> Set<T> getAllExercisesForExamByType(Long examId, Class<T> exerciseType) {
         var exam = examRepository.findWithExerciseGroupsAndExercisesByIdOrElseThrow(examId);
         return getAllExercisesForExamByType(exam, exerciseType);
-    }
-
-    private static Set<Exercise> getAllExercisesForExam(Exam exam) {
-        return getAllExercisesForExamByType(exam, Exercise.class);
-    }
-
-    private static <T extends Exercise> Set<T> getAllExercisesForExamByType(Exam exam, Class<T> exerciseType) {
-        return exam.getExerciseGroups().stream().flatMap(exerciseGroup -> exerciseGroup.getExercises().stream())
-                // this also filters potential null values
-                .filter(exerciseType::isInstance).map(exerciseType::cast).collect(Collectors.toSet());
     }
 
     /**
@@ -1371,5 +1373,7 @@ public class ExamService {
     private interface ExamBonusCalculator {
 
         BonusResultDTO calculateStudentGradesWithBonus(Long studentId, Double bonusToAchievedPoints);
+
     }
+
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As described by #10074, the check which is supposed to display to exam instructors whether all quizzes have been assessed is not implemented properly. Instead, the DTO containing the checklist which is sent to the instructor receives a NULL value, which is interpreted as 'No missing assessments'.

### Description
<!-- Describe your changes in detail -->
I used the variable `existsUnassessedQuizzes` which was already used by the DTO sent to non-instructors and included it in the DTO sent to instructors. Now on the checklist it correctly indicates that the quizzes have not been assessed yet, and instructors can press the button to assess the quizzes.

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 1 Students
- 1 Exam with a Quiz Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. As the instructor wait for the exam to finish or move the end time so that it finishes sooner
4. Navigate to the Exam Checklist and scroll down to point 3. of the `Exam Correction`, which is `Pubish the exam results`
5. If there is a warning that there is no publishing date for the results set, edit the exam to have a result publishing date at any point in the future
6. The `Unassessed Quiz Exercises` check should be red and the `Evaluate quizzes` button should be active
7. Pressing the `Evaluate quizzes` button should yield a success message and the check should now be green

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Exam Mode Test
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved organization and readability of internal logic for exam-related features. No changes to core functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->