### PR TITLE
`Quiz exercises`: Fix padding for quiz exercise header for the management view

### DIFF
--- a/src/main/webapp/app/quiz/overview/participation/quiz-participation.component.html
+++ b/src/main/webapp/app/quiz/overview/participation/quiz-participation.component.html
@@ -1,7 +1,7 @@
 <div [id]="'exercise-' + quizExercise?.id" class="position-relative min-h-100 d-flex flex-column">
     @if (quizExercise) {
         <div class="row sticky-top module-bg">
-            <div class="d-flex justify-content-between align-items-center module-bg gap-2" [ngClass]="isManagementView ? 'mt-2' : 'pt-2 mt-n3'">
+            <div class="d-flex justify-content-between align-items-center module-bg gap-2" [ngClass]="'pt-2 mt-n3'">
                 <h5 class="mb-0 d-flex gap-2 align-items-center">
                     {{ quizExercise.course?.title ? quizExercise.course?.title : quizExercise.exerciseGroup?.exam?.course?.title }}
                     - {{ quizExercise.title }}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client

- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
This is a small UI adjustment in the quiz preview and sample solution mode to avoid overlapping.
Previous:
![Scroll](https://github.com/user-attachments/assets/c2181f11-28d2-4164-9467-aef71900f789)
Expected:
![scroll_fixed](https://github.com/user-attachments/assets/17ff7dad-344d-4bd3-958e-59aa4986fc65)


### Description
I changed the padding for the quiz exercise header. 


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- Course with a quiz exercise (multiple questions to ensure scrolling is necessary)

1. Log in to Artemis
2. Navigate to Course Administration
3. Select the course 
4. Navigate to the quiz exercise
5. View the Sample Solution and the Quiz Preview 
6. The header should be displayed correctly at the top (no overlapping and gap when scrolling)


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated spacing styles in the quiz participation overview for a more consistent appearance. The layout now always uses the same spacing regardless of the view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->