### PR TITLE
`Development`: Use local directory for file tests

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/core/service/FileServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/FileServiceTest.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.core.service;
 
+import static de.tum.cit.aet.artemis.core.service.FileService.BACKGROUND_FILE_SUBPATH;
+import static de.tum.cit.aet.artemis.core.service.FileService.PICTURE_FILE_SUBPATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -45,7 +47,6 @@ import org.springframework.util.ResourceUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import de.tum.cit.aet.artemis.core.FilePathType;
-import de.tum.cit.aet.artemis.core.util.FilePathConverter;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
 class FileServiceTest extends AbstractSpringIntegrationIndependentTest {
@@ -61,17 +62,17 @@ class FileServiceTest extends AbstractSpringIntegrationIndependentTest {
     // the resource loader allows to load resources from the file system for this prefix
     private final Path overridableBasePath = Path.of("templates", "jenkins");
 
-    private static final URI VALID_BACKGROUND_PATH = URI.create("/api/core/uploads/images/drag-and-drop/backgrounds/1/BackgroundFile.jpg");
+    private static final URI VALID_BACKGROUND_PATH = URI.create("drag-and-drop/backgrounds/1/BackgroundFile.jpg");
 
-    private static final URI VALID_INTENDED_BACKGROUND_PATH = createURIWithPath("/api/core/", FilePathConverter.getDragAndDropBackgroundFilePath());
+    private static final URI VALID_INTENDED_BACKGROUND_PATH = URI.create(BACKGROUND_FILE_SUBPATH);
 
-    private static final URI INVALID_BACKGROUND_PATH = URI.create("/api/core/uploads/images/drag-and-drop/backgrounds/1/../../../exam-users/signatures/some-file.png");
+    private static final URI INVALID_BACKGROUND_PATH = URI.create("drag-and-drop/backgrounds/1/../../../exam-users/signatures/some-file.png");
 
-    private static final URI VALID_DRAGITEM_PATH = URI.create("/api/core/uploads/images/drag-and-drop/drag-items/1/PictureFile.jpg");
+    private static final URI VALID_DRAGITEM_PATH = URI.create("drag-and-drop/drag-items/1/PictureFile.jpg");
 
-    private static final URI VALID_INTENDED_DRAGITEM_PATH = createURIWithPath("/api/core/", FilePathConverter.getDragItemFilePath());
+    private static final URI VALID_INTENDED_DRAGITEM_PATH = URI.create(PICTURE_FILE_SUBPATH);
 
-    private static final URI INVALID_DRAGITEM_PATH = URI.create("/api/core/uploads/images/drag-and-drop/drag-items/1/../../../exam-users/signatures/some-file.png");
+    private static final URI INVALID_DRAGITEM_PATH = URI.create("drag-and-drop/drag-items/1/../../../exam-users/signatures/some-file.png");
 
     private static final Path lineEndingsUnixPath = Path.of(".", "exportTest", "LineEndingsUnix.java");
 

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -189,7 +189,7 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
     static void setup() {
         // Set the static file upload path for all tests
         // This makes it a simple unit test that doesn't require a server start.
-        FilePathConverter.setFileUploadPath(Path.of("uploads"));
+        FilePathConverter.setFileUploadPath(Path.of("local", "uploads"));
     }
 
     @BeforeEach


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We want to use `local/uploads` as uploads directory for our server tests instead of the default `uploads` to be able to cleanup their artifacts easily and giving developers the possibility to exclude this directory from certain operations on their machine.


### Description
<!-- Describe your changes in detail -->
Changed the file upload path in `AbstractArtemisIntegrationTest`to local/uploads. This caused two test failures in `FileServiceTest`. I rewrote the tests as they assumed URIs that 
1. we don't validate in production code to that extent and 
2. it's unnecessary to test the complete URI, as if the first part doesn't match, the file doesn't even reach the endpoint to upload the file.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

- Make sure all tests pass

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2