### PR TITLE
`Development`: Unify ldap profiles

### DIFF
--- a/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI_.xml
+++ b/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI_.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artemis (Server, LocalVC &amp; LocalCI)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="dev,localci,localvc,artemis,scheduling,buildagent,core,ldap-only,local" />
+    <option name="ACTIVE_PROFILES" value="dev,localci,localvc,artemis,scheduling,buildagent,core,ldap,local" />
     <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <module name="Artemis.main" />
     <option name="SHORTEN_COMMAND_LINE" value="ARGS_FILE" />

--- a/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI__Theia_.xml
+++ b/.idea/runConfigurations/Artemis__Server__LocalVC___LocalCI__Theia_.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Artemis (Server, LocalVC &amp; LocalCI, Theia)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="theia,dev,localci,localvc,artemis,scheduling,buildagent,core,ldap-only,local" />
+    <option name="ACTIVE_PROFILES" value="theia,dev,localci,localvc,artemis,scheduling,buildagent,core,ldap,local" />
     <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <module name="Artemis.main" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />

--- a/docs/admin/setup/distributed.rst
+++ b/docs/admin/setup/distributed.rst
@@ -528,7 +528,7 @@ For ICL, the run configuration for core nodes need to include the additional pro
 
 ::
 
-        --spring.profiles.active=prod,core,ldap-only,localvc,localci,athena,scheduling,iris,lti
+        --spring.profiles.active=prod,core,ldap,localvc,localci,athena,scheduling,iris,lti
 
 Core nodes do not require further adjustments to the ``application-prod.yml``, as long as you have added the necessary variables as described in the :ref:`Integrated Code Lifecycle Setup <Integrated Code Lifecycle Setup>`.
 

--- a/docs/dev/setup/server.rst
+++ b/docs/dev/setup/server.rst
@@ -101,7 +101,7 @@ module replacement in the client.
   `http://localhost:9000/ <http://localhost:9000/>`__ with hot module replacement enabled (also see
   :ref:`Client Setup <client-setup>`).
 * **Artemis (Server, LocalVC & LocalCI):** The server will be started separated from the client with the profiles
-  ``dev,localci,localvc,artemis,scheduling,buildagent,core,atlas,ldap-only,local``.
+  ``dev,localci,localvc,artemis,scheduling,buildagent,core,atlas,ldap,local``.
 * **Artemis (Server, LocalVC & Jenkins):** The server will be started separated from the client with the profiles
   ``dev,jenkins,localvc,artemis,scheduling,core,atlas,local``.
 * **Artemis (Server, LocalVC & LocalCI, Athena):** The server will be started separated from the client with ``athena`` profile and Local VC / CI enabled

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/Constants.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/Constants.java
@@ -263,8 +263,6 @@ public final class Constants {
 
     public static final String USE_EXTERNAL = "useExternal";
 
-    public static final String PASSKEY_ENABLED = "passkeyEnabled";
-
     public static final String EXTERNAL_CREDENTIAL_PROVIDER = "externalCredentialProvider";
 
     public static final String EXTERNAL_PASSWORD_RESET_LINK_MAP = "externalPasswordResetLinkMap";
@@ -332,18 +330,6 @@ public final class Constants {
      * Use this profile if you want to synchronize users with an external LDAP system, but you want to route the authentication through another system
      */
     public static final String PROFILE_LDAP = "ldap";
-
-    /**
-     * The name of the Spring profile used for authentication via LDAP only.
-     * Use this profile if you want to use LDAP authentication (incl. user synchronization)
-     * NOTE: in the future we will remove this profile and combine both (due to ambiguity), then there will only be the LDAP profile exclusively
-     */
-    @Deprecated
-    public static final String PROFILE_LDAP_ONLY = "ldap-only";
-
-    // Will be removed and replaced with PROFILE_LDAP
-    @Deprecated
-    public static final String PROFILE_LDAP_OR_LDAP_ONLY = PROFILE_LDAP + " | " + PROFILE_LDAP_ONLY;
 
     /**
      * The name of the Spring profile used for activating LTI in Artemis, see {@link de.tum.cit.aet.artemis.lti.web.LtiResource}.

--- a/src/main/java/de/tum/cit/aet/artemis/core/repository/ldap/LdapUserRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/repository/ldap/LdapUserRepository.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.artemis.core.repository.ldap;
 
-import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP_OR_LDAP_ONLY;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.ldap.repository.LdapRepository;
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import de.tum.cit.aet.artemis.core.service.ldap.LdapUserDto;
 
 @Repository
-@Profile(PROFILE_LDAP_OR_LDAP_ONLY)
+@Profile(PROFILE_LDAP)
 public interface LdapUserRepository extends LdapRepository<LdapUserDto> {
 
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/connectors/ldap/LdapAuthenticationProvider.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/connectors/ldap/LdapAuthenticationProvider.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.artemis.core.service.connectors.ldap;
 
-import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP_ONLY;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP;
 
 import java.util.HashSet;
 import java.util.Locale;
@@ -33,7 +33,7 @@ import de.tum.cit.aet.artemis.core.service.user.UserCreationService;
 import de.tum.cit.aet.artemis.core.util.TimeLogUtil;
 
 @Component
-@Profile(PROFILE_LDAP_ONLY)
+@Profile(PROFILE_LDAP)
 @Primary
 @ComponentScan("de.tum.cit.aet.artemis.*")
 public class LdapAuthenticationProvider extends ArtemisAuthenticationProviderImpl implements ArtemisAuthenticationProvider {

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/ldap/LdapConfig.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/ldap/LdapConfig.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.artemis.core.service.ldap;
 
-import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP_OR_LDAP_ONLY;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -11,7 +11,7 @@ import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.security.ldap.SpringSecurityLdapTemplate;
 
 @Configuration
-@Profile(PROFILE_LDAP_OR_LDAP_ONLY)
+@Profile(PROFILE_LDAP)
 @EnableLdapRepositories(basePackages = "de.tum.cit.aet.artemis.core.repository.ldap")
 public class LdapConfig {
 

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/ldap/LdapUserDto.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/ldap/LdapUserDto.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.artemis.core.service.ldap;
 
-import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP_OR_LDAP_ONLY;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP;
 import static de.tum.cit.aet.artemis.core.config.Constants.TUM_LDAP_MAIN_EMAIL;
 import static de.tum.cit.aet.artemis.core.config.Constants.TUM_LDAP_MATRIKEL_NUMBER;
 
@@ -12,7 +12,7 @@ import org.springframework.ldap.odm.annotations.Entry;
 import org.springframework.ldap.odm.annotations.Id;
 
 @Entry(base = "ou=users", objectClasses = { "imdPerson" })
-@Profile(PROFILE_LDAP_OR_LDAP_ONLY)
+@Profile(PROFILE_LDAP)
 // TODO: double check if we can use a Record here
 public final class LdapUserDto {
 

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/ldap/LdapUserService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/ldap/LdapUserService.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.artemis.core.service.ldap;
 
-import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP_OR_LDAP_ONLY;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP;
 import static de.tum.cit.aet.artemis.core.config.Constants.TUM_LDAP_EMAILS;
 import static de.tum.cit.aet.artemis.core.config.Constants.TUM_LDAP_MAIN_EMAIL;
 import static de.tum.cit.aet.artemis.core.config.Constants.TUM_LDAP_MATRIKEL_NUMBER;
@@ -23,7 +23,7 @@ import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.repository.ldap.LdapUserRepository;
 
 @Service
-@Profile(PROFILE_LDAP_OR_LDAP_ONLY)
+@Profile(PROFILE_LDAP)
 public class LdapUserService {
 
     private static final Logger log = LoggerFactory.getLogger(LdapUserService.class);

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/admin/AdminUserResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/admin/AdminUserResource.java
@@ -1,7 +1,7 @@
 package de.tum.cit.aet.artemis.core.web.admin;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
-import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP_OR_LDAP_ONLY;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -212,7 +212,7 @@ public class AdminUserResource {
      * @return the ResponseEntity with status 200 (OK) and with body the updated user
      */
     @PutMapping("users/{userId}/sync-ldap")
-    @Profile(PROFILE_LDAP_OR_LDAP_ONLY)
+    @Profile(PROFILE_LDAP)
     public ResponseEntity<UserDTO> syncUserViaLdap(@PathVariable Long userId) {
         log.debug("REST request to update ldap information User : {}", userId);
 

--- a/src/main/webapp/app/core/admin/user-management/user-management.component.ts
+++ b/src/main/webapp/app/core/admin/user-management/user-management.component.ts
@@ -212,7 +212,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
             this.userListSubscription = this.eventManager.subscribe('userListModification', () => this.loadAll());
             this.handleNavigation();
         });
-        this.isLdapProfileActive = this.profileService.isProfileActive('ldap') || this.profileService.isProfileActive('ldap-only');
+        this.isLdapProfileActive = this.profileService.isProfileActive('ldap');
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationLocalCILocalVCTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationLocalCILocalVCTest.java
@@ -5,7 +5,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_ARTEMIS;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_BUILDAGENT;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_IRIS;
-import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP_ONLY;
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LDAP;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LOCALCI;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LOCALVC;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LTI;
@@ -74,7 +74,7 @@ import de.tum.cit.aet.artemis.programming.test_repository.TemplateProgrammingExe
 @ResourceLock("AbstractSpringIntegrationLocalCILocalVCTest")
 // NOTE: we use a common set of active profiles to reduce the number of application launches during testing. This significantly saves time and memory!
 // NOTE: in a "single node" environment, PROFILE_BUILDAGENT must be before PROFILE_CORE to avoid issues
-@ActiveProfiles({ SPRING_PROFILE_TEST, PROFILE_ARTEMIS, PROFILE_BUILDAGENT, PROFILE_CORE, PROFILE_SCHEDULING, PROFILE_LOCALCI, PROFILE_LOCALVC, PROFILE_LDAP_ONLY, PROFILE_LTI,
+@ActiveProfiles({ SPRING_PROFILE_TEST, PROFILE_ARTEMIS, PROFILE_BUILDAGENT, PROFILE_CORE, PROFILE_SCHEDULING, PROFILE_LOCALCI, PROFILE_LOCALVC, PROFILE_LDAP, PROFILE_LTI,
         PROFILE_AEOLUS, PROFILE_THEIA, PROFILE_IRIS, "local" })
 // Note: the server.port property must correspond to the port used in the artemis.version-control.url property.
 @TestPropertySource(properties = { "server.port=49152", "artemis.version-control.url=http://localhost:49152", "artemis.user-management.use-external=false",


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


This PR unifies the profiles and removes deprecated code. We just need to make sure all relevant checks pass

### Review
- [x] Code review 1
- [x] Code review 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated references from 'ldap-only' to 'ldap' in setup and configuration guides.
- **Refactor**
  - Unified usage of the 'ldap' profile throughout the application, removing all references to 'ldap-only'.
  - Removed deprecated LDAP-related constants and an unused constant.
- **Bug Fixes**
  - Ensured that LDAP-related features and UI elements are now only activated when the 'ldap' profile is active, not 'ldap-only'.
- **Tests**
  - Adjusted test configurations to use the 'ldap' profile instead of 'ldap-only'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->