### PR TITLE
`Development`: Reduce logging in JWTFilter

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/security/jwt/JWTFilter.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/jwt/JWTFilter.java
@@ -278,8 +278,9 @@ public class JWTFilter extends GenericFilterBean {
      */
     private static boolean isIgnoredUri(final String uri) {
         // /git/**: used by Git clients with a token mechanism
+        // /api/iris/public/pyris/** used by Pyris status callbacks with a token mechanism
         // /api/programming/public/programming-exercises/new-result: used by Jenkins to send test results back to Artemis,
         // uses a separate secret token.
-        return uri.startsWith("/git/") || "/api/programming/public/programming-exercises/new-result".equals(uri);
+        return uri.startsWith("/git/") || uri.startsWith("/api/iris/public/pyris/") || "/api/programming/public/programming-exercises/new-result".equals(uri);
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/jwt/JWTFilterIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/jwt/JWTFilterIntegrationTest.java
@@ -12,11 +12,14 @@ import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
@@ -64,6 +67,15 @@ class JWTFilterIntegrationTest extends AbstractSpringIntegrationIndependentTest 
     @BeforeEach
     void setup() {
         userUtilService.addUsers(TEST_PREFIX, 1, 0, 0, 0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/git/EXERCISEID/exerciseid-studentLogin.git/info/refs", "/git/EXERCISEID/exerciseid-studentLogin.git/git-upload-pack", })
+    void shouldIgnoreSpecialUris(String uri) {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI(uri);
+
+        assertThat(JWTFilter.extractValidJwt(request, null)).isNull();
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The `JWTFilter` produces a lot of misleading log output like
```
Invalid JWT token detected. Details:
{
    "source": "bearer",
    "remote_ip": "***",
    "user_agent": "git/2.39.5",
    "request_uri": "/git/***/***-solution.git/git-upload-pack",
    "headers": [
        "x-forwarded-proto": "https",
        "x-forwarded-ssl": "on",
        "connection": "close",
        "content-length": "141",
        "user-agent": "git/2.39.5",
        "accept-encoding": "deflate, gzip, br, zstd",
        "content-type": "application/x-git-upload-pack-request",
        "accept": "application/x-git-upload-pack-result",
        "accept-language": "en-US, *;q=0.9"
    ]
}
```

### Description
<!-- Describe your changes in detail -->
Since the Git client does not use JWTs for security, such logs are just spam and can be safely ignored. I updated the `JWTFilter` to not even try to extract a JWT for requests to `/git/` endpoints, thus also silencing the logs.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- local Artemis instance, since the effect is only visible in the logs
- 1 Programming Exercise

1. Clone from/push to any repo in the programming exercise.
2. There should be no logs like `Invalid JWT token detected. Details: … request_uri: /git/…`.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1