### PR TITLE
`Development`: Fix sending login emails when logging in with email

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/repository/UserRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/repository/UserRepository.java
@@ -866,6 +866,17 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
     }
 
     /**
+     * Retrieve a user by its email (ignoring case), or else throw exception
+     *
+     * @param email the email of the user to search
+     * @return the user entity if it exists
+     */
+    @NotNull
+    default User getUserByEmailElseThrow(String email) {
+        return getValueElseThrow(findOneByEmailIgnoreCase(email));
+    }
+
+    /**
      * Get user with user groups and authorities of currently logged-in user
      *
      * @return currently logged-in user

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/ArtemisSuccessfulLoginService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/ArtemisSuccessfulLoginService.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Optional;
 
-import de.tum.cit.aet.artemis.core.security.SecurityUtils;
 import jakarta.annotation.Nullable;
 
 import org.slf4j.Logger;
@@ -26,6 +25,7 @@ import de.tum.cit.aet.artemis.core.domain.Language;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
+import de.tum.cit.aet.artemis.core.security.SecurityUtils;
 import de.tum.cit.aet.artemis.core.security.jwt.AuthenticationMethod;
 import de.tum.cit.aet.artemis.core.util.ClientEnvironment;
 
@@ -110,9 +110,10 @@ public class ArtemisSuccessfulLoginService {
         try {
             User recipient;
 
-            if (SecurityUtils.isEmail(lowercaseLoginOrEmail)){
+            if (SecurityUtils.isEmail(lowercaseLoginOrEmail)) {
                 recipient = userRepository.getUserByEmailElseThrow(lowercaseLoginOrEmail);
-            } else {
+            }
+            else {
                 recipient = userRepository.getUserByLoginElseThrow(lowercaseLoginOrEmail);
             }
 

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/ArtemisSuccessfulLoginService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/ArtemisSuccessfulLoginService.java
@@ -6,7 +6,6 @@ import java.net.URL;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Optional;
 
 import jakarta.annotation.Nullable;
@@ -105,16 +104,14 @@ public class ArtemisSuccessfulLoginService {
      * @see AuthenticationMethod for available authentication methods
      */
     public void sendLoginEmail(String loginOrEmail, AuthenticationMethod authenticationMethod, @Nullable ClientEnvironment clientEnvironment) {
-        String lowercaseLoginOrEmail = loginOrEmail.toLowerCase(Locale.ENGLISH);
-
         try {
             User recipient;
 
-            if (SecurityUtils.isEmail(lowercaseLoginOrEmail)) {
-                recipient = userRepository.getUserByEmailElseThrow(lowercaseLoginOrEmail);
+            if (SecurityUtils.isEmail(loginOrEmail)) {
+                recipient = userRepository.getUserByEmailElseThrow(loginOrEmail);
             }
             else {
-                recipient = userRepository.getUserByLoginElseThrow(lowercaseLoginOrEmail);
+                recipient = userRepository.getUserByLoginElseThrow(loginOrEmail);
             }
 
             if (!globalNotificationSettingRepository.isNotificationEnabled(recipient.getId(), GlobalNotificationType.NEW_LOGIN)) {
@@ -123,7 +120,7 @@ public class ArtemisSuccessfulLoginService {
 
             String localeKey = recipient.getLangKey();
             if (localeKey == null) {
-                log.warn("User {} has no language set, using default language 'en'", lowercaseLoginOrEmail);
+                log.warn("User {} has no language set, using default language 'en'", loginOrEmail);
                 localeKey = "en";
             }
             Language language = Language.fromLanguageShortName(localeKey);
@@ -152,7 +149,7 @@ public class ArtemisSuccessfulLoginService {
             mailSendingService.buildAndSendAsync(recipient, "email.notification.login.title", "mail/notification/newLoginEmail", contextVariables);
         }
         catch (EntityNotFoundException ignored) {
-            log.error("User with login {} not found when trying to send newLoginEmail", lowercaseLoginOrEmail);
+            log.error("User with login {} not found when trying to send newLoginEmail", loginOrEmail);
         }
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/ArtemisSuccessfulLoginServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/ArtemisSuccessfulLoginServiceTest.java
@@ -53,6 +53,19 @@ class ArtemisSuccessfulLoginServiceTest extends AbstractSpringIntegrationIndepen
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "INSTRUCTOR")
+    void shouldSendEmailToUserWhenLogingInWithEmail() throws EntityNotFoundException {
+        String username = TEST_PREFIX + "student1";
+
+        User user = userTestRepository.findOneByLogin(username).get();
+
+        doNothing().when(javaMailSender).send(any(MimeMessage.class));
+        artemisSuccessfulLoginService.sendLoginEmail(user.getEmail(), AuthenticationMethod.PASSWORD, null);
+        await().atMost(5, SECONDS)
+            .untilAsserted(() -> verify(mailSendingService).buildAndSendAsync(eq(user), eq("email.notification.login.title"), eq("mail/notification/newLoginEmail"), anyMap()));
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "INSTRUCTOR")
     void shouldHandleUserNotFoundGracefully() throws EntityNotFoundException {
         String username = "nonexistentuser";
         doNothing().when(javaMailSender).send(any(MimeMessage.class));

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/ArtemisSuccessfulLoginServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/ArtemisSuccessfulLoginServiceTest.java
@@ -61,7 +61,7 @@ class ArtemisSuccessfulLoginServiceTest extends AbstractSpringIntegrationIndepen
         doNothing().when(javaMailSender).send(any(MimeMessage.class));
         artemisSuccessfulLoginService.sendLoginEmail(user.getEmail(), AuthenticationMethod.PASSWORD, null);
         await().atMost(5, SECONDS)
-            .untilAsserted(() -> verify(mailSendingService).buildAndSendAsync(eq(user), eq("email.notification.login.title"), eq("mail/notification/newLoginEmail"), anyMap()));
+                .untilAsserted(() -> verify(mailSendingService).buildAndSendAsync(eq(user), eq("email.notification.login.title"), eq("mail/notification/newLoginEmail"), anyMap()));
     }
 
     @Test


### PR DESCRIPTION

### Checklist
#### General

- [x] This is a small issue that I tested locally and on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context

When you log in to an artemis instance, you will now normally receive an e-mail informing you about the login.
This does not happen if you log in with your e-mail address instead of your user name.

```
2025-07-03T15:58:23.467Z ERROR 1 --- [Artemis] [at-handler-3482] .c.a.a.c.s.ArtemisSuccessfulLoginService : User with login artemis-test-user.aet+testuser_7@xcit.tum.de not found when trying to send newLoginEmail
```

### Description

We have adjusted the search for the corresponding user for sending the login email so that it now also searches using email addresses.


### Steps for Testing

- Deploy to a test server
- Log in once with your e-mail address and once with your user name.
- Check whether you receive two e-mails.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now receive login notification emails when signing in with either their username or email address.

* **Bug Fixes**
  * Improved user lookup to support case-insensitive email matching during login notifications.

* **Tests**
  * Added a test to ensure email notifications are sent correctly when logging in with an email address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->