### PR TITLE
`Development`: Display if coverage threshold should be increased in client module

### DIFF
--- a/supporting_scripts/code-coverage/module-coverage-client/check-client-module-coverage.mjs
+++ b/supporting_scripts/code-coverage/module-coverage-client/check-client-module-coverage.mjs
@@ -145,11 +145,11 @@ const evaluateAndPrintMetrics = (module, aggregatedMetrics, thresholds) => {
         const percentage = total > 0 ? (covered / total) * 100 : 0;
         const threshold = thresholds[metric];
         const pass = Math.round(percentage * 100) / 100 >= threshold;
-        console.log(`  ${pass ? '✅' : '❌'} ${metric.padEnd(10)} : ${percentage.toFixed(2)}%  (need ≥ ${threshold}%)`);
+        const higherThanExpected = percentage > threshold && threshold < 90;
+        console.log(`  ${pass ? '✅' : '❌'}${higherThanExpected ? '⬆️' : ''} ${metric.padEnd(10)} : ${percentage.toFixed(2)}%  (need ≥ ${threshold}%)`);
         if (!pass) failed = true;
     }
     return failed;
-
 };
 
 let anyModuleFailed = false;

--- a/supporting_scripts/code-coverage/module-coverage-client/check-client-module-coverage.mjs
+++ b/supporting_scripts/code-coverage/module-coverage-client/check-client-module-coverage.mjs
@@ -102,7 +102,7 @@ const moduleThresholds = {
         lines:      91.91,
     },
     programming: {
-        statements: 88.67,
+        statements: 88.60,
         branches:   76.47,
         functions:  80.86,
         lines:      88.79,


### PR DESCRIPTION

### Checklist
#### General
- [ ] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
We want to get 90% client coverage, right now it is rather tedious to identify where the coverage can be bumped (and at least for my prompts LLMs did not do a good job there).

### Description
Direclty include in the generated report with a little icon if the coverage can (and should be bumped up).

If the coverage is over 90% (which is the current threshold we are aiming for) we do not nudge into bumping the coverage as it does not appear useful to aim for a 100% coverage and bump this value to high (at least to me).

### Steps for Testing
See the build Log TODO was generated properly (I lowered ... for that test run)

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


### Screenshots

