### PR TITLE
`Development`: Fix initialization date not set for programming exercises

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationService.java
@@ -162,10 +162,6 @@ public class ParticipationService {
                 // Only for quiz exercises, the participation status FINISHED should not be overwritten since the user must not change his submission once submitted
                 participation.setInitializationState(InitializationState.INITIALIZED);
             }
-
-            if (Optional.ofNullable(participation.getInitializationDate()).isEmpty()) {
-                participation.setInitializationDate(ZonedDateTime.now());
-            }
             // TODO: load submission with exercise for exam edge case:
             // clients creates missing participation for exercise, call on server succeeds, but response to client is lost
             // -> client tries to create participation again. In this case the submission is not loaded from db -> client errors
@@ -175,6 +171,9 @@ public class ParticipationService {
                     submissionRepository.initializeSubmission(participation, exercise, null);
                 }
             }
+        }
+        if (Optional.ofNullable(participation.getInitializationDate()).isEmpty()) {
+            participation.setInitializationDate(ZonedDateTime.now());
         }
         return studentParticipationRepository.saveAndFlush(participation);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/ParticipationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/ParticipationServiceTest.java
@@ -1,6 +1,12 @@
 package de.tum.cit.aet.artemis.exercise.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
@@ -12,6 +18,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +33,7 @@ import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.test_repository.UserTestRepository;
 import de.tum.cit.aet.artemis.core.user.util.UserUtilService;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
 import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
 import de.tum.cit.aet.artemis.exercise.domain.SubmissionType;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participant;
@@ -33,7 +41,9 @@ import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseParticipation;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
+import de.tum.cit.aet.artemis.programming.domain.VcsRepositoryUri;
 import de.tum.cit.aet.artemis.programming.repository.BuildLogEntryRepository;
 import de.tum.cit.aet.artemis.programming.service.BuildLogEntryService;
 import de.tum.cit.aet.artemis.programming.test_repository.ProgrammingExerciseTestRepository;
@@ -172,22 +182,36 @@ class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsLocalVCTe
         assertThat(programmingExercise.getStudentParticipations()).hasSize(2);
     }
 
-    @Test
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testStartExercise_newParticipation() {
-        Course course = textExerciseUtilService.addCourseWithOneReleasedTextExercise();
-        Exercise modelling = course.getExercises().iterator().next();
+    @EnumSource(value = ExerciseType.class, names = { "PROGRAMMING", "TEXT" })
+    void testStartExercise_newParticipation(ExerciseType exerciseType) {
+        Course course;
+        if (exerciseType == ExerciseType.PROGRAMMING) {
+            course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
+            setUpProgrammingExerciseMocks();
+        }
+        else {
+            course = textExerciseUtilService.addCourseWithOneReleasedTextExercise();
+        }
+        Exercise exercise = course.getExercises().iterator().next();
         Participant participant = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
 
-        StudentParticipation studentParticipationReceived = participationService.startExercise(modelling, participant, true);
+        StudentParticipation studentParticipationReceived = participationService.startExercise(exercise, participant, true);
 
-        assertThat(studentParticipationReceived.getExercise()).isEqualTo(modelling);
+        assertThat(studentParticipationReceived.getExercise()).isEqualTo(exercise);
         assertThat(studentParticipationReceived.getStudent()).isPresent();
         assertThat(studentParticipationReceived.getStudent().get()).isEqualTo(participant);
         // Acceptance range, initializationDate is to be set to now()
         assertThat(studentParticipationReceived.getInitializationDate()).isAfterOrEqualTo(ZonedDateTime.now().minusSeconds(10));
         assertThat(studentParticipationReceived.getInitializationDate()).isBeforeOrEqualTo(ZonedDateTime.now().plusSeconds(10));
         assertThat(studentParticipationReceived.getInitializationState()).isEqualTo(InitializationState.INITIALIZED);
+    }
+
+    private void setUpProgrammingExerciseMocks() {
+        doReturn(new VcsRepositoryUri()).when(versionControlService).copyRepository(anyString(), anyString(), anyString(), anyString(), anyString(), anyInt());
+        doReturn("fake-build-plan-id").when(continuousIntegrationService).copyBuildPlan(any(), anyString(), any(), anyString(), anyString(), anyBoolean());
+        doNothing().when(continuousIntegrationService).configureBuildPlan(any(ProgrammingExerciseParticipation.class));
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).


#### Changes affecting Programming Exercises
Unrelated to VCS and CIS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The initialization date is currently not set for programming exercises.


### Description
<!-- Describe your changes in detail -->
Moved it to the correct block in the method. Previously it was only set for all other exercise types other than programming.
This was also not tested, so I added a test to prevent this from breaking again as happened in #10340. 


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a programming exercise (or use an existing one you haven't started yet)
4. Go to the student view
5. Open the browser dev tools
6. Start the programming exercise
7. Check that the response for the REST call ` exercise/exercises/<exercise-id/participations` contains an initialization date again.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
my changes are covered
### Screenshots
![image](https://github.com/user-attachments/assets/af20a9d5-49d6-41a1-8c96-12b5f81081a8)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of participation initialization dates to ensure consistency across all exercise types.
- **Tests**
  - Enhanced test coverage for exercise participation initialization by converting a single test to a parameterized test for multiple exercise types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->