### PR TITLE
`Programming exercises`: Fix an issue in the online code editor when a result exists

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/repository/SubmissionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/repository/SubmissionRepository.java
@@ -577,4 +577,17 @@ public interface SubmissionRepository extends ArtemisJpaRepository<Submission, L
                 AND s.submitted = TRUE
             """)
     boolean existsByExerciseIdAndParticipantIdAndSubmitted(@Param("exerciseId") long exerciseId, @Param("userId") long userId);
+
+    @Query("""
+            SELECT s
+            FROM Submission s
+            WHERE s.participation.id = :participationId
+              AND s.id = (
+              SELECT MAX(s2.id)
+              FROM Submission s2
+              WHERE s2.participation.id = :participationId
+                 )
+             """)
+    Optional<Submission> findLatestSubmissionByParticipationId(@Param("participationId") long participationId);
+
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseStudentParticipationRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseStudentParticipationRepository.java
@@ -74,19 +74,6 @@ public interface ProgrammingExerciseStudentParticipationRepository extends Artem
         return getValueElseThrow(findByRepositoryUri(repositoryUri));
     }
 
-    @Query("""
-              SELECT p
-              FROM ProgrammingExerciseStudentParticipation p
-                LEFT JOIN FETCH p.submissions s
-              WHERE p.id = :participationId
-                AND s.id = (
-                  SELECT MAX(s2.id)
-                  FROM Submission s2
-                  WHERE s2.participation = p
-                )
-            """)
-    Optional<ProgrammingExerciseStudentParticipation> findWithLatestSubmissionById(@Param("participationId") long participationId);
-
     @EntityGraph(type = LOAD, attributePaths = { "team.students" })
     Optional<ProgrammingExerciseStudentParticipation> findByExerciseIdAndTeamId(long exerciseId, long teamId);
 
@@ -208,7 +195,4 @@ public interface ProgrammingExerciseStudentParticipationRepository extends Artem
             """)
     void unsetBuildPlanIdForExercise(@Param("exerciseId") Long exerciseId);
 
-    default ProgrammingExerciseStudentParticipation findWithLatestSubmissionByIdElseThrow(long participationId) {
-        return getValueElseThrow(findWithLatestSubmissionById(participationId), participationId);
-    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseParticipationResource.java
@@ -44,7 +44,6 @@ import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ParticipationRepository;
-import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
 import de.tum.cit.aet.artemis.exercise.service.ParticipationAuthorizationCheckService;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseParticipation;
@@ -107,15 +106,13 @@ public class ProgrammingExerciseParticipationResource {
 
     private final Optional<ContinuousIntegrationTriggerService> continuousIntegrationTriggerService;
 
-    private final SubmissionRepository submissionRepository;
-
     public ProgrammingExerciseParticipationResource(ProgrammingExerciseParticipationService programmingExerciseParticipationService, ResultRepository resultRepository,
             ParticipationRepository participationRepository, ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository,
             ProgrammingSubmissionService submissionService, ProgrammingExerciseRepository programmingExerciseRepository, AuthorizationCheckService authCheckService,
             ResultService resultService, ParticipationAuthorizationCheckService participationAuthCheckService, RepositoryService repositoryService,
             Optional<StudentExamApi> studentExamApi, Optional<VcsAccessLogRepository> vcsAccessLogRepository, AuxiliaryRepositoryRepository auxiliaryRepositoryRepository,
             Optional<SharedQueueManagementService> sharedQueueManagementService, Optional<ExamApi> examApi,
-            Optional<ContinuousIntegrationTriggerService> continuousIntegrationTriggerService, SubmissionRepository submissionRepository) {
+            Optional<ContinuousIntegrationTriggerService> continuousIntegrationTriggerService) {
         this.programmingExerciseParticipationService = programmingExerciseParticipationService;
         this.participationRepository = participationRepository;
         this.programmingExerciseStudentParticipationRepository = programmingExerciseStudentParticipationRepository;
@@ -132,7 +129,6 @@ public class ProgrammingExerciseParticipationResource {
         this.sharedQueueManagementService = sharedQueueManagementService;
         this.examApi = examApi;
         this.continuousIntegrationTriggerService = continuousIntegrationTriggerService;
-        this.submissionRepository = submissionRepository;
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalCIIntegrationTest.java
@@ -496,8 +496,7 @@ class LocalCIIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         processNewPush(commitHash, studentAssignmentRepository.originGit.getRepository(), userTestRepository.getUserWithGroupsAndAuthorities());
         localVCLocalCITestService.testLatestSubmission(studentParticipation.getId(), commitHash, 0, false);
 
-        studentParticipation = programmingExerciseStudentParticipationRepository
-                .findByIdWithLatestResultAndFeedbacksAndRelatedSubmissions(studentParticipation.getId(), ZonedDateTime.now()).orElseThrow();
+        studentParticipation = programmingExerciseParticipationService.findStudentParticipationWithLatestSubmissionResultAndFeedbacksElseThrow(studentParticipation.getId());
         var result = participationUtilService.getResultsForParticipation(studentParticipation).iterator().next();
 
         var noPrintTest = result.getFeedbacks().stream().filter(feedback -> feedback.getTestCase().getTestName().equals("testMergeSort()")).findFirst().orElseThrow();
@@ -549,8 +548,7 @@ class LocalCIIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         processNewPush(commitHash, studentAssignmentRepository.originGit.getRepository(), userTestRepository.getUserWithGroupsAndAuthorities());
         localVCLocalCITestService.testLatestSubmission(studentParticipation.getId(), commitHash, 0, true);
 
-        studentParticipation = programmingExerciseStudentParticipationRepository
-                .findByIdWithLatestResultAndFeedbacksAndRelatedSubmissions(studentParticipation.getId(), ZonedDateTime.now()).orElseThrow();
+        studentParticipation = programmingExerciseParticipationService.findStudentParticipationWithLatestSubmissionResultAndFeedbacksElseThrow(studentParticipation.getId());
         var result = participationUtilService.getResultsForParticipation(studentParticipation).iterator().next();
 
         var buildLogs = buildLogEntryService.getLatestBuildLogs((ProgrammingSubmission) result.getSubmission());


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.



#### Changes affecting Programming Exercises
Independent of VCS and CIS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When students open the code editor, it can happen that the server throws a NPE because of a wrong query that returns null values in the results collection.


### Description
<!-- Describe your changes in detail -->
Refactored the query to avoid the issue described above.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to a programming exercise with code editor enabled or enable the code editor
4. Go to the participations page and trigger a build for a student participation
5. Log in as the student
6. Go to the exercise
7. Open the code editor
8. Make sure no internal server error occurs


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
my change is covered by existing tests
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve the latest submission, result, and feedbacks for a student participation in programming exercises.
  * Introduced new repository methods to fetch the latest results and submissions efficiently.

* **Refactor**
  * Simplified fetching of participations and their latest related data by removing older complex repository methods.
  * Updated service and resource layers to use streamlined methods for participation data retrieval.

* **Bug Fixes**
  * Enhanced handling of participations without submissions to avoid errors.

* **Tests**
  * Updated integration and local CI tests to align with the new participation retrieval approach.
  * Removed a deprecated test related to participation results without completion dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->