### PR TITLE
`Programming exercises`: Reintroduce grace period for result handling

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.artemis.assessment.domain;
 
+import static de.tum.cit.aet.artemis.core.config.Constants.PROGRAMMING_GRACE_PERIOD_SECONDS;
 import static de.tum.cit.aet.artemis.core.config.Constants.SIZE_OF_UNSIGNED_TINYINT;
 import static de.tum.cit.aet.artemis.core.util.RoundingUtil.roundScoreSpecifiedByCourseSettings;
 import static de.tum.cit.aet.artemis.core.util.RoundingUtil.roundToNDecimalPlaces;
@@ -227,7 +228,11 @@ public class Result extends DomainObject implements Comparable<Result> {
             this.rated = true;
             return;
         }
-        this.rated = !submissionDate.isAfter(optionalDueDate.get());
+        var dueDate = optionalDueDate.get();
+        if (getSubmission().getParticipation().getExercise() instanceof ProgrammingExercise) {
+            dueDate = dueDate.plusSeconds(PROGRAMMING_GRACE_PERIOD_SECONDS);
+        }
+        this.rated = !submissionDate.isAfter(dueDate);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/Constants.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/Constants.java
@@ -42,6 +42,18 @@ public final class Constants {
      */
     public static final String ARTEMIS_FILE_PATH_PREFIX = "/api/core/files/";
 
+    /**
+     * This constant determines how many seconds after the exercise due dates submissions will still be considered rated.
+     * Submissions after the grace period exceeded will be unrated.
+     * <p>
+     * If the student was able to successfully push their solution, this solution should still be graded, even if
+     * the push was a few seconds late.
+     * <p>
+     * Have a look at setRatedIfNotAfterDueDate(Participation participation, ZonedDateTime submissionDate) in
+     * de.tum.cit.aet.artemis.assessment.domain.Result.
+     */
+    public static final int PROGRAMMING_GRACE_PERIOD_SECONDS = 1;
+
     public static final String FILEPATH_ID_PLACEHOLDER = "PLACEHOLDER_FOR_ID";
 
     public static final String EXERCISE_TOPIC_ROOT = "/topic/exercise/";

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/Constants.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/Constants.java
@@ -47,7 +47,7 @@ public final class Constants {
      * Submissions after the grace period exceeded will be unrated.
      * <p>
      * If the student was able to successfully push their solution, this solution should still be graded, even if
-     * the push was a few seconds late.
+     * the processing of the push was up to 1s late.
      * <p>
      * Have a look at setRatedIfNotAfterDueDate(Participation participation, ZonedDateTime submissionDate) in
      * de.tum.cit.aet.artemis.assessment.domain.Result.

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/repository/StudentParticipationRepository.java
@@ -114,7 +114,7 @@ public interface StudentParticipationRepository extends ArtemisJpaRepository<Stu
                 AND TYPE(ex) <> QuizExercise
                 AND p.testRun = FALSE
                 AND p.student IS NOT NULL
-                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, de.tum.cit.aet.artemis.core.config.Constants.PROGRAMMING_GRACE_PERIOD_SECONDS, GREATEST(ex.dueDate, p.individualDueDate)))
+                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, de.tum.cit.aet.artemis.core.config.Constants.PROGRAMMING_GRACE_PERIOD_SECONDS, COALESCE(p.individualDueDate, ex.dueDate)))
                 AND r.rated = TRUE
                 AND r.completionDate IS NOT NULL
                 AND r.score IS NOT NULL
@@ -135,7 +135,7 @@ public interface StudentParticipationRepository extends ArtemisJpaRepository<Stu
             WHERE ex.course.id = :courseId
                 AND p.testRun = FALSE
                 AND p.team IS NOT NULL
-                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, de.tum.cit.aet.artemis.core.config.Constants.PROGRAMMING_GRACE_PERIOD_SECONDS, GREATEST(ex.dueDate, p.individualDueDate)))
+                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, de.tum.cit.aet.artemis.core.config.Constants.PROGRAMMING_GRACE_PERIOD_SECONDS, COALESCE(p.individualDueDate, ex.dueDate)))
                 AND r.rated = TRUE
                 AND r.completionDate IS NOT NULL
                 AND r.score IS NOT NULL

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/repository/StudentParticipationRepository.java
@@ -114,7 +114,7 @@ public interface StudentParticipationRepository extends ArtemisJpaRepository<Stu
                 AND TYPE(ex) <> QuizExercise
                 AND p.testRun = FALSE
                 AND p.student IS NOT NULL
-                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, 1, ex.dueDate))
+                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, 1, GREATEST(ex.dueDate, p.individualDueDate)))
                 AND r.rated = TRUE
                 AND r.completionDate IS NOT NULL
                 AND r.score IS NOT NULL
@@ -135,7 +135,7 @@ public interface StudentParticipationRepository extends ArtemisJpaRepository<Stu
             WHERE ex.course.id = :courseId
                 AND p.testRun = FALSE
                 AND p.team IS NOT NULL
-                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, 1, ex.dueDate))
+                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, 1, GREATEST(ex.dueDate, p.individualDueDate)))
                 AND r.rated = TRUE
                 AND r.completionDate IS NOT NULL
                 AND r.score IS NOT NULL

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/repository/StudentParticipationRepository.java
@@ -114,7 +114,7 @@ public interface StudentParticipationRepository extends ArtemisJpaRepository<Stu
                 AND TYPE(ex) <> QuizExercise
                 AND p.testRun = FALSE
                 AND p.student IS NOT NULL
-                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, 1, GREATEST(ex.dueDate, p.individualDueDate)))
+                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, de.tum.cit.aet.artemis.core.config.Constants.PROGRAMMING_GRACE_PERIOD_SECONDS, GREATEST(ex.dueDate, p.individualDueDate)))
                 AND r.rated = TRUE
                 AND r.completionDate IS NOT NULL
                 AND r.score IS NOT NULL
@@ -135,7 +135,7 @@ public interface StudentParticipationRepository extends ArtemisJpaRepository<Stu
             WHERE ex.course.id = :courseId
                 AND p.testRun = FALSE
                 AND p.team IS NOT NULL
-                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, 1, GREATEST(ex.dueDate, p.individualDueDate)))
+                AND (ex.dueDate IS NULL OR s.submissionDate <= FUNCTION('timestampadd', SECOND, de.tum.cit.aet.artemis.core.config.Constants.PROGRAMMING_GRACE_PERIOD_SECONDS, GREATEST(ex.dueDate, p.individualDueDate)))
                 AND r.rated = TRUE
                 AND r.completionDate IS NOT NULL
                 AND r.score IS NOT NULL

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/ResultServiceIntegrationTest.java
@@ -288,8 +288,8 @@ class ResultServiceIntegrationTest extends AbstractSpringIntegrationLocalCILocal
         ZonedDateTime dateInPast = now.minusHours(1);
         ZonedDateTime dateClosePast = now.minusSeconds(5);
         return Stream.of(
-                // The result was created shortly after the due date and should still be considered rated
-                Arguments.of(true, dateInPast, SubmissionType.MANUAL, dateClosePast, now),
+                // The result was created shortly after the due date => unrated
+                Arguments.of(false, dateInPast, SubmissionType.MANUAL, dateClosePast, now),
                 // The due date has not passed, normal student submission => rated result.
                 Arguments.of(true, null, SubmissionType.MANUAL, dateInFuture, now),
                 // The due date is not set, normal student submission => rated result.

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/ResultServiceIntegrationTest.java
@@ -252,7 +252,7 @@ class ResultServiceIntegrationTest extends AbstractSpringIntegrationLocalCILocal
     @MethodSource("setResultRatedPermutations")
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void setProgrammingExerciseResultRated(boolean shouldBeRated, ZonedDateTime buildAndTestAfterDueDate, SubmissionType submissionType, ZonedDateTime dueDate,
-            ZonedDateTime submissionDate) {
+            ZonedDateTime individualDueDate, ZonedDateTime submissionDate) {
         programmingExercise.setBuildAndTestStudentSubmissionsAfterDueDate(buildAndTestAfterDueDate);
         programmingExercise.setDueDate(dueDate);
         programmingExercise = programmingExerciseRepository.save(programmingExercise);
@@ -287,8 +287,11 @@ class ResultServiceIntegrationTest extends AbstractSpringIntegrationLocalCILocal
         ZonedDateTime dateInFuture = now.plusHours(1);
         ZonedDateTime dateInPast = now.minusHours(1);
         ZonedDateTime dateClosePast = now.minusSeconds(5);
+        ZonedDateTime dateWithinGracePeriod = now.minusSeconds(1);
         return Stream.of(
-                // The result was created shortly after the due date => unrated
+                // The result was created shortly after the due date within the grace period => rated
+                Arguments.of(true, dateInPast, SubmissionType.MANUAL, dateWithinGracePeriod, now),
+                // The result was created shortly after the due date and grace period => unrated
                 Arguments.of(false, dateInPast, SubmissionType.MANUAL, dateClosePast, now),
                 // The due date has not passed, normal student submission => rated result.
                 Arguments.of(true, null, SubmissionType.MANUAL, dateInFuture, now),

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/ResultServiceIntegrationTest.java
@@ -252,7 +252,7 @@ class ResultServiceIntegrationTest extends AbstractSpringIntegrationLocalCILocal
     @MethodSource("setResultRatedPermutations")
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void setProgrammingExerciseResultRated(boolean shouldBeRated, ZonedDateTime buildAndTestAfterDueDate, SubmissionType submissionType, ZonedDateTime dueDate,
-            ZonedDateTime individualDueDate, ZonedDateTime submissionDate) {
+            ZonedDateTime submissionDate) {
         programmingExercise.setBuildAndTestStudentSubmissionsAfterDueDate(buildAndTestAfterDueDate);
         programmingExercise.setDueDate(dueDate);
         programmingExercise = programmingExerciseRepository.save(programmingExercise);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In #10971, the handling of illegal submissions was removed. 
One test case verifies the rating of a result that was created 5 seconds after the due date. With the illegal submission handling, this was still allowed.
Now, after the illegal submission handling was removed, this case should be considered as non-rated, as it was created after the due date.

### Description
<!-- Describe your changes in detail -->
Adapts the test so that the result for the specific case is considered unrated.
In addition, a grace period of 1 second is reintroduced for the result handling (graded vs ungraded).
And the SQL Query for retrieving grades was adapted to also respect the individual due date of a student.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Make sure the test setProgrammingExerciseResultRated() now passes again.



### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for result rating by distinguishing submissions within and beyond a configurable grace period after due dates.
* **New Features**
  * Introduced a configurable grace period allowing late programming exercise submissions to still be rated.
* **Bug Fixes**
  * Adjusted grade calculations to consider the configurable grace period after due dates for individual and team submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->