### PR TITLE
`Development`: Do not write pipeline script directly with curl in the Jenkins pipeline

### DIFF
--- a/src/main/resources/templates/jenkins/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/Jenkinsfile
@@ -53,7 +53,7 @@ node('docker') {
         }
         stage('Load') {
             timestamps {
-                sh "curl -o pipeline.groovy #buildPlanUrl"
+                sh "curl #buildPlanUrl > pipeline.groovy"
                 ownStages = load 'pipeline.groovy'
                 timeout(time: #jenkinsTimeout, unit: 'MINUTES') {
                     ownStages.testRunner()


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
On one of our test servers running Ubuntu testing, the Jenkins pipelines suddenly failed since `curl` could no longer write the `pipeline.groovy` downloaded from Artemis.

### Description
<!-- Describe your changes in detail -->
Due to an AppArmor update, a new policy did no longer allow `curl` to write files outside of `/home` and `/tmp`. Therefore, writing to the Jenkins workspace (in `/var/lib/jenkins/workspace/`) did not longer work.
The workaround is to use a stdout redirection to write the file instead.

This rule might not make it into Ubuntu stable, but just to be on the safe side and prevent sudden build failures that are somewhat hard to debug I propose to just switch to the new approach as a preventative measure.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Artemis instance with Jenkins CI setup

1. Create a new programming exercise.
2. The solution build should pass.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
unchanged

@coderabbitai ignore