### PR TITLE
`Development`: Only run database approval check on PRs where the global diff has migration changes

### DIFF
--- a/supporting_scripts/database_approval_check/main.py
+++ b/supporting_scripts/database_approval_check/main.py
@@ -34,6 +34,14 @@ def is_db_maintainer(user: NamedUser):
     return user in db_team.get_members()
 
 
+# Check if the PR has any changes to the database folder at all, before checking commits
+if not any(
+    file.filename.startswith(MIGRATION_DIRECTORY) for file in pr.get_files()
+):
+    print(f"PR #{pr_number} has no changes in the database folder.")
+    sys.exit(0)
+
+
 last_commit_with_db_changes = None
 for commit in pr.get_commits().reversed:
     # Ignore merges from the develop branch (local and remote-tracking)
@@ -77,6 +85,7 @@ for approval in approvals_from_db_maintainers:
             f"after the last commit with database changes."
         )
         sys.exit(0)
+
 print(
     f"PR #{pr_number} has not been approved by a database maintainer after the last commit with database changes."
 )


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It is apparently a bigger issue than thought at first where developers either
- Add and then remove changes to migrations in separate commits
- Merge develop with custom merge messages

This then caused the check to falsely mark their PRs as having unapproved changes.

### Description
<!-- Describe your changes in detail -->
I added a check that only runs the commit level migration checker if the PR overall has migration changes.
Works as seen here: https://github.com/ls1intum/Artemis/actions/runs/16001428331/job/45137161009 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved efficiency by skipping unnecessary checks when no database migration files are changed in a pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->