### PR TITLE
`Development`: Allow to run jacocoTestCoverageVerification task independently

### DIFF
--- a/docs/dev/guidelines/server-tests.rst
+++ b/docs/dev/guidelines/server-tests.rst
@@ -6,9 +6,13 @@ This section covers recommended practices for writing Artemis server tests. If y
 
 You can execute server tests with the following commands:
 
-* Execute tests with coverage report:          ``./gradlew test jacocoTestReport -x webapp``
-* Execute tests without coverage report:       ``./gradlew test -x webapp``
-* Run a single test:                           ``./gradlew test --tests ExamIntegrationTest -x webapp`` or ``./gradlew test --tests ExamIntegrationTest.testGetExamScore -x webapp``
+* Execute tests with coverage report:                   ``./gradlew test jacocoTestReport -x webapp``
+* Execute tests without coverage report:                ``./gradlew test -x webapp``
+* Execute tests with coverage report and verification:  ``./gradlew test jacocoTestReport -x webapp jacocoTestCoverageVerification``
+* Run a single test:                                    ``./gradlew test --tests ExamIntegrationTest -x webapp`` or ``./gradlew test --tests ExamIntegrationTest.testGetExamScore -x webapp``
+* Verify code coverage (after tests):                   ``./gradlew jacocoTestCoverageVerification -x webapp``
+
+The code coverage thresholds are defined in `jacoco.gradle <https://github.com/ls1intum/Artemis/blob/develop/gradle/jacoco.gradle>`__.
 
 To run the server tests against a real database in a Docker test container, use:
 

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -145,10 +145,10 @@ private JacocoCoverageVerification registerJacocoTestCoverageVerification(String
     prepareJacocoReportTask(task, moduleName, rootTask)
     applyVerificationRule(task, minInstructionCoveredRatio, maxNumberUncoveredClasses)
 
-    // Ensure the verification waits for its own report
+    // Ensure the verification waits for its own report if executed together with the report task
     def reportTaskName = "jacocoCoverageReport-$moduleName"
     if (project.tasks.names.contains(reportTaskName)) {
-        task.dependsOn(project.tasks.named(reportTaskName))
+        task.mustRunAfter(project.tasks.named(reportTaskName))
     }
 
     return task


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In #11023, jacocoTestCoverageVerification and its subtasks were made dependent on their corresponding jacocoTestReport tasks.
However, this prevented the independent execution of ./gradlew jacocoTestCoverageVerification -x webapp, which resulted in errors before.

### Description
<!-- Describe your changes in detail -->
Weakens dependency on previous tasks and uses `mustRunAfter` for jacocoTestCoverageVerification.
In addition, the documentation is updated to include the new Gradle commands and a link to the coverage thresholds.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
1. Run `./gradlew test jacocoTestReport -x webapp` locally -> Executes the test and generates a coverage report
2. Run `./gradlew jacocoTestCoverageVerification -x webapp` locally -> Validates coverage based on the just created reports in step 1
3. Run all tasks together with `./gradlew test jacocoTestReport -x webapp jacocoTestCoverageVerification` and also make sure it works
4. Check out the updated documentation here: https://artemis-platform--11061.org.readthedocs.build/en/11061/dev/guidelines/server-tests.html

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Improved the task execution order for test coverage verification, ensuring more flexible build processes. No impact on end-user features.
* **Documentation**
  * Enhanced server testing guidelines with new commands for code coverage verification and references to coverage thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->