### PR TITLE
`Lectures`: Improve performance when navigating into lectures

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CompetencyExerciseLinkRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CompetencyExerciseLinkRepository.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.atlas.repository;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.context.annotation.Conditional;
 import org.springframework.data.jpa.repository.Query;
@@ -21,4 +22,13 @@ public interface CompetencyExerciseLinkRepository extends ArtemisJpaRepository<C
                 WHERE cel.exercise.id = :exerciseId
             """)
     List<CompetencyExerciseLink> findByExerciseIdWithCompetency(@Param("exerciseId") long exerciseId);
+
+    @Query("""
+            SELECT cel
+            FROM CompetencyExerciseLink cel
+            LEFT JOIN FETCH cel.competency
+            WHERE cel.exercise.id IN :exerciseIds
+            """)
+    Set<CompetencyExerciseLink> findByExerciseIdInWithCompetency(@Param("exerciseIds") Set<Long> exerciseIds);
+
 }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/LearningObjectImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/LearningObjectImportService.java
@@ -44,7 +44,7 @@ import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.fileupload.api.FileUploadImportApi;
 import de.tum.cit.aet.artemis.fileupload.domain.FileUploadExercise;
-import de.tum.cit.aet.artemis.lecture.api.LectureApi;
+import de.tum.cit.aet.artemis.lecture.api.LectureImportApi;
 import de.tum.cit.aet.artemis.lecture.api.LectureRepositoryApi;
 import de.tum.cit.aet.artemis.lecture.api.LectureUnitApi;
 import de.tum.cit.aet.artemis.lecture.api.LectureUnitRepositoryApi;
@@ -99,7 +99,7 @@ public class LearningObjectImportService {
 
     private final Optional<LectureUnitApi> lectureUnitApi;
 
-    private final Optional<LectureApi> lectureApi;
+    private final Optional<LectureImportApi> lectureImportApi;
 
     private final CourseCompetencyRepository courseCompetencyRepository;
 
@@ -116,7 +116,7 @@ public class LearningObjectImportService {
             ModelingExerciseRepository modelingExerciseRepository, ModelingExerciseImportService modelingExerciseImportService,
             Optional<TextExerciseImportApi> textExerciseImportApi, QuizExerciseRepository quizExerciseRepository, QuizExerciseImportService quizExerciseImportService,
             Optional<LectureRepositoryApi> lectureRepositoryApi, Optional<LectureUnitRepositoryApi> lectureUnitRepositoryApi, Optional<LectureUnitApi> lectureUnitApi,
-            Optional<LectureApi> lectureApi, CourseCompetencyRepository courseCompetencyRepository, ProgrammingExerciseTaskRepository programmingExerciseTaskRepository,
+            Optional<LectureImportApi> lectureImportApi, CourseCompetencyRepository courseCompetencyRepository, ProgrammingExerciseTaskRepository programmingExerciseTaskRepository,
             GradingCriterionRepository gradingCriterionRepository, CompetencyExerciseLinkRepository competencyExerciseLinkRepository,
             CompetencyLectureUnitLinkRepository competencyLectureUnitLinkRepository) {
         this.exerciseRepository = exerciseRepository;
@@ -131,7 +131,7 @@ public class LearningObjectImportService {
         this.lectureRepositoryApi = lectureRepositoryApi;
         this.lectureUnitRepositoryApi = lectureUnitRepositoryApi;
         this.lectureUnitApi = lectureUnitApi;
-        this.lectureApi = lectureApi;
+        this.lectureImportApi = lectureImportApi;
         this.courseCompetencyRepository = courseCompetencyRepository;
         this.programmingExerciseTaskRepository = programmingExerciseTaskRepository;
         this.gradingCriterionRepository = gradingCriterionRepository;
@@ -361,14 +361,14 @@ public class LearningObjectImportService {
     }
 
     private Lecture importOrLoadLecture(Lecture sourceLecture, Course courseToImportInto, Map<String, Lecture> titleToImportedLectures) throws NoUniqueQueryException {
-        LectureApi api = lectureApi.orElseThrow(() -> new LectureApiNotPresentException(LectureApi.class));
+        LectureImportApi importApi = lectureImportApi.orElseThrow(() -> new LectureApiNotPresentException(LectureImportApi.class));
         LectureRepositoryApi repositoryApi = lectureRepositoryApi.orElseThrow(() -> new LectureApiNotPresentException(LectureRepositoryApi.class));
 
         Optional<Lecture> foundLecture = Optional.ofNullable(titleToImportedLectures.get(sourceLecture.getTitle()));
         if (foundLecture.isEmpty()) {
             foundLecture = repositoryApi.findUniqueByTitleAndCourseIdWithLectureUnitsElseThrow(sourceLecture.getTitle(), courseToImportInto.getId());
         }
-        Lecture importedLecture = foundLecture.orElseGet(() -> api.importLecture(sourceLecture, courseToImportInto, false));
+        Lecture importedLecture = foundLecture.orElseGet(() -> importApi.importLecture(sourceLecture, courseToImportInto, false));
         titleToImportedLectures.put(importedLecture.getTitle(), importedLecture);
 
         return importedLecture;

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/LearningObjectService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/LearningObjectService.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.atlas.service;
 import static de.tum.cit.aet.artemis.core.config.Constants.MIN_SCORE_GREEN;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -93,9 +94,8 @@ public class LearningObjectService {
 
         Set<LectureUnitCompletion> lectureUnitCompletions = lectureUnitRepositoryApi.get().findByLectureUnitsAndUserId(lectureUnits, user.getId());
         lectureUnits.forEach(lectureUnit -> {
-            Optional<LectureUnitCompletion> completion = lectureUnitCompletions.stream().filter(lectureUnitCompletion -> lectureUnitCompletion.getLectureUnit().equals(lectureUnit))
-                    .findFirst();
-            lectureUnit.setCompletedUsers(completion.map(Set::of).orElse(Set.of()));
+            var optionalCompletion = lectureUnitCompletions.stream().filter(completion -> Objects.equals(completion.getLectureUnit().getId(), lectureUnit.getId())).findFirst();
+            lectureUnit.setCompletedUsers(optionalCompletion.map(Set::of).orElse(Set.of()));
         });
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyService.java
@@ -126,6 +126,9 @@ public class CompetencyService extends CourseCompetencyService {
      * @param lecture the lecture to augment the exercise unit links for
      */
     public void addCompetencyLinksToExerciseUnits(Lecture lecture) {
+        // TODO: double check if this is really necessary, loading data from a database in a for loop is not a good practice, in the worst case
+        // a lecture could have ten exercise units. I wonder if we can load all links in one query and then set them on the exercise units.
+        // I also wonder if we really need to load them with the competency
         var exerciseUnits = lecture.getLectureUnits().stream().filter(unit -> unit instanceof ExerciseUnit);
         exerciseUnits.forEach(unit -> {
             var exerciseUnit = (ExerciseUnit) unit;

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyService.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.atlas.service.competency;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import de.tum.cit.aet.artemis.atlas.config.AtlasEnabled;
 import de.tum.cit.aet.artemis.atlas.domain.competency.Competency;
+import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyLectureUnitLink;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CourseCompetency;
 import de.tum.cit.aet.artemis.atlas.dto.CompetencyImportOptionsDTO;
@@ -126,19 +128,24 @@ public class CompetencyService extends CourseCompetencyService {
      * @param lecture the lecture to augment the exercise unit links for
      */
     public void addCompetencyLinksToExerciseUnits(Lecture lecture) {
-        // TODO: double check if this is really necessary, loading data from a database in a for loop is not a good practice, in the worst case
-        // a lecture could have ten exercise units. I wonder if we can load all links in one query and then set them on the exercise units.
-        // I also wonder if we really need to load them with the competency
-        var exerciseUnits = lecture.getLectureUnits().stream().filter(unit -> unit instanceof ExerciseUnit);
-        exerciseUnits.forEach(unit -> {
-            var exerciseUnit = (ExerciseUnit) unit;
+        List<ExerciseUnit> exerciseUnits = lecture.getLectureUnits().stream().filter(ExerciseUnit.class::isInstance).map(ExerciseUnit.class::cast)
+                .filter(unit -> unit.getExercise() != null).toList();
+
+        if (exerciseUnits.isEmpty()) {
+            return;
+        }
+
+        Set<Long> exerciseIds = exerciseUnits.stream().map(unit -> unit.getExercise().getId()).collect(Collectors.toSet());
+        Set<CompetencyExerciseLink> allCompetencyExerciseLinks = competencyExerciseLinkRepository.findByExerciseIdInWithCompetency(exerciseIds);
+
+        Map<Long, List<CompetencyExerciseLink>> linksByExerciseId = allCompetencyExerciseLinks.stream().collect(Collectors.groupingBy(link -> link.getExercise().getId()));
+
+        exerciseUnits.forEach(exerciseUnit -> {
             var exercise = exerciseUnit.getExercise();
-            if (exercise != null) {
-                var competencyExerciseLinks = competencyExerciseLinkRepository.findByExerciseIdWithCompetency(exercise.getId());
-                var competencyLectureUnitLinks = competencyExerciseLinks.stream().map(link -> new CompetencyLectureUnitLink(link.getCompetency(), exerciseUnit, link.getWeight()))
-                        .collect(Collectors.toSet());
-                exerciseUnit.setCompetencyLinks(competencyLectureUnitLinks);
-            }
+            List<CompetencyExerciseLink> competencyExerciseLinksForUnit = linksByExerciseId.getOrDefault(exercise.getId(), List.of());
+            Set<CompetencyLectureUnitLink> competencyLectureUnitLinks = competencyExerciseLinksForUnit.stream()
+                    .map(link -> new CompetencyLectureUnitLink(link.getCompetency(), exerciseUnit, link.getWeight())).collect(Collectors.toSet());
+            exerciseUnit.setCompetencyLinks(competencyLectureUnitLinks);
         });
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyService.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.hibernate.Hibernate;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 
@@ -145,6 +146,11 @@ public class CompetencyService extends CourseCompetencyService {
             List<CompetencyExerciseLink> competencyExerciseLinksForUnit = linksByExerciseId.getOrDefault(exercise.getId(), List.of());
             Set<CompetencyLectureUnitLink> competencyLectureUnitLinks = competencyExerciseLinksForUnit.stream()
                     .map(link -> new CompetencyLectureUnitLink(link.getCompetency(), exerciseUnit, link.getWeight())).collect(Collectors.toSet());
+            competencyExerciseLinksForUnit.forEach(competencyLink -> {
+                if (competencyLink.getCompetency() != null && Hibernate.isInitialized(competencyLink.getCompetency())) {
+                    competencyLink.getCompetency().setCourse(null); // Avoid sending the course to the client multiple times in the response to save data
+                }
+            });
             exerciseUnit.setCompetencyLinks(competencyLectureUnitLinks);
         });
     }

--- a/src/main/java/de/tum/cit/aet/artemis/core/repository/UserRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/repository/UserRepository.java
@@ -1267,4 +1267,58 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
                     OR (:#{T(de.tum.cit.aet.artemis.core.domain.Authority).ADMIN_AUTHORITY} MEMBER OF user.authorities)
             """)
     boolean isAtLeastInstructorInLectureUnit(@Param("login") String login, @Param("lectureUnitId") long lectureUnitId);
+
+    @Query("""
+            SELECT COUNT(user) > 0
+            FROM User user
+            INNER JOIN Lecture lecture
+            ON user.login = :login
+                AND lecture.id = :lectureId
+            LEFT JOIN lecture.course course
+            WHERE (course.studentGroupName MEMBER OF user.groups)
+                    OR (course.teachingAssistantGroupName MEMBER OF user.groups)
+                    OR (course.editorGroupName MEMBER OF user.groups)
+                    OR (course.instructorGroupName MEMBER OF user.groups)
+                    OR (:#{T(de.tum.cit.aet.artemis.core.domain.Authority).ADMIN_AUTHORITY} MEMBER OF user.authorities)
+            """)
+    boolean isAtLeastStudentInLecture(@Param("login") String login, @Param("lectureId") long lectureId);
+
+    @Query("""
+            SELECT COUNT(user) > 0
+            FROM User user
+            INNER JOIN Lecture lecture
+            ON user.login = :login
+                AND lecture.id = :lectureId
+            LEFT JOIN lecture.course course
+            WHERE (course.teachingAssistantGroupName MEMBER OF user.groups)
+                    OR (course.editorGroupName MEMBER OF user.groups)
+                    OR (course.instructorGroupName MEMBER OF user.groups)
+                    OR (:#{T(de.tum.cit.aet.artemis.core.domain.Authority).ADMIN_AUTHORITY} MEMBER OF user.authorities)
+            """)
+    boolean isAtLeastTeachingAssistantInLecture(@Param("login") String login, @Param("lectureId") long lectureId);
+
+    @Query("""
+            SELECT COUNT(user) > 0
+            FROM User user
+            INNER JOIN Lecture lecture
+            ON user.login = :login
+                AND lecture.id = :lectureId
+            LEFT JOIN lecture.course course
+            WHERE (course.editorGroupName MEMBER OF user.groups)
+                    OR (course.instructorGroupName MEMBER OF user.groups)
+                    OR (:#{T(de.tum.cit.aet.artemis.core.domain.Authority).ADMIN_AUTHORITY} MEMBER OF user.authorities)
+            """)
+    boolean isAtLeastEditorInLecture(@Param("login") String login, @Param("lectureId") long lectureId);
+
+    @Query("""
+            SELECT COUNT(user) > 0
+            FROM User user
+            INNER JOIN Lecture lecture
+            ON user.login = :login
+                AND lecture.id = :lectureId
+            LEFT JOIN lecture.course course
+            WHERE (course.instructorGroupName MEMBER OF user.groups)
+                    OR (:#{T(de.tum.cit.aet.artemis.core.domain.Authority).ADMIN_AUTHORITY} MEMBER OF user.authorities)
+            """)
+    boolean isAtLeastInstructorInLecture(@Param("login") String login, @Param("lectureId") long lectureId);
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceAtLeastEditorInLecture.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceAtLeastEditorInLecture.java
@@ -1,0 +1,27 @@
+package de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import de.tum.cit.aet.artemis.core.security.Role;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('EDITOR')")
+@EnforceRoleInLecture(Role.EDITOR)
+public @interface EnforceAtLeastEditorInLecture {
+
+    /**
+     * The name of the field in the method parameters that contains the lecture id.
+     * This is used to extract the lecture id from the method parameters
+     *
+     * @return the name of the field in the method parameters that contains the lecture id
+     */
+    @AliasFor(annotation = EnforceRoleInLecture.class)
+    String resourceIdFieldName() default "lectureId";
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceAtLeastInstructorInLecture.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceAtLeastInstructorInLecture.java
@@ -1,0 +1,27 @@
+package de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import de.tum.cit.aet.artemis.core.security.Role;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('INSTRUCTOR')")
+@EnforceRoleInLecture(Role.INSTRUCTOR)
+public @interface EnforceAtLeastInstructorInLecture {
+
+    /**
+     * The name of the field in the method parameters that contains the lecture id.
+     * This is used to extract the lecture id from the method parameters
+     *
+     * @return the name of the field in the method parameters that contains the lecture id
+     */
+    @AliasFor(annotation = EnforceRoleInLecture.class)
+    String resourceIdFieldName() default "lectureId";
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceAtLeastStudentInLecture.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceAtLeastStudentInLecture.java
@@ -1,0 +1,27 @@
+package de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import de.tum.cit.aet.artemis.core.security.Role;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('USER')")
+@EnforceRoleInLecture(Role.STUDENT)
+public @interface EnforceAtLeastStudentInLecture {
+
+    /**
+     * The name of the field in the method parameters that contains the lecture id.
+     * This is used to extract the lecture id from the method parameters
+     *
+     * @return the name of the field in the method parameters that contains the lecture id
+     */
+    @AliasFor(annotation = EnforceRoleInLecture.class)
+    String resourceIdFieldName() default "lectureId";
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceAtLeastTutorInLecture.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceAtLeastTutorInLecture.java
@@ -1,0 +1,27 @@
+package de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import de.tum.cit.aet.artemis.core.security.Role;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('TA')")
+@EnforceRoleInLecture(Role.TEACHING_ASSISTANT)
+public @interface EnforceAtLeastTutorInLecture {
+
+    /**
+     * The name of the field in the method parameters that contains the lecture id.
+     * This is used to extract the lecture id from the method parameters
+     *
+     * @return the name of the field in the method parameters that contains the lecture id
+     */
+    @AliasFor(annotation = EnforceRoleInLecture.class)
+    String resourceIdFieldName() default "lectureId";
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceRoleInLecture.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceRoleInLecture.java
@@ -1,0 +1,38 @@
+package de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import de.tum.cit.aet.artemis.core.security.Role;
+
+/**
+ * All classes or methods annotated with this will check (used for controller classes) if the current user has the specified role in the target lectures course.
+ * This is done using a custom aspect
+ *
+ * @see EnforceRoleInLectureAspect
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface EnforceRoleInLecture {
+
+    /**
+     * The role that is required to access the annotated endpoint
+     *
+     * @return the role that is required to access the annotated endpoint
+     */
+    Role value();
+
+    /**
+     * The name of the field in the method parameters that contains the lecture id.
+     * This is used to extract the lecture id from the method parameters
+     *
+     * @return the name of the field in the method parameters that contains the lecture id
+     */
+    String resourceIdFieldName() default "lectureId";
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceRoleInLectureAspect.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/enforceRoleInLecture/EnforceRoleInLectureAspect.java
@@ -1,0 +1,36 @@
+package de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import de.tum.cit.aet.artemis.core.security.Role;
+import de.tum.cit.aet.artemis.core.security.annotations.EnforceRoleInResourceAspect;
+import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
+
+@Profile(PROFILE_CORE)
+@Component
+@Aspect
+public class EnforceRoleInLectureAspect extends EnforceRoleInResourceAspect {
+
+    public EnforceRoleInLectureAspect(AuthorizationCheckService authorizationCheckService) {
+        super(authorizationCheckService, EnforceRoleInLecture.class, EnforceAtLeastStudentInLecture.class, EnforceAtLeastTutorInLecture.class, EnforceAtLeastEditorInLecture.class,
+                EnforceAtLeastInstructorInLecture.class);
+    }
+
+    /**
+     * Pointcut around all methods or classes annotated with {@link EnforceRoleInLecture}.
+     */
+    @Pointcut("@within(de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceRoleInLecture) || @annotation(de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceRoleInLecture) || execution(@(@de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceRoleInLecture *) * *(..))")
+    @Override
+    protected void callAt() {
+    }
+
+    @Override
+    protected void authorizationCheck(Role role, long resourceId) {
+        authorizationCheckService.checkIsAtLeastRoleInLectureElseThrow(role, resourceId);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/AuthorizationCheckService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/AuthorizationCheckService.java
@@ -132,8 +132,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastEditorInCourse(long courseId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastEditorInCourse(s, courseId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastEditorInCourse(login, courseId)).isPresent();
     }
 
     /**
@@ -247,8 +247,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastTeachingAssistantInCourse(long courseId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastTeachingAssistantInCourse(s, courseId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastTeachingAssistantInCourse(login, courseId)).isPresent();
     }
 
     /**
@@ -405,8 +405,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastStudentInCourse(long courseId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastStudentInCourse(s, courseId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastStudentInCourse(login, courseId)).isPresent();
     }
 
     /**
@@ -525,8 +525,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastInstructorInCourse(long courseId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastInstructorInCourse(s, courseId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastInstructorInCourse(login, courseId)).isPresent();
     }
 
     /**
@@ -864,8 +864,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastStudentInExercise(long exerciseId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastStudentInExercise(s, exerciseId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastStudentInExercise(login, exerciseId)).isPresent();
     }
 
     /**
@@ -876,8 +876,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastTeachingAssistantInExercise(long exerciseId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastTeachingAssistantInExercise(s, exerciseId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastTeachingAssistantInExercise(login, exerciseId)).isPresent();
     }
 
     /**
@@ -900,8 +900,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastEditorInExercise(long exerciseId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastEditorInExercise(s, exerciseId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastEditorInExercise(login, exerciseId)).isPresent();
     }
 
     /**
@@ -912,8 +912,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastInstructorInExercise(long exerciseId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastInstructorInExercise(s, exerciseId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastInstructorInExercise(login, exerciseId)).isPresent();
     }
 
     /**
@@ -961,8 +961,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastStudentInLectureUnit(long lectureUnitId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastStudentInLectureUnit(s, lectureUnitId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastStudentInLectureUnit(login, lectureUnitId)).isPresent();
     }
 
     /**
@@ -973,8 +973,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastTeachingAssistantInLectureUnit(long lectureUnitId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastTeachingAssistantInLectureUnit(s, lectureUnitId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastTeachingAssistantInLectureUnit(login, lectureUnitId)).isPresent();
     }
 
     /**
@@ -985,8 +985,8 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastEditorInLectureUnit(long lectureUnitId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastEditorInLectureUnit(s, lectureUnitId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastEditorInLectureUnit(login, lectureUnitId)).isPresent();
     }
 
     /**
@@ -997,8 +997,56 @@ public class AuthorizationCheckService {
      */
     @CheckReturnValue
     public boolean isAtLeastInstructorInLectureUnit(long lectureUnitId) {
-        final var login = SecurityUtils.getCurrentUserLogin();
-        return login.filter(s -> userRepository.isAtLeastInstructorInLectureUnit(s, lectureUnitId)).isPresent();
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastInstructorInLectureUnit(login, lectureUnitId)).isPresent();
+    }
+
+    /**
+     * Checks if the current user is at least an instructor in the given lecture.
+     *
+     * @param lectureId the id of the lecture that needs to be checked
+     * @return true if the user is at least an instructor in the course, false otherwise
+     */
+    @CheckReturnValue
+    public boolean isAtLeastStudentInLecture(long lectureId) {
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastStudentInLecture(login, lectureId)).isPresent();
+    }
+
+    /**
+     * Checks if the current user is at least an instructor in the given lecture.
+     *
+     * @param lectureId the id of the lecture that needs to be checked
+     * @return true if the user is at least an instructor in the course, false otherwise
+     */
+    @CheckReturnValue
+    public boolean isAtLeastTeachingAssistantInLecture(long lectureId) {
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastTeachingAssistantInLecture(login, lectureId)).isPresent();
+    }
+
+    /**
+     * Checks if the current user is at least an editor in the given lecture.
+     *
+     * @param lectureId the id of the lecture that needs to be checked
+     * @return true if the user is at least an instructor in the course, false otherwise
+     */
+    @CheckReturnValue
+    public boolean isAtLeastEditorInLecture(long lectureId) {
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastEditorInLecture(login, lectureId)).isPresent();
+    }
+
+    /**
+     * Checks if the current user is at least an instructor in the given lecture.
+     *
+     * @param lectureId the id of the lecture that needs to be checked
+     * @return true if the user is at least an instructor in the course, false otherwise
+     */
+    @CheckReturnValue
+    public boolean isAtLeastInstructorInLecture(long lectureId) {
+        final var userLogin = SecurityUtils.getCurrentUserLogin();
+        return userLogin.filter(login -> userRepository.isAtLeastInstructorInLecture(login, lectureId)).isPresent();
     }
 
     /**
@@ -1023,6 +1071,31 @@ public class AuthorizationCheckService {
     public void checkIsAtLeastRoleInLectureUnitElseThrow(Role role, long lectureUnitId) {
         if (!isAtLeastRoleInLectureUnit(role, lectureUnitId)) {
             throw new AccessForbiddenException("LectureUnit", lectureUnitId);
+        }
+    }
+
+    /**
+     * Checks if the current user has at least the given role in the given lecture.
+     *
+     * @param role      the role that should be checked
+     * @param lectureId the id of the lecture that needs to be checked
+     * @return true if the user has at least the role in the lecture, false otherwise
+     */
+    @CheckReturnValue
+    public boolean isAtLeastRoleInLecture(Role role, long lectureId) {
+        return switch (role) {
+            case ADMIN -> isAdmin();
+            case INSTRUCTOR -> isAtLeastInstructorInLecture(lectureId);
+            case EDITOR -> isAtLeastEditorInLecture(lectureId);
+            case TEACHING_ASSISTANT -> isAtLeastTeachingAssistantInLecture(lectureId);
+            case STUDENT -> isAtLeastStudentInLecture(lectureId);
+            case ANONYMOUS -> false;
+        };
+    }
+
+    public void checkIsAtLeastRoleInLectureElseThrow(Role role, long lectureId) {
+        if (!isAtLeastRoleInLecture(role, lectureId)) {
+            throw new AccessForbiddenException("Lecture", lectureId);
         }
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/api/LectureImportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/api/LectureImportApi.java
@@ -2,42 +2,28 @@ package de.tum.cit.aet.artemis.lecture.api;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
-import java.util.Set;
-
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 
 import de.tum.cit.aet.artemis.core.domain.Course;
-import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.service.LectureImportService;
-import de.tum.cit.aet.artemis.lecture.service.LectureService;
 
 /**
  * API for managing lectures.
  */
 @Profile(PROFILE_CORE)
 @Controller
-public class LectureApi extends AbstractLectureApi {
-
-    private final LectureService lectureService;
+public class LectureImportApi extends AbstractLectureApi {
 
     private final LectureImportService lectureImportService;
 
-    public LectureApi(LectureService lectureService, LectureImportService lectureImportService) {
-        this.lectureService = lectureService;
+    public LectureImportApi(LectureImportService lectureImportService) {
         this.lectureImportService = lectureImportService;
-    }
-
-    public Set<Lecture> filterVisibleLecturesWithActiveAttachments(Course course, Set<Lecture> lecturesWithAttachments, User user) {
-        return lectureService.filterVisibleLecturesWithActiveAttachments(course, lecturesWithAttachments, user);
     }
 
     public Lecture importLecture(final Lecture importedLecture, final Course course, boolean importLectureUnits) {
         return lectureImportService.importLecture(importedLecture, course, importLectureUnits);
     }
 
-    public void delete(Lecture lecture, boolean updateCompetencyProgress) {
-        lectureService.delete(lecture, updateCompetencyProgress);
-    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/LectureUnitCompletion.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/LectureUnitCompletion.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
@@ -32,12 +33,12 @@ public class LectureUnitCompletion {
     @JsonIgnore
     private LectureUnitUserId id = new LectureUnitUserId();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("userId")
     @JsonIgnore
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("lectureUnitId")
     @JsonIgnore
     private LectureUnit lectureUnit;

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/LectureUnitCompletion.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/LectureUnitCompletion.java
@@ -38,6 +38,7 @@ public class LectureUnitCompletion {
     @JsonIgnore
     private User user;
 
+    // TODO: double check if this could lead to issues when using learning paths
     @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("lectureUnitId")
     @JsonIgnore

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/LectureUnitCompletion.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/LectureUnitCompletion.java
@@ -33,7 +33,7 @@ public class LectureUnitCompletion {
     @JsonIgnore
     private LectureUnitUserId id = new LectureUnitUserId();
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @MapsId("userId")
     @JsonIgnore
     private User user;

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureRepository.java
@@ -62,12 +62,12 @@ public interface LectureRepository extends ArtemisJpaRepository<Lecture, Long> {
             """)
     Set<Lecture> findAllByCourseIdWithAttachmentsAndLectureUnits(@Param("courseId") Long courseId);
 
+    // TODO: this query loads too much data, we should reduce the number of left join fetches
     @Query("""
             SELECT lecture
             FROM Lecture lecture
                 LEFT JOIN FETCH lecture.attachments
                 LEFT JOIN FETCH lecture.lectureUnits lu
-                LEFT JOIN FETCH lu.completedUsers cu
                 LEFT JOIN FETCH lu.competencyLinks cl
                 LEFT JOIN FETCH cl.competency
                 LEFT JOIN FETCH lu.exercise e
@@ -77,6 +77,7 @@ public interface LectureRepository extends ArtemisJpaRepository<Lecture, Long> {
             """)
     Optional<Lecture> findByIdWithAttachmentsAndLectureUnitsAndCompetenciesAndCompletions(@Param("lectureId") Long lectureId);
 
+    // TODO: this query loads too much data, we should reduce the number of left join fetches
     @Query("""
             SELECT lecture
             FROM Lecture lecture

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureRepository.java
@@ -68,14 +68,10 @@ public interface LectureRepository extends ArtemisJpaRepository<Lecture, Long> {
             FROM Lecture lecture
                 LEFT JOIN FETCH lecture.attachments
                 LEFT JOIN FETCH lecture.lectureUnits lu
-                LEFT JOIN FETCH lu.competencyLinks cl
-                LEFT JOIN FETCH cl.competency
-                LEFT JOIN FETCH lu.exercise e
-                LEFT JOIN FETCH e.competencyLinks ecl
-                LEFT JOIN FETCH ecl.competency
+                LEFT JOIN FETCH lu.completedUsers cu
             WHERE lecture.id = :lectureId
             """)
-    Optional<Lecture> findByIdWithAttachmentsAndLectureUnitsAndCompetenciesAndCompletions(@Param("lectureId") Long lectureId);
+    Optional<Lecture> findByIdWithAttachmentsAndLectureUnitsAndCompletions(@Param("lectureId") Long lectureId);
 
     // TODO: this query loads too much data, we should reduce the number of left join fetches
     @Query("""
@@ -179,8 +175,8 @@ public interface LectureRepository extends ArtemisJpaRepository<Lecture, Long> {
     }
 
     @NotNull
-    default Lecture findByIdWithAttachmentsAndLectureUnitsAndCompetenciesAndCompletionsElseThrow(Long lectureId) {
-        return getValueElseThrow(findByIdWithAttachmentsAndLectureUnitsAndCompetenciesAndCompletions(lectureId), lectureId);
+    default Lecture findByIdWithAttachmentsAndLectureUnitsAndCompletionsElseThrow(Long lectureId) {
+        return getValueElseThrow(findByIdWithAttachmentsAndLectureUnitsAndCompletions(lectureId), lectureId);
     }
 
     @NotNull

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureRepository.java
@@ -168,6 +168,21 @@ public interface LectureRepository extends ArtemisJpaRepository<Lecture, Long> {
         return getValueElseThrow(findByIdWithLectureUnitsAndAttachments(lectureId), lectureId);
     }
 
+    @NotNull
+    default Lecture findByIdWithLectureUnitsWithCompetencyLinksAndAttachmentsElseThrow(Long lectureId) {
+        return getValueElseThrow(findByIdWithLectureUnitsWithCompetencyLinksAndAttachments(lectureId), lectureId);
+    }
+
+    @Query("""
+            SELECT lecture
+            FROM Lecture lecture
+                LEFT JOIN FETCH lecture.lectureUnits lu
+                LEFT JOIN FETCH lecture.attachments
+                LEFT JOIN FETCH lu.competencyLinks
+            WHERE lecture.id = :lectureId
+            """)
+    Optional<Lecture> findByIdWithLectureUnitsWithCompetencyLinksAndAttachments(@Param("lectureId") Long lectureId);
+
     @Query("""
             SELECT new de.tum.cit.aet.artemis.core.dto.CourseContentCountDTO(
                 COUNT(l.id),

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureRepository.java
@@ -63,15 +63,6 @@ public interface LectureRepository extends ArtemisJpaRepository<Lecture, Long> {
     Set<Lecture> findAllByCourseIdWithAttachmentsAndLectureUnits(@Param("courseId") Long courseId);
 
     // TODO: this query loads too much data, we should reduce the number of left join fetches
-    @Query("""
-            SELECT lecture
-            FROM Lecture lecture
-                LEFT JOIN FETCH lecture.attachments
-                LEFT JOIN FETCH lecture.lectureUnits lu
-                LEFT JOIN FETCH lu.completedUsers cu
-            WHERE lecture.id = :lectureId
-            """)
-    Optional<Lecture> findByIdWithAttachmentsAndLectureUnitsAndCompletions(@Param("lectureId") Long lectureId);
 
     // TODO: this query loads too much data, we should reduce the number of left join fetches
     @Query("""
@@ -172,11 +163,6 @@ public interface LectureRepository extends ArtemisJpaRepository<Lecture, Long> {
     @NotNull
     default Lecture findByIdWithLectureUnitsAndCompetenciesElseThrow(Long lectureId) {
         return getValueElseThrow(findByIdWithLectureUnitsAndCompetencies(lectureId), lectureId);
-    }
-
-    @NotNull
-    default Lecture findByIdWithAttachmentsAndLectureUnitsAndCompletionsElseThrow(Long lectureId) {
-        return getValueElseThrow(findByIdWithAttachmentsAndLectureUnitsAndCompletions(lectureId), lectureId);
     }
 
     @NotNull

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureRepository.java
@@ -63,8 +63,6 @@ public interface LectureRepository extends ArtemisJpaRepository<Lecture, Long> {
     Set<Lecture> findAllByCourseIdWithAttachmentsAndLectureUnits(@Param("courseId") Long courseId);
 
     // TODO: this query loads too much data, we should reduce the number of left join fetches
-
-    // TODO: this query loads too much data, we should reduce the number of left join fetches
     @Query("""
             SELECT lecture
             FROM Lecture lecture

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureUnitCompletionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureUnitCompletionRepository.java
@@ -33,6 +33,7 @@ public interface LectureUnitCompletionRepository extends ArtemisJpaRepository<Le
     @Query("""
             SELECT lectureUnitCompletion
             FROM LectureUnitCompletion lectureUnitCompletion
+                LEFT JOIN FETCH lectureUnitCompletion.lectureUnit
             WHERE lectureUnitCompletion.lectureUnit IN :lectureUnits
                 AND lectureUnitCompletion.user.id = :userId
             """)

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureUnitRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureUnitRepository.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 
 import de.tum.cit.aet.artemis.core.repository.base.ArtemisJpaRepository;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
+import de.tum.cit.aet.artemis.lecture.domain.LectureUnitCompletion;
 
 /**
  * Spring Data JPA repository for the Lecture Unit entity.
@@ -76,6 +77,15 @@ public interface LectureUnitRepository extends ArtemisJpaRepository<LectureUnit,
             WHERE lu.id = :lectureUnitId
             """)
     Optional<LectureUnit> findByIdWithCompletedUsers(@Param("lectureUnitId") long lectureUnitId);
+
+    @Query("""
+            SELECT cu
+            FROM LectureUnit lu
+              JOIN lu.completedUsers cu
+            WHERE lu.lecture.id = :lectureId
+              AND cu.user.id = :userId
+              """)
+    Set<LectureUnitCompletion> findCompletionsForLectureAndUser(@Param("lectureId") long lectureId, @Param("userId") long userId);
 
     /**
      * Finds a lecture unit by name, lecture title and course id. Currently, name duplicates are allowed but this method throws an exception if multiple lecture units with the

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureUnitRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureUnitRepository.java
@@ -81,10 +81,10 @@ public interface LectureUnitRepository extends ArtemisJpaRepository<LectureUnit,
     @Query("""
             SELECT cu
             FROM LectureUnit lu
-              JOIN lu.completedUsers cu
+                JOIN lu.completedUsers cu
             WHERE lu.lecture.id = :lectureId
-              AND cu.user.id = :userId
-              """)
+                AND cu.user.id = :userId
+            """)
     Set<LectureUnitCompletion> findCompletionsForLectureAndUser(@Param("lectureId") long lectureId, @Param("userId") long userId);
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureService.java
@@ -128,6 +128,7 @@ public class LectureService {
 
     /**
      * Search for all lectures fitting a {@link SearchTermPageableSearchDTO search query}. The result is paged.
+     * It only returns results for which the user (at least editor) has access to the course.
      *
      * @param search The search query defining the search term and the size of the returned page
      * @param user   The user for whom to fetch all available lectures

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureService.java
@@ -237,7 +237,7 @@ public class LectureService {
      * @throws BadRequestAlertException if the lecture is not linked to a course
      */
     public Lecture getForDetails(long lectureId, User user) {
-        Lecture lecture = lectureRepository.findByIdWithLectureUnitsAndAttachmentsElseThrow(lectureId);
+        Lecture lecture = lectureRepository.findByIdWithLectureUnitsWithCompetencyLinksAndAttachmentsElseThrow(lectureId);
         Course course = lecture.getCourse();
         if (course == null) {
             throw new BadRequestAlertException("The course belonging to this lecture does not exist", "lecture", "courseNotFound");
@@ -268,7 +268,7 @@ public class LectureService {
      * <strong>Rationale:</strong> Ensures that only authorized and fully detailed content is shown to the user. It handles Hibernate’s quirks (e.g., null entries) and aligns with
      * access control and information completeness for the dashboard.
      *
-     * @param lecture the {@link Lecture} to filter
+     * @param lecture the {@link Lecture} to filter which includes lecture units (with competency links) and attachments
      * @param user    the user requesting access
      * @return the filtered {@link Lecture}
      */
@@ -292,7 +292,7 @@ public class LectureService {
             default -> authCheckService.isAllowedToSeeLectureUnit(lectureUnit, user);
         }).peek(lectureUnit -> {
             lectureUnit.setCompleted(lectureUnit.isCompletedFor(user));
-
+            // lecture units already contain the competency links, so we do not need to load them again
             if (lectureUnit instanceof ExerciseUnit exerciseUnit) {
                 Exercise exercise = exerciseUnit.getExercise();
                 // we replace the exercise with one that contains all the information needed for correct display

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/LectureResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/LectureResource.java
@@ -51,6 +51,7 @@ import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastInstructor
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
 import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInCourse.EnforceAtLeastInstructorInCourse;
 import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInCourse.EnforceAtLeastStudentInCourse;
+import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceAtLeastStudentInLecture;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
@@ -371,7 +372,7 @@ public class LectureResource {
      * @return the ResponseEntity with status 200 (OK) and with body the lecture including posts, lecture units and competencies, or with status 404 (Not Found)
      */
     @GetMapping("lectures/{lectureId}/details")
-    @EnforceAtLeastStudent
+    @EnforceAtLeastStudentInLecture
     public ResponseEntity<Lecture> getLectureWithDetails(@PathVariable Long lectureId) {
         log.debug("REST request to get lecture {} with details", lectureId);
         Lecture lecture = lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompetenciesAndCompletionsElseThrow(lectureId);
@@ -380,10 +381,9 @@ public class LectureResource {
         }
         Course course = lecture.getCourse();
         if (course == null) {
-            return ResponseEntity.badRequest().build();
+            throw new BadRequestAlertException("The course belonging to this lecture does not exist", ENTITY_NAME, "courseNotFound");
         }
         User user = userRepository.getUserWithGroupsAndAuthorities();
-        authCheckService.checkIsAllowedToSeeLectureElseThrow(lecture, user);
         lecture = filterLectureContentForUser(lecture, user);
 
         return ResponseEntity.ok(lecture);

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/LectureResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/LectureResource.java
@@ -375,7 +375,7 @@ public class LectureResource {
     @EnforceAtLeastStudentInLecture
     public ResponseEntity<Lecture> getLectureWithDetails(@PathVariable Long lectureId) {
         log.debug("REST request to get lecture {} with details", lectureId);
-        Lecture lecture = lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompetenciesAndCompletionsElseThrow(lectureId);
+        Lecture lecture = lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompletionsElseThrow(lectureId);
         if (competencyApi.isPresent()) {
             competencyApi.get().addCompetencyLinksToExerciseUnits(lecture);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/LectureResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/LectureResource.java
@@ -361,6 +361,7 @@ public class LectureResource {
      */
     @GetMapping("lectures/{lectureId}/details")
     @EnforceAtLeastStudentInLecture
+    // TODO: we should use a proper DTO here to avoid sending too much irrelevant data to the client
     public ResponseEntity<Lecture> getLectureWithDetails(@PathVariable Long lectureId) {
         log.debug("REST request to get lecture {} with details", lectureId);
         User user = userRepository.getUserWithGroupsAndAuthorities();

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/LectureResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/LectureResource.java
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.atlas.api.CompetencyApi;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Channel;
 import de.tum.cit.aet.artemis.communication.repository.conversation.ChannelRepository;
 import de.tum.cit.aet.artemis.communication.service.conversation.ChannelService;
@@ -53,7 +52,6 @@ import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInCourse.Enfo
 import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceAtLeastStudentInLecture;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
-import de.tum.cit.aet.artemis.exercise.service.ExerciseService;
 import de.tum.cit.aet.artemis.lecture.domain.Attachment;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
@@ -80,8 +78,6 @@ public class LectureResource {
     @Value("${jhipster.clientApp.name}")
     private String applicationName;
 
-    private final Optional<CompetencyApi> competencyApi;
-
     private final LectureRepository lectureRepository;
 
     private final LectureService lectureService;
@@ -94,25 +90,21 @@ public class LectureResource {
 
     private final UserRepository userRepository;
 
-    private final ExerciseService exerciseService;
-
     private final ChannelService channelService;
 
     private final ChannelRepository channelRepository;
 
     public LectureResource(LectureRepository lectureRepository, LectureService lectureService, LectureImportService lectureImportService, CourseRepository courseRepository,
-            UserRepository userRepository, AuthorizationCheckService authCheckService, ExerciseService exerciseService, ChannelService channelService,
-            ChannelRepository channelRepository, Optional<CompetencyApi> competencyApi, SlideRepository slideRepository) {
+            UserRepository userRepository, AuthorizationCheckService authCheckService, ChannelService channelService, ChannelRepository channelRepository,
+            SlideRepository slideRepository) {
         this.lectureRepository = lectureRepository;
         this.lectureService = lectureService;
         this.lectureImportService = lectureImportService;
         this.courseRepository = courseRepository;
         this.userRepository = userRepository;
         this.authCheckService = authCheckService;
-        this.exerciseService = exerciseService;
         this.channelService = channelService;
         this.channelRepository = channelRepository;
-        this.competencyApi = competencyApi;
         this.slideRepository = slideRepository;
     }
 

--- a/src/main/webapp/app/atlas/shared/competencies-popover/competencies-popover.component.ts
+++ b/src/main/webapp/app/atlas/shared/competencies-popover/competencies-popover.component.ts
@@ -14,12 +14,9 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
     imports: [TranslateDirective, RouterLink, NgbPopover, FaIconComponent],
 })
 export class CompetenciesPopoverComponent implements OnInit {
-    @Input()
-    courseId: number;
-    @Input()
-    competencyLinks: CompetencyLectureUnitLink[] = [];
-    @Input()
-    navigateTo: 'competencyManagement' | 'courseCompetencies' = 'courseCompetencies';
+    @Input() courseId: number;
+    @Input() competencyLinks: CompetencyLectureUnitLink[] = [];
+    @Input() navigateTo: 'competencyManagement' | 'courseCompetencies' = 'courseCompetencies';
 
     navigationArray: string[] = [];
 

--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.spec.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.spec.ts
@@ -134,7 +134,12 @@ describe('CourseLectureDetailsComponent', () => {
                 {
                     provide: ActivatedRoute,
                     useValue: {
-                        params: of({ lectureId: '1', courseId: '1' }),
+                        params: of({ lectureId: '1' }),
+                        parent: {
+                            parent: {
+                                params: of({ courseId: '1' }),
+                            },
+                        },
                     },
                 },
                 MockProvider(Router),

--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.ts
@@ -83,6 +83,7 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
     hasPdfLectureUnit: boolean;
     irisSettings?: IrisSettings;
     paramsSubscription: Subscription;
+    courseParamsSubscription: Subscription;
     isProduction = true;
     isTestServer = false;
     endsSameDay = false;
@@ -100,6 +101,10 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
         this.isProduction = this.profileService.isProduction();
         this.isTestServer = this.profileService.isTestServer();
         this.irisEnabled = this.profileService.isProfileActive(PROFILE_IRIS);
+
+        this.courseParamsSubscription = this.activatedRoute.parent!.parent!.params.subscribe((params) => {
+            this.courseId = +params.courseId;
+        });
 
         this.paramsSubscription = this.activatedRoute.params.subscribe((params) => {
             this.lectureId = +params.lectureId;
@@ -193,5 +198,6 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
 
     ngOnDestroy() {
         this.paramsSubscription?.unsubscribe();
+        this.courseParamsSubscription?.unsubscribe();
     }
 }

--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.ts
@@ -102,9 +102,14 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
         this.isTestServer = this.profileService.isTestServer();
         this.irisEnabled = this.profileService.isProfileActive(PROFILE_IRIS);
 
-        this.courseParamsSubscription = this.activatedRoute.parent!.parent!.params.subscribe((params) => {
-            this.courseId = +params.courseId;
-        });
+        // As defined in courses.route.ts, the courseId is in the grand parent route of the lectureId route.
+        const grandParentRoute = this.activatedRoute.parent?.parent;
+        if (grandParentRoute) {
+            this.courseParamsSubscription = grandParentRoute.params.subscribe((params) => {
+                // Note: if courseId is not found, sub components cannot navigate properly
+                this.courseId = +params.courseId;
+            });
+        }
 
         this.paramsSubscription = this.activatedRoute.params.subscribe((params) => {
             this.lectureId = +params.lectureId;

--- a/src/main/webapp/app/lecture/shared/course-lectures/course-lectures.component.ts
+++ b/src/main/webapp/app/lecture/shared/course-lectures/course-lectures.component.ts
@@ -100,7 +100,7 @@ export class CourseLecturesComponent implements OnInit, OnDestroy {
     navigateToLecture() {
         const upcomingLecture = this.courseOverviewService.getUpcomingLecture(this.course?.lectures);
         const lastSelectedLecture = this.getLastSelectedLecture();
-        const lectureId = this.route.firstChild?.snapshot.params.lectureId;
+        const lectureId = this.route.firstChild?.snapshot?.params?.lectureId;
         if (!lectureId && lastSelectedLecture) {
             this.router.navigate([lastSelectedLecture], { relativeTo: this.route, replaceUrl: true });
         } else if (!lectureId && upcomingLecture) {

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/AbstractAtlasIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/AbstractAtlasIntegrationTest.java
@@ -34,11 +34,11 @@ import de.tum.cit.aet.artemis.exercise.service.ParticipationService;
 import de.tum.cit.aet.artemis.exercise.team.TeamUtilService;
 import de.tum.cit.aet.artemis.exercise.test_repository.SubmissionTestRepository;
 import de.tum.cit.aet.artemis.lecture.repository.ExerciseUnitRepository;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitRepository;
 import de.tum.cit.aet.artemis.lecture.repository.TextUnitRepository;
 import de.tum.cit.aet.artemis.lecture.service.LectureUnitService;
 import de.tum.cit.aet.artemis.lecture.test_repository.AttachmentVideoUnitTestRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseBuildConfigRepository;
 import de.tum.cit.aet.artemis.programming.test_repository.ProgrammingExerciseTestRepository;
@@ -95,7 +95,7 @@ public abstract class AbstractAtlasIntegrationTest extends AbstractSpringIntegra
 
     // External Repositories
     @Autowired
-    protected LectureRepository lectureRepository;
+    protected LectureTestRepository lectureRepository;
 
     @Autowired
     protected LectureUnitRepository lectureUnitRepository;

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/learningpath/LearningPathIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/learningpath/LearningPathIntegrationTest.java
@@ -541,6 +541,10 @@ class LearningPathIntegrationTest extends AbstractAtlasIntegrationTest {
         final var learningPath = learningPathRepository.findByCourseIdAndUserIdElseThrow(course.getId(), student.getId());
         final var result = request.get("/api/atlas/learning-path/" + learningPath.getId() + "/navigation", HttpStatus.OK, LearningPathNavigationDTO.class);
 
+        assertThat(result.predecessorLearningObject()).isNotNull();
+        assertThat(result.currentLearningObject()).isNotNull();
+        assertThat(result.successorLearningObject()).isNotNull();
+
         assertThat(result.predecessorLearningObject().completed()).isTrue();
         assertThat(result.currentLearningObject().completed()).isFalse();
         assertThat(result.successorLearningObject().completed()).isFalse();

--- a/src/test/java/de/tum/cit/aet/artemis/communication/ChannelIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/ChannelIntegrationTest.java
@@ -40,7 +40,7 @@ import de.tum.cit.aet.artemis.core.domain.Language;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.user.util.UserFactory;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseUtilService;
@@ -67,7 +67,7 @@ class ChannelIntegrationTest extends AbstractConversationTest {
     private TutorialGroupUtilService tutorialGroupUtilService;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/communication/util/ConversationUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/util/ConversationUtilService.java
@@ -42,7 +42,7 @@ import de.tum.cit.aet.artemis.core.util.CourseFactory;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseTestRepository;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureFactory;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
@@ -70,7 +70,7 @@ public class ConversationUtilService {
     private ExerciseTestRepository exerciseRepo;
 
     @Autowired
-    private LectureRepository lectureRepo;
+    private LectureTestRepository lectureRepo;
 
     @Autowired
     private PlagiarismCaseRepository plagiarismCaseRepository;

--- a/src/test/java/de/tum/cit/aet/artemis/core/FileIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/FileIntegrationTest.java
@@ -48,9 +48,9 @@ import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
 import de.tum.cit.aet.artemis.lecture.repository.AttachmentRepository;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitCompletionRepository;
 import de.tum.cit.aet.artemis.lecture.test_repository.AttachmentVideoUnitTestRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureFactory;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
@@ -69,7 +69,7 @@ class FileIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     private LectureUnitCompletionRepository lectureUnitCompletionRepository;
 
     @Autowired
-    private LectureRepository lectureRepo;
+    private LectureTestRepository lectureRepo;
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/core/aspects/EnforceRoleInLectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/aspects/EnforceRoleInLectureTest.java
@@ -1,0 +1,178 @@
+package de.tum.cit.aet.artemis.core.aspects;
+
+import java.time.ZonedDateTime;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import de.tum.cit.aet.artemis.lecture.domain.Lecture;
+import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
+
+class EnforceRoleInLectureTest extends AbstractEnforceRoleInResourceTest {
+
+    @Autowired
+    private LectureUtilService lectureUtilService;
+
+    private Lecture lecture;
+
+    private static final String TEST_PREFIX = "enforceroleinlecture";
+
+    private static final String OTHER_PREFIX = "other" + TEST_PREFIX;
+
+    private static final String STUDENT_OF_COURSE = TEST_PREFIX + "student1";
+
+    private static final String STUDENT_OF_OTHER_COURSE = OTHER_PREFIX + "student1";
+
+    private static final String TUTOR_OF_COURSE = TEST_PREFIX + "tutor1";
+
+    private static final String TUTOR_OF_OTHER_COURSE = OTHER_PREFIX + "tutor1";
+
+    private static final String EDITOR_OF_COURSE = TEST_PREFIX + "editor1";
+
+    private static final String EDITOR_OF_OTHER_COURSE = OTHER_PREFIX + "editor1";
+
+    private static final String INSTRUCTOR_OF_COURSE = TEST_PREFIX + "instructor1";
+
+    private static final String INSTRUCTOR_OF_OTHER_COURSE = OTHER_PREFIX + "instructor1";
+
+    @Override
+    String getTestPrefix() {
+        return TEST_PREFIX;
+    }
+
+    @Override
+    String getOtherPrefix() {
+        return OTHER_PREFIX;
+    }
+
+    @Override
+    void customSetup() {
+        // Add a lecture to the course
+        lecture = lectureUtilService.createLecture(course, ZonedDateTime.now());
+    }
+
+    private void callEndpoint(String endpoint, HttpStatus expectedStatus) throws Exception {
+        request.get("/api/core/test/" + endpoint + "/" + lecture.getId(), expectedStatus, Void.class);
+    }
+
+    private static Stream<Arguments> generateArgumentStream(HttpStatus[] expectedStatus) {
+        return Stream.of(Arguments.of("testEnforceAtLeastStudentInLectureExplicit", expectedStatus[0]), Arguments.of("testEnforceAtLeastStudentInLecture", expectedStatus[1]),
+                Arguments.of("testEnforceAtLeastTutorInLectureExplicit", expectedStatus[2]), Arguments.of("testEnforceAtLeastTutorInLecture", expectedStatus[3]),
+                Arguments.of("testEnforceAtLeastEditorInLectureExplicit", expectedStatus[4]), Arguments.of("testEnforceAtLeastEditorInLecture", expectedStatus[5]),
+                Arguments.of("testEnforceAtLeastInstructorInLectureExplicit", expectedStatus[6]), Arguments.of("testEnforceAtLeastInstructorInLecture", expectedStatus[7]),
+                Arguments.of("testEnforceRoleInLectureFieldName", expectedStatus[8]), Arguments.of("testEnforceAtLeastStudentInLectureFieldName", expectedStatus[9]),
+                Arguments.of("testEnforceAtLeastTutorInLectureFieldName", expectedStatus[10]), Arguments.of("testEnforceAtLeastEditorInLectureFieldName", expectedStatus[11]),
+                Arguments.of("testEnforceAtLeastInstructorInLectureFieldName", expectedStatus[12]));
+    }
+
+    private static Stream<Arguments> allSameStatusProvider(HttpStatus expectedStatus) {
+        return generateArgumentStream(Stream.generate(() -> expectedStatus).limit(13).toArray(HttpStatus[]::new));
+    }
+
+    private static Stream<Arguments> testAsStudentOfCourseProvider() {
+        return generateArgumentStream(new HttpStatus[] { HttpStatus.OK, HttpStatus.OK, HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN,
+                HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN, HttpStatus.OK, HttpStatus.OK, HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
+    @MethodSource("testAsStudentOfCourseProvider")
+    @WithMockUser(username = STUDENT_OF_COURSE, roles = "USER")
+    void testAsStudentOfCourse(String endpoint, HttpStatus expectedStatus) throws Exception {
+        callEndpoint(endpoint, expectedStatus);
+    }
+
+    private static Stream<Arguments> testAsStudentOfOtherCourseProvider() {
+        return allSameStatusProvider(HttpStatus.FORBIDDEN);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
+    @MethodSource("testAsStudentOfOtherCourseProvider")
+    @WithMockUser(username = STUDENT_OF_OTHER_COURSE, roles = "USER")
+    void testAsStudentOfOther(String endpoint, HttpStatus expectedStatus) throws Exception {
+        callEndpoint(endpoint, expectedStatus);
+    }
+
+    private static Stream<Arguments> testAsTutorOfCourseProvider() {
+        return generateArgumentStream(new HttpStatus[] { HttpStatus.OK, HttpStatus.OK, HttpStatus.OK, HttpStatus.OK, HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN,
+                HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN, HttpStatus.OK, HttpStatus.OK, HttpStatus.OK, HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
+    @MethodSource("testAsTutorOfCourseProvider")
+    @WithMockUser(username = TUTOR_OF_COURSE, roles = "TA")
+    void testAsTutorOfCourse(String endpoint, HttpStatus expectedStatus) throws Exception {
+        callEndpoint(endpoint, expectedStatus);
+    }
+
+    private static Stream<Arguments> testAsTutorOfOtherCourseProvider() {
+        return allSameStatusProvider(HttpStatus.FORBIDDEN);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
+    @MethodSource("testAsTutorOfOtherCourseProvider")
+    @WithMockUser(username = TUTOR_OF_OTHER_COURSE, roles = "TA")
+    void testAsTutorOfOtherCourse(String endpoint, HttpStatus expectedStatus) throws Exception {
+        callEndpoint(endpoint, expectedStatus);
+    }
+
+    private static Stream<Arguments> testAsEditorOfCourseProvider() {
+        return generateArgumentStream(new HttpStatus[] { HttpStatus.OK, HttpStatus.OK, HttpStatus.OK, HttpStatus.OK, HttpStatus.OK, HttpStatus.OK, HttpStatus.FORBIDDEN,
+                HttpStatus.FORBIDDEN, HttpStatus.OK, HttpStatus.OK, HttpStatus.OK, HttpStatus.OK, HttpStatus.FORBIDDEN });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
+    @MethodSource("testAsEditorOfCourseProvider")
+    @WithMockUser(username = EDITOR_OF_COURSE, roles = "EDITOR")
+    void testAsEditorOfCourse(String endpoint, HttpStatus expectedStatus) throws Exception {
+        callEndpoint(endpoint, expectedStatus);
+    }
+
+    private static Stream<Arguments> testAsEditorOfOtherCourseProvider() {
+        return allSameStatusProvider(HttpStatus.FORBIDDEN);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
+    @MethodSource("testAsEditorOfOtherCourseProvider")
+    @WithMockUser(username = EDITOR_OF_OTHER_COURSE, roles = "EDITOR")
+    void testAsEditorOfOtherCourse(String endpoint, HttpStatus expectedStatus) throws Exception {
+        callEndpoint(endpoint, expectedStatus);
+    }
+
+    private static Stream<Arguments> testAsInstructorOfCourseProvider() {
+        return allSameStatusProvider(HttpStatus.OK);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
+    @MethodSource("testAsInstructorOfCourseProvider")
+    @WithMockUser(username = INSTRUCTOR_OF_COURSE, roles = "INSTRUCTOR")
+    void testAsInstructorOfCourse(String endpoint, HttpStatus expectedStatus) throws Exception {
+        callEndpoint(endpoint, expectedStatus);
+    }
+
+    private static Stream<Arguments> testAsInstructorOfOtherCourseProvider() {
+        return allSameStatusProvider(HttpStatus.FORBIDDEN);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
+    @MethodSource("testAsInstructorOfOtherCourseProvider")
+    @WithMockUser(username = INSTRUCTOR_OF_OTHER_COURSE, roles = "INSTRUCTOR")
+    void testAsInstructorOfOtherCourse(String endpoint, HttpStatus expectedStatus) throws Exception {
+        callEndpoint(endpoint, expectedStatus);
+    }
+
+    private static Stream<Arguments> testAsAdminProvider() {
+        return allSameStatusProvider(HttpStatus.OK);
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
+    @MethodSource("testAsAdminProvider")
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void testAsAdmin(String endpoint, HttpStatus expectedStatus) throws Exception {
+        callEndpoint(endpoint, expectedStatus);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/aspects/util/EnforceRoleInLectureResource.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/aspects/util/EnforceRoleInLectureResource.java
@@ -1,0 +1,101 @@
+package de.tum.cit.aet.artemis.core.aspects.util;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.tum.cit.aet.artemis.core.security.Role;
+import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceAtLeastEditorInLecture;
+import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceAtLeastInstructorInLecture;
+import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceAtLeastStudentInLecture;
+import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceAtLeastTutorInLecture;
+import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceRoleInLecture;
+
+@Profile(PROFILE_CORE)
+@RestController
+@RequestMapping("api/core/test/")
+public class EnforceRoleInLectureResource {
+
+    @GetMapping("testEnforceAtLeastStudentInLectureExplicit/{lectureId}")
+    @EnforceRoleInLecture(Role.STUDENT)
+    public ResponseEntity<Void> testEnforceAtLeastStudentInLectureExplicit(@PathVariable long lectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastStudentInLecture/{lectureId}")
+    @EnforceAtLeastStudentInLecture
+    public ResponseEntity<Void> testEnforceAtLeastStudentInLecture(@PathVariable long lectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastTutorInLectureExplicit/{lectureId}")
+    @EnforceRoleInLecture(Role.TEACHING_ASSISTANT)
+    public ResponseEntity<Void> testEnforceAtLeastTutorInLectureExplicit(@PathVariable long lectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastTutorInLecture/{lectureId}")
+    @EnforceAtLeastTutorInLecture
+    public ResponseEntity<Void> testEnforceAtLeastTutorInLecture(@PathVariable long lectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastEditorInLectureExplicit/{lectureId}")
+    @EnforceRoleInLecture(Role.EDITOR)
+    public ResponseEntity<Void> testEnforceAtLeastEditorInLectureExplicit(@PathVariable long lectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastEditorInLecture/{lectureId}")
+    @EnforceAtLeastEditorInLecture
+    public ResponseEntity<Void> testEnforceAtLeastEditorInLecture(@PathVariable long lectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastInstructorInLectureExplicit/{lectureId}")
+    @EnforceRoleInLecture(Role.INSTRUCTOR)
+    public ResponseEntity<Void> testEnforceAtLeastInstructorInLectureExplicit(@PathVariable long lectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastInstructorInLecture/{lectureId}")
+    @EnforceAtLeastInstructorInLecture
+    public ResponseEntity<Void> testEnforceAtLeastInstructorInLecture(@PathVariable long lectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceRoleInLectureFieldName/{renamedLectureId}")
+    @EnforceRoleInLecture(value = Role.STUDENT, resourceIdFieldName = "renamedLectureId")
+    public ResponseEntity<Void> testEnforceRoleInLectureFieldName(@PathVariable long renamedLectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastStudentInLectureFieldName/{renamedLectureId}")
+    @EnforceAtLeastStudentInLecture(resourceIdFieldName = "renamedLectureId")
+    public ResponseEntity<Void> testEnforceAtLeastStudentInLectureFieldName(@PathVariable long renamedLectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastTutorInLectureFieldName/{renamedLectureId}")
+    @EnforceAtLeastTutorInLecture(resourceIdFieldName = "renamedLectureId")
+    public ResponseEntity<Void> testEnforceAtLeastTutorInLectureFieldName(@PathVariable long renamedLectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastEditorInLectureFieldName/{renamedLectureId}")
+    @EnforceAtLeastEditorInLecture(resourceIdFieldName = "renamedLectureId")
+    public ResponseEntity<Void> testEnforceAtLeastEditorInLectureFieldName(@PathVariable long renamedLectureId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("testEnforceAtLeastInstructorInLectureFieldName/{renamedLectureId}")
+    @EnforceAtLeastInstructorInLecture(resourceIdFieldName = "renamedLectureId")
+    public ResponseEntity<Void> testEnforceAtLeastInstructorInLectureFieldName(@PathVariable long renamedLectureId) {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/TitleCacheEvictionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/TitleCacheEvictionServiceTest.java
@@ -15,7 +15,7 @@ import de.tum.cit.aet.artemis.core.util.CourseUtilService;
 import de.tum.cit.aet.artemis.core.util.Pair;
 import de.tum.cit.aet.artemis.exam.test_repository.ExamTestRepository;
 import de.tum.cit.aet.artemis.exam.util.ExamUtilService;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.modeling.domain.DiagramType;
 import de.tum.cit.aet.artemis.modeling.repository.ApollonDiagramRepository;
@@ -36,7 +36,7 @@ class TitleCacheEvictionServiceTest extends AbstractSpringIntegrationIndependent
     private CacheManager cacheManager;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private OrganizationRepository organizationRepository;

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/CourseTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/CourseTestService.java
@@ -141,7 +141,7 @@ import de.tum.cit.aet.artemis.fileupload.domain.FileUploadExercise;
 import de.tum.cit.aet.artemis.fileupload.domain.FileUploadSubmission;
 import de.tum.cit.aet.artemis.fileupload.repository.FileUploadExerciseRepository;
 import de.tum.cit.aet.artemis.fileupload.util.ZipFileTestUtilService;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
 import de.tum.cit.aet.artemis.lti.domain.OnlineCourseConfiguration;
 import de.tum.cit.aet.artemis.lti.test_repository.LtiPlatformConfigurationTestRepository;
@@ -184,7 +184,7 @@ public class CourseTestService {
     private ExerciseTestRepository exerciseRepo;
 
     @Autowired
-    private LectureRepository lectureRepo;
+    private LectureTestRepository lectureRepo;
 
     @Autowired
     private ResultTestRepository resultRepo;

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/CourseUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/CourseUtilService.java
@@ -66,7 +66,7 @@ import de.tum.cit.aet.artemis.lecture.domain.ExerciseUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.TextUnit;
 import de.tum.cit.aet.artemis.lecture.repository.AttachmentRepository;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureFactory;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.lti.domain.OnlineCourseConfiguration;
@@ -112,7 +112,7 @@ public class CourseUtilService {
     private CourseTestRepository courseRepo;
 
     @Autowired
-    private LectureRepository lectureRepo;
+    private LectureTestRepository lectureRepo;
 
     @Autowired
     private AttachmentRepository attachmentRepo;

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisLectureChatMessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisLectureChatMessageIntegrationTest.java
@@ -30,7 +30,6 @@ import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.util.CourseUtilService;
-import de.tum.cit.aet.artemis.exercise.test_repository.StudentParticipationTestRepository;
 import de.tum.cit.aet.artemis.iris.domain.message.IrisMessage;
 import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageContent;
 import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender;
@@ -45,7 +44,6 @@ import de.tum.cit.aet.artemis.iris.service.pyris.dto.chat.PyrisChatStatusUpdateD
 import de.tum.cit.aet.artemis.iris.service.pyris.dto.status.PyrisStageDTO;
 import de.tum.cit.aet.artemis.iris.service.pyris.dto.status.PyrisStageState;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 
 class IrisLectureChatMessageIntegrationTest extends AbstractIrisIntegrationTest {
@@ -60,12 +58,6 @@ class IrisLectureChatMessageIntegrationTest extends AbstractIrisIntegrationTest 
 
     @Autowired
     private IrisMessageRepository irisMessageRepository;
-
-    @Autowired
-    private LectureRepository lectureRepository;
-
-    @Autowired
-    private StudentParticipationTestRepository studentParticipationRepository;
 
     @Autowired
     private CourseUtilService courseUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisLectureIngestionTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisLectureIngestionTest.java
@@ -21,7 +21,6 @@ import de.tum.cit.aet.artemis.core.util.CourseUtilService;
 import de.tum.cit.aet.artemis.iris.domain.settings.IrisCourseSettings;
 import de.tum.cit.aet.artemis.iris.repository.IrisSettingsRepository;
 import de.tum.cit.aet.artemis.iris.service.pyris.PyrisJobService;
-import de.tum.cit.aet.artemis.iris.service.pyris.PyrisStatusUpdateService;
 import de.tum.cit.aet.artemis.iris.service.pyris.PyrisWebhookService;
 import de.tum.cit.aet.artemis.iris.service.pyris.dto.lectureingestionwebhook.PyrisLectureIngestionStatusUpdateDTO;
 import de.tum.cit.aet.artemis.iris.service.pyris.dto.status.PyrisStageDTO;
@@ -29,8 +28,7 @@ import de.tum.cit.aet.artemis.iris.service.pyris.dto.status.PyrisStageState;
 import de.tum.cit.aet.artemis.lecture.domain.Attachment;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
-import de.tum.cit.aet.artemis.lecture.repository.LectureUnitRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureFactory;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 
@@ -42,7 +40,7 @@ class PyrisLectureIngestionTest extends AbstractIrisIntegrationTest {
     private PyrisWebhookService pyrisWebhookService;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private UserUtilService userUtilService;
@@ -54,16 +52,10 @@ class PyrisLectureIngestionTest extends AbstractIrisIntegrationTest {
     private LectureUtilService lectureUtilService;
 
     @Autowired
-    protected PyrisStatusUpdateService pyrisStatusUpdateService;
-
-    @Autowired
     protected PyrisJobService pyrisJobService;
 
     @Autowired
     protected IrisSettingsRepository irisSettingsRepository;
-
-    @Autowired
-    protected LectureUnitRepository lectureUnitRepository;
 
     private Attachment attachment;
 

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisLectureTranscriptionIngestionTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisLectureTranscriptionIngestionTest.java
@@ -18,9 +18,9 @@ import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureTranscription;
 import de.tum.cit.aet.artemis.lecture.domain.LectureTranscriptionSegment;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureTranscriptionRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 
 class PyrisLectureTranscriptionIngestionTest extends AbstractIrisIntegrationTest {
@@ -31,7 +31,7 @@ class PyrisLectureTranscriptionIngestionTest extends AbstractIrisIntegrationTest
     private LectureTranscriptionRepository lectureTranscriptionRepository;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/AttachmentResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/AttachmentResourceIntegrationTest.java
@@ -19,7 +19,7 @@ import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
 import de.tum.cit.aet.artemis.lecture.domain.Attachment;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.repository.AttachmentRepository;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureFactory;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
@@ -33,7 +33,7 @@ class AttachmentResourceIntegrationTest extends AbstractSpringIntegrationIndepen
     private AttachmentRepository attachmentRepository;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/AttachmentVideoUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/AttachmentVideoUnitIntegrationTest.java
@@ -51,8 +51,8 @@ import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Slide;
 import de.tum.cit.aet.artemis.lecture.repository.AttachmentRepository;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.test_repository.AttachmentVideoUnitTestRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.test_repository.SlideTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureFactory;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
@@ -71,7 +71,7 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
     private AttachmentVideoUnitTestRepository attachmentVideoUnitRepository;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private SlideTestRepository slideRepository;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
@@ -37,9 +37,9 @@ import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
 import de.tum.cit.aet.artemis.lecture.domain.OnlineUnit;
 import de.tum.cit.aet.artemis.lecture.domain.TextUnit;
 import de.tum.cit.aet.artemis.lecture.repository.AttachmentRepository;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitRepository;
 import de.tum.cit.aet.artemis.lecture.test_repository.AttachmentVideoUnitTestRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureFactory;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
@@ -51,7 +51,7 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     private static final String TEST_PREFIX = "lectureintegrationtest";
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private TextExerciseRepository textExerciseRepository;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/LectureTranscriptionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/LectureTranscriptionIntegrationTest.java
@@ -19,9 +19,9 @@ import de.tum.cit.aet.artemis.lecture.domain.LectureTranscription;
 import de.tum.cit.aet.artemis.lecture.domain.LectureTranscriptionSegment;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
 import de.tum.cit.aet.artemis.lecture.dto.LectureTranscriptionDTO;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureTranscriptionRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
@@ -33,7 +33,7 @@ class LectureTranscriptionIntegrationTest extends AbstractSpringIntegrationIndep
     private LectureTranscriptionRepository lectureTranscriptionRepository;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/LectureUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/LectureUnitIntegrationTest.java
@@ -27,9 +27,9 @@ import de.tum.cit.aet.artemis.lecture.domain.LectureUnitCompletion;
 import de.tum.cit.aet.artemis.lecture.domain.OnlineUnit;
 import de.tum.cit.aet.artemis.lecture.domain.TextUnit;
 import de.tum.cit.aet.artemis.lecture.dto.LectureUnitForLearningPathNodeDetailsDTO;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitCompletionRepository;
 import de.tum.cit.aet.artemis.lecture.repository.TextUnitRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
@@ -41,7 +41,7 @@ class LectureUnitIntegrationTest extends AbstractSpringIntegrationIndependentTes
     private TextUnitRepository textUnitRepository;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private LectureUnitCompletionRepository lectureUnitCompletionRepository;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/LectureUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/LectureUnitIntegrationTest.java
@@ -224,7 +224,7 @@ class LectureUnitIntegrationTest extends AbstractSpringIntegrationIndependentTes
         request.postWithoutLocation("/api/lecture/lectures/" + lecture1.getId() + "/lecture-units/" + lecture1.getLectureUnits().getFirst().getId() + "/completion?completed=true",
                 null, HttpStatus.OK, null);
 
-        this.lecture1 = lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompetenciesAndCompletionsElseThrow(lecture1.getId());
+        this.lecture1 = lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompletionsElseThrow(lecture1.getId());
         LectureUnit lectureUnit = this.lecture1.getLectureUnits().getFirst();
 
         assertThat(lectureUnit.getCompletedUsers()).isNotEmpty();
@@ -234,7 +234,7 @@ class LectureUnitIntegrationTest extends AbstractSpringIntegrationIndependentTes
         request.postWithoutLocation("/api/lecture/lectures/" + lecture1.getId() + "/lecture-units/" + lecture1.getLectureUnits().getFirst().getId() + "/completion?completed=false",
                 null, HttpStatus.OK, null);
 
-        this.lecture1 = lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompetenciesAndCompletionsElseThrow(lecture1.getId());
+        this.lecture1 = lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompletionsElseThrow(lecture1.getId());
         lectureUnit = this.lecture1.getLectureUnits().getFirst();
 
         assertThat(lectureUnit.getCompletedUsers()).isEmpty();

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/OnlineUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/OnlineUnitIntegrationTest.java
@@ -35,8 +35,8 @@ import de.tum.cit.aet.artemis.core.dto.OnlineResourceDTO;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
 import de.tum.cit.aet.artemis.lecture.domain.OnlineUnit;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.OnlineUnitRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
@@ -48,7 +48,7 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
     private OnlineUnitRepository onlineUnitRepository;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/TextUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/TextUnitIntegrationTest.java
@@ -21,8 +21,8 @@ import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyLectureUnitLink;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
 import de.tum.cit.aet.artemis.lecture.domain.TextUnit;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.TextUnitRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
@@ -34,7 +34,7 @@ class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     private TextUnitRepository textUnitRepository;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private LectureUtilService lectureUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureImportServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureImportServiceTest.java
@@ -50,7 +50,7 @@ class LectureImportServiceTest extends AbstractSpringIntegrationIndependentTest 
         List<Course> courses = courseUtilService.createCoursesWithExercisesAndLecturesAndLectureUnits(TEST_PREFIX, false, true, 0);
         Course course1 = courseRepository.findByIdWithExercisesAndExerciseDetailsAndLecturesElseThrow(courses.getFirst().getId());
         long lecture1Id = course1.getLectures().stream().findFirst().orElseThrow().getId();
-        lecture1 = lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompetenciesAndCompletionsElseThrow(lecture1Id);
+        lecture1 = lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompletionsElseThrow(lecture1Id);
         course2 = courseUtilService.createCourse();
 
         assertThat(lecture1.getLectureUnits()).isNotEmpty();
@@ -76,7 +76,7 @@ class LectureImportServiceTest extends AbstractSpringIntegrationIndependentTest 
 
         // Find the imported lecture and fetch it with lecture units
         Long lecture2Id = this.course2.getLectures().stream().skip(lectureCount).findFirst().orElseThrow().getId();
-        Lecture lecture2 = this.lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompetenciesAndCompletionsElseThrow(lecture2Id);
+        Lecture lecture2 = this.lectureRepository.findByIdWithAttachmentsAndLectureUnitsAndCompletionsElseThrow(lecture2Id);
 
         assertThat(lecture2.getTitle()).isEqualTo(this.lecture1.getTitle());
         assertThat(lecture2.getDescription()).isNotNull().isEqualTo(this.lecture1.getDescription());

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureImportServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureImportServiceTest.java
@@ -17,7 +17,7 @@ import de.tum.cit.aet.artemis.lecture.domain.Attachment;
 import de.tum.cit.aet.artemis.lecture.domain.ExerciseUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
@@ -29,7 +29,7 @@ class LectureImportServiceTest extends AbstractSpringIntegrationIndependentTest 
     private LectureImportService lectureImportService;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private UserUtilService userUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureServiceTest.java
@@ -22,9 +22,8 @@ import de.tum.cit.aet.artemis.core.user.util.UserUtilService;
 import de.tum.cit.aet.artemis.core.util.PageableSearchUtilService;
 import de.tum.cit.aet.artemis.lecture.domain.Attachment;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.util.LectureFactory;
-import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
 class LectureServiceTest extends AbstractSpringIntegrationIndependentTest {
@@ -35,13 +34,10 @@ class LectureServiceTest extends AbstractSpringIntegrationIndependentTest {
     private LectureService lectureService;
 
     @Autowired
-    private LectureRepository lectureRepository;
+    private LectureTestRepository lectureRepository;
 
     @Autowired
     private UserUtilService userUtilService;
-
-    @Autowired
-    private LectureUtilService lectureUtilService;
 
     @Autowired
     private PageableSearchUtilService pageableSearchUtilService;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/test_repository/LectureTestRepository.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/test_repository/LectureTestRepository.java
@@ -1,0 +1,33 @@
+package de.tum.cit.aet.artemis.lecture.test_repository;
+
+import java.util.Optional;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import de.tum.cit.aet.artemis.lecture.domain.Lecture;
+import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
+
+@Repository
+@Primary
+public interface LectureTestRepository extends LectureRepository {
+
+    @NotNull
+    default Lecture findByIdWithAttachmentsAndLectureUnitsAndCompletionsElseThrow(long lectureId) {
+        return getValueElseThrow(findByIdWithAttachmentsAndLectureUnitsAndCompletions(lectureId), lectureId);
+    }
+
+    @Query("""
+            SELECT DISTINCT lecture
+            FROM Lecture lecture
+              LEFT JOIN FETCH lecture.attachments
+              LEFT JOIN FETCH lecture.lectureUnits lu
+              LEFT JOIN FETCH lu.completedUsers cu
+            WHERE lecture.id = :lectureId
+            """)
+    Optional<Lecture> findByIdWithAttachmentsAndLectureUnitsAndCompletions(@Param("lectureId") long lectureId);
+}

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/util/LectureUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/util/LectureUtilService.java
@@ -40,12 +40,12 @@ import de.tum.cit.aet.artemis.lecture.domain.Slide;
 import de.tum.cit.aet.artemis.lecture.domain.TextUnit;
 import de.tum.cit.aet.artemis.lecture.repository.AttachmentRepository;
 import de.tum.cit.aet.artemis.lecture.repository.ExerciseUnitRepository;
-import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitCompletionRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitRepository;
 import de.tum.cit.aet.artemis.lecture.repository.OnlineUnitRepository;
 import de.tum.cit.aet.artemis.lecture.repository.TextUnitRepository;
 import de.tum.cit.aet.artemis.lecture.test_repository.AttachmentVideoUnitTestRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.LectureTestRepository;
 import de.tum.cit.aet.artemis.lecture.test_repository.SlideTestRepository;
 
 /**
@@ -63,7 +63,7 @@ public class LectureUtilService {
     private CourseTestRepository courseRepo;
 
     @Autowired
-    private LectureRepository lectureRepo;
+    private LectureTestRepository lectureRepo;
 
     @Autowired
     private LectureUnitRepository lectureUnitRepository;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
There are overly complex database queries in the REST call `lectures/{lectureId}/details` in `LectureResource` that can lead to a high load on the database and long waiting times. Too much (unnecesary) data is fetched.

### Description
This PR reduces the data that is fetched from the database and splits the queries into multiple smaller ones. It reduces the payload size and avoid sending course information multiple times. In a follow-up PR, the REST call should use a DTO to send minimal data.
The PR also fixes a client navigation issue when clicking on competencies.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student

1. **Instructor:** Add some lectures with multiple lecture units (including exercises)
2. **Instructor:** Add mulitple competencies into the course and link many of them to these lecture units
3. **Instructor:** Add many students to the course (potentially using a supporting script)
4. Optional: **Instructor:** Use a supporting script to let many students complete those lecture units
5. **Student:** Navigate into the lecture details and check that the REST call `lectures/{lectureId}/details` does not take too long


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Performance Tests
- [x] Test 1
- [x] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced fine-grained role-based access control annotations enforcing student, tutor, editor, and instructor roles specifically for lectures.
  - Added a new API for importing lectures with enhanced handling.
  - Expanded lecture details endpoint to include user-specific completion data and competency links.
  - Added new user role checks for lectures to improve access control.
  - Added new query methods to fetch lecture unit completions for specific users.

- **Improvements**
  - Optimized loading of competency links for exercise units in lectures through bulk queries.
  - Improved efficiency in fetching lecture unit completions and lecture retrieval by reducing data loading.
  - Refined lecture content filtering based on user permissions and access rights.
  - Updated lecture unit completion matching logic for better reliability.

- **Bug Fixes**
  - Fixed endpoint security to ensure correct role enforcement for lecture details.

- **Documentation**
  - Updated method documentation to clarify access requirements.

- **Tests**
  - Added comprehensive tests for lecture role-based access control.
  - Introduced test controller endpoints to verify role enforcement annotations.
  - Updated test infrastructure and multiple test classes to use a dedicated test lecture repository for improved isolation and clarity.

- **Chores**
  - Refactored multiple test classes to use a test-specific lecture repository for improved isolation and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->