### PR TITLE
`Development`: Move method only used for testing to test repository

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
@@ -98,8 +98,6 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
 
     List<ProgrammingExercise> findAllByProjectKey(String projectKey);
 
-    List<ProgrammingExercise> findAllByCourseId(Long courseId);
-
     @EntityGraph(type = LOAD, attributePaths = { "categories" })
     List<ProgrammingExercise> findAllWithCategoriesByCourseId(Long courseId);
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/test_repository/ProgrammingExerciseTestRepository.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/test_repository/ProgrammingExerciseTestRepository.java
@@ -79,11 +79,7 @@ public interface ProgrammingExerciseTestRepository extends ProgrammingExerciseRe
     @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation" })
     List<ProgrammingExercise> findAllWithTemplateAndSolutionParticipationByIdIn(Set<Long> exerciseIds);
 
-    List<ProgrammingExercise> findAllByCourse_InstructorGroupNameIn(Set<String> groupNames);
-
-    List<ProgrammingExercise> findAllByCourse_EditorGroupNameIn(Set<String> groupNames);
-
-    List<ProgrammingExercise> findAllByCourse_TeachingAssistantGroupNameIn(Set<String> groupNames);
+    List<ProgrammingExercise> findAllByCourseId(Long courseId);
 
     @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation", "studentParticipations.team.students", "buildConfig" })
     Optional<ProgrammingExercise> findWithAllParticipationsAndBuildConfigById(long exerciseId);


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
We have a failing architecture test on develop since https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS-JAVATEST-7341 - the arch tests should pass on develop.

### Description
- Moved the test-only method to the test repository
- Removed unused methods

### Steps for Testing

1. Run `ProgrammingRepositoryArchitectureTest` locally (or verify from the pipeline https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS8315-JAVATEST-1)
2. Verify all tests pass

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


### Screenshots
![image](https://github.com/user-attachments/assets/94f192f9-9b90-431d-a165-75cfbef58cf9)

