### PR TITLE
`Development`: Use signals in title channel name component

### DIFF
--- a/src/main/webapp/app/exercise/exercise-title-channel-name/exercise-title-channel-name.component.ts
+++ b/src/main/webapp/app/exercise/exercise-title-channel-name/exercise-title-channel-name.component.ts
@@ -51,14 +51,14 @@ export class ExerciseTitleChannelNameComponent implements OnChanges {
         }
     }
 
-    updateTitle(newTitle: string) {
+    updateTitle(newTitle: string | undefined) {
         this.exercise.title = newTitle;
         this.onTitleChange.emit(newTitle ?? '');
     }
 
-    updateChannelName(newName: string) {
+    updateChannelName(newName: string | undefined) {
         this.exercise.channelName = newName;
-        this.onChannelNameChange.emit(newName);
+        this.onChannelNameChange.emit(newName ?? '');
     }
 
     /**

--- a/src/main/webapp/app/exercise/exercise-title-channel-name/exercise-title-channel-name.component.ts
+++ b/src/main/webapp/app/exercise/exercise-title-channel-name/exercise-title-channel-name.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges, ViewChild, effect, inject, input, output, signal } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, effect, inject, input, output, signal, viewChild } from '@angular/core';
 import { Course, isCommunicationEnabled } from 'app/core/course/shared/entities/course.model';
 import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { TitleChannelNameComponent } from 'app/shared/form/title-channel-name/title-channel-name.component';
@@ -22,7 +22,11 @@ export class ExerciseTitleChannelNameComponent implements OnChanges {
     @Input() isImport: boolean;
     @Input() hideTitleLabel: boolean;
 
-    @ViewChild(TitleChannelNameComponent) titleChannelNameComponent: TitleChannelNameComponent;
+    // readonly content = viewChild<ElementRef>('itemsContainer');
+
+    // @ViewChild(TitleChannelNameComponent)
+
+    readonly titleChannelNameComponent = viewChild<TitleChannelNameComponent>('titleChannelNameComponent');
 
     onTitleChange = output<string>();
     onChannelNameChange = output<string>();

--- a/src/main/webapp/app/exercise/exercise-title-channel-name/exercise-title-channel-name.component.ts
+++ b/src/main/webapp/app/exercise/exercise-title-channel-name/exercise-title-channel-name.component.ts
@@ -53,7 +53,7 @@ export class ExerciseTitleChannelNameComponent implements OnChanges {
 
     updateTitle(newTitle: string) {
         this.exercise.title = newTitle;
-        this.onTitleChange.emit(newTitle);
+        this.onTitleChange.emit(newTitle ?? '');
     }
 
     updateChannelName(newName: string) {

--- a/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.spec.ts
@@ -25,6 +25,7 @@ import { NgModel } from '@angular/forms';
 import { ExerciseCategory } from 'app/exercise/shared/entities/exercise/exercise-category.model';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MockRouter } from 'test/helpers/mocks/mock-router';
+import { signal } from '@angular/core';
 
 describe('FileUploadExerciseUpdateComponent', () => {
     let comp: FileUploadExerciseUpdateComponent;
@@ -147,7 +148,7 @@ describe('FileUploadExerciseUpdateComponent', () => {
 
         it('should calculate valid sections', () => {
             const calculateValidSpy = jest.spyOn(comp, 'calculateFormSectionStatus');
-            comp.exerciseTitleChannelNameComponent = { titleChannelNameComponent: { formValidChanges: new Subject() } } as ExerciseTitleChannelNameComponent;
+            comp.exerciseTitleChannelNameComponent = { titleChannelNameComponent: { isValid: signal(false) } } as ExerciseTitleChannelNameComponent;
             comp.teamConfigFormGroupComponent = { formValidChanges: new Subject() } as TeamConfigFormGroupComponent;
             comp.bonusPoints = { valueChanges: new Subject(), valid: true } as unknown as NgModel;
             comp.points = { valueChanges: new Subject(), valid: true } as unknown as NgModel;
@@ -157,7 +158,6 @@ describe('FileUploadExerciseUpdateComponent', () => {
             expect(comp.titleChannelNameComponentSubscription).toBeDefined();
 
             comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid.set(true);
-            comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValidChanges.next(true);
             expect(calculateValidSpy).toHaveBeenCalledOnce();
             expect(comp.formStatusSections).toBeDefined();
             expect(comp.formStatusSections[0].valid).toBeTrue();

--- a/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.spec.ts
@@ -156,7 +156,7 @@ describe('FileUploadExerciseUpdateComponent', () => {
             comp.ngAfterViewInit();
             expect(comp.titleChannelNameComponentSubscription).toBeDefined();
 
-            comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValid = true;
+            comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid.set(true);
             comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValidChanges.next(true);
             expect(calculateValidSpy).toHaveBeenCalledOnce();
             expect(comp.formStatusSections).toBeDefined();

--- a/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.ts
+++ b/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.ts
@@ -170,7 +170,7 @@ export class FileUploadExerciseUpdateComponent implements AfterViewInit, OnDestr
         this.formStatusSections = [
             {
                 title: 'artemisApp.exercise.sections.general',
-                valid: this.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValid,
+                valid: this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid(),
             },
             { title: 'artemisApp.exercise.sections.mode', valid: this.teamConfigFormGroupComponent.formValid },
             { title: 'artemisApp.exercise.sections.problem', valid: true, empty: !this.fileUploadExercise.problemStatement },

--- a/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.ts
+++ b/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, OnDestroy, OnInit, ViewChild, effect, inject } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { AlertService, AlertType } from 'app/shared/service/alert.service';
@@ -122,6 +122,21 @@ export class FileUploadExerciseUpdateComponent implements AfterViewInit, OnDestr
         return this.fileUploadExercise.id == undefined ? EditType.CREATE : EditType.UPDATE;
     }
 
+    constructor() {
+        effect(() => {
+            this.updateFormSectionsOnIsValidChange();
+        });
+    }
+
+    /**
+     * Triggers {@link calculateFormSectionStatus} whenever a relevant signal changes
+     */
+    private updateFormSectionsOnIsValidChange() {
+        this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid();
+
+        this.calculateFormSectionStatus();
+    }
+
     /**
      * Initializes information relevant to file upload exercise
      */
@@ -151,9 +166,6 @@ export class FileUploadExerciseUpdateComponent implements AfterViewInit, OnDestr
     }
 
     ngAfterViewInit() {
-        this.titleChannelNameComponentSubscription = this.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValidChanges.subscribe(() =>
-            this.calculateFormSectionStatus(),
-        );
         this.pointsSubscription = this.points?.valueChanges?.subscribe(() => this.calculateFormSectionStatus());
         this.bonusPointsSubscription = this.bonusPoints?.valueChanges?.subscribe(() => this.calculateFormSectionStatus());
         this.teamSubscription = this.teamConfigFormGroupComponent.formValidChanges.subscribe(() => this.calculateFormSectionStatus());

--- a/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.ts
+++ b/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.ts
@@ -132,7 +132,7 @@ export class FileUploadExerciseUpdateComponent implements AfterViewInit, OnDestr
      * Triggers {@link calculateFormSectionStatus} whenever a relevant signal changes
      */
     private updateFormSectionsOnIsValidChange() {
-        this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid();
+        this.exerciseTitleChannelNameComponent.titleChannelNameComponent()?.isValid();
 
         this.calculateFormSectionStatus();
     }
@@ -182,7 +182,7 @@ export class FileUploadExerciseUpdateComponent implements AfterViewInit, OnDestr
         this.formStatusSections = [
             {
                 title: 'artemisApp.exercise.sections.general',
-                valid: this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid(),
+                valid: this.exerciseTitleChannelNameComponent.titleChannelNameComponent()?.isValid() ?? false,
             },
             { title: 'artemisApp.exercise.sections.mode', valid: this.teamConfigFormGroupComponent.formValid },
             { title: 'artemisApp.exercise.sections.problem', valid: true, empty: !this.fileUploadExercise.problemStatement },

--- a/src/main/webapp/app/lecture/manage/lecture-update/lecture-update.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-update/lecture-update.component.ts
@@ -93,7 +93,7 @@ export class LectureUpdateComponent implements OnInit, OnDestroy {
 
     areSectionsValid = computed(() => {
         return (
-            this.titleSection().titleChannelNameComponent().isFormValidSignal() &&
+            this.titleSection().titleChannelNameComponent().isValid() &&
             this.lecturePeriodSection().isPeriodSectionValid() &&
             (this.unitSection()?.isUnitConfigurationValid() ?? true) &&
             (this.attachmentsSection()?.isFormValid() ?? true)
@@ -174,7 +174,7 @@ export class LectureUpdateComponent implements OnInit, OnDestroy {
         updatedFormStatusSections.push(
             {
                 title: 'artemisApp.lecture.sections.title',
-                valid: Boolean(this.titleSection().titleChannelNameComponent().isFormValidSignal()),
+                valid: Boolean(this.titleSection().titleChannelNameComponent().isValid()),
             },
             {
                 title: 'artemisApp.lecture.sections.period',

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.spec.ts
@@ -303,7 +303,7 @@ describe('ModelingExerciseUpdateComponent', () => {
     it('should subscribe and unsubscribe to input element changes', () => {
         const calculateValidSpy = jest.spyOn(comp, 'calculateFormSectionStatus');
         comp.modelingExercise = { startDate: dayjs(), dueDate: dayjs(), assessmentDueDate: dayjs(), releaseDate: dayjs() } as ModelingExercise;
-        comp.exerciseTitleChannelNameComponent = { titleChannelNameComponent: { formValidChanges: new Subject(), isValid: signal(true) } } as ExerciseTitleChannelNameComponent;
+        comp.exerciseTitleChannelNameComponent = { titleChannelNameComponent: { isValid: signal(true) } } as ExerciseTitleChannelNameComponent;
         comp.teamConfigFormGroupComponent = { formValidChanges: new Subject(), formValid: true } as TeamConfigFormGroupComponent;
         comp.bonusPoints = { valueChanges: new Subject(), valid: true } as any as NgModel;
         comp.points = { valueChanges: new Subject(), valid: true } as any as NgModel;
@@ -313,7 +313,7 @@ describe('ModelingExerciseUpdateComponent', () => {
         (comp.points.valueChanges as Subject<boolean>).next(false);
         (comp.bonusPoints.valueChanges as Subject<boolean>).next(false);
         comp.teamConfigFormGroupComponent.formValidChanges.next(false);
-        comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValidChanges.next(false);
+        comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid.set(false);
         expect(calculateValidSpy).toHaveBeenCalledTimes(4);
 
         comp.ngOnDestroy();

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { Subject, of } from 'rxjs';
 import { ActivatedRoute, Router, UrlSegment } from '@angular/router';
+import { signal } from '@angular/core';
 
 import { ModelingExerciseUpdateComponent } from 'app/modeling/manage/update/modeling-exercise-update.component';
 import { ModelingExerciseService } from 'app/modeling/manage/services/modeling-exercise.service';
@@ -302,7 +303,7 @@ describe('ModelingExerciseUpdateComponent', () => {
     it('should subscribe and unsubscribe to input element changes', () => {
         const calculateValidSpy = jest.spyOn(comp, 'calculateFormSectionStatus');
         comp.modelingExercise = { startDate: dayjs(), dueDate: dayjs(), assessmentDueDate: dayjs(), releaseDate: dayjs() } as ModelingExercise;
-        comp.exerciseTitleChannelNameComponent = { titleChannelNameComponent: { formValidChanges: new Subject(), formValid: true } } as ExerciseTitleChannelNameComponent;
+        comp.exerciseTitleChannelNameComponent = { titleChannelNameComponent: { formValidChanges: new Subject(), isValid: signal(true) } } as ExerciseTitleChannelNameComponent;
         comp.teamConfigFormGroupComponent = { formValidChanges: new Subject(), formValid: true } as TeamConfigFormGroupComponent;
         comp.bonusPoints = { valueChanges: new Subject(), valid: true } as any as NgModel;
         comp.points = { valueChanges: new Subject(), valid: true } as any as NgModel;

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
@@ -229,7 +229,7 @@ export class ModelingExerciseUpdateComponent implements AfterViewInit, OnDestroy
         this.formSectionStatus = [
             {
                 title: 'artemisApp.exercise.sections.general',
-                valid: Boolean(this.exerciseTitleChannelNameComponent?.titleChannelNameComponent.formValid),
+                valid: Boolean(this.exerciseTitleChannelNameComponent?.titleChannelNameComponent.isValid()),
             },
             { title: 'artemisApp.exercise.sections.mode', valid: Boolean(this.teamConfigFormGroupComponent?.formValid) },
             { title: 'artemisApp.exercise.sections.problem', valid: true, empty: !this.modelingExercise.problemStatement },

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild, effect, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ModelingExercise } from 'app/modeling/shared/entities/modeling-exercise.model';
@@ -134,12 +134,24 @@ export class ModelingExerciseUpdateComponent implements AfterViewInit, OnDestroy
     }
 
     ngAfterViewInit() {
-        this.titleChannelNameComponentSubscription = this.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValidChanges.subscribe(() =>
-            this.calculateFormSectionStatus(),
-        );
         this.pointsSubscription = this.points?.valueChanges?.subscribe(() => this.calculateFormSectionStatus());
         this.bonusPointsSubscription = this.bonusPoints?.valueChanges?.subscribe(() => this.calculateFormSectionStatus());
         this.teamSubscription = this.teamConfigFormGroupComponent?.formValidChanges.subscribe(() => this.calculateFormSectionStatus());
+    }
+
+    constructor() {
+        effect(() => {
+            this.updateFormSectionsOnIsValidChange();
+        });
+    }
+
+    /**
+     * Triggers {@link calculateFormSectionStatus} whenever a relevant signal changes
+     */
+    private updateFormSectionsOnIsValidChange() {
+        this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid();
+
+        this.calculateFormSectionStatus().then();
     }
 
     /**

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
@@ -149,7 +149,7 @@ export class ModelingExerciseUpdateComponent implements AfterViewInit, OnDestroy
      * Triggers {@link calculateFormSectionStatus} whenever a relevant signal changes
      */
     private updateFormSectionsOnIsValidChange() {
-        this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid();
+        this.exerciseTitleChannelNameComponent.titleChannelNameComponent()?.isValid();
 
         this.calculateFormSectionStatus().then();
     }
@@ -241,7 +241,7 @@ export class ModelingExerciseUpdateComponent implements AfterViewInit, OnDestroy
         this.formSectionStatus = [
             {
                 title: 'artemisApp.exercise.sections.general',
-                valid: Boolean(this.exerciseTitleChannelNameComponent?.titleChannelNameComponent.isValid()),
+                valid: Boolean(this.exerciseTitleChannelNameComponent?.titleChannelNameComponent()?.isValid()),
             },
             { title: 'artemisApp.exercise.sections.mode', valid: Boolean(this.teamConfigFormGroupComponent?.formValid) },
             { title: 'artemisApp.exercise.sections.problem', valid: true, empty: !this.modelingExercise.problemStatement },

--- a/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.ts
@@ -988,7 +988,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
                 translateKey: 'artemisApp.exercise.form.title.pattern',
                 translateValues: {},
             });
-        } else if (this.exerciseInfoComponent?.titleComponent?.titleChannelNameComponent?.field_title?.control?.errors?.disallowedValue) {
+        } else if (this.exerciseInfoComponent?.titleComponent?.titleChannelNameComponent()?.field_title?.control?.errors?.disallowedValue) {
             validationErrorReasons.push({
                 translateKey: 'artemisApp.exercise.form.title.disallowedValue',
                 translateValues: {},

--- a/src/main/webapp/app/programming/manage/update/update-components/information/programming-exercise-information.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/information/programming-exercise-information.component.ts
@@ -148,7 +148,7 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
     }
 
     private updateFormStatus(): void {
-        this.exerciseTitleChannelComponent()?.titleChannelNameComponent?.isValid(); // triggers effect
+        this.exerciseTitleChannelComponent()?.titleChannelNameComponent()?.isValid(); // triggers effect
 
         this.calculateFormValid();
     }
@@ -185,7 +185,7 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
             fields.toArray().forEach((field) => this.inputFieldSubscriptions.push(field.editingInput.valueChanges?.subscribe(() => this.calculateFormValid())));
         });
 
-        this.titleComponent?.titleChannelNameComponent?.field_title?.valueChanges?.subscribe((newTitle: string) => {
+        this.titleComponent?.titleChannelNameComponent()?.field_title?.valueChanges?.subscribe((newTitle: string) => {
             if (this.isSimpleMode()) {
                 this.updateShortName(newTitle);
             }
@@ -207,7 +207,7 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
         const areAuxiliaryRepositoriesValid = this.areAuxiliaryRepositoriesValid();
         const areCheckoutPathsValid = this.areCheckoutPathsValid();
         this.formValid = Boolean(
-            this.exerciseTitleChannelComponent()?.titleChannelNameComponent?.isValid() &&
+            this.exerciseTitleChannelComponent()?.titleChannelNameComponent()?.isValid() &&
                 this.getIsShortNameFieldValid() &&
                 isCheckoutSolutionRepositoryValid &&
                 isRecreateBuildPlansValid &&

--- a/src/main/webapp/app/programming/manage/update/update-components/information/programming-exercise-information.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/information/programming-exercise-information.component.ts
@@ -141,6 +141,16 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
         effect(() => {
             this.fetchAndInitializeTakenTitlesAndShortNames();
         });
+
+        effect(() => {
+            this.updateFormStatus();
+        });
+    }
+
+    private updateFormStatus(): void {
+        this.exerciseTitleChannelComponent()?.titleChannelNameComponent?.isValid(); // triggers effect
+
+        this.calculateFormValid();
     }
 
     ngOnInit() {
@@ -166,7 +176,6 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
     registerInputFields() {
         this.inputFieldSubscriptions.forEach((subscription) => subscription?.unsubscribe());
 
-        this.inputFieldSubscriptions.push(this.exerciseTitleChannelComponent()?.titleChannelNameComponent?.formValidChanges.subscribe(() => this.calculateFormValid()));
         this.inputFieldSubscriptions.push(this.shortNameField()?.valueChanges?.subscribe(() => this.calculateFormValid()));
         this.inputFieldSubscriptions.push(this.checkoutSolutionRepositoryField?.valueChanges?.subscribe(() => this.calculateFormValid()));
         this.inputFieldSubscriptions.push(this.recreateBuildPlansField?.valueChanges?.subscribe(() => this.calculateFormValid()));
@@ -198,7 +207,7 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
         const areAuxiliaryRepositoriesValid = this.areAuxiliaryRepositoriesValid();
         const areCheckoutPathsValid = this.areCheckoutPathsValid();
         this.formValid = Boolean(
-            this.exerciseTitleChannelComponent()?.titleChannelNameComponent?.isFormValidSignal() &&
+            this.exerciseTitleChannelComponent()?.titleChannelNameComponent?.isValid() &&
                 this.getIsShortNameFieldValid() &&
                 isCheckoutSolutionRepositoryValid &&
                 isRecreateBuildPlansValid &&

--- a/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.html
+++ b/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.html
@@ -7,8 +7,8 @@
             <input
                 #field_title="ngModel"
                 required
-                [minlength]="minTitleLength()"
-                [pattern]="titlePattern()"
+                [minlength]="minTitleLength() ?? null"
+                [pattern]="titlePattern() ?? ''"
                 type="text"
                 class="form-control"
                 name="title"

--- a/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.html
+++ b/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.html
@@ -1,19 +1,19 @@
 <div>
     @if (!this.isEditFieldDisplayedRecord() || this.isEditFieldDisplayedRecord()?.title) {
         <div class="form-group">
-            @if (!hideTitleLabel) {
-                <label [class]="'form-control-label' + (emphasizeLabels ? ' emphasized-label' : '')" jhiTranslate="artemisApp.lecture.title" for="field_title"></label>
+            @if (!hideTitleLabel()) {
+                <label [class]="'form-control-label' + (emphasizeLabels() ? ' emphasized-label' : '')" jhiTranslate="artemisApp.lecture.title" for="field_title"></label>
             }
             <input
                 #field_title="ngModel"
                 required
-                [minlength]="minTitleLength"
-                [pattern]="titlePattern"
+                [minlength]="minTitleLength()"
+                [pattern]="titlePattern()"
                 type="text"
                 class="form-control"
                 name="title"
                 id="field_title"
-                [ngModel]="title"
+                [ngModel]="title()"
                 (ngModelChange)="updateTitle($event)"
                 notIncludedIn
                 [disallowedValues]="alreadyUsedTitles()"
@@ -26,9 +26,11 @@
     @if (isChannelFieldDisplayed()) {
         <div class="form-group">
             <div>
-                <label [class]="'form-control-label' + (emphasizeLabels ? ' emphasized-label' : '')" jhiTranslate="artemisApp.lecture.channelName" for="field_channel_name"
-                    >Channel Name</label
-                >
+                <label
+                    [class]="'form-control-label' + (emphasizeLabels() ? ' emphasized-label' : '')"
+                    jhiTranslate="artemisApp.lecture.channelName"
+                    for="field_channel_name"
+                ></label>
                 <jhi-help-icon text="artemisApp.programmingExercise.channelNameTooltip" />
             </div>
             <input
@@ -38,7 +40,7 @@
                 class="form-control"
                 name="channelName"
                 id="field_channel_name"
-                [ngModel]="channelName"
+                [ngModel]="channelName()"
                 (ngModelChange)="formatChannelName($event)"
                 maxlength="30"
             />

--- a/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
+++ b/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Input, OnDestroy, OnInit, ViewChild, computed, effect, input, output, signal, viewChild } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild, computed, effect, input, model, output, signal, viewChild } from '@angular/core';
 import { ControlContainer, FormsModule, NgForm, NgModel } from '@angular/forms';
 import { Subject, Subscription } from 'rxjs';
 import { ProgrammingExerciseInputField } from 'app/programming/manage/update/programming-exercise-update.helper';
@@ -13,14 +13,14 @@ import { HelpIconComponent } from '../../components/help-icon/help-icon.componen
     imports: [TranslateDirective, FormsModule, CustomNotIncludedInValidatorDirective, HelpIconComponent],
 })
 export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnInit {
-    @Input() title?: string;
-    @Input() channelName?: string;
-    @Input() channelNamePrefix: string;
-    @Input() titlePattern: string;
-    @Input() hideTitleLabel: boolean;
-    @Input() emphasizeLabels = false;
-    @Input() minTitleLength: number;
-    @Input() initChannelName = true;
+    title = model<string>('');
+    channelName = model<string>('');
+    channelNamePrefix = input<string>('');
+    titlePattern = input<string>();
+    hideTitleLabel = input<boolean>(false);
+    emphasizeLabels = input<boolean>(false);
+    minTitleLength = input<number>();
+    initChannelName = input<boolean>(true);
     hideChannelName = input<boolean>();
     isEditFieldDisplayedRecord = input<Record<ProgrammingExerciseInputField, boolean>>();
     alreadyUsedTitles = input<Set<string>>(new Set());
@@ -70,20 +70,15 @@ export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnIn
     }
 
     ngOnInit(): void {
-        if (!this.channelNamePrefix) {
-            this.channelNamePrefix = '';
-        }
-
-        if (this.initChannelName) {
+        if (this.initChannelName()) {
             // Defer updating the channel name into the next change detection cycle to avoid the
             // "NG0100: Expression has changed after it was checked" error
             setTimeout(() => {
-                // Remove trailing hyphens if title is not undefined or empty
-                this.formatChannelName(this.channelNamePrefix + (this.title ?? ''), false, !!this.title);
+                this.updateChannelName();
             });
         }
 
-        this.titleOnPageLoad.set(this.title);
+        this.titleOnPageLoad.set(this.title());
     }
 
     private registerChangeListeners() {
@@ -104,16 +99,27 @@ export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnIn
     }
 
     updateTitle(newTitle: string) {
-        this.title = newTitle;
-        this.titleChange.emit(this.title);
-        // Remove trailing hyphens if title is not undefined or empty
-        this.formatChannelName(this.channelNamePrefix + this.title, false, !!this.title);
+        this.title.set(newTitle);
+        this.titleChange.emit(this.title());
+        this.updateChannelName();
     }
 
-    formatChannelName(newName: string, allowDuplicateHyphens = true, removeTrailingHyphens = false) {
+    updateChannelName() {
+        this.formatChannelName(this.channelNamePrefix() + this.title(), false, !!this.title());
+    }
+
+    /**
+     * Formats a channel name by applying specific transformations based on the provided options.
+     *
+     * @param {string} newName - The new channel name to be formatted.
+     * @param {boolean} [allowDuplicateHyphens=true] - Flag indicating whether duplicate hyphens should be allowed in the formatted name.
+     * @param {boolean} [removeTrailingHyphens=false] - Flag indicating whether trailing hyphens should be removed from the formatted name.
+     * @return {void} This method does not return a value but emits the formatted channel name.
+     */
+    private formatChannelName(newName: string, allowDuplicateHyphens: boolean = true, removeTrailingHyphens: boolean = false): void {
         const specialCharacters: RegExp = allowDuplicateHyphens ? /[^a-z0-9-]+/g : /[^a-z0-9]+/g;
         const trailingHyphens = removeTrailingHyphens ? /-$/ : new RegExp('[]');
-        this.channelName = newName.toLowerCase().replaceAll(specialCharacters, '-').replace(trailingHyphens, '').slice(0, 30);
-        this.channelNameChange.emit(this.channelName);
+        this.channelName.set(newName.toLowerCase().replaceAll(specialCharacters, '-').replace(trailingHyphens, '').slice(0, 30));
+        this.channelNameChange.emit(this.channelName());
     }
 }

--- a/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
+++ b/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild, computed, effect, input, model, output, signal, viewChild } from '@angular/core';
 import { ControlContainer, FormsModule, NgForm, NgModel } from '@angular/forms';
-import { Subject, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { ProgrammingExerciseInputField } from 'app/programming/manage/update/programming-exercise-update.helper';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { CustomNotIncludedInValidatorDirective } from '../../validators/custom-not-included-in-validator.directive';
@@ -34,11 +34,6 @@ export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnIn
     channelNameChange = output<string>();
 
     isValid = signal<boolean>(false);
-
-    /**
-     * @deprecated Use {@link isValid} instead.
-     */
-    formValidChanges = new Subject();
 
     fieldTitleSubscription?: Subscription;
     fieldChannelNameSubscription?: Subscription;

--- a/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
+++ b/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
@@ -13,9 +13,9 @@ import { HelpIconComponent } from '../../components/help-icon/help-icon.componen
     imports: [TranslateDirective, FormsModule, CustomNotIncludedInValidatorDirective, HelpIconComponent],
 })
 export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnInit {
-    title = model<string>('');
-    channelName = model<string>('');
-    channelNamePrefix = input<string>('');
+    title = model<string | undefined>(undefined);
+    channelName = model<string | undefined>(undefined);
+    channelNamePrefix = input<string | undefined>(undefined);
     titlePattern = input<string>();
     hideTitleLabel = input<boolean>(false);
     emphasizeLabels = input<boolean>(false);
@@ -90,12 +90,12 @@ export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnIn
 
     updateTitle(newTitle: string) {
         this.title.set(newTitle);
-        this.titleChange.emit(this.title());
+        this.titleChange.emit(this.title() ?? '');
         this.updateChannelName();
     }
 
     updateChannelName() {
-        this.formatChannelName(this.channelNamePrefix() + this.title(), false, !!this.title());
+        this.formatChannelName(this.channelNamePrefix() ?? '-' + (this.title() ?? '-'), false, !!this.title());
     }
 
     /**
@@ -106,10 +106,10 @@ export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnIn
      * @param {boolean} [removeTrailingHyphens=false] - Flag indicating whether trailing hyphens should be removed from the formatted name.
      * @return {void} This method does not return a value but emits the formatted channel name.
      */
-    private formatChannelName(newName: string, allowDuplicateHyphens: boolean = true, removeTrailingHyphens: boolean = false): void {
+    protected formatChannelName(newName: string, allowDuplicateHyphens: boolean = true, removeTrailingHyphens: boolean = false): void {
         const specialCharacters: RegExp = allowDuplicateHyphens ? /[^a-z0-9-]+/g : /[^a-z0-9]+/g;
         const trailingHyphens = removeTrailingHyphens ? /-$/ : new RegExp('[]');
         this.channelName.set(newName.toLowerCase().replaceAll(specialCharacters, '-').replace(trailingHyphens, '').slice(0, 30));
-        this.channelNameChange.emit(this.channelName());
+        this.channelNameChange.emit(this.channelName() ?? '');
     }
 }

--- a/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
+++ b/src/main/webapp/app/shared/form/title-channel-name/title-channel-name.component.ts
@@ -33,13 +33,10 @@ export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnIn
     titleChange = output<string>();
     channelNameChange = output<string>();
 
-    isFormValidSignal = signal<boolean>(false);
+    isValid = signal<boolean>(false);
+
     /**
-     * @deprecated Use {@link isFormValidSignal} instead.
-     */
-    formValid: boolean;
-    /**
-     * @deprecated Use {@link isFormValidSignal} instead.
+     * @deprecated Use {@link isValid} instead.
      */
     formValidChanges = new Subject();
 
@@ -93,9 +90,7 @@ export class TitleChannelNameComponent implements AfterViewInit, OnDestroy, OnIn
 
     calculateFormValid(): void {
         const updatedFormValidValue = Boolean(this.field_title.valid && (!this.isChannelFieldDisplayed() || this.field_channel_name()?.valid));
-        this.isFormValidSignal.set(updatedFormValidValue);
-        this.formValid = updatedFormValidValue;
-        this.formValidChanges.next(this.formValid);
+        this.isValid.set(updatedFormValidValue);
     }
 
     updateTitle(newTitle: string) {

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.spec.ts
@@ -26,7 +26,8 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MockRouter } from 'test/helpers/mocks/mock-router';
 import { ExerciseUpdatePlagiarismComponent } from 'app/plagiarism/manage/exercise-update-plagiarism/exercise-update-plagiarism.component';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
-import { MockProfileService } from '../../../../../../../test/javascript/spec/helpers/mocks/service/mock-profile.service';
+import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
+import { signal } from '@angular/core';
 
 describe('TextExercise Management Update Component', () => {
     let comp: TextExerciseUpdateComponent;
@@ -205,7 +206,7 @@ describe('TextExercise Management Update Component', () => {
 
         it('should calculate valid sections', () => {
             const calculateValidSpy = jest.spyOn(comp, 'calculateFormSectionStatus');
-            comp.exerciseTitleChannelNameComponent = { titleChannelNameComponent: { formValidChanges: new Subject() } } as ExerciseTitleChannelNameComponent;
+            comp.exerciseTitleChannelNameComponent = { titleChannelNameComponent: { isValid: signal(false) } } as ExerciseTitleChannelNameComponent;
             comp.exerciseUpdatePlagiarismComponent = {
                 formValidChanges: new Subject(),
                 formValid: true,
@@ -219,7 +220,6 @@ describe('TextExercise Management Update Component', () => {
             expect(comp.titleChannelNameComponentSubscription).toBeDefined();
 
             comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid.set(true);
-            comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValidChanges.next(true);
             expect(calculateValidSpy).toHaveBeenCalledOnce();
             expect(comp.formSectionStatus).toBeDefined();
             expect(comp.formSectionStatus[0].valid).toBeTrue();

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.spec.ts
@@ -218,7 +218,7 @@ describe('TextExercise Management Update Component', () => {
             comp.ngAfterViewInit();
             expect(comp.titleChannelNameComponentSubscription).toBeDefined();
 
-            comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValid = true;
+            comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid.set(true);
             comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValidChanges.next(true);
             expect(calculateValidSpy).toHaveBeenCalledOnce();
             expect(comp.formSectionStatus).toBeDefined();

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.spec.ts
@@ -217,7 +217,6 @@ describe('TextExercise Management Update Component', () => {
 
             comp.ngOnInit();
             comp.ngAfterViewInit();
-            expect(comp.titleChannelNameComponentSubscription).toBeDefined();
 
             comp.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid.set(true);
             expect(calculateValidSpy).toHaveBeenCalledOnce();
@@ -228,7 +227,6 @@ describe('TextExercise Management Update Component', () => {
             expect(calculateValidSpy).toHaveBeenCalledTimes(2);
 
             comp.ngOnDestroy();
-            expect(comp.titleChannelNameComponentSubscription?.closed).toBeTrue();
         });
     });
 

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.ts
@@ -123,7 +123,6 @@ export class TextExerciseUpdateComponent implements OnInit, OnDestroy, AfterView
     formSectionStatus: FormSectionStatus[];
 
     // subcriptions
-    titleChannelNameComponentSubscription?: Subscription;
     pointsSubscription?: Subscription;
     bonusPointsSubscription?: Subscription;
     plagiarismSubscription?: Subscription;
@@ -148,6 +147,8 @@ export class TextExerciseUpdateComponent implements OnInit, OnDestroy, AfterView
      */
     private updateFormSectionsOnIsValidChange() {
         this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid();
+
+        // console.log("triggered updateFormSectionsOnIsValidChange");
 
         this.calculateFormSectionStatus();
     }
@@ -228,7 +229,6 @@ export class TextExerciseUpdateComponent implements OnInit, OnDestroy, AfterView
     }
 
     ngOnDestroy() {
-        this.titleChannelNameComponentSubscription?.unsubscribe();
         this.pointsSubscription?.unsubscribe();
         this.bonusPointsSubscription?.unsubscribe();
         this.plagiarismSubscription?.unsubscribe();

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, OnDestroy, OnInit, ViewChild, effect, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
@@ -137,10 +137,22 @@ export class TextExerciseUpdateComponent implements OnInit, OnDestroy, AfterView
         return this.textExercise.id == undefined ? EditType.CREATE : EditType.UPDATE;
     }
 
+    constructor() {
+        effect(() => {
+            this.updateFormSectionsOnIsValidChange();
+        });
+    }
+
+    /**
+     * Triggers {@link calculateFormSectionStatus} whenever a relevant signal changes
+     */
+    private updateFormSectionsOnIsValidChange() {
+        this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid();
+
+        this.calculateFormSectionStatus();
+    }
+
     ngAfterViewInit() {
-        this.titleChannelNameComponentSubscription = this.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValidChanges.subscribe(() =>
-            this.calculateFormSectionStatus(),
-        );
         this.pointsSubscription = this.points?.valueChanges?.subscribe(() => this.calculateFormSectionStatus());
         this.bonusPointsSubscription = this.bonusPoints?.valueChanges?.subscribe(() => this.calculateFormSectionStatus());
         this.plagiarismSubscription = this.exerciseUpdatePlagiarismComponent?.formValidChanges.subscribe(() => this.calculateFormSectionStatus());

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.ts
@@ -228,7 +228,7 @@ export class TextExerciseUpdateComponent implements OnInit, OnDestroy, AfterView
             this.formSectionStatus = [
                 {
                     title: 'artemisApp.exercise.sections.general',
-                    valid: this.exerciseTitleChannelNameComponent.titleChannelNameComponent.formValid,
+                    valid: this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid(),
                 },
                 { title: 'artemisApp.exercise.sections.mode', valid: this.teamConfigFormGroupComponent.formValid },
                 { title: 'artemisApp.exercise.sections.problem', valid: true, empty: !this.textExercise.problemStatement },

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.ts
@@ -138,7 +138,9 @@ export class TextExerciseUpdateComponent implements OnInit, OnDestroy, AfterView
 
     constructor() {
         effect(() => {
-            this.updateFormSectionsOnIsValidChange();
+            if (this.exerciseTitleChannelNameComponent?.titleChannelNameComponent()) {
+                this.updateFormSectionsOnIsValidChange();
+            }
         });
     }
 
@@ -146,9 +148,7 @@ export class TextExerciseUpdateComponent implements OnInit, OnDestroy, AfterView
      * Triggers {@link calculateFormSectionStatus} whenever a relevant signal changes
      */
     private updateFormSectionsOnIsValidChange() {
-        this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid();
-
-        // console.log("triggered updateFormSectionsOnIsValidChange");
+        this.exerciseTitleChannelNameComponent.titleChannelNameComponent()?.isValid(); // trigger the effect
 
         this.calculateFormSectionStatus();
     }
@@ -240,7 +240,7 @@ export class TextExerciseUpdateComponent implements OnInit, OnDestroy, AfterView
             this.formSectionStatus = [
                 {
                     title: 'artemisApp.exercise.sections.general',
-                    valid: this.exerciseTitleChannelNameComponent.titleChannelNameComponent.isValid(),
+                    valid: this.exerciseTitleChannelNameComponent.titleChannelNameComponent()?.isValid() ?? false,
                 },
                 { title: 'artemisApp.exercise.sections.mode', valid: this.teamConfigFormGroupComponent.formValid },
                 { title: 'artemisApp.exercise.sections.problem', valid: true, empty: !this.textExercise.problemStatement },


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ ] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [ ] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


### Description
<!-- Describe your changes in detail -->


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://docs.artemis.cit.tum.de/user/exam_mode/) as reference.
4. ...

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
