### PR TITLE
`Programming exercises`: Update programming-exercise-theia.component to align with new exercise creation workflow

### DIFF
--- a/src/main/webapp/app/programming/manage/update/update-components/theia/programming-exercise-theia.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/theia/programming-exercise-theia.component.ts
@@ -70,9 +70,12 @@ export class ProgrammingExerciseTheiaComponent implements OnChanges {
                 this.theiaImages = images;
 
                 // Set the first image as default if none is selected and not in the language-specified ones
-                if (this.programmingExercise && this.programmingExercise.buildConfig && 
-                    (!this.programmingExercise.buildConfig.theiaImage || !Object.values(images).includes(this.programmingExercise.buildConfig.theiaImage)) && 
-                    Object.values(images).length > 0) {
+                if (
+                    this.programmingExercise &&
+                    this.programmingExercise.buildConfig &&
+                    (!this.programmingExercise.buildConfig.theiaImage || !Object.values(images).includes(this.programmingExercise.buildConfig.theiaImage)) &&
+                    Object.values(images).length > 0
+                ) {
                     this.programmingExercise.buildConfig.theiaImage = Object.values(images).first() as string;
                 }
             },

--- a/src/main/webapp/app/programming/manage/update/update-components/theia/programming-exercise-theia.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/theia/programming-exercise-theia.component.ts
@@ -69,8 +69,10 @@ export class ProgrammingExerciseTheiaComponent implements OnChanges {
 
                 this.theiaImages = images;
 
-                // Set the first image as default if none is selected
-                if (this.programmingExercise && this.programmingExercise.buildConfig && !this.programmingExercise.buildConfig.theiaImage && Object.values(images).length > 0) {
+                // Set the first image as default if none is selected and not in the language-specified ones
+                if (this.programmingExercise && this.programmingExercise.buildConfig && 
+                    (!this.programmingExercise.buildConfig.theiaImage || !Object.values(images).includes(this.programmingExercise.buildConfig.theiaImage)) && 
+                    Object.values(images).length > 0) {
                     this.programmingExercise.buildConfig.theiaImage = Object.values(images).first() as string;
                 }
             },


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
There was a bug that the used Theia image always defaulted to the one used for Java exercises as the toggle for "Allow online-ide" move before the language selection
<!-- If it fixes an open issue, please link to the issue here. -->


### Description
<!-- Describe your changes in detail -->
Add check to see whether the selected image is still a valid image for this programming exercise. Otherwise set the first valid image as new image. This also handles the case, where we first toggle the checkbox to use Online IDE and then change the programming language afterwards.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a new programming exercise
4. Select "Allow Online IDE" checkbox when creating
5. Change the language and/or image
6. Now the correct image is stored in the BuildConfig

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the logic for setting the default Theia image to ensure a valid image is always selected, even if the previously chosen image is no longer available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->