### PR TITLE
`Programming exercises`: Fix issues with inconsistent test naming and XML parsing in C++ exercise

### DIFF
--- a/src/main/resources/templates/c_plus_plus/test/testUtils/junit/Junit.py
+++ b/src/main/resources/templates/c_plus_plus/test/testUtils/junit/Junit.py
@@ -43,7 +43,13 @@ class Junit:
             r'(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?'  # Parameter bytes
             r'[0-9A-ORZcf-nqry=><~]')  # Final byte
 
-        return ansi_escape_pattern.sub('', text)
+        # Filter any remaining non-ASCII characters that may be remaining
+        # from escape patterns that were truncated due to stdout limits
+        # from https://stackoverflow.com/questions/730133/what-are-invalid-characters-in-xml
+        nonprintable_pattern = re.compile(
+            r"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]"
+        )
+        return nonprintable_pattern.sub("", ansi_escape_pattern.sub("", text))
 
     @staticmethod
     def createOutputPath(outputPath: str) -> None:

--- a/src/main/resources/templates/c_plus_plus/test/testUtils/junit/Junit.py
+++ b/src/main/resources/templates/c_plus_plus/test/testUtils/junit/Junit.py
@@ -29,6 +29,10 @@ class Junit:
         root: Et.Element = Et.Element("testsuites")
         root.append(suiteXml)
         root.extend(self.additionalSuites)
+        # add another empty test suite
+        # to make sure the tests have consistent names
+        # independent of whether there are additional suites or not
+        root.append(TestSuite("empty-suite").toXml())
         tree: Et.ElementTree = Et.ElementTree(root)
         self.createOutputPath(outputPath)
         tree.write(outputPath, xml_declaration=True)


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).




### Motivation and Context
The C++ template has two issues that can cause no tests to be listed as executed, despite parts of the test runs being successful
1. The tester may produce incorrect output when the stdout is truncated right at where an ANSI escape code for colors begins
2. Artemis produces inconsistent naming dependent on whether any Catch2 tests were run (and their test suites were imported)

### Description
1. Remove any remaining non-printable characters from the output
2. Add an empty test suite to ensure the test suite name is always prepended to the test name

### Steps for Testing
1. Create a new C++ project
2. Cause the compilation to fail in the template repository, e.g. by introducing a syntax error into sort.hpp
3. Inspect the "Template Result", it shows
```
Test Case · No result information for GBS-Tester-1.36.TestConfigure

Test was not executed.
```
without this change. After the change, it shows the test as succeeded.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved XML output by ensuring an empty test suite is always included for consistent naming.
  - Enhanced output sanitization to remove both ANSI escape sequences and invalid non-ASCII characters, preventing potential XML errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->