### PR TITLE
`Programming exercises`: Fix issue when no results exist in course management exercises overview

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
@@ -859,4 +859,16 @@ public interface ResultRepository extends ArtemisJpaRepository<Result, Long> {
             """)
     Optional<Result> findLatestResultWithFeedbacksAndTestcasesForSubmission(@Param("submissionId") long submissionId);
 
+    @Query("""
+            SELECT r
+            FROM Result r
+            WHERE r.submission.id IN :submissionIds
+            AND r.id = (
+                 SELECT MAX(r2.id)
+                 FROM Result r2
+                 WHERE r2.submission.id = r.submission.id
+               )
+            """)
+    Set<Result> findLatestResultsBySubmissionIds(@Param("submissionIds") Set<Long> submissionIds);
+
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
@@ -44,29 +44,6 @@ import de.tum.cit.aet.artemis.programming.domain.TemplateProgrammingExercisePart
 @Repository
 public interface ProgrammingExerciseRepository extends DynamicSpecificationRepository<ProgrammingExercise, Long, ProgrammingExerciseFetchOptions> {
 
-    /**
-     * Does a max join on the result table for each participation by result id (the newer the result id, the newer the result).
-     * This makes sure that we only receive the latest result for the template and the solution participation if they exist.
-     *
-     * @param courseId the course the returned programming exercises belong to.
-     * @return all exercises for the given course with only the latest results for solution and template each (if present).
-     */
-    @Query("""
-            SELECT DISTINCT pe
-            FROM ProgrammingExercise pe
-                LEFT JOIN FETCH pe.templateParticipation tp
-                LEFT JOIN FETCH pe.solutionParticipation sp
-                LEFT JOIN FETCH tp.submissions tps
-                LEFT JOIN FETCH sp.submissions s
-                LEFT JOIN FETCH tps.results tpr
-                LEFT JOIN FETCH s.results spr
-                LEFT JOIN FETCH pe.categories
-            WHERE pe.course.id = :courseId
-                AND (tpr.id = (SELECT MAX(r1.id) FROM Submission stp JOIN stp.results r1 WHERE stp.participation = tp) OR tpr.id IS NULL)
-                AND (spr.id = (SELECT MAX(r2.id) FROM Submission s2 JOIN s2.results r2 WHERE s2.participation = sp) OR spr.id IS NULL)
-            """)
-    List<ProgrammingExercise> findByCourseIdWithLatestResultForTemplateSolutionParticipations(@Param("courseId") long courseId);
-
     @EntityGraph(type = LOAD, attributePaths = { "templateParticipation" })
     Optional<ProgrammingExercise> findWithTemplateParticipationById(long exerciseId);
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/SolutionProgrammingExerciseParticipationRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/SolutionProgrammingExerciseParticipationRepository.java
@@ -6,6 +6,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 import jakarta.validation.constraints.NotNull;
 
@@ -79,6 +80,22 @@ public interface SolutionProgrammingExerciseParticipationRepository
                 )
             """)
     Optional<SolutionProgrammingExerciseParticipation> findWithLatestSubmissionByExerciseId(@Param("exerciseId") long exerciseId);
+
+    @Query("""
+            SELECT DISTINCT sp
+              FROM SolutionProgrammingExerciseParticipation sp
+              LEFT JOIN FETCH sp.submissions s
+             WHERE sp.programmingExercise.id IN :exerciseIds
+               AND (
+                 s.id = (
+                   SELECT MAX(s2.id)
+                     FROM Submission s2
+                    WHERE s2.participation.id = sp.id
+                 )
+                 OR s.id IS NULL
+               )
+            """)
+    Set<SolutionProgrammingExerciseParticipation> findAllWithLatestSubmissionByExerciseIds(@Param("exerciseIds") Set<Long> exerciseIds);
 
     @NotNull
     default SolutionProgrammingExerciseParticipation findByExerciseIdElseThrow(final Specification<SolutionProgrammingExerciseParticipation> specification, long exerciseId) {

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/TemplateProgrammingExerciseParticipationRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/TemplateProgrammingExerciseParticipationRepository.java
@@ -6,6 +6,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 import jakarta.validation.constraints.NotNull;
 
@@ -57,6 +58,22 @@ public interface TemplateProgrammingExerciseParticipationRepository
 
     @EntityGraph(type = LOAD, attributePaths = { "submissions", "submissions.results", "submissions.results.feedbacks", "submissions.results.feedbacks.testCase" })
     Optional<TemplateProgrammingExerciseParticipation> findWithEagerResultsAndFeedbacksAndTestCasesAndSubmissionsByProgrammingExerciseId(long exerciseId);
+
+    @Query("""
+            SELECT DISTINCT tp
+              FROM TemplateProgrammingExerciseParticipation tp
+              LEFT JOIN FETCH tp.submissions s
+             WHERE tp.programmingExercise.id IN :exerciseIds
+               AND (
+                 s.id = (
+                   SELECT MAX(s2.id)
+                     FROM Submission s2
+                    WHERE s2.participation.id = tp.id
+                 )
+                 OR s.id IS NULL
+               )
+            """)
+    Set<TemplateProgrammingExerciseParticipation> findAllWithLatestSubmissionByExerciseIds(@Param("exerciseIds") Set<Long> exerciseIds);
 
     @NotNull
     default TemplateProgrammingExerciseParticipation findByExerciseIdElseThrow(final Specification<TemplateProgrammingExerciseParticipation> specification, long exerciseId) {

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseService.java
@@ -20,11 +20,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
@@ -51,6 +53,7 @@ import de.tum.cit.aet.artemis.buildagent.dto.DockerFlagsDTO;
 import de.tum.cit.aet.artemis.communication.service.conversation.ChannelService;
 import de.tum.cit.aet.artemis.communication.service.notifications.GroupNotificationScheduleService;
 import de.tum.cit.aet.artemis.core.domain.Course;
+import de.tum.cit.aet.artemis.core.domain.DomainObject;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.dto.SearchResultPageDTO;
 import de.tum.cit.aet.artemis.core.dto.pageablesearch.SearchTermPageableSearchDTO;
@@ -61,6 +64,7 @@ import de.tum.cit.aet.artemis.core.service.ProfileService;
 import de.tum.cit.aet.artemis.core.service.messaging.InstanceMessageSendService;
 import de.tum.cit.aet.artemis.core.util.PageUtil;
 import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
+import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.repository.ParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseService;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseSpecificationService;
@@ -1129,5 +1133,67 @@ public class ProgrammingExerciseService {
         programmingExerciseWithTemplate.setAuxiliaryRepositories(auxiliaryRepositories);
 
         return programmingExerciseWithTemplate;
+    }
+
+    /**
+     * Retrieves all programming exercises for a given course, including their categories, template and solution participations with their latest submissions and results.
+     * This method avoids one big and expensive query by splitting the retrieval into multiple smaller queries.
+     *
+     * @param courseId the course the returned programming exercises belong to.
+     * @return all exercises for the given course with only the latest result and latest submission for solution and template each (if present).
+     */
+    public List<ProgrammingExercise> findByCourseIdWithCategoriesLatestSubmissionResultForTemplateAndSolutionParticipation(long courseId) {
+        List<ProgrammingExercise> programmingExercisesWithCategories = programmingExerciseRepository.findAllWithCategoriesByCourseId(courseId);
+        if (programmingExercisesWithCategories.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Set<Long> exerciseIds = programmingExercisesWithCategories.stream().map(ProgrammingExercise::getId).collect(Collectors.toSet());
+
+        Set<SolutionProgrammingExerciseParticipation> solutionParticipationsWithLatestSubmission = solutionProgrammingExerciseParticipationRepository
+                .findAllWithLatestSubmissionByExerciseIds(exerciseIds);
+        Set<TemplateProgrammingExerciseParticipation> templateParticipationsWithLatestSubmission = templateProgrammingExerciseParticipationRepository
+                .findAllWithLatestSubmissionByExerciseIds(exerciseIds);
+
+        Set<Long> solutionSubmissionIds = solutionParticipationsWithLatestSubmission.stream().flatMap(p -> p.getSubmissions().stream().map(DomainObject::getId))
+                .collect(Collectors.toSet());
+        Set<Long> templateSubmissionIds = templateParticipationsWithLatestSubmission.stream().flatMap(p -> p.getSubmissions().stream().map(DomainObject::getId))
+                .collect(Collectors.toSet());
+
+        Map<Long, Result> latestResultsForSolutionSubmissions = resultRepository.findLatestResultsBySubmissionIds(solutionSubmissionIds).stream()
+                .collect(Collectors.toMap(result -> result.getSubmission().getId(), result -> result, (r1, r2) -> r1)); // In case of multiple, take first
+
+        Map<Long, Result> latestResultsForTemplateSubmissions = resultRepository.findLatestResultsBySubmissionIds(templateSubmissionIds).stream()
+                .collect(Collectors.toMap(result -> result.getSubmission().getId(), result -> result, (r1, r2) -> r1));
+
+        Map<Long, SolutionProgrammingExerciseParticipation> solutionParticipationMap = solutionParticipationsWithLatestSubmission.stream()
+                .collect(Collectors.toMap(p -> p.getProgrammingExercise().getId(), p -> p));
+
+        Map<Long, TemplateProgrammingExerciseParticipation> templateParticipationMap = templateParticipationsWithLatestSubmission.stream()
+                .collect(Collectors.toMap(p -> p.getProgrammingExercise().getId(), p -> p));
+
+        for (ProgrammingExercise programmingExercise : programmingExercisesWithCategories) {
+            TemplateProgrammingExerciseParticipation templateParticipation = templateParticipationMap.get(programmingExercise.getId());
+            if (templateParticipation != null) {
+                programmingExercise.setTemplateParticipation(templateParticipation);
+                connectSubmissionAndResult(latestResultsForTemplateSubmissions, templateParticipation.getSubmissions());
+            }
+            SolutionProgrammingExerciseParticipation solutionParticipation = solutionParticipationMap.get(programmingExercise.getId());
+            if (solutionParticipation != null) {
+                programmingExercise.setSolutionParticipation(solutionParticipation);
+                connectSubmissionAndResult(latestResultsForSolutionSubmissions, solutionParticipation.getSubmissions());
+            }
+        }
+        return programmingExercisesWithCategories;
+    }
+
+    private void connectSubmissionAndResult(Map<Long, Result> latestResultsForSolutionSubmissions, Set<Submission> submissions) {
+        if (submissions != null && !submissions.isEmpty()) {
+            Submission submission = submissions.iterator().next();
+            Result res = latestResultsForSolutionSubmissions.get(submission.getId());
+            if (res != null) {
+                submission.setResults(Collections.singletonList(res));
+            }
+        }
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseResource.java
@@ -445,7 +445,7 @@ public class ProgrammingExerciseResource {
         log.debug("REST request to get all ProgrammingExercises for the course with id : {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
-        List<ProgrammingExercise> exercises = programmingExerciseRepository.findAllWithCategoriesByCourseId(courseId);
+        List<ProgrammingExercise> exercises = programmingExerciseService.findByCourseIdWithCategoriesLatestSubmissionResultForTemplateAndSolutionParticipation(courseId);
         for (ProgrammingExercise exercise : exercises) {
             // not required in the returned json body
             exercise.setStudentParticipations(null);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseResource.java
@@ -445,7 +445,7 @@ public class ProgrammingExerciseResource {
         log.debug("REST request to get all ProgrammingExercises for the course with id : {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
-        List<ProgrammingExercise> exercises = programmingExerciseRepository.findByCourseIdWithLatestResultForTemplateSolutionParticipations(courseId);
+        List<ProgrammingExercise> exercises = programmingExerciseRepository.findAllWithCategoriesByCourseId(courseId);
         for (ProgrammingExercise exercise : exercises) {
             // not required in the returned json body
             exercise.setStudentParticipations(null);

--- a/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaRepositoryExportServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaRepositoryExportServiceTest.java
@@ -66,7 +66,7 @@ class AthenaRepositoryExportServiceTest extends AbstractSpringIntegrationIndepen
     @WithMockUser(username = TEST_PREFIX + "instructor1")
     void shouldExportRepository() throws Exception {
         Course course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
-        var programmingExercise = programmingExerciseRepository.findByCourseIdWithLatestResultForTemplateSolutionParticipations(course.getId()).stream().iterator().next();
+        var programmingExercise = programmingExerciseRepository.findAllByCourseId(course.getId()).getFirst();
         programmingExercise.setFeedbackSuggestionModule(ATHENA_MODULE_PROGRAMMING_TEST);
         programmingExerciseParticipationUtilService.addTemplateParticipationForProgrammingExercise(programmingExercise);
         programmingExerciseParticipationUtilService.addSolutionParticipationForProgrammingExercise(programmingExercise);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [ ] I **strictly** followed the principle of **data economy** for all database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.




#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.
Does not affect VCS/CIS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#10549 refactored a query incorrectly, so that it now returns null in the results array when no results exist for a submission. Additionally, it fetched all submissions and all results although only the last one is necessary.


### Description
<!-- Describe your changes in detail -->
Split the one big query into 5 smaller ones and connect the query results to return the correct list of programming exercises in the end.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- TS1 to verify step 8 onwards
1. Log in to Artemis
2. Navigate to Course Administration
3. Go to any programming exercise
4. Click on edit in editor
5. Adapt the solution such that not all tests pass
6. Adapt the template such that at least one test passes
7. Go back to the exercises page in the course management and check that a yellow warning sign is shown next to template and solution that tells you that there might be a problem
8. Check that no console error on the exercises page occurs
9. (Optional): Check that the REST call to /programming-exercises doesn't contain any null values


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->