### PR TITLE
`Development`: Add docker debugging documentation

### DIFF
--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -78,6 +78,7 @@ After completing the server setup, proceed with setting up the Artemis client by
    setup/aeolus
    setup/common-problems
    setup/docker-compose
+   setup/docker-debugging
    setup/local-database-tests
 
 Production Setup and Extension Services

--- a/docs/dev/setup/docker-debugging.rst
+++ b/docs/dev/setup/docker-debugging.rst
@@ -1,0 +1,57 @@
+.. _docker_debugging:
+
+Debugging Artemis in Docker container
+---------------------------------------------
+
+Sometimes it is useful to debug Artemis while it is running in a Docker container as some bugs can be most easily reproduced in a Docker setup (e.g., for multi-node setups).
+
+Follow these steps to set up debugging:
+
+1. Adjust the docker setup to start the JVM with the correct arguments and to expose a debug port.
+
+This can be done by adding the following lines to the relevant docker compose file and setting the debug port for each `artemis` service:
+
+.. code-block:: yaml
+
+   environment:
+     - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:<debug-port>
+   ports:
+     - "<debug-port>:<host-port>"
+
+
+This will start the JVM with the Java Debug Wire Protocol (JDWP) agent, allowing you to connect a debugger to port `<host-port>`.
+If you use a multi-node setup, you need to add this to all nodes that you want to debug. Make sure that all use different host ports.
+
+
+2. If you want to debug your own PR, replace the image name with your own PR image `ghcr.io/ls1intum/artemis:pr-<pr-number>`.
+
+3. Use the `Remote Java Debugging for Docker` run configuration
+
+  - This configuration is set up to connect to port 5005 as the default debug port.
+  - If you used another port for the debugger port on the host, you need to change the port in the run configuration accordingly.
+  - You can find the run configuration in the `Run/Debug Configurations` dialog in IntelliJ under `Remote JVM Debug -> Remote Java Debugging for Docker`.
+  - For each Artemis node you want to debug, you need to create a separate run configuration with the correct port.
+
+
+
+4. Start the relevant docker compose file with `docker compose -f <docker compose file name> up -d`.
+
+5. If the server start fails with Liquibase errors, you can run the following command to reset the database:
+
+.. attention::
+
+   This command **deletes all data** in the `artemis` database by dropping it.
+   Make sure you have a backup if you need to preserve existing data.
+
+.. code-block:: bash
+
+    docker exec -i artemis-mysql mysql -u root -p'' -e "DROP DATABASE artemis;"
+
+
+Afterward, you can start the server again with the same command as in step 4.
+
+
+6. Start the Remote JVM Debug configuration in IntelliJ.
+
+7. Set breakpoints in the code you want to debug.
+


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Debugging Artemis in a docker container is not straightforward and is not documented at all. This makes it very difficult for developers with limited docker knowledge to debug Artemis in a docker container but this is sometimes necessary to reproduce specific behavior.

### Description
<!-- Describe your changes in detail -->
Added a section to the setup guide to describe how to set up everything to debug Artemis running in a docker container.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
https://artemis-platform--11022.org.readthedocs.build/en/11022/dev/setup/docker-debugging.html
- Make sure you understand the documentation
- Try out the steps locally and make sure everything works.
- You can e.g. use the docker compose file `docker/test-server-mysql-localci.yml`


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/user-attachments/assets/aeddc582-7894-4703-ad20-ea3c7015d837)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new guide on debugging the application inside Docker containers, including instructions for enabling remote JVM debugging and configuring IntelliJ.
  - Updated the setup guide to include the new Docker debugging documentation in the list of setup topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->