### PR TITLE
`Assessment`: Fix issues with results and feedback

### DIFF
--- a/src/main/webapp/app/app.routes.ts
+++ b/src/main/webapp/app/app.routes.ts
@@ -169,6 +169,9 @@ const routes: Routes = [
     {
         path: 'courses/:courseId/exercises/:exerciseId/participations/:participationId/results/:resultId/feedback',
         pathMatch: 'full',
+        data: {
+            pageTitle: 'artemisApp.feedback.home.title',
+        },
         loadComponent: () => import('app/exercise/feedback/standalone-feedback/standalone-feedback.component').then((m) => m.StandaloneFeedbackComponent),
     },
 

--- a/src/main/webapp/app/core/course/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/core/course/overview/exercise-details/course-exercise-details.component.ts
@@ -272,18 +272,19 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
                 .flatMap(
                     (participation) =>
                         participation.submissions?.flatMap((submission) => {
-                            submission.results?.forEach((result) => {
-                                result.submission = submission;
-                            });
-                            submission.participation = participation;
-                            return submission.results ?? [];
+                            return (
+                                submission.results?.map((result) => {
+                                    result.submission = submission;
+                                    result.submission.participation = participation;
+                                    return result;
+                                }) ?? []
+                            );
                         }) ?? [],
                 )
                 .sort(this.resultSortFunction)
                 .filter((result) => !(result.assessmentType === AssessmentType.AUTOMATIC_ATHENA && !result.successful));
         }
     }
-
     private resultSortFunction = (a: Result, b: Result) => {
         const aValue = dayjs(a.completionDate!).valueOf();
         const bValue = dayjs(b.completionDate!).valueOf();

--- a/src/main/webapp/app/exam/overview/summary/exam-result-summary.component.ts
+++ b/src/main/webapp/app/exam/overview/summary/exam-result-summary.component.ts
@@ -495,8 +495,8 @@ export class ExamResultSummaryComponent implements OnInit {
         const templateStatus = evaluateTemplateStatus(exercise, participation, result, isBuilding);
 
         return {
-            textColorClass: getTextColorClass(result, templateStatus),
-            resultIconClass: getResultIconClass(result, templateStatus),
+            textColorClass: getTextColorClass(result, participation, templateStatus),
+            resultIconClass: getResultIconClass(result, participation, templateStatus),
         };
     }
 

--- a/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.html
+++ b/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.html
@@ -29,6 +29,7 @@
                         <jhi-result-detail
                             [exercise]="feedbackComponentParameters.exercise"
                             [result]="feedbackComponentParameters.result"
+                            [participation]="feedbackComponentParameters.participation"
                             [showScoreChart]="false"
                             [exerciseType]="feedbackComponentParameters.exerciseType ?? ExerciseType.PROGRAMMING"
                             [latestDueDate]="feedbackComponentParameters.latestDueDate"

--- a/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.html
+++ b/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.html
@@ -29,6 +29,7 @@
                         <jhi-result-detail
                             [exercise]="feedbackComponentParameters.exercise"
                             [result]="feedbackComponentParameters.result"
+                            [participation]="participation"
                             [showScoreChart]="false"
                             [exerciseType]="feedbackComponentParameters.exerciseType ?? ExerciseType.PROGRAMMING"
                             [latestDueDate]="feedbackComponentParameters.latestDueDate"

--- a/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.html
+++ b/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.html
@@ -29,7 +29,6 @@
                         <jhi-result-detail
                             [exercise]="feedbackComponentParameters.exercise"
                             [result]="feedbackComponentParameters.result"
-                            [participation]="participation"
                             [showScoreChart]="false"
                             [exerciseType]="feedbackComponentParameters.exerciseType ?? ExerciseType.PROGRAMMING"
                             [latestDueDate]="feedbackComponentParameters.latestDueDate"

--- a/src/main/webapp/app/exercise/feedback/feedback.component.html
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.html
@@ -111,7 +111,7 @@
                     <hr />
                 }
 
-                @if (!loadingFailed && resultIsPreliminary(result)) {
+                @if (!loadingFailed && resultIsPreliminary(result, participation)) {
                     <div>
                         <div class="d-flex justify-content-end m-1">
                             <div class="badge bg-warning">{{ 'artemisApp.result.preliminary' | artemisTranslate | uppercase }}</div>

--- a/src/main/webapp/app/exercise/feedback/feedback.component.spec.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.spec.ts
@@ -24,6 +24,7 @@ import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.
 import { TranslateService } from '@ngx-translate/core';
 import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
 import { ProfileInfo } from 'app/core/layouts/profiles/profile-info.model';
+import { ProgrammingExerciseStudentParticipation } from 'app/exercise/shared/entities/participation/programming-exercise-student-participation.model';
 
 describe('FeedbackComponent', () => {
     let comp: FeedbackComponent;
@@ -199,6 +200,12 @@ describe('FeedbackComponent', () => {
         course.title = 'Testcourse';
         exercise.course = course;
         comp.exercise = exercise;
+        comp.participation = {
+            id: 55,
+            type: ParticipationType.PROGRAMMING,
+            participantIdentifier: 'student42',
+            repositoryUri: 'https://artemis.tum.de/projects/somekey/repos/somekey-student42',
+        } as ProgrammingExerciseStudentParticipation;
         comp.result = {
             id: 89,
             submission: {
@@ -289,7 +296,7 @@ describe('FeedbackComponent', () => {
         comp.ngOnInit();
 
         expect(getFeedbackDetailsForResultStub).toHaveBeenCalledOnce();
-        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledWith(comp.result.submission!.participation!.id!, comp.result);
+        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledWith(55, comp.result);
         expect(comp.isLoading).toBeFalse();
     });
 

--- a/src/main/webapp/app/exercise/feedback/feedback.component.spec.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.spec.ts
@@ -234,7 +234,7 @@ describe('FeedbackComponent', () => {
 
     it('should set the exercise from the participation if available', () => {
         comp.exercise = undefined;
-        comp.result.submission!.participation!.exercise = exercise;
+        comp.participation.exercise = exercise;
 
         comp.ngOnInit();
 
@@ -302,12 +302,12 @@ describe('FeedbackComponent', () => {
 
     it('should try to retrieve build logs if the exercise type is PROGRAMMING and a submission was provided which was marked with build failed.', () => {
         comp.exerciseType = ExerciseType.PROGRAMMING;
-        comp.result.submission = { ...comp.result.submission, buildFailed: true } as ProgrammingSubmission;
+        comp.participation = { ...comp.participation, submissions: [{ buildFailed: true } as ProgrammingSubmission] };
 
         comp.ngOnInit();
 
         expect(buildlogsStub).toHaveBeenCalledOnce();
-        expect(buildlogsStub).toHaveBeenCalledWith(comp.result.submission!.participation!.id, comp.result.id);
+        expect(buildlogsStub).toHaveBeenCalledWith(55, 89);
         expect(comp.buildLogs).toBeArrayOfSize(0);
         expect(comp.isLoading).toBeFalse();
     });
@@ -336,27 +336,27 @@ describe('FeedbackComponent', () => {
 
     it('fetchBuildLogs should suppress 403 error', () => {
         comp.exerciseType = ExerciseType.PROGRAMMING;
-        comp.result.submission = { ...comp.result.submission, buildFailed: true } as ProgrammingSubmission;
+        comp.participation = { ...comp.participation, submissions: [{ buildFailed: true } as ProgrammingSubmission] };
         const response = new HttpErrorResponse({ status: 403 });
         buildlogsStub.mockReturnValue(throwError(() => response));
 
         comp.ngOnInit();
 
         expect(buildlogsStub).toHaveBeenCalledOnce();
-        expect(buildlogsStub).toHaveBeenCalledWith(comp.result.submission!.participation!.id, comp.result.id);
+        expect(buildlogsStub).toHaveBeenCalledWith(55, 89);
         expect(comp.loadingFailed).toBeFalse();
         expect(comp.isLoading).toBeFalse();
     });
 
     it('fetchBuildLogs should not suppress errors with status other than 403', () => {
         comp.exerciseType = ExerciseType.PROGRAMMING;
-        comp.result.submission = { ...comp.result.submission, buildFailed: true } as ProgrammingSubmission;
+        comp.participation = { ...comp.participation, submissions: [{ buildFailed: true } as ProgrammingSubmission] };
         const response = new HttpErrorResponse({ status: 500 });
         buildlogsStub.mockReturnValue(throwError(() => response));
         comp.ngOnInit();
 
         expect(buildlogsStub).toHaveBeenCalledOnce();
-        expect(buildlogsStub).toHaveBeenCalledWith(comp.result.submission!.participation!.id, comp.result.id);
+        expect(buildlogsStub).toHaveBeenCalledWith(55, 89);
         expect(comp.loadingFailed).toBeTrue();
         expect(comp.isLoading).toBeFalse();
     });

--- a/src/main/webapp/app/exercise/feedback/feedback.component.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.ts
@@ -37,7 +37,6 @@ import { FeedbackNodeComponent } from './node/feedback-node.component';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisTimeAgoPipe } from 'app/shared/pipes/artemis-time-ago.pipe';
-import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 // Modal -> Result details view
 @Component({
@@ -78,7 +77,6 @@ export class FeedbackComponent implements OnInit, OnChanges {
 
     @Input() exercise?: Exercise;
     @Input() result: Result;
-    @Input() participation: Participation;
 
     /**
      * Specify the feedback.testCase.id values that should be shown, all other values will not be visible.
@@ -216,7 +214,7 @@ export class FeedbackComponent implements OnInit, OnChanges {
                         feedbacks.forEach((feedback) => (feedback.result = this.result));
                         return of(feedbacks);
                     } else {
-                        return this.resultService.getFeedbackDetailsForResult(this.participation?.id, this.result).pipe(map((response) => response.body));
+                        return this.resultService.getFeedbackDetailsForResult(this.result.submission!.participation!.id!, this.result).pipe(map((response) => response.body));
                     }
                 }),
                 switchMap((feedbacks: Feedback[] | undefined | null) => {

--- a/src/main/webapp/app/exercise/feedback/feedback.component.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.ts
@@ -37,7 +37,7 @@ import { FeedbackNodeComponent } from './node/feedback-node.component';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisTimeAgoPipe } from 'app/shared/pipes/artemis-time-ago.pipe';
-import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
+import { Participation, getLatestSubmission } from 'app/exercise/shared/entities/participation/participation.model';
 
 // Modal -> Result details view
 @Component({
@@ -237,11 +237,9 @@ export class FeedbackComponent implements OnInit, OnChanges {
                     }
 
                     // If the submission is marked with buildFailed, fetch the build logs.
-                    if (
-                        this.result.assessmentType !== AssessmentType.AUTOMATIC_ATHENA &&
-                        this.exerciseType === ExerciseType.PROGRAMMING &&
-                        (this.participation?.submissions?.[0] as ProgrammingSubmission)?.buildFailed
-                    ) {
+                    const buildFailed = (getLatestSubmission(this.participation) as ProgrammingSubmission)?.buildFailed;
+
+                    if (this.result.assessmentType !== AssessmentType.AUTOMATIC_ATHENA && this.exerciseType === ExerciseType.PROGRAMMING && buildFailed) {
                         return this.fetchAndSetBuildLogs(this.participation.id!, this.result.id);
                     }
 

--- a/src/main/webapp/app/exercise/feedback/feedback.component.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.ts
@@ -78,7 +78,7 @@ export class FeedbackComponent implements OnInit, OnChanges {
 
     @Input() exercise?: Exercise;
     @Input() result: Result;
-    @Input() participation?: Participation;
+    @Input() participation: Participation;
 
     /**
      * Specify the feedback.testCase.id values that should be shown, all other values will not be visible.
@@ -185,7 +185,7 @@ export class FeedbackComponent implements OnInit, OnChanges {
      * Sets up the information related to the exercise.
      */
     private initializeExerciseInformation() {
-        this.exercise ??= this.result.submission?.participation?.exercise;
+        this.exercise ??= this.participation?.exercise;
         if (this.exercise) {
             this.course = getCourseFromExercise(this.exercise);
         }
@@ -195,7 +195,7 @@ export class FeedbackComponent implements OnInit, OnChanges {
         }
 
         // In case the exerciseType is not set, we try to set it back if the participation is from a programming exercise
-        if (!this.exerciseType && isProgrammingExerciseParticipation(this.result?.submission?.participation)) {
+        if (!this.exerciseType && isProgrammingExerciseParticipation(this.participation)) {
             this.exerciseType = ExerciseType.PROGRAMMING;
         }
 
@@ -236,10 +236,9 @@ export class FeedbackComponent implements OnInit, OnChanges {
                     if (
                         this.result.assessmentType !== AssessmentType.AUTOMATIC_ATHENA &&
                         this.exerciseType === ExerciseType.PROGRAMMING &&
-                        this.result.submission?.participation &&
-                        (this.result.submission as ProgrammingSubmission).buildFailed
+                        (this.participation?.submissions?.[0] as ProgrammingSubmission)?.buildFailed
                     ) {
-                        return this.fetchAndSetBuildLogs(this.result.submission.participation.id!, this.result.id);
+                        return this.fetchAndSetBuildLogs(this.participation.id!, this.result.id);
                     }
 
                     if (this.showScoreChart) {

--- a/src/main/webapp/app/exercise/feedback/feedback.component.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.ts
@@ -163,7 +163,11 @@ export class FeedbackComponent implements OnInit, OnChanges {
 
         this.commitHash = this.getCommitHash().slice(0, 11);
 
-        this.isOnlyCompilationTested = isOnlyCompilationTested(this.result, evaluateTemplateStatus(this.exercise, this.result.submission?.participation, this.result, false));
+        this.isOnlyCompilationTested = isOnlyCompilationTested(
+            this.result,
+            this.participation,
+            evaluateTemplateStatus(this.exercise, this.result.submission?.participation, this.result, false),
+        );
     }
 
     /**

--- a/src/main/webapp/app/exercise/feedback/feedback.component.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.ts
@@ -37,6 +37,7 @@ import { FeedbackNodeComponent } from './node/feedback-node.component';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisTimeAgoPipe } from 'app/shared/pipes/artemis-time-ago.pipe';
+import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 // Modal -> Result details view
 @Component({
@@ -77,6 +78,7 @@ export class FeedbackComponent implements OnInit, OnChanges {
 
     @Input() exercise?: Exercise;
     @Input() result: Result;
+    @Input() participation: Participation;
 
     /**
      * Specify the feedback.testCase.id values that should be shown, all other values will not be visible.
@@ -214,7 +216,7 @@ export class FeedbackComponent implements OnInit, OnChanges {
                         feedbacks.forEach((feedback) => (feedback.result = this.result));
                         return of(feedbacks);
                     } else {
-                        return this.resultService.getFeedbackDetailsForResult(this.result.submission!.participation!.id!, this.result).pipe(map((response) => response.body));
+                        return this.resultService.getFeedbackDetailsForResult(this.participation?.id, this.result).pipe(map((response) => response.body));
                     }
                 }),
                 switchMap((feedbacks: Feedback[] | undefined | null) => {

--- a/src/main/webapp/app/exercise/feedback/feedback.component.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.ts
@@ -245,8 +245,8 @@ export class FeedbackComponent implements OnInit, OnChanges {
                         this.updateChart(this.feedbackItemNodes);
                     }
 
-                    if (isStudentParticipation(this.result)) {
-                        this.badge = ResultService.evaluateBadge(this.result.submission!.participation!, this.result);
+                    if (isStudentParticipation(this.participation)) {
+                        this.badge = ResultService.evaluateBadge(this.participation, this.result);
                     }
 
                     return of(null);

--- a/src/main/webapp/app/exercise/feedback/feedback.component.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.ts
@@ -37,6 +37,7 @@ import { FeedbackNodeComponent } from './node/feedback-node.component';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisTimeAgoPipe } from 'app/shared/pipes/artemis-time-ago.pipe';
+import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 // Modal -> Result details view
 @Component({
@@ -77,6 +78,7 @@ export class FeedbackComponent implements OnInit, OnChanges {
 
     @Input() exercise?: Exercise;
     @Input() result: Result;
+    @Input() participation?: Participation;
 
     /**
      * Specify the feedback.testCase.id values that should be shown, all other values will not be visible.
@@ -214,7 +216,7 @@ export class FeedbackComponent implements OnInit, OnChanges {
                         feedbacks.forEach((feedback) => (feedback.result = this.result));
                         return of(feedbacks);
                     } else {
-                        return this.resultService.getFeedbackDetailsForResult(this.result.submission!.participation!.id!, this.result).pipe(map((response) => response.body));
+                        return this.resultService.getFeedbackDetailsForResult(this.participation?.id, this.result).pipe(map((response) => response.body));
                     }
                 }),
                 switchMap((feedbacks: Feedback[] | undefined | null) => {

--- a/src/main/webapp/app/exercise/feedback/feedback.utils.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.utils.ts
@@ -11,6 +11,7 @@ import { ExerciseService } from 'app/exercise/services/exercise.service';
 export type FeedbackComponentPreparedParams = {
     exercise: Exercise | undefined;
     result: Result;
+    participation: Participation;
     exerciseType?: ExerciseType;
     showScoreChart?: boolean;
     messageKey?: string;
@@ -32,6 +33,7 @@ export function prepareFeedbackComponentParameters(
     const preparedParameters: FeedbackComponentPreparedParams = {
         exercise: exercise,
         result: result,
+        participation: participation,
     };
 
     if (exercise) {

--- a/src/main/webapp/app/exercise/feedback/standalone-feedback/standalone-feedback.component.html
+++ b/src/main/webapp/app/exercise/feedback/standalone-feedback/standalone-feedback.component.html
@@ -3,6 +3,7 @@
         [exercise]="exercise"
         [result]="result"
         [showScoreChart]="true"
+        [participation]="participation"
         [exerciseType]="exerciseType"
         [latestDueDate]="latestDueDate"
         [messageKey]="messageKey"

--- a/src/main/webapp/app/exercise/feedback/standalone-feedback/standalone-feedback.component.html
+++ b/src/main/webapp/app/exercise/feedback/standalone-feedback/standalone-feedback.component.html
@@ -2,6 +2,7 @@
     <jhi-result-detail
         [exercise]="exercise"
         [result]="result"
+        [participation]="participation"
         [showScoreChart]="true"
         [exerciseType]="exerciseType"
         [latestDueDate]="latestDueDate"

--- a/src/main/webapp/app/exercise/feedback/standalone-feedback/standalone-feedback.component.html
+++ b/src/main/webapp/app/exercise/feedback/standalone-feedback/standalone-feedback.component.html
@@ -2,7 +2,6 @@
     <jhi-result-detail
         [exercise]="exercise"
         [result]="result"
-        [participation]="participation"
         [showScoreChart]="true"
         [exerciseType]="exerciseType"
         [latestDueDate]="latestDueDate"

--- a/src/main/webapp/app/exercise/feedback/standalone-feedback/standalone-feedback.component.ts
+++ b/src/main/webapp/app/exercise/feedback/standalone-feedback/standalone-feedback.component.ts
@@ -9,7 +9,6 @@ import { ExerciseCacheService } from 'app/exercise/services/exercise-cache.servi
 import { ResultTemplateStatus, evaluateTemplateStatus } from 'app/exercise/result/result.utils';
 import { FeedbackComponent } from '../feedback.component';
 import { getAllResultsOfAllSubmissions } from 'app/exercise/shared/entities/submission/submission.model';
-import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 @Component({
     selector: 'jhi-standalone-feedback',
@@ -24,7 +23,6 @@ export class StandaloneFeedbackComponent implements OnInit {
 
     exercise?: Exercise;
     result?: Result;
-    participation: Participation;
 
     showMissingAutomaticFeedbackInformation = false;
     messageKey?: string;
@@ -43,7 +41,6 @@ export class StandaloneFeedbackComponent implements OnInit {
                 const participation = this.exercise?.studentParticipations?.find((participation) => participation.id === participationId);
                 if (participation) {
                     participation.exercise = this.exercise;
-                    this.participation = participation;
                 }
 
                 const relevantResult = getAllResultsOfAllSubmissions(participation?.submissions).find((result) => result.id == resultId);

--- a/src/main/webapp/app/exercise/feedback/standalone-feedback/standalone-feedback.component.ts
+++ b/src/main/webapp/app/exercise/feedback/standalone-feedback/standalone-feedback.component.ts
@@ -9,6 +9,7 @@ import { ExerciseCacheService } from 'app/exercise/services/exercise-cache.servi
 import { ResultTemplateStatus, evaluateTemplateStatus } from 'app/exercise/result/result.utils';
 import { FeedbackComponent } from '../feedback.component';
 import { getAllResultsOfAllSubmissions } from 'app/exercise/shared/entities/submission/submission.model';
+import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 @Component({
     selector: 'jhi-standalone-feedback',
@@ -23,6 +24,7 @@ export class StandaloneFeedbackComponent implements OnInit {
 
     exercise?: Exercise;
     result?: Result;
+    participation: Participation;
 
     showMissingAutomaticFeedbackInformation = false;
     messageKey?: string;
@@ -41,6 +43,7 @@ export class StandaloneFeedbackComponent implements OnInit {
                 const participation = this.exercise?.studentParticipations?.find((participation) => participation.id === participationId);
                 if (participation) {
                     participation.exercise = this.exercise;
+                    this.participation = participation;
                 }
 
                 const relevantResult = getAllResultsOfAllSubmissions(participation?.submissions).find((result) => result.id == resultId);

--- a/src/main/webapp/app/exercise/result-history/result-history.component.html
+++ b/src/main/webapp/app/exercise/result-history/result-history.component.html
@@ -10,11 +10,11 @@
                     [ngClass]="
                         result.id === selectedResultId()
                             ? 'text-primary'
-                            : getTextColorClass(result, evaluateTemplateStatus(exercise(), result.submission?.participation, result, false, MissingResultInfo.NONE))
+                            : getTextColorClass(result, participation()!, evaluateTemplateStatus(exercise(), participation()!, result, false, MissingResultInfo.NONE))
                     "
                 >
                     <fa-icon
-                        [icon]="getResultIconClass(result, evaluateTemplateStatus(exercise(), result.submission?.participation, result, false, MissingResultInfo.NONE))"
+                        [icon]="getResultIconClass(result, participation()!, evaluateTemplateStatus(exercise(), participation()!, result, false, MissingResultInfo.NONE))"
                         size="xl"
                     />
                 </div>
@@ -22,7 +22,7 @@
                     class="result-score-info text-center"
                     [exercise]="exercise()"
                     [result]="result"
-                    [participation]="result.submission!.participation!"
+                    [participation]="participation()!"
                     [showUngradedResults]="true"
                     [showBadge]="true"
                     [showIcon]="false"

--- a/src/main/webapp/app/exercise/result-history/result-history.component.html
+++ b/src/main/webapp/app/exercise/result-history/result-history.component.html
@@ -10,11 +10,11 @@
                     [ngClass]="
                         result.id === selectedResultId()
                             ? 'text-primary'
-                            : getTextColorClass(result, participation()!, evaluateTemplateStatus(exercise(), participation()!, result, false, MissingResultInfo.NONE))
+                            : getTextColorClass(result, participation()!, evaluateTemplateStatus(exercise(), participation(), result, false, MissingResultInfo.NONE))
                     "
                 >
                     <fa-icon
-                        [icon]="getResultIconClass(result, participation()!, evaluateTemplateStatus(exercise(), participation()!, result, false, MissingResultInfo.NONE))"
+                        [icon]="getResultIconClass(result, participation()!, evaluateTemplateStatus(exercise(), participation(), result, false, MissingResultInfo.NONE))"
                         size="xl"
                     />
                 </div>

--- a/src/main/webapp/app/exercise/result-history/result-history.component.ts
+++ b/src/main/webapp/app/exercise/result-history/result-history.component.ts
@@ -34,7 +34,6 @@ export class ResultHistoryComponent implements OnChanges {
 
     ngOnChanges() {
         this.showPreviousDivider = this.results().length > MAX_RESULT_HISTORY_LENGTH;
-        this.participation.set(this.participationInput() ?? this.displayedResults?.[0]?.submission?.participation);
         if (this.exercise()?.type === ExerciseType.TEXT || this.exercise()?.type === ExerciseType.MODELING) {
             this.displayedResults = this.results().filter((result) => result.successful !== undefined);
         } else {
@@ -51,5 +50,6 @@ export class ResultHistoryComponent implements OnChanges {
                 this.movedLastRatedResult = true;
             }
         }
+        this.participation.set(this.participationInput() ?? this.displayedResults?.[0]?.submission?.participation);
     }
 }

--- a/src/main/webapp/app/exercise/result-history/result-history.component.ts
+++ b/src/main/webapp/app/exercise/result-history/result-history.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnChanges, input } from '@angular/core';
+import { Component, OnChanges, input, signal } from '@angular/core';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { MissingResultInformation, evaluateTemplateStatus, getResultIconClass, getTextColorClass } from 'app/exercise/result/result.utils';
 import { NgClass, NgStyle } from '@angular/common';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ResultComponent } from '../../exercise/result/result.component';
+import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 export const MAX_RESULT_HISTORY_LENGTH = 5;
 
@@ -22,6 +23,8 @@ export class ResultHistoryComponent implements OnChanges {
     readonly MissingResultInfo = MissingResultInformation;
 
     results = input.required<Result[]>();
+    participationInput = input<Participation>();
+    participation = signal<Participation | undefined>(undefined);
     exercise = input<Exercise>();
     selectedResultId = input<number>();
 
@@ -31,6 +34,7 @@ export class ResultHistoryComponent implements OnChanges {
 
     ngOnChanges() {
         this.showPreviousDivider = this.results().length > MAX_RESULT_HISTORY_LENGTH;
+        this.participation.set(this.participationInput() ?? this.displayedResults?.[0]?.submission?.participation);
         if (this.exercise()?.type === ExerciseType.TEXT || this.exercise()?.type === ExerciseType.MODELING) {
             this.displayedResults = this.results().filter((result) => result.successful !== undefined);
         } else {

--- a/src/main/webapp/app/exercise/result/result.component.spec.ts
+++ b/src/main/webapp/app/exercise/result/result.component.spec.ts
@@ -63,6 +63,7 @@ const mockResult: Result = {
 
 const preparedFeedback: FeedbackComponentPreparedParams = {
     exercise: mockExercise,
+    participation: mockParticipation,
     result: mockResult,
     exerciseType: ExerciseType.PROGRAMMING,
     showScoreChart: true,

--- a/src/main/webapp/app/exercise/result/result.component.ts
+++ b/src/main/webapp/app/exercise/result/result.component.ts
@@ -320,6 +320,7 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
 
         modalComponentInstance.exercise = this.exercise;
         modalComponentInstance.result = result;
+        modalComponentInstance.participation = this.participation;
         if (feedbackComponentParameters.exerciseType) {
             modalComponentInstance.exerciseType = feedbackComponentParameters.exerciseType;
         }

--- a/src/main/webapp/app/exercise/result/result.component.ts
+++ b/src/main/webapp/app/exercise/result/result.component.ts
@@ -162,7 +162,7 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
 
         this.translateService.onLangChange.subscribe(() => {
             if (this.resultString) {
-                this.resultString = this.resultService.getResultString(this.result, this.exercise, this.short);
+                this.resultString = this.resultService.getResultString(this.result, this.exercise, this.participation, this.short);
             }
         });
 
@@ -221,14 +221,14 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
         if (this.templateStatus === ResultTemplateStatus.LATE) {
             this.textColorClass = getTextColorClass(this.result, this.templateStatus);
             this.resultIconClass = getResultIconClass(this.result, this.templateStatus);
-            this.resultString = this.resultService.getResultString(this.result, this.exercise, this.short);
+            this.resultString = this.resultService.getResultString(this.result, this.exercise, this.participation, this.short);
         } else if (
             this.result &&
             ((this.result.score !== undefined && (this.result.rated || this.result.rated == undefined || this.showUngradedResults)) || isAthenaAIResult(this.result))
         ) {
             this.textColorClass = getTextColorClass(this.result, this.templateStatus);
             this.resultIconClass = getResultIconClass(this.result, this.templateStatus);
-            this.resultString = this.resultService.getResultString(this.result, this.exercise, this.short);
+            this.resultString = this.resultService.getResultString(this.result, this.exercise, this.participation, this.short);
             this.resultTooltip = this.buildResultTooltip();
         } else if (this.templateStatus !== ResultTemplateStatus.MISSING) {
             // make sure that we do not display results that are 'rated=false' or that do not have a score

--- a/src/main/webapp/app/exercise/result/result.component.ts
+++ b/src/main/webapp/app/exercise/result/result.component.ts
@@ -219,15 +219,15 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
     evaluate() {
         this.templateStatus = evaluateTemplateStatus(this.exercise, this.participation, this.result, this.isBuilding, this.missingResultInfo, this.isQueued);
         if (this.templateStatus === ResultTemplateStatus.LATE) {
-            this.textColorClass = getTextColorClass(this.result, this.templateStatus);
-            this.resultIconClass = getResultIconClass(this.result, this.templateStatus);
+            this.textColorClass = getTextColorClass(this.result, this.participation, this.templateStatus);
+            this.resultIconClass = getResultIconClass(this.result, this.participation, this.templateStatus);
             this.resultString = this.resultService.getResultString(this.result, this.exercise, this.participation, this.short);
         } else if (
             this.result &&
             ((this.result.score !== undefined && (this.result.rated || this.result.rated == undefined || this.showUngradedResults)) || isAthenaAIResult(this.result))
         ) {
-            this.textColorClass = getTextColorClass(this.result, this.templateStatus);
-            this.resultIconClass = getResultIconClass(this.result, this.templateStatus);
+            this.textColorClass = getTextColorClass(this.result, this.participation, this.templateStatus);
+            this.resultIconClass = getResultIconClass(this.result, this.participation, this.templateStatus);
             this.resultString = this.resultService.getResultString(this.result, this.exercise, this.participation, this.short);
             this.resultTooltip = this.buildResultTooltip();
         } else if (this.templateStatus !== ResultTemplateStatus.MISSING) {
@@ -272,7 +272,7 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
             this.participation &&
             isProgrammingExerciseStudentParticipation(this.participation) &&
             !isPracticeMode(this.participation) &&
-            isResultPreliminary(this.result!, programmingExercise)
+            isResultPreliminary(this.result!, this.participation, programmingExercise)
         ) {
             if (programmingExercise?.assessmentType !== AssessmentType.AUTOMATIC) {
                 return 'artemisApp.result.preliminaryTooltipSemiAutomatic';

--- a/src/main/webapp/app/exercise/result/result.component.ts
+++ b/src/main/webapp/app/exercise/result/result.component.ts
@@ -320,7 +320,6 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
 
         modalComponentInstance.exercise = this.exercise;
         modalComponentInstance.result = result;
-        modalComponentInstance.participation = this.participation;
         if (feedbackComponentParameters.exerciseType) {
             modalComponentInstance.exerciseType = feedbackComponentParameters.exerciseType;
         }

--- a/src/main/webapp/app/exercise/result/result.service.spec.ts
+++ b/src/main/webapp/app/exercise/result/result.service.spec.ts
@@ -58,6 +58,7 @@ describe('ResultService', () => {
     const participation2: StudentParticipation = { type: ParticipationType.STUDENT, exercise: programmingExercise };
     const submission1: ProgrammingSubmission = { buildFailed: true, participation: participation1 };
     const submission2: ProgrammingSubmission = { buildFailed: false, participation: participation2 };
+    const participation3: StudentParticipation = { type: ParticipationType.STUDENT, exercise: programmingExercise, submissions: [submission1] };
     const result1: Result = { id: 1, completionDate: dayjs().add(1, 'hours'), submission: submission1, score: 0 };
     const result2: Result = { id: 2, submission: submission2, completionDate: dayjs().add(2, 'hours'), score: 20 };
     const result3: Result = {
@@ -222,20 +223,20 @@ describe('ResultService', () => {
         });
 
         it('should return correct string for non programming exercise long format', () => {
-            expect(resultService.getResultString(modelingResult, modelingExercise)).toBe('artemisApp.result.resultString.nonProgramming');
+            expect(resultService.getResultString(modelingResult, modelingExercise, modelingParticipation)).toBe('artemisApp.result.resultString.nonProgramming');
             expect(translateServiceSpy).toHaveBeenCalledOnce();
             expect(translateServiceSpy).toHaveBeenCalledWith('artemisApp.result.resultString.nonProgramming', { relativeScore: 42, points: 21 });
         });
 
         it('should return correct string for non programming exercise short format', () => {
-            expect(resultService.getResultString(modelingResult, modelingExercise, true)).toBe('artemisApp.result.resultString.short');
+            expect(resultService.getResultString(modelingResult, modelingExercise, modelingParticipation, true)).toBe('artemisApp.result.resultString.short');
             expect(translateServiceSpy).toHaveBeenCalledOnce();
             expect(translateServiceSpy).toHaveBeenCalledWith('artemisApp.result.resultString.short', { relativeScore: 42 });
         });
 
         it.each([true, false])('should return correct string for programming exercise with build failure', (short: boolean) => {
             const expectedProgrammingString = short ? 'artemisApp.result.resultString.programmingShort' : 'artemisApp.result.resultString.programming';
-            expect(resultService.getResultString(result1, programmingExercise, short)).toBe(expectedProgrammingString);
+            expect(resultService.getResultString(result1, programmingExercise, participation3, short)).toBe(expectedProgrammingString);
             expect(translateServiceSpy).toHaveBeenCalledTimes(2);
             expect(translateServiceSpy).toHaveBeenCalledWith('artemisApp.result.resultString.buildFailed');
             if (short) {
@@ -254,7 +255,7 @@ describe('ResultService', () => {
 
         it.each([true, false])('should return correct string for programming exercise with no tests', (short: boolean) => {
             const expectedProgrammingString = short ? 'artemisApp.result.resultString.programmingShort' : 'artemisApp.result.resultString.programming';
-            expect(resultService.getResultString(result2, programmingExercise, short)).toBe(expectedProgrammingString);
+            expect(resultService.getResultString(result2, programmingExercise, participation2, short)).toBe(expectedProgrammingString);
             expect(translateServiceSpy).toHaveBeenCalledTimes(2);
             expect(translateServiceSpy).toHaveBeenCalledWith('artemisApp.result.resultString.buildSuccessfulNoTests');
             if (short) {
@@ -273,7 +274,7 @@ describe('ResultService', () => {
 
         it.each([true, false])('should return correct string for programming exercise with tests', (short: boolean) => {
             const expectedProgrammingString = short ? 'artemisApp.result.resultString.short' : 'artemisApp.result.resultString.programming';
-            expect(resultService.getResultString(result3, programmingExercise, short)).toBe(expectedProgrammingString);
+            expect(resultService.getResultString(result3, programmingExercise, participation1, short)).toBe(expectedProgrammingString);
             expect(translateServiceSpy).toHaveBeenCalledTimes(2);
             expect(translateServiceSpy).toHaveBeenCalledWith('artemisApp.result.resultString.buildSuccessfulTests', { numberOfTestsPassed: 1, numberOfTestsTotal: 2 });
             if (short) {
@@ -290,7 +291,7 @@ describe('ResultService', () => {
         });
 
         it('should return correct string for programming exercise with code issues', () => {
-            expect(resultService.getResultString(result4, programmingExercise)).toBe('artemisApp.result.resultString.programmingCodeIssues');
+            expect(resultService.getResultString(result4, programmingExercise, participation1)).toBe('artemisApp.result.resultString.programmingCodeIssues');
             expect(translateServiceSpy).toHaveBeenCalledTimes(2);
             expect(translateServiceSpy).toHaveBeenCalledWith('artemisApp.result.resultString.buildSuccessfulTests', { numberOfTestsPassed: 1, numberOfTestsTotal: 2 });
             expect(translateServiceSpy).toHaveBeenCalledWith(`artemisApp.result.resultString.programmingCodeIssues`, {
@@ -304,7 +305,7 @@ describe('ResultService', () => {
         it('should return correct string for programming exercise preliminary', () => {
             programmingExercise.assessmentDueDate = dayjs().add(5, 'minutes');
 
-            expect(resultService.getResultString(result5, programmingExercise)).toBe('artemisApp.result.resultString.programming (artemisApp.result.preliminary)');
+            expect(resultService.getResultString(result5, programmingExercise, participation1)).toBe('artemisApp.result.resultString.programming (artemisApp.result.preliminary)');
             expect(translateServiceSpy).toHaveBeenCalledTimes(3);
             expect(translateServiceSpy).toHaveBeenCalledWith('artemisApp.result.resultString.buildSuccessfulNoTests');
             expect(translateServiceSpy).toHaveBeenCalledWith(`artemisApp.result.resultString.programming`, {
@@ -318,7 +319,7 @@ describe('ResultService', () => {
         it('should return correct string for Athena non graded successful feedback', () => {
             programmingExercise.assessmentDueDate = dayjs().subtract(5, 'minutes');
 
-            expect(resultService.getResultString(result6, programmingExercise)).toBe(
+            expect(resultService.getResultString(result6, programmingExercise, participation1)).toBe(
                 'artemisApp.result.resultString.automaticAIFeedbackSuccessful (artemisApp.result.preliminary)',
             );
             expect(translateServiceSpy).toHaveBeenCalledTimes(2);
@@ -327,14 +328,14 @@ describe('ResultService', () => {
         it('should return correct string for Athena non graded unsuccessful feedback', () => {
             programmingExercise.assessmentDueDate = dayjs().subtract(5, 'minutes');
 
-            expect(resultService.getResultString(result7, programmingExercise)).toBe('artemisApp.result.resultString.automaticAIFeedbackFailed');
+            expect(resultService.getResultString(result7, programmingExercise, participation1)).toBe('artemisApp.result.resultString.automaticAIFeedbackFailed');
             expect(translateServiceSpy).toHaveBeenCalledOnce();
         });
 
         it('should return correct string for Athena timed out non graded feedback', () => {
             programmingExercise.assessmentDueDate = dayjs().add(5, 'minutes');
 
-            expect(resultService.getResultString(result8, programmingExercise)).toBe('artemisApp.result.resultString.automaticAIFeedbackTimedOut');
+            expect(resultService.getResultString(result8, programmingExercise, participation1)).toBe('artemisApp.result.resultString.automaticAIFeedbackTimedOut');
             expect(translateServiceSpy).toHaveBeenCalledOnce();
             expect(translateServiceSpy).toHaveBeenCalledWith('artemisApp.result.resultString.automaticAIFeedbackTimedOut');
         });
@@ -342,7 +343,7 @@ describe('ResultService', () => {
         it('should return correct string for in progress Athena non-graded feedback', () => {
             programmingExercise.assessmentDueDate = dayjs().add(5, 'minutes');
 
-            expect(resultService.getResultString(result9, programmingExercise)).toBe('artemisApp.result.resultString.automaticAIFeedbackInProgress');
+            expect(resultService.getResultString(result9, programmingExercise, participation1)).toBe('artemisApp.result.resultString.automaticAIFeedbackInProgress');
             expect(translateServiceSpy).toHaveBeenCalledOnce();
             expect(translateServiceSpy).toHaveBeenCalledWith('artemisApp.result.resultString.automaticAIFeedbackInProgress');
         });

--- a/src/main/webapp/app/exercise/result/result.service.spec.ts
+++ b/src/main/webapp/app/exercise/result/result.service.spec.ts
@@ -352,7 +352,7 @@ describe('ResultService', () => {
             // Re-mock to get reference because direct import doesn't work here
             const captureExceptionSpy = jest.spyOn(Sentry, 'captureException');
             captureExceptionSpy.mockClear();
-            expect(resultService.getResultString(undefined, undefined)).toBe('');
+            expect(resultService.getResultString(undefined, undefined, undefined)).toBe('');
             expect(captureExceptionSpy).toHaveBeenCalledOnce();
             expect(captureExceptionSpy).toHaveBeenCalledWith('Tried to generate a result string, but either the result or exercise was undefined');
         });

--- a/src/main/webapp/app/exercise/result/result.service.ts
+++ b/src/main/webapp/app/exercise/result/result.service.ts
@@ -72,11 +72,12 @@ export class ResultService implements IResultService {
      * If either of the arguments is undefined the error is forwarded to sentry and an empty string is returned
      * @param result the result containing all necessary information like the achieved points
      * @param exercise the exercise where the result belongs to
+     * @param participation the participation of the exercise and result
      * @param short flag that indicates if the resultString should use the short format
      */
-    getResultString(result: Result | undefined, exercise: Exercise | undefined, short?: boolean): string {
-        if (result && exercise) {
-            return this.getResultStringDefinedParameters(result, exercise, short);
+    getResultString(result: Result | undefined, exercise: Exercise | undefined, participation: Participation | undefined, short?: boolean): string {
+        if (result && exercise && participation) {
+            return this.getResultStringDefinedParameters(result, exercise, participation, short);
         } else {
             captureException('Tried to generate a result string, but either the result or exercise was undefined');
             return '';
@@ -88,9 +89,10 @@ export class ResultService implements IResultService {
      * Contains the score, achieved points and if it's a programming exercise the tests and code issues as well
      * @param result the result containing all necessary information like the achieved points
      * @param exercise the exercise where the result belongs to
+     * @param participation the participation of the exercise and result
      * @param short flag that indicates if the resultString should use the short format
      */
-    private getResultStringDefinedParameters(result: Result, exercise: Exercise, short: boolean | undefined): string {
+    private getResultStringDefinedParameters(result: Result, exercise: Exercise, participation: Participation, short: boolean | undefined): string {
         const relativeScore = roundValueSpecifiedByCourseSettings(result.score!, getCourseFromExercise(exercise));
         const points = roundValueSpecifiedByCourseSettings((result.score! * exercise.maxPoints!) / 100, getCourseFromExercise(exercise));
         if (exercise.type !== ExerciseType.PROGRAMMING) {
@@ -99,7 +101,7 @@ export class ResultService implements IResultService {
             }
             return this.getResultStringNonProgrammingExercise(relativeScore, points, short);
         } else {
-            return this.getResultStringProgrammingExercise(result, exercise as ProgrammingExercise, relativeScore, points, short);
+            return this.getResultStringProgrammingExercise(result, exercise as ProgrammingExercise, participation, relativeScore, points, short);
         }
     }
 
@@ -146,11 +148,19 @@ export class ResultService implements IResultService {
      * If the result is a build failure or no tests were executed, the string replaces some parts with a helpful explanation
      * @param result the result containing all necessary information like the achieved points
      * @param exercise the exercise where the result belongs to
+     * @param participation the participation of the exercise and result
      * @param relativeScore the achieved score in percent
      * @param points the amount of achieved points
      * @param short flag that indicates if the resultString should use the short format
      */
-    private getResultStringProgrammingExercise(result: Result, exercise: ProgrammingExercise, relativeScore: number, points: number, short: boolean | undefined): string {
+    private getResultStringProgrammingExercise(
+        result: Result,
+        exercise: ProgrammingExercise,
+        participation: Participation,
+        relativeScore: number,
+        points: number,
+        short: boolean | undefined,
+    ): string {
         let buildAndTestMessage: string;
         if (isAIResultAndFailed(result)) {
             buildAndTestMessage = this.translateService.instant('artemisApp.result.resultString.automaticAIFeedbackFailed');
@@ -160,7 +170,7 @@ export class ResultService implements IResultService {
             buildAndTestMessage = this.translateService.instant('artemisApp.result.resultString.automaticAIFeedbackTimedOut');
         } else if (isAIResultAndProcessed(result)) {
             buildAndTestMessage = this.translateService.instant('artemisApp.result.resultString.automaticAIFeedbackSuccessful');
-        } else if (result.submission && (result.submission as ProgrammingSubmission).buildFailed) {
+        } else if ((participation?.submissions?.[0] as ProgrammingSubmission)?.buildFailed) {
             buildAndTestMessage = this.translateService.instant('artemisApp.result.resultString.buildFailed');
         } else if (!result.testCaseCount) {
             buildAndTestMessage = this.translateService.instant('artemisApp.result.resultString.buildSuccessfulNoTests');

--- a/src/main/webapp/app/exercise/result/result.service.ts
+++ b/src/main/webapp/app/exercise/result/result.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import dayjs from 'dayjs/esm';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { ResultWithPointsPerGradingCriterion } from 'app/exercise/shared/entities/result/result-with-points-per-grading-criterion.model';
@@ -230,7 +230,10 @@ export class ResultService implements IResultService {
             .pipe(map((res: ResultsWithPointsArrayResponseType) => this.convertResultsWithPointsResponse(res)));
     }
 
-    getFeedbackDetailsForResult(participationId: number, result: Result): Observable<HttpResponse<Feedback[]>> {
+    getFeedbackDetailsForResult(participationId: number | undefined, result: Result): Observable<HttpResponse<Feedback[]>> {
+        if (!participationId || !result.id) {
+            return of(new HttpResponse<Feedback[]>({ body: [] }));
+        }
         return this.http.get<Feedback[]>(`${this.participationResourceUrl}/${participationId}/results/${result.id!}/details`, { observe: 'response' }).pipe(
             map((res) => {
                 const feedbacks = res.body ?? [];

--- a/src/main/webapp/app/exercise/result/result.service.ts
+++ b/src/main/webapp/app/exercise/result/result.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import dayjs from 'dayjs/esm';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { ResultWithPointsPerGradingCriterion } from 'app/exercise/shared/entities/result/result-with-points-per-grading-criterion.model';
@@ -230,10 +230,7 @@ export class ResultService implements IResultService {
             .pipe(map((res: ResultsWithPointsArrayResponseType) => this.convertResultsWithPointsResponse(res)));
     }
 
-    getFeedbackDetailsForResult(participationId: number | undefined, result: Result): Observable<HttpResponse<Feedback[]>> {
-        if (!participationId || !result.id) {
-            return of(new HttpResponse<Feedback[]>({ body: [] }));
-        }
+    getFeedbackDetailsForResult(participationId: number, result: Result): Observable<HttpResponse<Feedback[]>> {
         return this.http.get<Feedback[]>(`${this.participationResourceUrl}/${participationId}/results/${result.id!}/details`, { observe: 'response' }).pipe(
             map((res) => {
                 const feedbacks = res.body ?? [];

--- a/src/main/webapp/app/exercise/result/result.service.ts
+++ b/src/main/webapp/app/exercise/result/result.service.ts
@@ -161,6 +161,7 @@ export class ResultService implements IResultService {
         points: number,
         short: boolean | undefined,
     ): string {
+        const latestSubmission = (result.submission ?? participation.submissions?.[0]) as ProgrammingSubmission;
         let buildAndTestMessage: string;
         if (isAIResultAndFailed(result)) {
             buildAndTestMessage = this.translateService.instant('artemisApp.result.resultString.automaticAIFeedbackFailed');
@@ -170,7 +171,7 @@ export class ResultService implements IResultService {
             buildAndTestMessage = this.translateService.instant('artemisApp.result.resultString.automaticAIFeedbackTimedOut');
         } else if (isAIResultAndProcessed(result)) {
             buildAndTestMessage = this.translateService.instant('artemisApp.result.resultString.automaticAIFeedbackSuccessful');
-        } else if ((participation?.submissions?.[0] as ProgrammingSubmission)?.buildFailed) {
+        } else if (latestSubmission?.buildFailed) {
             buildAndTestMessage = this.translateService.instant('artemisApp.result.resultString.buildFailed');
         } else if (!result.testCaseCount) {
             buildAndTestMessage = this.translateService.instant('artemisApp.result.resultString.buildSuccessfulNoTests');

--- a/src/main/webapp/app/exercise/result/result.service.ts
+++ b/src/main/webapp/app/exercise/result/result.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import dayjs from 'dayjs/esm';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { ResultWithPointsPerGradingCriterion } from 'app/exercise/shared/entities/result/result-with-points-per-grading-criterion.model';
@@ -184,7 +184,7 @@ export class ResultService implements IResultService {
 
         let resultString = this.getBaseResultStringProgrammingExercise(result, relativeScore, points, buildAndTestMessage, short);
 
-        if (isStudentParticipation(result) && isResultPreliminary(result, exercise)) {
+        if (isStudentParticipation(result) && isResultPreliminary(result, participation, exercise)) {
             resultString += ' (' + this.translateService.instant('artemisApp.result.preliminary') + ')';
         }
 
@@ -241,9 +241,6 @@ export class ResultService implements IResultService {
     }
 
     getFeedbackDetailsForResult(participationId: number | undefined, result: Result): Observable<HttpResponse<Feedback[]>> {
-        if (!participationId || !result.id) {
-            return of(new HttpResponse<Feedback[]>({ body: [] }));
-        }
         return this.http.get<Feedback[]>(`${this.participationResourceUrl}/${participationId}/results/${result.id!}/details`, { observe: 'response' }).pipe(
             map((res) => {
                 const feedbacks = res.body ?? [];

--- a/src/main/webapp/app/exercise/result/result.utils.spec.ts
+++ b/src/main/webapp/app/exercise/result/result.utils.spec.ts
@@ -14,7 +14,7 @@ import { Participation, ParticipationType } from 'app/exercise/shared/entities/p
 import { MIN_SCORE_GREEN, MIN_SCORE_ORANGE } from 'app/app.constants';
 import { faCheckCircle, faQuestionCircle, faTimesCircle } from '@fortawesome/free-regular-svg-icons';
 import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
-import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import dayjs from 'dayjs/esm';
 
@@ -77,11 +77,11 @@ describe('ResultUtils', () => {
     });
 
     it.each([
-        { result: undefined, participation: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-secondary' },
+        { result: undefined, participation: {} as Participation, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-secondary' },
         { result: {}, participation: {}, templateStatus: ResultTemplateStatus.LATE, expected: 'result-late' },
         {
             result: { submission: { submissionExerciseType: SubmissionExerciseType.PROGRAMMING, buildFailed: true }, assessmentType: AssessmentType.AUTOMATIC },
-            participation: {},
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: 'text-danger',
         },
@@ -89,35 +89,35 @@ describe('ResultUtils', () => {
             result: {
                 assessmentType: AssessmentType.AUTOMATIC,
             },
-            participation: { type: ParticipationType.PROGRAMMING, exercise: { type: ExerciseType.PROGRAMMING } },
+            participation: { type: ParticipationType.PROGRAMMING, exercise: { type: ExerciseType.PROGRAMMING } } as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: 'text-secondary',
         },
         {
             result: { score: undefined, successful: true },
-            participation: {},
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: 'text-success',
         },
         {
             result: { score: 0, successful: undefined, assessmentType: AssessmentType.AUTOMATIC_ATHENA },
-            participation: {},
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.IS_GENERATING_FEEDBACK,
             expected: 'text-secondary',
         },
         {
             result: { score: 0, successful: true, assessmentType: AssessmentType.AUTOMATIC_ATHENA },
-            participation: {},
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: 'text-secondary',
         },
-        { result: { score: undefined, successful: false }, participation: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-danger' },
-        { result: { score: MIN_SCORE_GREEN, testCaseCount: 1 }, participation: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-success' },
-        { result: { score: MIN_SCORE_ORANGE, testCaseCount: 1 }, participation: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'result-orange' },
-        { result: {}, participation: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-danger' },
+        { result: { score: undefined, successful: false }, participation: {} as Participation, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-danger' },
+        { result: { score: MIN_SCORE_GREEN, testCaseCount: 1 }, participation: {} as Participation, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-success' },
+        { result: { score: MIN_SCORE_ORANGE, testCaseCount: 1 }, participation: {} as Participation, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'result-orange' },
+        { result: {}, participation: {} as Participation, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-danger' },
         {
             result: { score: 1 } as Result,
-            participation: { exercise: { type: ExerciseType.PROGRAMMING, submissions: [{ id: 1 }] } } as Participation,
+            participation: { exercise: { type: ExerciseType.PROGRAMMING } as Exercise, submissions: [{ id: 1 }] } as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: 'text-success',
         },
@@ -126,41 +126,52 @@ describe('ResultUtils', () => {
     });
 
     it.each([
-        { participation: { exercise: { type: ExerciseType.PROGRAMMING } }, result: {} as Result, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: faCheckCircle },
-        { result: undefined, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: faQuestionCircle },
+        {
+            result: {} as Result,
+            participation: { exercise: { type: ExerciseType.PROGRAMMING } as Exercise } as Participation,
+            templateStatus: ResultTemplateStatus.HAS_RESULT,
+            expected: faCheckCircle,
+        },
+        { result: undefined, participation: {} as Participation, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: faQuestionCircle },
         {
             result: { submission: { submissionExerciseType: SubmissionExerciseType.PROGRAMMING, buildFailed: true }, assessmentType: AssessmentType.AUTOMATIC },
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faTimesCircle,
         },
         {
-            participation: { type: ParticipationType.PROGRAMMING, exercise: { type: ExerciseType.PROGRAMMING } },
             result: {} as Result,
+            participation: { type: ParticipationType.PROGRAMMING, exercise: { type: ExerciseType.PROGRAMMING } as Exercise } as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faQuestionCircle,
         },
         {
             result: { score: undefined, successful: true, feedbacks: [{ type: FeedbackType.AUTOMATIC, text: 'This is a test case' }], testCaseCount: 1 },
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faCheckCircle,
         },
         {
             result: { score: undefined, successful: false, feedbacks: [{ type: FeedbackType.AUTOMATIC, text: 'This is a test case' }], testCaseCount: 1 },
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faTimesCircle,
         },
         {
             result: { score: MIN_SCORE_GREEN, feedbacks: [{ type: FeedbackType.AUTOMATIC, text: 'This is a test case' }], testCaseCount: 1 },
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faCheckCircle,
         },
         {
             result: { score: MIN_SCORE_ORANGE, feedbacks: [{ type: FeedbackType.AUTOMATIC, text: 'This is a test case' }], testCaseCount: 1 },
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faTimesCircle,
         },
         {
             result: { feedbacks: [{ type: FeedbackType.AUTOMATIC, text: 'This is a test case' }], testCaseCount: 1 },
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faTimesCircle,
         },
@@ -171,6 +182,7 @@ describe('ResultUtils', () => {
                 successful: undefined,
                 completionDate: dayjs().add(5, 'minutes'),
             },
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.IS_GENERATING_FEEDBACK,
             expected: faCircleNotch,
         },
@@ -182,6 +194,7 @@ describe('ResultUtils', () => {
                 assessmentType: AssessmentType.AUTOMATIC_ATHENA,
                 completionDate: dayjs().subtract(5, 'minutes'),
             } as Result,
+            participation: {} as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faCheckCircle,
         },
@@ -191,11 +204,11 @@ describe('ResultUtils', () => {
             },
             participation: {
                 type: ParticipationType.STUDENT,
-                exercise: { type: ExerciseType.TEXT },
+                exercise: { type: ExerciseType.TEXT } as Exercise,
                 successful: false,
                 assessmentType: AssessmentType.AUTOMATIC_ATHENA,
                 completionDate: dayjs().subtract(5, 'minutes'),
-            } as Result,
+            } as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faTimesCircle,
         },

--- a/src/main/webapp/app/exercise/result/result.utils.spec.ts
+++ b/src/main/webapp/app/exercise/result/result.utils.spec.ts
@@ -47,81 +47,86 @@ describe('ResultUtils', () => {
     it.each([
         {
             result: {
-                submission: {
-                    participation: { exercise: { type: ExerciseType.PROGRAMMING } },
-                },
-
                 feedbacks: [{ type: FeedbackType.AUTOMATIC, text: STATIC_CODE_ANALYSIS_FEEDBACK_IDENTIFIER }, { type: FeedbackType.MANUAL }],
                 testCaseCount: 0,
             } as Result,
+            participation: { exercise: { type: ExerciseType.PROGRAMMING } } as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: true,
         },
         {
             result: { feedbacks: [{ type: FeedbackType.AUTOMATIC, text: 'This is a test case' }, { type: FeedbackType.MANUAL }], testCaseCount: 1 },
+            participation: { exercise: { type: ExerciseType.PROGRAMMING } } as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: false,
         },
         {
             result: { feedbacks: [{ type: FeedbackType.AUTOMATIC, text: STATIC_CODE_ANALYSIS_FEEDBACK_IDENTIFIER }, { type: FeedbackType.MANUAL }], testCaseCount: 0 },
+            participation: { exercise: { type: ExerciseType.PROGRAMMING } } as Participation,
             templateStatus: ResultTemplateStatus.NO_RESULT,
             expected: false,
         },
         {
             result: { feedbacks: [{ type: FeedbackType.AUTOMATIC, text: STATIC_CODE_ANALYSIS_FEEDBACK_IDENTIFIER }, { type: FeedbackType.MANUAL }], testCaseCount: 0 },
+            participation: { exercise: { type: ExerciseType.PROGRAMMING } } as Participation,
             templateStatus: ResultTemplateStatus.IS_BUILDING,
             expected: false,
         },
-    ])('should correctly determine if compilation is tested', ({ result, templateStatus, expected }) => {
-        expect(isOnlyCompilationTested(result, templateStatus!)).toBe(expected);
+    ])('should correctly determine if compilation is tested', ({ result, participation, templateStatus, expected }) => {
+        expect(isOnlyCompilationTested(result, participation, templateStatus!)).toBe(expected);
     });
 
     it.each([
-        { result: undefined, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-secondary' },
-        { result: {}, templateStatus: ResultTemplateStatus.LATE, expected: 'result-late' },
+        { result: undefined, participation: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-secondary' },
+        { result: {}, participation: {}, templateStatus: ResultTemplateStatus.LATE, expected: 'result-late' },
         {
             result: { submission: { submissionExerciseType: SubmissionExerciseType.PROGRAMMING, buildFailed: true }, assessmentType: AssessmentType.AUTOMATIC },
+            participation: {},
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: 'text-danger',
         },
         {
             result: {
-                submission: { participation: { type: ParticipationType.PROGRAMMING, exercise: { type: ExerciseType.PROGRAMMING } } } as Result,
                 assessmentType: AssessmentType.AUTOMATIC,
             },
+            participation: { type: ParticipationType.PROGRAMMING, exercise: { type: ExerciseType.PROGRAMMING } },
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: 'text-secondary',
         },
-        { result: { score: undefined, successful: true }, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-success' },
+        {
+            result: { score: undefined, successful: true },
+            participation: {},
+            templateStatus: ResultTemplateStatus.HAS_RESULT,
+            expected: 'text-success',
+        },
         {
             result: { score: 0, successful: undefined, assessmentType: AssessmentType.AUTOMATIC_ATHENA },
+            participation: {},
             templateStatus: ResultTemplateStatus.IS_GENERATING_FEEDBACK,
             expected: 'text-secondary',
         },
         {
             result: { score: 0, successful: true, assessmentType: AssessmentType.AUTOMATIC_ATHENA },
+            participation: {},
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: 'text-secondary',
         },
-        { result: { score: undefined, successful: false }, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-danger' },
-        { result: { score: MIN_SCORE_GREEN, testCaseCount: 1 }, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-success' },
-        { result: { score: MIN_SCORE_ORANGE, testCaseCount: 1 }, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'result-orange' },
-        { result: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-danger' },
+        { result: { score: undefined, successful: false }, participation: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-danger' },
+        { result: { score: MIN_SCORE_GREEN, testCaseCount: 1 }, participation: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-success' },
+        { result: { score: MIN_SCORE_ORANGE, testCaseCount: 1 }, participation: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'result-orange' },
+        { result: {}, participation: {}, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: 'text-danger' },
         {
-            result: { score: 1, submission: { participation: { exercise: { type: ExerciseType.PROGRAMMING } } } } as Result,
+            result: { score: 1 } as Result,
+            participation: { exercise: { type: ExerciseType.PROGRAMMING, submissions: [{ id: 1 }] } } as Participation,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: 'text-success',
         },
-    ])('should correctly determine text color class', ({ result, templateStatus, expected }) => {
-        expect(getTextColorClass(result, templateStatus!)).toBe(expected);
+    ])('should correctly determine text color class', ({ result, participation, templateStatus, expected }) => {
+        expect(getTextColorClass(result, participation, templateStatus!)).toBe(expected);
     });
 
     it.each([
-        {
-            result: { submission: { participation: { exercise: { type: ExerciseType.PROGRAMMING } } } } as Result,
-            templateStatus: ResultTemplateStatus.HAS_RESULT,
-            expected: faCheckCircle,
-        },
+        { participation: { exercise: { type: ExerciseType.PROGRAMMING } }, result: {} as Result, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: faCheckCircle },
         { result: undefined, templateStatus: ResultTemplateStatus.HAS_RESULT, expected: faQuestionCircle },
         {
             result: { submission: { submissionExerciseType: SubmissionExerciseType.PROGRAMMING, buildFailed: true }, assessmentType: AssessmentType.AUTOMATIC },
@@ -129,7 +134,8 @@ describe('ResultUtils', () => {
             expected: faTimesCircle,
         },
         {
-            result: { submission: { participation: { type: ParticipationType.PROGRAMMING, exercise: { type: ExerciseType.PROGRAMMING } } } } as Result,
+            participation: { type: ParticipationType.PROGRAMMING, exercise: { type: ExerciseType.PROGRAMMING } },
+            result: {} as Result,
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faQuestionCircle,
         },
@@ -182,7 +188,10 @@ describe('ResultUtils', () => {
         {
             result: {
                 feedbacks: [{ type: FeedbackType.AUTOMATIC, text: 'AI result failed to generate' }],
-                participation: { type: ParticipationType.STUDENT, exercise: { type: ExerciseType.TEXT } },
+            },
+            participation: {
+                type: ParticipationType.STUDENT,
+                exercise: { type: ExerciseType.TEXT },
                 successful: false,
                 assessmentType: AssessmentType.AUTOMATIC_ATHENA,
                 completionDate: dayjs().subtract(5, 'minutes'),
@@ -190,8 +199,8 @@ describe('ResultUtils', () => {
             templateStatus: ResultTemplateStatus.HAS_RESULT,
             expected: faTimesCircle,
         },
-    ])('should correctly determine result icon', ({ result, templateStatus, expected }) => {
-        expect(getResultIconClass(result, templateStatus!)).toBe(expected);
+    ])('should correctly determine result icon', ({ result, participation, templateStatus, expected }) => {
+        expect(getResultIconClass(result, participation, templateStatus!)).toBe(expected);
     });
 
     describe('circular reference breaker', () => {

--- a/src/main/webapp/app/exercise/result/result.utils.ts
+++ b/src/main/webapp/app/exercise/result/result.utils.ts
@@ -394,7 +394,8 @@ export const isStudentParticipation = (participation: Participation) => {
  * @param participation
  */
 export const isBuildFailedAndResultIsAutomatic = (result: Result, participation: Participation) => {
-    return isBuildFailed(participation?.submissions?.[0]) && !isManualResult(result);
+    const latestSubmission = result?.submission ?? participation?.submissions?.[0];
+    return isBuildFailed(latestSubmission) && !isManualResult(result);
 };
 
 /**

--- a/src/main/webapp/app/exercise/result/result.utils.ts
+++ b/src/main/webapp/app/exercise/result/result.utils.ts
@@ -257,13 +257,13 @@ export const evaluateTemplateStatus = (
  * Checks if only compilation was tested. This is the case, when a successful result is present with 0 of 0 passed tests
  * This could be because all test cases are only visible after the due date.
  */
-export const isOnlyCompilationTested = (result: Result | undefined, templateStatus: ResultTemplateStatus): boolean => {
+export const isOnlyCompilationTested = (result: Result | undefined, participation: Participation, templateStatus: ResultTemplateStatus): boolean => {
     const zeroTests = !result?.testCaseCount;
-    const isProgrammingExercise: boolean = result?.submission?.participation?.exercise?.type === ExerciseType.PROGRAMMING;
+    const isProgrammingExercise: boolean = participation?.exercise?.type === ExerciseType.PROGRAMMING;
     return (
         templateStatus !== ResultTemplateStatus.NO_RESULT &&
         templateStatus !== ResultTemplateStatus.IS_BUILDING &&
-        !isBuildFailed(result?.submission) &&
+        !isBuildFailed(participation?.submissions?.[0]) &&
         zeroTests &&
         isProgrammingExercise
     );
@@ -274,7 +274,7 @@ export const isOnlyCompilationTested = (result: Result | undefined, templateStat
  *
  * @return {string} the css class
  */
-export const getTextColorClass = (result: Result | undefined, templateStatus: ResultTemplateStatus) => {
+export const getTextColorClass = (result: Result | undefined, participation: Participation, templateStatus: ResultTemplateStatus) => {
     if (!result) {
         return 'text-secondary';
     }
@@ -293,11 +293,11 @@ export const getTextColorClass = (result: Result | undefined, templateStatus: Re
         return 'result-late';
     }
 
-    if (isBuildFailedAndResultIsAutomatic(result)) {
+    if (isBuildFailedAndResultIsAutomatic(result, participation)) {
         return 'text-danger';
     }
 
-    if (resultIsPreliminary(result)) {
+    if (resultIsPreliminary(result, participation)) {
         return 'text-secondary';
     }
 
@@ -305,7 +305,7 @@ export const getTextColorClass = (result: Result | undefined, templateStatus: Re
         return result?.successful ? 'text-success' : 'text-danger';
     }
 
-    if (isOnlyCompilationTested(result, templateStatus)) {
+    if (isOnlyCompilationTested(result, participation, templateStatus)) {
         return 'text-success';
     }
 
@@ -324,7 +324,7 @@ export const getTextColorClass = (result: Result | undefined, templateStatus: Re
  * Get the icon type for the result icon as an array
  *
  */
-export const getResultIconClass = (result: Result | undefined, templateStatus: ResultTemplateStatus): IconProp => {
+export const getResultIconClass = (result: Result | undefined, participation: Participation, templateStatus: ResultTemplateStatus): IconProp => {
     if (!result) {
         return faQuestionCircle;
     }
@@ -342,7 +342,7 @@ export const getResultIconClass = (result: Result | undefined, templateStatus: R
         return faTimesCircle;
     }
 
-    if (isBuildFailedAndResultIsAutomatic(result) || isAIResultAndFailed(result)) {
+    if (isBuildFailedAndResultIsAutomatic(result, participation) || isAIResultAndFailed(result)) {
         return faTimesCircle;
     }
 
@@ -350,11 +350,11 @@ export const getResultIconClass = (result: Result | undefined, templateStatus: R
         return faCircleNotch;
     }
 
-    if (resultIsPreliminary(result) || isAIResultAndTimedOut(result)) {
+    if (resultIsPreliminary(result, participation) || isAIResultAndTimedOut(result)) {
         return faQuestionCircle;
     }
 
-    if (isOnlyCompilationTested(result, templateStatus)) {
+    if (isOnlyCompilationTested(result, participation, templateStatus)) {
         return faCheckCircle;
     }
 
@@ -369,39 +369,32 @@ export const getResultIconClass = (result: Result | undefined, templateStatus: R
 
 /**
  * Returns true if the specified result is preliminary.
- * @param result the result. It must include a participation and exercise.
+ * @param result the result.
+ * @param participation the participation
  */
-export const resultIsPreliminary = (result: Result) => {
-    const exerciseType = result.submission?.participation?.exercise?.type;
+export const resultIsPreliminary = (result: Result, participation: Participation) => {
+    const exerciseType = participation?.exercise?.type;
     if (exerciseType === ExerciseType.TEXT || exerciseType === ExerciseType.MODELING) {
         return result.assessmentType === AssessmentType.AUTOMATIC_ATHENA;
-    } else
-        return (
-            result.submission?.participation &&
-            isProgrammingExerciseStudentParticipation(result.submission.participation) &&
-            isResultPreliminary(result, result.submission?.participation?.exercise as ProgrammingExercise)
-        );
+    } else return isProgrammingExerciseStudentParticipation(participation) && isResultPreliminary(result, participation, participation?.exercise as ProgrammingExercise);
 };
 
 /**
  * Returns true if the specified result is a student Participation
- * @param result the result.
+ * @param participation the participation
  */
-export const isStudentParticipation = (result: Result) => {
-    return Boolean(
-        result.submission?.participation &&
-            result.submission.participation.type !== ParticipationType.TEMPLATE &&
-            result.submission.participation.type !== ParticipationType.SOLUTION,
-    );
+export const isStudentParticipation = (participation: Participation) => {
+    return Boolean(participation.type !== ParticipationType.TEMPLATE && participation.type !== ParticipationType.SOLUTION);
 };
 
 /**
  * Returns true if the submission of the result is of type programming, is automatic, and
  * its build has failed.
  * @param result
+ * @param participation
  */
-export const isBuildFailedAndResultIsAutomatic = (result: Result) => {
-    return isBuildFailed(result.submission) && !isManualResult(result);
+export const isBuildFailedAndResultIsAutomatic = (result: Result, participation: Participation) => {
+    return isBuildFailed(participation?.submissions?.[0]) && !isManualResult(result);
 };
 
 /**

--- a/src/main/webapp/app/exercise/result/result.utils.ts
+++ b/src/main/webapp/app/exercise/result/result.utils.ts
@@ -12,7 +12,7 @@ import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
 import { isModelingOrTextOrFileUpload, isParticipationInDueTime, isProgrammingOrQuiz } from 'app/exercise/participation/participation.utils';
 import { getExerciseDueDate } from 'app/exercise/util/exercise.utils';
 import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
-import { Participation, ParticipationType } from 'app/exercise/shared/entities/participation/participation.model';
+import { Participation, ParticipationType, getLatestSubmission } from 'app/exercise/shared/entities/participation/participation.model';
 import dayjs from 'dayjs/esm';
 import { ResultWithPointsPerGradingCriterion } from 'app/exercise/shared/entities/result/result-with-points-per-grading-criterion.model';
 import { TestCaseResult } from 'app/programming/shared/entities/test-case-result.model';
@@ -263,7 +263,7 @@ export const isOnlyCompilationTested = (result: Result | undefined, participatio
     return (
         templateStatus !== ResultTemplateStatus.NO_RESULT &&
         templateStatus !== ResultTemplateStatus.IS_BUILDING &&
-        !isBuildFailed(participation?.submissions?.[0]) &&
+        !isBuildFailed(getLatestSubmission(participation)) &&
         zeroTests &&
         isProgrammingExercise
     );
@@ -394,7 +394,7 @@ export const isStudentParticipation = (participation: Participation) => {
  * @param participation
  */
 export const isBuildFailedAndResultIsAutomatic = (result: Result, participation: Participation) => {
-    const latestSubmission = result?.submission ?? participation?.submissions?.[0];
+    const latestSubmission = result?.submission ?? getLatestSubmission(participation);
     return isBuildFailed(latestSubmission) && !isManualResult(result);
 };
 

--- a/src/main/webapp/app/exercise/shared/entities/participation/participation.model.ts
+++ b/src/main/webapp/app/exercise/shared/entities/participation/participation.model.ts
@@ -73,3 +73,13 @@ export const getExercise = (participation: Participation): Exercise | undefined 
         }
     }
 };
+
+export const getLatestSubmission = (participation: Participation): Submission | undefined => {
+    if (participation.submissions && participation.submissions.length === 1) {
+        return participation.submissions[0];
+    } else if (participation.submissions && participation.submissions.length > 1) {
+        participation.submissions.sort((a, b) => (b.id ?? 0) - (a.id ?? 0)); // sort by id descending
+        return participation.submissions[0];
+    }
+    return undefined;
+};

--- a/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.component.html
+++ b/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.component.html
@@ -63,7 +63,12 @@
     @if (isFeedbackView && showResultHistory) {
         <div class="mb-4">
             <div id="result-history" class="row mb-2">
-                <jhi-result-history [results]="sortedResultHistory" [exercise]="modelingExercise" [selectedResultId]="submission.latestResult?.id!" />
+                <jhi-result-history
+                    [results]="sortedResultHistory"
+                    [exercise]="modelingExercise"
+                    [participationInput]="participation"
+                    [selectedResultId]="submission.latestResult?.id!"
+                />
             </div>
         </div>
     }

--- a/src/main/webapp/app/programming/manage/grading/feedback-analysis/modal/feedback-affected-students/feedback-affected-students-modal.component.spec.ts
+++ b/src/main/webapp/app/programming/manage/grading/feedback-analysis/modal/feedback-affected-students/feedback-affected-students-modal.component.spec.ts
@@ -9,8 +9,6 @@ import '@angular/localize/init';
 describe('AffectedStudentsModalComponent', () => {
     let fixture: ComponentFixture<AffectedStudentsModalComponent>;
     let component: AffectedStudentsModalComponent;
-    let feedbackService: FeedbackAnalysisService;
-
     const feedbackDetailMock: FeedbackDetail = {
         feedbackIds: [1, 2, 3, 4, 5],
         count: 5,
@@ -44,8 +42,6 @@ describe('AffectedStudentsModalComponent', () => {
 
         fixture = TestBed.createComponent(AffectedStudentsModalComponent);
         component = fixture.componentInstance;
-        feedbackService = TestBed.inject(FeedbackAnalysisService);
-
         fixture.componentRef.setInput('courseId', 1);
         fixture.componentRef.setInput('exerciseId', 1);
         fixture.componentRef.setInput('feedbackDetail', feedbackDetailMock);
@@ -53,11 +49,11 @@ describe('AffectedStudentsModalComponent', () => {
     });
 
     it('should handle error when loadAffected fails', async () => {
-        jest.spyOn(feedbackService, 'getParticipationForFeedbackDetailText').mockReturnValueOnce(Promise.reject(new Error('Error loading data')));
+        jest.spyOn(component.feedbackService, 'getParticipationForFeedbackDetailText').mockReturnValue(Promise.reject(new Error('Error loading data')));
         const alertServiceSpy = jest.spyOn(component.alertService, 'error');
         jest.spyOn(console, 'error').mockImplementation(() => {});
 
-        // @ts-ignore
+        // @ts-expect-error
         await component.loadAffected();
 
         expect(component.participation()).toEqual([]);

--- a/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.html
+++ b/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.html
@@ -1,6 +1,6 @@
 @if (!isLoading) {
     <div class="instructions__content border-0">
-        <jhi-programming-exercise-instructions-step-wizard [exercise]="exercise" [latestResult]="latestResultValue" [tasks]="tasks" />
+        <jhi-programming-exercise-instructions-step-wizard [exercise]="exercise" [latestResult]="latestResultValue" [participation]="participation" [tasks]="tasks" />
         <!-- problem statement update & difference highlighter -->
         @if (exercise && exercise.exerciseGroup) {
             <jhi-exam-exercise-update-highlighter [exercise]="exercise" (problemStatementUpdateEvent)="renderUpdatedProblemStatement()" />

--- a/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.ts
@@ -395,7 +395,6 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
             environmentInjector: this.injector,
         });
         componentRef.instance.exercise = this.exercise;
-        componentRef.instance.participation = this.participation;
         componentRef.instance.taskName = taskName;
         componentRef.instance.latestResult = this.latestResult;
         componentRef.instance.testIds = testIds;

--- a/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.ts
@@ -395,6 +395,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
             environmentInjector: this.injector,
         });
         componentRef.instance.exercise = this.exercise;
+        componentRef.instance.participation = this.participation;
         componentRef.instance.taskName = taskName;
         componentRef.instance.latestResult = this.latestResult;
         componentRef.instance.testIds = testIds;

--- a/src/main/webapp/app/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.component.ts
@@ -8,6 +8,7 @@ import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { faCheck, faCircle, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 @Component({
     selector: 'jhi-programming-exercise-instructions-step-wizard',
@@ -22,6 +23,7 @@ export class ProgrammingExerciseInstructionStepWizardComponent implements OnChan
     TestCaseState = TestCaseState;
 
     @Input() exercise: Exercise;
+    @Input() participation: Participation;
     @Input() latestResult?: Result;
     @Input() tasks: TaskArray;
 
@@ -62,6 +64,7 @@ export class ProgrammingExerciseInstructionStepWizardComponent implements OnChan
         const componentInstance = modalRef.componentInstance as FeedbackComponent;
         componentInstance.exercise = this.exercise;
         componentInstance.result = this.latestResult;
+        componentInstance.participation = this.participation;
         componentInstance.feedbackFilter = tests;
         componentInstance.exerciseType = ExerciseType.PROGRAMMING;
         componentInstance.taskName = taskName;

--- a/src/main/webapp/app/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.component.ts
@@ -8,6 +8,7 @@ import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { faCheck, faCircle, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 @Component({
     selector: 'jhi-programming-exercise-instructions-step-wizard',
@@ -24,6 +25,7 @@ export class ProgrammingExerciseInstructionStepWizardComponent implements OnChan
     @Input() exercise: Exercise;
     @Input() latestResult?: Result;
     @Input() tasks: TaskArray;
+    @Input() participation: Participation;
 
     steps: Array<{ done: TestCaseState; title: string; testIds: number[] }>;
 
@@ -62,6 +64,7 @@ export class ProgrammingExerciseInstructionStepWizardComponent implements OnChan
         const componentInstance = modalRef.componentInstance as FeedbackComponent;
         componentInstance.exercise = this.exercise;
         componentInstance.result = this.latestResult;
+        componentInstance.participation = this.participation;
         componentInstance.feedbackFilter = tests;
         componentInstance.exerciseType = ExerciseType.PROGRAMMING;
         componentInstance.taskName = taskName;

--- a/src/main/webapp/app/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.component.ts
@@ -8,7 +8,6 @@ import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { faCheck, faCircle, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 @Component({
     selector: 'jhi-programming-exercise-instructions-step-wizard',
@@ -25,7 +24,6 @@ export class ProgrammingExerciseInstructionStepWizardComponent implements OnChan
     @Input() exercise: Exercise;
     @Input() latestResult?: Result;
     @Input() tasks: TaskArray;
-    @Input() participation: Participation;
 
     steps: Array<{ done: TestCaseState; title: string; testIds: number[] }>;
 
@@ -64,7 +62,6 @@ export class ProgrammingExerciseInstructionStepWizardComponent implements OnChan
         const componentInstance = modalRef.componentInstance as FeedbackComponent;
         componentInstance.exercise = this.exercise;
         componentInstance.result = this.latestResult;
-        componentInstance.participation = this.participation;
         componentInstance.feedbackFilter = tests;
         componentInstance.exerciseType = ExerciseType.PROGRAMMING;
         componentInstance.taskName = taskName;

--- a/src/main/webapp/app/programming/shared/instructions-render/task/programming-exercise-instruction-task-status.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/task/programming-exercise-instruction-task-status.component.ts
@@ -8,6 +8,7 @@ import { FeedbackComponent } from 'app/exercise/feedback/feedback.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { SafeHtmlPipe } from 'app/shared/pipes/safe-html.pipe';
+import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 @Component({
     selector: 'jhi-programming-exercise-instructions-task-status',
@@ -33,6 +34,7 @@ export class ProgrammingExerciseInstructionTaskStatusComponent {
     }
     @Input() exercise: Exercise;
     @Input() latestResult?: Result;
+    @Input() participation: Participation;
 
     testIdsValue: number[];
     testCaseState: TestCaseState;
@@ -87,6 +89,7 @@ export class ProgrammingExerciseInstructionTaskStatusComponent {
         const componentInstance = modalRef.componentInstance as FeedbackComponent;
         componentInstance.exercise = this.exercise;
         componentInstance.result = this.latestResult;
+        componentInstance.participation = this.participation;
         componentInstance.feedbackFilter = this.testIds;
         componentInstance.exerciseType = ExerciseType.PROGRAMMING;
         componentInstance.taskName = this.taskName;

--- a/src/main/webapp/app/programming/shared/instructions-render/task/programming-exercise-instruction-task-status.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/task/programming-exercise-instruction-task-status.component.ts
@@ -88,7 +88,7 @@ export class ProgrammingExerciseInstructionTaskStatusComponent {
         const modalRef = this.modalService.open(FeedbackComponent, { keyboard: true, size: 'lg' });
         const componentInstance = modalRef.componentInstance as FeedbackComponent;
         componentInstance.exercise = this.exercise;
-        componentInstance.participation = this;
+        componentInstance.participation = this.participation;
         componentInstance.result = this.latestResult;
         componentInstance.feedbackFilter = this.testIds;
         componentInstance.exerciseType = ExerciseType.PROGRAMMING;

--- a/src/main/webapp/app/programming/shared/instructions-render/task/programming-exercise-instruction-task-status.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/task/programming-exercise-instruction-task-status.component.ts
@@ -8,7 +8,6 @@ import { FeedbackComponent } from 'app/exercise/feedback/feedback.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { SafeHtmlPipe } from 'app/shared/pipes/safe-html.pipe';
-import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 @Component({
     selector: 'jhi-programming-exercise-instructions-task-status',
@@ -34,7 +33,6 @@ export class ProgrammingExerciseInstructionTaskStatusComponent {
     }
     @Input() exercise: Exercise;
     @Input() latestResult?: Result;
-    @Input() participation: Participation;
 
     testIdsValue: number[];
     testCaseState: TestCaseState;
@@ -88,7 +86,6 @@ export class ProgrammingExerciseInstructionTaskStatusComponent {
         const modalRef = this.modalService.open(FeedbackComponent, { keyboard: true, size: 'lg' });
         const componentInstance = modalRef.componentInstance as FeedbackComponent;
         componentInstance.exercise = this.exercise;
-        componentInstance.participation = this.participation;
         componentInstance.result = this.latestResult;
         componentInstance.feedbackFilter = this.testIds;
         componentInstance.exerciseType = ExerciseType.PROGRAMMING;

--- a/src/main/webapp/app/programming/shared/instructions-render/task/programming-exercise-instruction-task-status.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/task/programming-exercise-instruction-task-status.component.ts
@@ -8,6 +8,7 @@ import { FeedbackComponent } from 'app/exercise/feedback/feedback.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { SafeHtmlPipe } from 'app/shared/pipes/safe-html.pipe';
+import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 @Component({
     selector: 'jhi-programming-exercise-instructions-task-status',
@@ -33,6 +34,7 @@ export class ProgrammingExerciseInstructionTaskStatusComponent {
     }
     @Input() exercise: Exercise;
     @Input() latestResult?: Result;
+    @Input() participation: Participation;
 
     testIdsValue: number[];
     testCaseState: TestCaseState;
@@ -86,6 +88,7 @@ export class ProgrammingExerciseInstructionTaskStatusComponent {
         const modalRef = this.modalService.open(FeedbackComponent, { keyboard: true, size: 'lg' });
         const componentInstance = modalRef.componentInstance as FeedbackComponent;
         componentInstance.exercise = this.exercise;
+        componentInstance.participation = this;
         componentInstance.result = this.latestResult;
         componentInstance.feedbackFilter = this.testIds;
         componentInstance.exerciseType = ExerciseType.PROGRAMMING;

--- a/src/main/webapp/app/programming/shared/utils/programming-exercise.utils.spec.ts
+++ b/src/main/webapp/app/programming/shared/utils/programming-exercise.utils.spec.ts
@@ -96,68 +96,71 @@ describe('ProgrammingExerciseUtils', () => {
     describe('isResultPreliminary', () => {
         let result: Result;
         let exercise: ProgrammingExercise;
+        let participation: ProgrammingExerciseStudentParticipation;
 
         beforeEach(() => {
             result = new Result();
             exercise = new ProgrammingExercise(undefined, undefined);
+            participation = new ProgrammingExerciseStudentParticipation();
             exercise.assessmentType = AssessmentType.AUTOMATIC;
         });
 
         it('returns false on undefined exercise', () => {
-            expect(isResultPreliminary(result, undefined)).toBeFalse();
+            expect(isResultPreliminary(result, participation, undefined)).toBeFalse();
         });
 
         it('return true if the result completion date is not set', () => {
-            expect(isResultPreliminary(result, exercise)).toBeTrue();
+            expect(isResultPreliminary(result, participation, exercise)).toBeTrue();
         });
 
         it('return true on invalid date', () => {
             result.completionDate = dayjs('Invalid date');
-            expect(isResultPreliminary(result, exercise)).toBeTrue();
+            expect(isResultPreliminary(result, participation, exercise)).toBeTrue();
         });
 
         describe('manual assessment set for the exercise', () => {
             beforeEach(() => {
                 exercise.assessmentType = AssessmentType.SEMI_AUTOMATIC;
                 result.completionDate = dayjs();
+                participation = new ProgrammingExerciseStudentParticipation();
             });
 
             it('return true if the assessment due date is set and in the future', () => {
                 exercise.assessmentDueDate = dayjs().add(5, 'hours');
-                expect(isResultPreliminary(result, exercise)).toBeTrue();
+                expect(isResultPreliminary(result, participation, exercise)).toBeTrue();
             });
 
             it('return false if the assessment due date is set and in the past', () => {
                 exercise.assessmentDueDate = dayjs().subtract(5, 'hours');
-                expect(isResultPreliminary(result, exercise)).toBeFalse();
+                expect(isResultPreliminary(result, participation, exercise)).toBeFalse();
             });
 
             it('return true if the assessment due date is not set and the latest result is an automatic assessment', () => {
                 result.assessmentType = AssessmentType.AUTOMATIC;
-                expect(isResultPreliminary(result, exercise)).toBeTrue();
+                expect(isResultPreliminary(result, participation, exercise)).toBeTrue();
             });
 
             it('return false if the assessment due date is not set and the latest result is not an automatic assessment', () => {
                 result.assessmentType = AssessmentType.SEMI_AUTOMATIC;
-                expect(isResultPreliminary(result, exercise)).toBeFalse();
+                expect(isResultPreliminary(result, participation, exercise)).toBeFalse();
             });
         });
 
         it('return true if buildAndTest date is set and in the future', () => {
             result.completionDate = dayjs();
             exercise.buildAndTestStudentSubmissionsAfterDueDate = dayjs().add(5, 'hours');
-            expect(isResultPreliminary(result, exercise)).toBeTrue();
+            expect(isResultPreliminary(result, participation, exercise)).toBeTrue();
         });
 
         it('return false if buildAndTest date is set and in the past', () => {
             result.completionDate = dayjs();
             exercise.buildAndTestStudentSubmissionsAfterDueDate = dayjs().subtract(5, 'hours');
-            expect(isResultPreliminary(result, exercise)).toBeFalse();
+            expect(isResultPreliminary(result, participation, exercise)).toBeFalse();
         });
 
         it('return false if completion date is valid and buildAndTest date is not set', () => {
             result.completionDate = dayjs();
-            expect(isResultPreliminary(result, exercise)).toBeFalse();
+            expect(isResultPreliminary(result, participation, exercise)).toBeFalse();
         });
     });
 });

--- a/src/main/webapp/app/programming/shared/utils/programming-exercise.utils.ts
+++ b/src/main/webapp/app/programming/shared/utils/programming-exercise.utils.ts
@@ -20,9 +20,10 @@ export const createBuildPlanUrl = (template: string, projectKey: string, buildPl
  * Note: We check some error cases in this method as a undefined value for the given parameters, because the clients using this method might unwillingly provide them (result component).
  *
  * @param latestResult Result with attached Submission - if submission is undefined, method will use the result completionDate as a reference.
+ * @param participation Participation of the result
  * @param programmingExercise ProgrammingExercise
  */
-export const isResultPreliminary = (latestResult: Result, programmingExercise?: ProgrammingExercise) => {
+export const isResultPreliminary = (latestResult: Result, participation: Participation, programmingExercise?: ProgrammingExercise) => {
     if (!programmingExercise) {
         return false;
     }
@@ -32,7 +33,7 @@ export const isResultPreliminary = (latestResult: Result, programmingExercise?: 
     if (isAIResultAndIsBeingProcessed(latestResult) || isAIResultAndTimedOut(latestResult) || isAIResultAndFailed(latestResult)) {
         return false;
     }
-    if (latestResult.submission?.participation?.type === ParticipationType.PROGRAMMING && isPracticeMode(latestResult.submission.participation)) {
+    if (participation?.type === ParticipationType.PROGRAMMING && isPracticeMode(participation)) {
         return false;
     }
 

--- a/src/main/webapp/app/text/overview/text-editor/text-editor.component.html
+++ b/src/main/webapp/app/text/overview/text-editor/text-editor.component.html
@@ -54,7 +54,12 @@
         @if (isReadOnlyWithShowResult) {
             @if (showHistory) {
                 <div id="result-history" class="row mb-2">
-                    <jhi-result-history [results]="sortedHistoryResults" [exercise]="textExercise" [selectedResultId]="submission.latestResult?.id!" />
+                    <jhi-result-history
+                        [results]="sortedHistoryResults"
+                        [exercise]="textExercise"
+                        [participationInput]="participation"
+                        [selectedResultId]="submission.latestResult?.id!"
+                    />
                 </div>
             }
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #11069 
Additionally, I noticed that the feedback component has more issues. e.g. build failures are not correctly recognized.


### Description
<!-- Describe your changes in detail -->
The root cause was almost everywhere that we accessed result.submission.participation which is in most cases not defined.
As in  almost all components we have the participation anyway, we now pass it directly to the components and the helper methods
only in the result history, we still rely on result.submission.participation as it's defined there and it would be difficult to pass the correct participation there.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Student

1. You  need an exercise with at least one participation and at least one result.
2. Access the page http://`server-url`/courses/`courseId`/exercises/`exercisseId`/participations/`participationId`/results/`resultId`/feedback
3. Check the result history is shown correctly (correct colors, icons, text) **for all exercise types**
4. Check on the exercise details page for students, the last score is shown correctly **for all exercise types**
5. **For programming exercises**, produce a build failure and make sure that when you click on the result, the log of the failed build is shown

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 1 Student
1. Log in to Artemis
2. Create an exam with all exercise types
3. Particpate in the exam
4. Assess all exercises
5. View the results as student and make sure everything is displayed correctly

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [x] Test 1
- [ ] Test 2
### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
my changes are covered

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://github.com/user-attachments/assets/e5fcfcd6-2bf9-49fd-b989-5ce708b37ead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced feedback display by allowing participation details to be passed and accessed in feedback components.
  * The feedback page now sets a specific page title for improved navigation and clarity.
  * Participation context is now consistently included in result strings and feedback modals across multiple components.
  * Programming exercise instructions and task status components now support participation data for more detailed feedback.
  * Result history and modeling submission views now include participation data for improved context.
  * Result evaluation utilities and visual indicators now consider participation context for accuracy.
  * Added utility to retrieve the latest submission from a participation for consistent data access.

* **Bug Fixes**
  * Prevented unnecessary feedback data requests when required identifiers are missing, improving performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->