### PR TITLE
`Development`: Modernize java stream code style

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/websocket/WebsocketConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/websocket/WebsocketConfiguration.java
@@ -164,8 +164,7 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
      * @return a TCP client with a round-robin use
      */
     private ReactorNettyTcpClient<byte[]> createTcpClient() {
-        final List<InetSocketAddress> brokerAddressList = brokerAddresses.stream().map(InetSocketAddressValidator::getValidAddress).filter(Optional::isPresent).map(Optional::get)
-                .toList();
+        final List<InetSocketAddress> brokerAddressList = brokerAddresses.stream().map(InetSocketAddressValidator::getValidAddress).flatMap(Optional::stream).toList();
 
         // Return null if no valid addresses can be found. This is e.g. due to an invalid config or a development setup without a broker.
         if (!brokerAddressList.isEmpty()) {

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
@@ -191,7 +191,7 @@ public class SubmissionService {
         List<T> submissions;
         if (examMode) {
             var participations = this.studentParticipationRepository.findAllByParticipationExerciseIdAndResultAssessorAndCorrectionRoundIgnoreTestRuns(exerciseId, tutor);
-            submissions = participations.stream().map(StudentParticipation::findLatestSubmission).filter(Optional::isPresent).map(Optional::get).map(submission -> (T) submission)
+            submissions = participations.stream().map(StudentParticipation::findLatestSubmission).flatMap(Optional::stream).map(submission -> (T) submission)
                     .filter(submission -> submission.getResults().size() - 1 >= correctionRound && submission.getResults().get(correctionRound) != null)
                     .collect(Collectors.toCollection(ArrayList::new));
         }
@@ -222,7 +222,7 @@ public class SubmissionService {
                     ZonedDateTime.now());
         }
 
-        var submissionsWithoutResult = participations.stream().map(Participation::findLatestSubmission).filter(Optional::isPresent).map(Optional::get).toList();
+        var submissionsWithoutResult = participations.stream().map(Participation::findLatestSubmission).flatMap(Optional::stream).toList();
 
         if (correctionRound > 0) {
             // remove submission if user already assessed first correction round
@@ -828,7 +828,7 @@ public class SubmissionService {
         String searchTerm = search.getSearchTerm();
         Page<StudentParticipation> studentParticipationPage = studentParticipationRepository.findAllWithEagerSubmissionsAndResultsByExerciseId(exerciseId, searchTerm, pageable);
 
-        var latestSubmissions = studentParticipationPage.getContent().stream().map(Participation::findLatestSubmission).filter(Optional::isPresent).map(Optional::get).toList();
+        var latestSubmissions = studentParticipationPage.getContent().stream().map(Participation::findLatestSubmission).flatMap(Optional::stream).toList();
         final Page<Submission> submissionPage = new PageImpl<>(latestSubmissions, pageable, latestSubmissions.size());
         return new SearchResultPageDTO<>(submissionPage.getContent(), studentParticipationPage.getTotalPages());
     }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/TextPlagiarismDetectionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/TextPlagiarismDetectionService.java
@@ -69,7 +69,7 @@ public class TextPlagiarismDetectionService {
      */
     public List<TextSubmission> textSubmissionsForComparison(TextExercise exerciseWithParticipationsAndSubmissions, int minimumScore, int minimumSize) {
         var textSubmissions = exerciseWithParticipationsAndSubmissions.getStudentParticipations().parallelStream().filter(plagiarismService.filterForStudents())
-                .map(Participation::findLatestSubmission).filter(Optional::isPresent).map(Optional::get).filter(submission -> submission instanceof TextSubmission)
+                .map(Participation::findLatestSubmission).flatMap(Optional::stream).filter(submission -> submission instanceof TextSubmission)
                 .map(submission -> (TextSubmission) submission).filter(submission -> minimumSize == 0 || submission.getText() != null && submission.countWords() >= minimumSize)
                 .filter(submission -> hasMinimumScore(submission, minimumScore)).toList();
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingSubmissionService.java
@@ -366,7 +366,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
         if (examMode) {
             var participations = studentParticipationRepository.findAllByParticipationExerciseIdAndResultAssessorAndCorrectionRoundIgnoreTestRuns(exerciseId, tutor);
             // Latest submission might be illegal
-            submissions = participations.stream().map(StudentParticipation::findLatestSubmission).filter(Optional::isPresent).map(Optional::get)
+            submissions = participations.stream().map(StudentParticipation::findLatestSubmission).flatMap(Optional::stream)
                     // filter out the submissions that don't have a result (but a null value) for the correctionRound
                     .filter(submission -> submission.hasResultForCorrectionRound(correctionRound)).toList();
         }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/structureoraclegenerator/OracleGenerator.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/structureoraclegenerator/OracleGenerator.java
@@ -79,8 +79,7 @@ public class OracleGenerator {
         Map<JavaClass, JavaClass> solutionToTemplateMapping = generateSolutionToTemplateMapping(solutionProjectPath, templateProjectPath);
         ArrayNode structureOracleJSON = mapper.createArrayNode();
 
-        solutionToTemplateMapping.entrySet().stream().map(entry -> generateDiffJSON(entry.getKey(), entry.getValue())).filter(Optional::isPresent).map(Optional::get)
-                .forEach(structureOracleJSON::add);
+        solutionToTemplateMapping.entrySet().stream().map(entry -> generateDiffJSON(entry.getKey(), entry.getValue())).flatMap(Optional::stream).forEach(structureOracleJSON::add);
 
         return prettyPrint(structureOracleJSON);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/core/MetricsIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/MetricsIntegrationTest.java
@@ -195,7 +195,7 @@ class MetricsIntegrationTest extends AbstractSpringIntegrationIndependentTest {
                 var expectedScores = exercises.stream()
                         .map(exercise -> studentScoreRepository.findByExercise_IdAndUser_Id(exercise.getId(), userID)
                                 .map(studentScore -> Map.entry(exercise.getId(), studentScore.getLastRatedScore())))
-                        .filter(Optional::isPresent).map(Optional::get).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                        .flatMap(Optional::stream).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
                 assertThat(score).isEqualTo(expectedScores);
             }, context).run();
@@ -259,7 +259,7 @@ class MetricsIntegrationTest extends AbstractSpringIntegrationIndependentTest {
                         .flatMap(participation -> participation.getSubmissions().stream()).max(Comparator.comparing(Submission::getSubmissionDate));
 
                 return latestSubmission.map(submission -> new ResourceTimestampDTO(exercise.getId(), submission.getSubmissionDate(), submission.getParticipation().getId()));
-            }).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toSet());
+            }).flatMap(Optional::stream).collect(Collectors.toSet());
 
             Set<ResourceTimestampDTO> result = exerciseMetricsRepository.findLatestSubmissionDates(exerciseIds);
             assertThat(result).isEqualTo(expectedSet);

--- a/src/test/java/de/tum/cit/aet/artemis/core/user/util/UserTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/user/util/UserTestService.java
@@ -259,8 +259,7 @@ public class UserTestService {
         final var newLastName = "Wayne";
         final var newImageUrl = "foobar.png";
         final var newLangKey = "DE";
-        final var newAuthorities = Stream.of(Role.TEACHING_ASSISTANT.getAuthority()).map(authorityRepository::findById).filter(Optional::isPresent).map(Optional::get)
-                .collect(Collectors.toSet());
+        final var newAuthorities = Stream.of(Role.TEACHING_ASSISTANT.getAuthority()).map(authorityRepository::findById).flatMap(Optional::stream).collect(Collectors.toSet());
         final var oldGroups = student.getGroups();
         student.setAuthorities(newAuthorities);
         student.setEmail(newEmail);

--- a/src/test/java/de/tum/cit/aet/artemis/shared/ObjectMethodTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/ObjectMethodTest.java
@@ -77,7 +77,7 @@ class ObjectMethodTest {
      */
     Optional<DynamicNode> generateTestContainerForClasses(ClassPathNode classPathStructure) {
         return classPathStructure.mapTree(this::generateTestsForClass, (packageNode, dynamicNodes) -> {
-            var tests = dynamicNodes.filter(Optional::isPresent).map(Optional::get).toList();
+            var tests = dynamicNodes.flatMap(Optional::stream).toList();
             if (tests.isEmpty()) {
                 return Optional.empty();
             }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [ ] I **strictly** followed the principle of **data economy** for all database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Modernizes java stream code quality when extracting optionals.

### Description
<!-- Describe your changes in detail -->
Replaces out-dated style: `.filter(Optional::isPresent).map(Optional::get)`
With recommended: `.flatMap(Optional::stream)`

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2