### PR TITLE
`Exam mode`: Improve number of exercises UI field

### DIFF
--- a/src/main/webapp/app/exam/manage/exams/update/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/update/exam-update.component.html
@@ -161,7 +161,7 @@
                     <label class="form-check-label" for="numberOfExercisesInExam" jhiTranslate="artemisApp.examManagement.numberOfExercisesInExam"
                         >Number of Exercises in Exam</label
                     >
-                    <input id="numberOfExercisesInExam" name="numberOfExercisesInExam" class="form-control" type="number" min="0" [(ngModel)]="exam.numberOfExercisesInExam" />
+                    <input id="numberOfExercisesInExam" name="numberOfExercisesInExam" class="form-control" type="number" min="1" [(ngModel)]="exam.numberOfExercisesInExam" />
                 </div>
             </div>
             <div class="form-check mb-3">

--- a/src/main/webapp/app/exam/manage/exams/update/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/update/exam-update.component.html
@@ -161,6 +161,7 @@
                     <label class="form-check-label" for="numberOfExercisesInExam" jhiTranslate="artemisApp.examManagement.numberOfExercisesInExam"
                         >Number of Exercises in Exam</label
                     >
+                    <jhi-help-icon [text]="'artemisApp.examManagement.numberOfExercisesInExamTooltip'" />
                     <input id="numberOfExercisesInExam" name="numberOfExercisesInExam" class="form-control" type="number" min="1" [(ngModel)]="exam.numberOfExercisesInExam" />
                 </div>
             </div>

--- a/src/main/webapp/app/exam/manage/exams/update/exam-update.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/update/exam-update.component.ts
@@ -137,7 +137,7 @@ export class ExamUpdateComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Returns the exma working time in minutes, rounded to one decimal place.
+     * Returns the exam working time in minutes, rounded to one decimal place.
      * Used for display purposes.
      */
     get workingTimeInMinutesRounded(): number {

--- a/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.html
+++ b/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.html
@@ -62,6 +62,6 @@
 @if (warning()) {
     <div class="invalid-feedback">
         <fa-icon class="text-warning" [icon]="faTriangleExclamation" />
-        <span class="visible-date-warning" jhiTranslate="entity.warningError" ngbTooltip="{{ 'entity.warningToolTip' | artemisTranslate }}"></span>
+        <span class="visible-date-warning" jhiTranslate="entity.visibleDateWarningError" ngbTooltip="{{ 'entity.visibleDateWarningToolTip' | artemisTranslate }}"></span>
     </div>
 }

--- a/src/main/webapp/app/shared/validators/custom-max-validator.directive.ts
+++ b/src/main/webapp/app/shared/validators/custom-max-validator.directive.ts
@@ -4,6 +4,8 @@ import { FormControl, NG_VALIDATORS, Validator } from '@angular/forms';
 /**
  * Custom max validator as angular offers no such validator for template driven forms
  * See: https://github.com/angular/angular/issues/16352
+ *
+ * @deprecated use `max` instead
  */
 @Directive({
     selector: '[customMax][formControlName],[customMax][formControl],[customMax][ngModel]',

--- a/src/main/webapp/app/shared/validators/custom-min-validator.directive.ts
+++ b/src/main/webapp/app/shared/validators/custom-min-validator.directive.ts
@@ -4,6 +4,8 @@ import { FormControl, NG_VALIDATORS, Validator } from '@angular/forms';
 /**
  * Custom min validator as angular offers no such validator for template driven forms
  * See: https://github.com/angular/angular/issues/16352
+ *
+ * @deprecated use `min` instead
  */
 @Directive({
     selector: '[customMin][formControlName],[customMin][formControl],[customMin][ngModel]',

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -474,6 +474,7 @@
             },
             "numberOfExerciseGroups": "Anzahl Aufgabengruppen:",
             "numberOfExercisesInExam": "Anzahl an Aufgaben in der Klausur",
+            "numberOfExercisesInExamTooltip": "Die Anzahl der Aufgaben muss mit der Anzahl der Aufgabengruppen übereinstimmen",
             "numberOfCorrectionRoundsInExam": "Anzahl der Korrekturrunden der Klausur",
             "randomizeQuestionOrder": "Zufällige Reihenfolge der Aufgabengruppen",
             "examWithAttendanceCheck": "Klausur mit Anwesenheitskontrolle",

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -344,8 +344,8 @@
         "dateMissingOrNotValid": "'{{labelName}}' fehlt/ungültig",
         "startDateError": "'Bearbeitungszeit ab' sollte zwischen 'Sichtbar ab' und 'Bearbeitungszeit bis' liegen",
         "endDateError": "'Bearbeitungszeit bis' sollte nach 'Bearbeitungszeit ab' liegen",
-        "warningError": "'Sichtbar ab' ist zu früh eingestellt. Wir empfehlen, es innerhalb von 4 Stunden vor dem 'Bearbeitungszeit ab' festzulegen.",
-        "warningToolTip": "Das Datum zu früh festzulegen kann Verwirrung stiften und zu einem vorzeitigen Zugriff auf die Klausurunterlagen führen. Es wird empfohlen, die Klausur erst wenige Stunden vor dem Beginn sichtbar zu machen."
+        "visibleDateWarningError": "'Sichtbar ab' ist zu früh eingestellt. Wir empfehlen, es innerhalb von 4 Stunden vor dem 'Bearbeitungszeit ab' festzulegen.",
+        "visibleDateWarningToolTip": "Das Datum zu früh festzulegen kann Verwirrung stiften und zu einem vorzeitigen Zugriff auf die Klausurunterlagen führen. Es wird empfohlen, die Klausur erst wenige Stunden vor dem Beginn sichtbar zu machen."
     },
     "aboutUs": "Über",
     "contact": "Kontaktiere uns",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -474,6 +474,7 @@
             },
             "numberOfExerciseGroups": "Number of exercise groups:",
             "numberOfExercisesInExam": "Number of exercises in exam",
+            "numberOfExercisesInExamTooltip": "The number of exercises must be equal to the number of exercise groups",
             "numberOfCorrectionRoundsInExam": "Number of correction rounds in exam",
             "randomizeQuestionOrder": "Randomize order of exercise groups",
             "examWithAttendanceCheck": "Exam with attendance check",

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -344,8 +344,8 @@
         "dateMissingOrNotValid": "'{{labelName}}' is missing/invalid",
         "startDateError": "'Start of working time' should be between 'Visible from' and 'End of working time'",
         "endDateError": "'End of working time' should be later than 'Start of working time'",
-        "warningError": "'Visible from' is set too early. We recommend setting it within 4 hours before the 'Start of working time'.",
-        "warningToolTip": "Setting the date too early may cause confusion and lead to premature access to exam materials. It is recommended to make the exam visible only a few hours before the start time."
+        "visibleDateWarningError": "'Visible from' is set too early. We recommend setting it within 4 hours before the 'Start of working time'.",
+        "visibleDateWarningToolTip": "Setting the date too early may cause confusion and lead to premature access to exam materials. It is recommended to make the exam visible only a few hours before the start time."
     },
     "aboutUs": "About",
     "contact": "Contact us",


### PR DESCRIPTION
### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
When creating an exam, especially as a first-time user, the `Number of Exercises` field is a bit confusing, as you only learn that it has to be equal to the number of exercise groups after you've created the exam.\
Additionally, Artemis currently accepts `0` as a valid number of exercises, despite that being impossible due to the fact that every exam needs at least one exercise group.


### Description
I added a tooltip that explains that the number of exercises must be equal to the number of exercise groups and also fixed the minimum number of exercises to `1`.
While doing that, I stumbled over the `CustomMin` and `CustomMax` validators, which are nowadays replaced by the built-in `min` and `max` validators, so I deprecated our custom ones.
Lastly, I added some Client tests for the number of exercises field.


### Steps for Testing
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to any course and go into the Manage view
3. Go into the exam creation screen, either by creating a new exam, or by importing an exam.
4. Check that the tooltip for the `Number of Exercises in Exam` field is present.
5. Ensure that the `Title`, `Visible From`, `Start of Working Time`, and `End of Working Time` fields have valid values, as you otherwise can't create a new exam.
6. Leave the `Number of Exercises in Exam` field empty and see if you can create a new exam; you should be able to do so.
7. Repeat steps 3 & 4, then fill in `0` for the number of exercises; you shouldn't be able to create this new exam now.
8. Fill in a negative number for the number of exercises; you shouldn't be able to create this new exam now.
9. Fill in a positive number `>= 1` and verify that it's allowing you to save the exam.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
#### Before
![image](https://github.com/user-attachments/assets/64a1c72c-03ac-4c20-9909-11e24893d20a)

#### Now
[Screencast from 2025-06-22 19-00-57.webm](https://github.com/user-attachments/assets/91332d31-1fa5-4740-93a5-2980f1afe254)
