### PR TITLE
`Iris`: Only load sessions with messages

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/iris/domain/session/IrisSession.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/domain/session/IrisSession.java
@@ -64,6 +64,7 @@ public abstract class IrisSession extends DomainObject {
     private String latestSuggestions;
 
     // TODO: This is only used in the tests -> Remove
+    @Deprecated
     public IrisMessage newMessage() {
         var message = new IrisMessage();
         message.setSession(this);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisChatSessionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisChatSessionRepository.java
@@ -21,7 +21,7 @@ import de.tum.cit.aet.artemis.iris.domain.session.IrisChatSession;
 public interface IrisChatSessionRepository extends ArtemisJpaRepository<IrisChatSession, Long> {
 
     /**
-     * Finds a list of {@link IrisChatSession} based on the course and user ID.
+     * Finds a list of {@link IrisChatSession} based on the course and user ID. Filters sessions without messages and sorts them by creation date in descending order.
      *
      * @param courseId The ID of the course.
      * @param userId   The ID of the user.
@@ -34,15 +34,20 @@ public interface IrisChatSessionRepository extends ArtemisJpaRepository<IrisChat
                       COALESCE(ccs.courseId, e1.id, e2.id, l.id, -1)
                   )
                 FROM IrisChatSession s
-                LEFT JOIN IrisCourseChatSession ccs ON s.id = ccs.id
-                LEFT JOIN IrisLectureChatSession lcs ON s.id = lcs.id
-                LEFT JOIN IrisTextExerciseChatSession tecs ON s.id = tecs.id
-                LEFT JOIN IrisProgrammingExerciseChatSession pecs ON s.id = pecs.id
-                LEFT JOIN Lecture l ON l.id = lcs.lectureId
-                LEFT JOIN Exercise e1 ON e1.id = tecs.exerciseId
-                LEFT JOIN Exercise e2 ON e2.id = pecs.exerciseId
+                    LEFT JOIN IrisCourseChatSession ccs ON s.id = ccs.id
+                    LEFT JOIN IrisLectureChatSession lcs ON s.id = lcs.id
+                    LEFT JOIN IrisTextExerciseChatSession tecs ON s.id = tecs.id
+                    LEFT JOIN IrisProgrammingExerciseChatSession pecs ON s.id = pecs.id
+                    LEFT JOIN Lecture l ON l.id = lcs.lectureId
+                    LEFT JOIN Exercise e1 ON e1.id = tecs.exerciseId
+                    LEFT JOIN Exercise e2 ON e2.id = pecs.exerciseId
+                    LEFT JOIN s.messages m
+                    LEFT JOIN m.content c
                 WHERE s.userId = :userId AND TYPE(s) IN (:types)
-                  AND (ccs.courseId = :courseId OR l.course.id = :courseId OR e1.course.id = :courseId OR e2.course.id = :courseId)
+                    AND (ccs.courseId = :courseId OR l.course.id = :courseId OR e1.course.id = :courseId OR e2.course.id = :courseId)
+                    AND m.sender = de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender.USER
+                GROUP BY s, ccs.courseId, e1.id, e2.id, l.id
+                HAVING COUNT(m) > 0
                 ORDER BY s.creationDate DESC
             """)
     List<IrisChatSessionDAO> findByCourseIdAndUserId(@Param("courseId") long courseId, @Param("userId") long userId,

--- a/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisChatSessionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisChatSessionRepository.java
@@ -29,31 +29,26 @@ public interface IrisChatSessionRepository extends ArtemisJpaRepository<IrisChat
      * @return A list of chat sessions sorted by creation date in descending order.
      */
     @Query("""
-                SELECT new de.tum.cit.aet.artemis.iris.dao.IrisChatSessionDAO(
-                          s,
-                          COALESCE(ccs.courseId, e1.id, e2.id, l.id, -1)
-                      )
-                  FROM IrisChatSession s
-                      LEFT JOIN IrisCourseChatSession ccs ON s.id = ccs.id
-                      LEFT JOIN IrisLectureChatSession lcs ON s.id = lcs.id
-                      LEFT JOIN IrisTextExerciseChatSession tecs ON s.id = tecs.id
-                      LEFT JOIN IrisProgrammingExerciseChatSession pecs ON s.id = pecs.id
-                      LEFT JOIN Lecture l ON l.id = lcs.lectureId
-                      LEFT JOIN Exercise e1 ON e1.id = tecs.exerciseId
-                      LEFT JOIN Exercise e2 ON e2.id = pecs.exerciseId
-                      LEFT JOIN s.messages m
-                  WHERE s.userId = :userId AND TYPE(s) IN (:types)
-                      AND (ccs.courseId = :courseId OR l.course.id = :courseId OR e1.course.id = :courseId OR e2.course.id = :courseId)
-                  GROUP BY s, ccs.courseId, e1.id, e2.id, l.id
-                  HAVING COUNT(CASE WHEN m.sender = de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender.USER THEN 1 END) > 0
-                         OR s.id = (
-                            SELECT s2.id
-                            FROM IrisChatSession s2
-                            WHERE s2.userId = :userId
-                            ORDER BY s2.creationDate DESC
-                            LIMIT 1
-                         )
-                  ORDER BY s.creationDate DESC
+            SELECT new de.tum.cit.aet.artemis.iris.dao.IrisChatSessionDAO(
+                      s,
+                      COALESCE(ccs.courseId, e1.id, e2.id, l.id, -1)
+                  )
+                FROM IrisChatSession s
+                    LEFT JOIN IrisCourseChatSession ccs ON s.id = ccs.id
+                    LEFT JOIN IrisLectureChatSession lcs ON s.id = lcs.id
+                    LEFT JOIN IrisTextExerciseChatSession tecs ON s.id = tecs.id
+                    LEFT JOIN IrisProgrammingExerciseChatSession pecs ON s.id = pecs.id
+                    LEFT JOIN Lecture l ON l.id = lcs.lectureId
+                    LEFT JOIN Exercise e1 ON e1.id = tecs.exerciseId
+                    LEFT JOIN Exercise e2 ON e2.id = pecs.exerciseId
+                    LEFT JOIN s.messages m
+                    LEFT JOIN m.content c
+                WHERE s.userId = :userId AND TYPE(s) IN (:types)
+                    AND (ccs.courseId = :courseId OR l.course.id = :courseId OR e1.course.id = :courseId OR e2.course.id = :courseId)
+                    AND m.sender = de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender.USER
+                GROUP BY s, ccs.courseId, e1.id, e2.id, l.id
+                HAVING COUNT(m) > 0
+                ORDER BY s.creationDate DESC
             """)
     List<IrisChatSessionDAO> findByCourseIdAndUserId(@Param("courseId") long courseId, @Param("userId") long userId,
             @Param("types") Collection<Class<? extends IrisChatSession>> types);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisChatSessionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisChatSessionRepository.java
@@ -22,6 +22,8 @@ public interface IrisChatSessionRepository extends ArtemisJpaRepository<IrisChat
 
     /**
      * Finds a list of {@link IrisChatSession} based on the course and user ID. Filters sessions without messages and sorts them by creation date in descending order.
+     * Always includes the most recent session for the user, even if it has no messages (e.g. when opening the dashboard for the first time, we want to display the new session in
+     * the history)
      *
      * @param courseId The ID of the course.
      * @param userId   The ID of the user.

--- a/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisChatSessionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisChatSessionRepository.java
@@ -29,26 +29,31 @@ public interface IrisChatSessionRepository extends ArtemisJpaRepository<IrisChat
      * @return A list of chat sessions sorted by creation date in descending order.
      */
     @Query("""
-            SELECT new de.tum.cit.aet.artemis.iris.dao.IrisChatSessionDAO(
-                      s,
-                      COALESCE(ccs.courseId, e1.id, e2.id, l.id, -1)
-                  )
-                FROM IrisChatSession s
-                    LEFT JOIN IrisCourseChatSession ccs ON s.id = ccs.id
-                    LEFT JOIN IrisLectureChatSession lcs ON s.id = lcs.id
-                    LEFT JOIN IrisTextExerciseChatSession tecs ON s.id = tecs.id
-                    LEFT JOIN IrisProgrammingExerciseChatSession pecs ON s.id = pecs.id
-                    LEFT JOIN Lecture l ON l.id = lcs.lectureId
-                    LEFT JOIN Exercise e1 ON e1.id = tecs.exerciseId
-                    LEFT JOIN Exercise e2 ON e2.id = pecs.exerciseId
-                    LEFT JOIN s.messages m
-                    LEFT JOIN m.content c
-                WHERE s.userId = :userId AND TYPE(s) IN (:types)
-                    AND (ccs.courseId = :courseId OR l.course.id = :courseId OR e1.course.id = :courseId OR e2.course.id = :courseId)
-                    AND m.sender = de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender.USER
-                GROUP BY s, ccs.courseId, e1.id, e2.id, l.id
-                HAVING COUNT(m) > 0
-                ORDER BY s.creationDate DESC
+                SELECT new de.tum.cit.aet.artemis.iris.dao.IrisChatSessionDAO(
+                          s,
+                          COALESCE(ccs.courseId, e1.id, e2.id, l.id, -1)
+                      )
+                  FROM IrisChatSession s
+                      LEFT JOIN IrisCourseChatSession ccs ON s.id = ccs.id
+                      LEFT JOIN IrisLectureChatSession lcs ON s.id = lcs.id
+                      LEFT JOIN IrisTextExerciseChatSession tecs ON s.id = tecs.id
+                      LEFT JOIN IrisProgrammingExerciseChatSession pecs ON s.id = pecs.id
+                      LEFT JOIN Lecture l ON l.id = lcs.lectureId
+                      LEFT JOIN Exercise e1 ON e1.id = tecs.exerciseId
+                      LEFT JOIN Exercise e2 ON e2.id = pecs.exerciseId
+                      LEFT JOIN s.messages m
+                  WHERE s.userId = :userId AND TYPE(s) IN (:types)
+                      AND (ccs.courseId = :courseId OR l.course.id = :courseId OR e1.course.id = :courseId OR e2.course.id = :courseId)
+                  GROUP BY s, ccs.courseId, e1.id, e2.id, l.id
+                  HAVING COUNT(CASE WHEN m.sender = de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender.USER THEN 1 END) > 0
+                         OR s.id = (
+                            SELECT s2.id
+                            FROM IrisChatSession s2
+                            WHERE s2.userId = :userId
+                            ORDER BY s2.creationDate DESC
+                            LIMIT 1
+                         )
+                  ORDER BY s.creationDate DESC
             """)
     List<IrisChatSessionDAO> findByCourseIdAndUserId(@Param("courseId") long courseId, @Param("userId") long userId,
             @Param("types") Collection<Class<? extends IrisChatSession>> types);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisChatSessionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisChatSessionRepository.java
@@ -22,8 +22,6 @@ public interface IrisChatSessionRepository extends ArtemisJpaRepository<IrisChat
 
     /**
      * Finds a list of {@link IrisChatSession} based on the course and user ID. Filters sessions without messages and sorts them by creation date in descending order.
-     * Always includes the most recent session for the user, even if it has no messages (e.g. when opening the dashboard for the first time, we want to display the new session in
-     * the history)
      *
      * @param courseId The ID of the course.
      * @param userId   The ID of the user.

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisHealthIndicator.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisHealthIndicator.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.iris.service.pyris;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_IRIS;
 
 import java.net.URI;
+import java.util.HashMap;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,6 +27,8 @@ public class PyrisHealthIndicator implements HealthIndicator {
     private int CACHE_TTL;
 
     private final RestTemplate restTemplate;
+
+    private static final String IRIS_URL_KEY = "url";
 
     @Value("${artemis.iris.url}")
     private URI irisUrl;
@@ -62,10 +65,12 @@ public class PyrisHealthIndicator implements HealthIndicator {
         }
 
         ConnectorHealth health;
+        var additionalInfo = new HashMap<String, Object>();
+        additionalInfo.put(IRIS_URL_KEY, irisUrl);
         try {
             PyrisHealthStatusDTO[] status = restTemplate.getForObject(irisUrl + "/api/v1/health/", PyrisHealthStatusDTO[].class);
             var isUp = status != null;
-            health = new ConnectorHealth(isUp, null, null);
+            health = new ConnectorHealth(isUp, additionalInfo, null);
         }
         catch (RestClientException e) {
             health = new ConnectorHealth(false, null, e);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisExerciseChatSessionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisExerciseChatSessionService.java
@@ -115,6 +115,7 @@ public class IrisExerciseChatSessionService extends AbstractIrisChatSessionServi
      * @return The created session
      */
     // TODO: This function is only used in tests. Replace with createSession once the tests are refactored.
+    @Deprecated
     public IrisProgrammingExerciseChatSession createChatSessionForProgrammingExercise(ProgrammingExercise exercise, User user) {
         checkIfExamExercise(exercise);
         return irisSessionRepository.save(new IrisProgrammingExerciseChatSession(exercise, user));

--- a/src/main/java/de/tum/cit/aet/artemis/iris/web/IrisChatSessionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/web/IrisChatSessionResource.java
@@ -101,7 +101,7 @@ public class IrisChatSessionResource {
     }
 
     /**
-     * GET chat-history/{courseId}/sessions: Retrieve all Iris Sessions for the course
+     * GET chat-history/{courseId}/sessions: Retrieve all Iris Sessions for the course and the current user.
      *
      * @param courseId of the course
      * @return the {@link ResponseEntity} with status {@code 200 (Ok)} and with body a list of the iris sessions for the course or {@code 404 (Not Found)} if no session exists

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
@@ -514,7 +514,7 @@ export class IrisBaseChatbotComponent implements OnInit, OnDestroy, AfterViewIni
         rangeEndDate.setDate(today.getDate() - daysAgoNewer);
         rangeEndDate.setHours(23, 59, 59, 999); // Set to the end of the 'daysAgoNewer' day
 
-        let rangeStartDate: Date | null = null;
+        let rangeStartDate: Date | undefined = undefined;
         if (!ignoreOlderBoundary && daysAgoOlder !== undefined) {
             rangeStartDate = new Date(today);
             rangeStartDate.setDate(today.getDate() - daysAgoOlder);

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
@@ -166,20 +166,24 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void getAllSessionsForCourseWithSessions2() throws Exception {
+    void getAllSessionsForCourseWithSessions_shouldReturnSessionsWithMessages() throws Exception {
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
 
         // Create and save lecture session with messages
         IrisLectureChatSession lectureSession = IrisChatSessionFactory.createLectureSessionForUserWithMessages(lecture, user);
-
         irisLectureChatSessionRepository.save(lectureSession);
         irisMessageRepository.saveAll(lectureSession.getMessages());
+
+        IrisChatSession courseSession = IrisChatSessionFactory.createCourseSessionForUserWithMessages(course, user);
+        irisSessionRepository.save(courseSession);
+        irisMessageRepository.saveAll(courseSession.getMessages());
 
         // Execute the request
         List<IrisChatSessionDTO> irisChatSessions = request.getList("/api/iris/chat-history/" + course.getId() + "/sessions", HttpStatus.OK, IrisChatSessionDTO.class);
 
         // Assertions
-        assertThat(irisChatSessions).hasSize(1);
+        assertThat(irisChatSessions).hasSize(2);
         assertThat(irisChatSessions.stream().filter(s -> s.id().equals(lectureSession.getId())).findFirst()).isPresent();
+        assertThat(irisChatSessions.stream().filter(s -> s.id().equals(courseSession.getId())).findFirst()).isPresent();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
@@ -158,7 +158,7 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
         irisSessionRepository.save(IrisChatSessionFactory.createCourseChatSessionForUser(course, user));
         irisSessionRepository.save(IrisChatSessionFactory.createLectureSessionForUser(lecture, user));
         irisSessionRepository.save(IrisChatSessionFactory.createTextExerciseChatSessionForUser(textExercise, user));
-        irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, user);
+        irisSessionRepository.save(IrisChatSessionFactory.createProgrammingExerciseChatSessionForUser(soloExercise, user));
 
         List<IrisChatSessionDTO> irisChatSessions = request.getList("/api/iris/chat-history/" + course.getId() + "/sessions", HttpStatus.OK, IrisChatSessionDTO.class);
         assertThat(irisChatSessions).hasSize(0);
@@ -169,7 +169,6 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
     void getAllSessionsForCourseWithSessions_shouldReturnSessionsWithMessages() throws Exception {
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
 
-        // Create and save lecture session with messages
         IrisLectureChatSession lectureSession = IrisChatSessionFactory.createLectureSessionForUserWithMessages(lecture, user);
         irisLectureChatSessionRepository.save(lectureSession);
         irisMessageRepository.saveAll(lectureSession.getMessages());
@@ -186,10 +185,8 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
         irisSessionRepository.save(programmingExerciseSession);
         irisMessageRepository.saveAll(programmingExerciseSession.getMessages());
 
-        // Execute the request
         List<IrisChatSessionDTO> irisChatSessions = request.getList("/api/iris/chat-history/" + course.getId() + "/sessions", HttpStatus.OK, IrisChatSessionDTO.class);
 
-        // Assertions
         assertThat(irisChatSessions).hasSize(4);
         assertThat(irisChatSessions.stream().filter(s -> s.id().equals(lectureSession.getId())).findFirst()).isPresent();
         assertThat(irisChatSessions.stream().filter(s -> s.id().equals(courseSession.getId())).findFirst()).isPresent();

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
@@ -182,13 +182,18 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
         irisSessionRepository.save(textExerciseSession);
         irisMessageRepository.saveAll(textExerciseSession.getMessages());
 
+        IrisChatSession programmingExerciseSession = IrisChatSessionFactory.createProgrammingExerciseChatSessionForUserWithMessages(soloExercise, user);
+        irisSessionRepository.save(programmingExerciseSession);
+        irisMessageRepository.saveAll(programmingExerciseSession.getMessages());
+
         // Execute the request
         List<IrisChatSessionDTO> irisChatSessions = request.getList("/api/iris/chat-history/" + course.getId() + "/sessions", HttpStatus.OK, IrisChatSessionDTO.class);
 
         // Assertions
-        assertThat(irisChatSessions).hasSize(3);
+        assertThat(irisChatSessions).hasSize(4);
         assertThat(irisChatSessions.stream().filter(s -> s.id().equals(lectureSession.getId())).findFirst()).isPresent();
         assertThat(irisChatSessions.stream().filter(s -> s.id().equals(courseSession.getId())).findFirst()).isPresent();
         assertThat(irisChatSessions.stream().filter(s -> s.id().equals(textExerciseSession.getId())).findFirst()).isPresent();
+        assertThat(irisChatSessions.stream().filter(s -> s.id().equals(programmingExerciseSession.getId())).findFirst()).isPresent();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
@@ -6,7 +6,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,7 +19,6 @@ import de.tum.cit.aet.artemis.core.util.CourseUtilService;
 import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
 import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
-import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.exercise.repository.TeamRepository;
 import de.tum.cit.aet.artemis.exercise.test_repository.StudentParticipationTestRepository;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
@@ -30,32 +28,16 @@ import de.tum.cit.aet.artemis.iris.domain.session.IrisSession;
 import de.tum.cit.aet.artemis.iris.dto.IrisChatSessionDTO;
 import de.tum.cit.aet.artemis.iris.repository.IrisMessageRepository;
 import de.tum.cit.aet.artemis.iris.repository.IrisSessionRepository;
-import de.tum.cit.aet.artemis.iris.service.IrisMessageService;
-import de.tum.cit.aet.artemis.iris.service.session.IrisExerciseChatSessionService;
-import de.tum.cit.aet.artemis.iris.service.session.IrisLectureChatSessionService;
 import de.tum.cit.aet.artemis.iris.util.IrisChatSessionFactory;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.util.LectureUtilService;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
-import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParticipation;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.util.TextExerciseUtilService;
 
 class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
 
     private static final String TEST_PREFIX = "iristextchatmessageintegration";
-
-    @Autowired
-    private IrisExerciseChatSessionService irisExerciseChatSessionService;
-
-    @Autowired
-    private IrisSessionRepository irisLectureChatSessionRepository;
-
-    @Autowired
-    private IrisLectureChatSessionService irisLectureChatSessionService;
-
-    @Autowired
-    private IrisMessageService irisMessageService;
 
     @Autowired
     private IrisSessionRepository irisSessionRepository;
@@ -65,9 +47,6 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
 
     @Autowired
     private TeamRepository teamRepository;
-
-    @Autowired
-    private ParticipationUtilService participationUtilService;
 
     @Autowired
     private TextExerciseUtilService textExerciseUtilService;
@@ -80,15 +59,7 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
 
     private ProgrammingExercise soloExercise;
 
-    private ProgrammingExerciseStudentParticipation soloParticipation;
-
-    private ProgrammingExercise teamExercise;
-
     private TextExercise textExercise;
-
-    private ProgrammingExerciseStudentParticipation teamParticipation;
-
-    private AtomicBoolean pipelineDone;
 
     @Autowired
     private LectureUtilService lectureUtilService;
@@ -109,7 +80,7 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
         studentParticipationRepository.save(studentParticipation);
 
         soloExercise = ExerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
-        teamExercise = programmingExerciseUtilService.addProgrammingExerciseToCourse(course);
+        ProgrammingExercise teamExercise = programmingExerciseUtilService.addProgrammingExerciseToCourse(course);
         teamExercise.setMode(ExerciseMode.TEAM);
         programmingExerciseRepository.save(teamExercise);
 
@@ -120,8 +91,6 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
         team.setStudents(Set.of(users.get(1), users.get(2)));
         team.setOwner(users.get(1));
         teamRepository.save(team);
-
-        pipelineDone = new AtomicBoolean(false);
 
         lecture = lectureUtilService.createLecture(course, ZonedDateTime.now());
         activateIrisGlobally();

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
@@ -127,12 +127,9 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
         irisSessionRepository.save(IrisChatSessionFactory.createLectureSessionForUser(lecture, user));
         irisSessionRepository.save(IrisChatSessionFactory.createTextExerciseChatSessionForUser(textExercise, user));
         irisSessionRepository.save(IrisChatSessionFactory.createProgrammingExerciseChatSessionForUser(soloExercise, user));
-        IrisChatSession latestSessionThatShouldBeIncluded = IrisChatSessionFactory.createCourseChatSessionForUser(course, user);
-        irisSessionRepository.save(latestSessionThatShouldBeIncluded);
 
         List<IrisChatSessionDTO> irisChatSessions = request.getList("/api/iris/chat-history/" + course.getId() + "/sessions", HttpStatus.OK, IrisChatSessionDTO.class);
-        assertThat(irisChatSessions).hasSize(1);
-        assertThat(irisChatSessions.stream().anyMatch(session -> session.id().equals(latestSessionThatShouldBeIncluded.getId()))).isTrue();
+        assertThat(irisChatSessions).hasSize(0);
     }
 
     private void saveChatSessionWithMessages(IrisChatSession session) {
@@ -145,22 +142,17 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
     void getAllSessionsForCourseWithSessions_shouldReturnSessionsWithMessages() throws Exception {
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
 
-        irisSessionRepository.save(IrisChatSessionFactory.createCourseChatSessionForUser(course, user)); // empty session, should be filtered out
         saveChatSessionWithMessages(IrisChatSessionFactory.createLectureSessionForUserWithMessages(lecture, user));
         saveChatSessionWithMessages(IrisChatSessionFactory.createCourseSessionForUserWithMessages(course, user));
         saveChatSessionWithMessages(IrisChatSessionFactory.createTextExerciseSessionForUserWithMessages(textExercise, user));
         saveChatSessionWithMessages(IrisChatSessionFactory.createProgrammingExerciseChatSessionForUserWithMessages(soloExercise, user));
-        IrisChatSession latestSessionThatShouldBeIncluded = IrisChatSessionFactory.createCourseChatSessionForUser(course, user); // empty session but created last (opening
-                                                                                                                                 // dashboard), should be included
-        irisSessionRepository.save(latestSessionThatShouldBeIncluded);
 
         List<IrisChatSessionDTO> irisChatSessions = request.getList("/api/iris/chat-history/" + course.getId() + "/sessions", HttpStatus.OK, IrisChatSessionDTO.class);
 
-        assertThat(irisChatSessions).hasSize(5);
+        assertThat(irisChatSessions).hasSize(4);
         assertThat(irisChatSessions.stream().anyMatch(session -> session.entityId().equals(lecture.getId()))).isTrue();
         assertThat(irisChatSessions.stream().anyMatch(session -> session.entityId().equals(course.getId()))).isTrue();
         assertThat(irisChatSessions.stream().anyMatch(session -> session.entityId().equals(textExercise.getId()))).isTrue();
         assertThat(irisChatSessions.stream().anyMatch(session -> session.entityId().equals(soloExercise.getId()))).isTrue();
-        assertThat(irisChatSessions.stream().anyMatch(session -> session.id().equals(latestSessionThatShouldBeIncluded.getId()))).isTrue();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
@@ -170,7 +170,7 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
 
         // Create and save lecture session with messages
-        IrisLectureChatSession lectureSession = IrisChatSessionFactory.createLectureSessionWithMessages(lecture, user);
+        IrisLectureChatSession lectureSession = IrisChatSessionFactory.createLectureSessionForUserWithMessages(lecture, user);
 
         irisLectureChatSessionRepository.save(lectureSession);
         irisMessageRepository.saveAll(lectureSession.getMessages());

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
@@ -158,7 +158,7 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
         irisSessionRepository.save(IrisChatSessionFactory.createCourseChatSessionForUser(course, user));
         irisSessionRepository.save(IrisChatSessionFactory.createLectureSessionForUser(lecture, user));
         irisSessionRepository.save(IrisChatSessionFactory.createTextExerciseChatSessionForUser(textExercise, user));
-        irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        irisExerciseChatSessionService.createChatSessionForProgrammingExercise(soloExercise, user);
 
         List<IrisChatSessionDTO> irisChatSessions = request.getList("/api/iris/chat-history/" + course.getId() + "/sessions", HttpStatus.OK, IrisChatSessionDTO.class);
         assertThat(irisChatSessions).hasSize(0);

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatSessionResourceTest.java
@@ -178,12 +178,17 @@ class IrisChatSessionResourceTest extends AbstractIrisIntegrationTest {
         irisSessionRepository.save(courseSession);
         irisMessageRepository.saveAll(courseSession.getMessages());
 
+        IrisChatSession textExerciseSession = IrisChatSessionFactory.createTextExerciseSessionForUserWithMessages(textExercise, user);
+        irisSessionRepository.save(textExerciseSession);
+        irisMessageRepository.saveAll(textExerciseSession.getMessages());
+
         // Execute the request
         List<IrisChatSessionDTO> irisChatSessions = request.getList("/api/iris/chat-history/" + course.getId() + "/sessions", HttpStatus.OK, IrisChatSessionDTO.class);
 
         // Assertions
-        assertThat(irisChatSessions).hasSize(2);
+        assertThat(irisChatSessions).hasSize(3);
         assertThat(irisChatSessions.stream().filter(s -> s.id().equals(lectureSession.getId())).findFirst()).isPresent();
         assertThat(irisChatSessions.stream().filter(s -> s.id().equals(courseSession.getId())).findFirst()).isPresent();
+        assertThat(irisChatSessions.stream().filter(s -> s.id().equals(textExerciseSession.getId())).findFirst()).isPresent();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatTokenTrackingIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatTokenTrackingIntegrationTest.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.artemis.iris;
 
-import static de.tum.cit.aet.artemis.iris.utils.IrisLLMMock.getMockLLMCosts;
+import static de.tum.cit.aet.artemis.iris.util.IrisLLMMock.getMockLLMCosts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.awaitility.Awaitility.await;

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisConcistencyCheckIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisConcistencyCheckIntegrationTest.java
@@ -1,7 +1,7 @@
 package de.tum.cit.aet.artemis.iris;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_IRIS;
-import static de.tum.cit.aet.artemis.iris.utils.IrisLLMMock.getMockLLMCosts;
+import static de.tum.cit.aet.artemis.iris.util.IrisLLMMock.getMockLLMCosts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisRewritingIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisRewritingIntegrationTest.java
@@ -1,7 +1,7 @@
 package de.tum.cit.aet.artemis.iris;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_IRIS;
-import static de.tum.cit.aet.artemis.iris.utils.IrisLLMMock.getMockLLMCosts;
+import static de.tum.cit.aet.artemis.iris.util.IrisLLMMock.getMockLLMCosts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.timeout;

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
@@ -7,6 +7,7 @@ import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.iris.domain.message.IrisMessage;
 import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender;
+import de.tum.cit.aet.artemis.iris.domain.session.IrisChatSession;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisCourseChatSession;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisLectureChatSession;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisTextExerciseChatSession;
@@ -31,37 +32,26 @@ public class IrisChatSessionFactory {
         return new IrisTextExerciseChatSession(textExercise, user);
     }
 
-    public static IrisLectureChatSession createLectureSessionForUserWithMessages(Lecture lecture, User user) {
+    public static <T extends IrisChatSession> T createSessionWithMessages(T session, Long id) {
         List<IrisMessage> messages = new ArrayList<>();
-
         messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.LLM));
         messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.USER));
+        messages.forEach(message -> message.setSession(session));
 
-        return createLectureSessionForUserWithMessages(lecture, user, messages);
+        session.setMessages(messages);
+
+        return session;
     }
 
-    public static IrisLectureChatSession createLectureSessionForUserWithMessages(Lecture lecture, User user, List<IrisMessage> messages) {
-        IrisLectureChatSession session = new IrisLectureChatSession(lecture, user);
-        session.setLectureId(lecture.getId());
-        session.setMessages(messages);
-        messages.forEach(message -> message.setSession(session));
-        return session;
+    public static IrisLectureChatSession createLectureSessionForUserWithMessages(Lecture lecture, User user) {
+        IrisLectureChatSession chatSession = createLectureSessionForUser(lecture, user);
+        chatSession.setLectureId(lecture.getId());
+        return createSessionWithMessages(chatSession, lecture.getId());
     }
 
     public static IrisCourseChatSession createCourseSessionForUserWithMessages(Course course, User user) {
-        List<IrisMessage> messages = new ArrayList<>();
-
-        messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.LLM));
-        messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.USER));
-
-        return createCourseSessionForUserWithMessages(course, user, messages);
-    }
-
-    public static IrisCourseChatSession createCourseSessionForUserWithMessages(Course course, User user, List<IrisMessage> messages) {
-        IrisCourseChatSession session = new IrisCourseChatSession(course, user);
-        session.setCourseId(course.getId());
-        session.setMessages(messages);
-        messages.forEach(message -> message.setSession(session));
-        return session;
+        IrisCourseChatSession chatSession = createCourseChatSessionForUser(course, user);
+        chatSession.setCourseId(course.getId());
+        return createSessionWithMessages(chatSession, course.getId());
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
@@ -9,7 +9,9 @@ import de.tum.cit.aet.artemis.iris.domain.message.IrisMessage;
 import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisCourseChatSession;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisLectureChatSession;
+import de.tum.cit.aet.artemis.iris.domain.session.IrisTextExerciseChatSession;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
 
 public class IrisChatSessionFactory {
 
@@ -24,6 +26,18 @@ public class IrisChatSessionFactory {
         messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.USER));
 
         return createLectureSessionWithMessages(lecture, user, messages);
+    }
+
+    public static IrisLectureChatSession createLectureSessionForUser(Lecture lecture, User user) {
+        return new IrisLectureChatSession(lecture, user);
+    }
+
+    public static IrisCourseChatSession createCourseChatSessionForUser(Course course, User user) {
+        return new IrisCourseChatSession(course, user);
+    }
+
+    public static IrisTextExerciseChatSession createTextExerciseChatSessionForUser(TextExercise textExercise, User user) {
+        return new IrisTextExerciseChatSession(textExercise, user);
     }
 
     public static IrisLectureChatSession createLectureSessionWithMessages(Lecture lecture, User user, List<IrisMessage> messages) {

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
@@ -18,8 +18,10 @@ import de.tum.cit.aet.artemis.text.domain.TextExercise;
 
 public class IrisChatSessionFactory {
 
+    /**
+     * This is a utility class that should not be instantiated, which is why the constructor is private.
+     */
     private IrisChatSessionFactory() {
-        // Prevent instantiation of this utility class
     }
 
     public static IrisLectureChatSession createLectureSessionForUser(Lecture lecture, User user) {

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
@@ -38,7 +38,7 @@ public class IrisChatSessionFactory {
         return new IrisProgrammingExerciseChatSession(programmingExercise, user);
     }
 
-    public static <T extends IrisChatSession> T createSessionWithMessages(T session, Long id) {
+    public static <T extends IrisChatSession> T createSessionWithMessages(T session) {
         List<IrisMessage> messages = new ArrayList<>();
         messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.LLM));
         messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.USER));
@@ -51,25 +51,21 @@ public class IrisChatSessionFactory {
 
     public static IrisLectureChatSession createLectureSessionForUserWithMessages(Lecture lecture, User user) {
         IrisLectureChatSession chatSession = createLectureSessionForUser(lecture, user);
-        chatSession.setLectureId(lecture.getId());
-        return createSessionWithMessages(chatSession, lecture.getId());
+        return createSessionWithMessages(chatSession);
     }
 
     public static IrisCourseChatSession createCourseSessionForUserWithMessages(Course course, User user) {
         IrisCourseChatSession chatSession = createCourseChatSessionForUser(course, user);
-        chatSession.setCourseId(course.getId());
-        return createSessionWithMessages(chatSession, course.getId());
+        return createSessionWithMessages(chatSession);
     }
 
     public static IrisTextExerciseChatSession createTextExerciseSessionForUserWithMessages(TextExercise textExercise, User user) {
         IrisTextExerciseChatSession chatSession = createTextExerciseChatSessionForUser(textExercise, user);
-        chatSession.setExerciseId(textExercise.getId());
-        return createSessionWithMessages(chatSession, textExercise.getId());
+        return createSessionWithMessages(chatSession);
     }
 
     public static IrisProgrammingExerciseChatSession createProgrammingExerciseChatSessionForUserWithMessages(ProgrammingExercise programmingExercise, User user) {
         IrisProgrammingExerciseChatSession chatSession = createProgrammingExerciseChatSessionForUser(programmingExercise, user);
-        chatSession.setExerciseId(programmingExercise.getId());
-        return createSessionWithMessages(chatSession, programmingExercise.getId());
+        return createSessionWithMessages(chatSession);
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
@@ -19,15 +19,6 @@ public class IrisChatSessionFactory {
         // Prevent instantiation of this utility class
     }
 
-    public static IrisLectureChatSession createLectureSessionWithMessages(Lecture lecture, User user) {
-        List<IrisMessage> messages = new ArrayList<>();
-
-        messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.LLM));
-        messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.USER));
-
-        return createLectureSessionWithMessages(lecture, user, messages);
-    }
-
     public static IrisLectureChatSession createLectureSessionForUser(Lecture lecture, User user) {
         return new IrisLectureChatSession(lecture, user);
     }
@@ -40,7 +31,16 @@ public class IrisChatSessionFactory {
         return new IrisTextExerciseChatSession(textExercise, user);
     }
 
-    public static IrisLectureChatSession createLectureSessionWithMessages(Lecture lecture, User user, List<IrisMessage> messages) {
+    public static IrisLectureChatSession createLectureSessionForUserWithMessages(Lecture lecture, User user) {
+        List<IrisMessage> messages = new ArrayList<>();
+
+        messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.LLM));
+        messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.USER));
+
+        return createLectureSessionForUserWithMessages(lecture, user, messages);
+    }
+
+    public static IrisLectureChatSession createLectureSessionForUserWithMessages(Lecture lecture, User user, List<IrisMessage> messages) {
         IrisLectureChatSession session = new IrisLectureChatSession(lecture, user);
         session.setLectureId(lecture.getId());
         session.setMessages(messages);
@@ -48,20 +48,20 @@ public class IrisChatSessionFactory {
         return session;
     }
 
-    public static IrisCourseChatSession createCourseSessionWithMessages(Course course, User user) {
+    public static IrisCourseChatSession createCourseSessionForUserWithMessages(Course course, User user) {
         List<IrisMessage> messages = new ArrayList<>();
 
         messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.LLM));
         messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.USER));
 
-        return createCourseSession(course, user, messages);
+        return createCourseSessionForUserWithMessages(course, user, messages);
     }
 
-    public static IrisCourseChatSession createCourseSession(Course course, User user, List<IrisMessage> messages) {
+    public static IrisCourseChatSession createCourseSessionForUserWithMessages(Course course, User user, List<IrisMessage> messages) {
         IrisCourseChatSession session = new IrisCourseChatSession(course, user);
         session.setCourseId(course.getId());
-        messages.forEach(message -> message.setSession(session));
         session.setMessages(messages);
+        messages.forEach(message -> message.setSession(session));
         return session;
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
@@ -1,0 +1,53 @@
+package de.tum.cit.aet.artemis.iris.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.tum.cit.aet.artemis.core.domain.Course;
+import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.iris.domain.message.IrisMessage;
+import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender;
+import de.tum.cit.aet.artemis.iris.domain.session.IrisCourseChatSession;
+import de.tum.cit.aet.artemis.iris.domain.session.IrisLectureChatSession;
+import de.tum.cit.aet.artemis.lecture.domain.Lecture;
+
+public class IrisChatSessionFactory {
+
+    private IrisChatSessionFactory() {
+        // Prevent instantiation of this utility class
+    }
+
+    public static IrisLectureChatSession createLectureSessionWithMessages(Lecture lecture, User user) {
+        List<IrisMessage> messages = new ArrayList<>();
+
+        messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.LLM));
+        messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.USER));
+
+        return createLectureSessionWithMessages(lecture, user, messages);
+    }
+
+    public static IrisLectureChatSession createLectureSessionWithMessages(Lecture lecture, User user, List<IrisMessage> messages) {
+        IrisLectureChatSession session = new IrisLectureChatSession(lecture, user);
+        session.setLectureId(lecture.getId());
+        session.setMessages(messages);
+        messages.forEach(message -> message.setSession(session));
+        return session;
+    }
+
+    public static IrisCourseChatSession createCourseSessionWithMessages(Course course, User user) {
+        List<IrisMessage> messages = new ArrayList<>();
+
+        messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.LLM));
+        messages.add(IrisMessageFactory.createIrisMessage(IrisMessageSender.USER));
+
+        return createCourseSession(course, user, messages);
+    }
+
+    public static IrisCourseChatSession createCourseSession(Course course, User user, List<IrisMessage> messages) {
+        IrisCourseChatSession session = new IrisCourseChatSession(course, user);
+        session.setCourseId(course.getId());
+        messages.forEach(message -> message.setSession(session));
+        session.setMessages(messages);
+        return session;
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
@@ -10,8 +10,10 @@ import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisChatSession;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisCourseChatSession;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisLectureChatSession;
+import de.tum.cit.aet.artemis.iris.domain.session.IrisProgrammingExerciseChatSession;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisTextExerciseChatSession;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 
 public class IrisChatSessionFactory {
@@ -30,6 +32,10 @@ public class IrisChatSessionFactory {
 
     public static IrisTextExerciseChatSession createTextExerciseChatSessionForUser(TextExercise textExercise, User user) {
         return new IrisTextExerciseChatSession(textExercise, user);
+    }
+
+    public static IrisProgrammingExerciseChatSession createProgrammingExerciseChatSessionForUser(ProgrammingExercise programmingExercise, User user) {
+        return new IrisProgrammingExerciseChatSession(programmingExercise, user);
     }
 
     public static <T extends IrisChatSession> T createSessionWithMessages(T session, Long id) {
@@ -59,5 +65,11 @@ public class IrisChatSessionFactory {
         IrisTextExerciseChatSession chatSession = createTextExerciseChatSessionForUser(textExercise, user);
         chatSession.setExerciseId(textExercise.getId());
         return createSessionWithMessages(chatSession, textExercise.getId());
+    }
+
+    public static IrisProgrammingExerciseChatSession createProgrammingExerciseChatSessionForUserWithMessages(ProgrammingExercise programmingExercise, User user) {
+        IrisProgrammingExerciseChatSession chatSession = createProgrammingExerciseChatSessionForUser(programmingExercise, user);
+        chatSession.setExerciseId(programmingExercise.getId());
+        return createSessionWithMessages(chatSession, programmingExercise.getId());
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisChatSessionFactory.java
@@ -54,4 +54,10 @@ public class IrisChatSessionFactory {
         chatSession.setCourseId(course.getId());
         return createSessionWithMessages(chatSession, course.getId());
     }
+
+    public static IrisTextExerciseChatSession createTextExerciseSessionForUserWithMessages(TextExercise textExercise, User user) {
+        IrisTextExerciseChatSession chatSession = createTextExerciseChatSessionForUser(textExercise, user);
+        chatSession.setExerciseId(textExercise.getId());
+        return createSessionWithMessages(chatSession, textExercise.getId());
+    }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisLLMMock.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisLLMMock.java
@@ -1,4 +1,4 @@
-package de.tum.cit.aet.artemis.iris.utils;
+package de.tum.cit.aet.artemis.iris.util;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisMessageContentFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisMessageContentFactory.java
@@ -1,0 +1,32 @@
+package de.tum.cit.aet.artemis.iris.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageContent;
+import de.tum.cit.aet.artemis.iris.domain.message.IrisTextMessageContent;
+
+public class IrisMessageContentFactory {
+
+    private IrisMessageContentFactory() {
+        // Prevent instantiation of this utility class
+    }
+
+    public static List<IrisMessageContent> createIrisMessageContents() {
+        return createIrisMessageContents(3);
+    }
+
+    public static List<IrisMessageContent> createIrisMessageContents(int numberOfMessages) {
+        List<IrisMessageContent> messageContents = new ArrayList<>();
+        for (int i = 0; i < numberOfMessages; i++) {
+            messageContents.add(createIrisMessageContent("Text content " + i));
+        }
+        return messageContents;
+    }
+
+    public static IrisMessageContent createIrisMessageContent(String textContent) {
+        IrisTextMessageContent messageContent = new IrisTextMessageContent();
+        messageContent.setTextContent(textContent);
+        return messageContent;
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisMessageContentFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisMessageContentFactory.java
@@ -8,8 +8,10 @@ import de.tum.cit.aet.artemis.iris.domain.message.IrisTextMessageContent;
 
 public class IrisMessageContentFactory {
 
+    /**
+     * This is a utility class that should not be instantiated, which is why the constructor is private.
+     */
     private IrisMessageContentFactory() {
-        // Prevent instantiation of this utility class
     }
 
     public static List<IrisMessageContent> createIrisMessageContents() {

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisMessageFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisMessageFactory.java
@@ -5,8 +5,10 @@ import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender;
 
 public class IrisMessageFactory {
 
+    /**
+     * This is a utility class that should not be instantiated, which is why the constructor is private.
+     */
     private IrisMessageFactory() {
-        // Prevent instantiation of this utility class
     }
 
     public static IrisMessage createIrisMessage(IrisMessageSender irisMessageSender) {

--- a/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisMessageFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/util/IrisMessageFactory.java
@@ -1,0 +1,18 @@
+package de.tum.cit.aet.artemis.iris.util;
+
+import de.tum.cit.aet.artemis.iris.domain.message.IrisMessage;
+import de.tum.cit.aet.artemis.iris.domain.message.IrisMessageSender;
+
+public class IrisMessageFactory {
+
+    private IrisMessageFactory() {
+        // Prevent instantiation of this utility class
+    }
+
+    public static IrisMessage createIrisMessage(IrisMessageSender irisMessageSender) {
+        IrisMessage message = new IrisMessage();
+        message.setSender(irisMessageSender);
+        message.setContent(IrisMessageContentFactory.createIrisMessageContents());
+        return message;
+    }
+}


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).


### Motivation and Context
Resolves #11100 


### Description
- Filtering out Iris sessions where users did not interact
- Add pyris URL to connector health info
- Using undefined > null (client guidelines)
- Marked methods that are to be removed as @Deprecated to ensure they are not used any further
- Removed unused imports from tests
- Removed usage of deprecated methods in `IrisChatSessionResourceTest`
- Adjusted tests to check for properly filtering iris chat sessions
- Added factories for creating test data to be saved in the repositories
- Renamed folder `utils` -> to `util` to ensure consistency with other parts of the project

### Steps for Testing
Only test on testservers with Iris activated (ts1, ts3, ts5)

1. Navigate to the dashboard
2. See that your old chats with Iris are displayed
3. Verify that chats where you did not interact with Iris are not displayed anymore in the history
4. Verify you are not missing any previous chats where you did interact with Iris

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Performance Review
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots

#### Before filtering out sessions without messages
![irisHistoryIncludingSessionsWithoutMessages](https://github.com/user-attachments/assets/f217c585-b843-4a01-8e8d-7e9adee5ef6a)

Which includes empty chats:
<img src="https://github.com/user-attachments/assets/9e71e592-d56f-4077-ac92-cc0020cf84ac" width="500" />

<img src="https://github.com/user-attachments/assets/be01ead9-e06f-47f1-a8b8-866248cdf541" width="500" />


#### NOW: Filtering out sessions without messages 
![image](https://github.com/user-attachments/assets/7b8f4ce2-75b1-4d92-8f52-14a8edfa1e54)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of chat sessions to only display those with user-sent messages.
  * Clarified session retrieval to indicate results are specific to the current user and course.

* **Enhancements**
  * Health check status now displays the Iris service URL as additional metadata.

* **Documentation**
  * Updated endpoint descriptions for greater clarity.

* **Style**
  * Minor code improvements for variable initialization in session filtering logic.

* **Tests**
  * Simplified and enhanced chat session tests using a new factory utility.
  * Added tests verifying filtering of sessions without messages.
  * Corrected import paths in integration tests.

* **New Features**
  * Introduced utilities for creating chat sessions, messages, and message contents for testing purposes.

* **Deprecations**
  * Marked certain chat session creation methods as deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->