### PR TITLE
`Development`: Enhance database migration approval check

### DIFF
--- a/supporting_scripts/database_approval_check/main.py
+++ b/supporting_scripts/database_approval_check/main.py
@@ -36,8 +36,10 @@ def is_db_maintainer(user: NamedUser):
 
 last_commit_with_db_changes = None
 for commit in pr.get_commits().reversed:
-    # Ignore merges from the develop branch
-    if commit.commit.message.startswith("Merge branch 'develop' into"):
+    # Ignore merges from the develop branch (local and remote-tracking)
+    if (commit.commit.message.startswith("Merge branch 'develop' into") or 
+        commit.commit.message.startswith("Merge branch 'origin/develop' into") or
+        commit.commit.message.startswith("Merge remote-tracking branch 'origin/develop' into")):
         continue
     if has_db_changes(commit):
         last_commit_with_db_changes = commit


### PR DESCRIPTION
**Problem:**
The database approval check script only ignored merge commits from the local develop branch, but not from remote-tracking branches like origin/develop.

**Solution:**
Extended the merge commit filtering to also ignore:
Merge branch 'origin/develop' into
Merge remote-tracking branch 'origin/develop' into