### PR TITLE
`Communication`: Keep original file name and shorten url for uploads

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/util/FileUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/FileUtil.java
@@ -141,10 +141,9 @@ public class FileUtil {
 
         validateExtension(sanitizedOriginalFilename, true);
 
-        final String filenamePrefix = "Markdown_";
         final Path path = FilePathConverter.getMarkdownFilePathForConversation(courseId, conversationId);
 
-        String fileName = generateFilename(filenamePrefix, sanitizedOriginalFilename, false);
+        String fileName = generateFilename("", sanitizedOriginalFilename, true);
         Path filePath = path.resolve(fileName);
 
         copyFile(file, filePath);


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


### Motivation and Context
When uploading a file or image in a conversation, the generated path for use in markdown looks like this:
`/api/core/files/courses/{courseId}/conversations/{conversationId}/Markdown_{timestamp}_{random}`. This makes it hard for users to know which file they added and can make editing the message more complicated because it is not clear which markdown URL corresponds to which file. We thus want to improve this path by keeping the original file name (instead of 8 random bytes), and as all files for communication start with `Markdown_`, we can omit this prefix too.

### Description
We change the markdown path for uploaded files to `/api/core/files/courses/{courseId}/conversations/{conversationId}/{timestamp}_{fileName}`. This makes the URL shorter and allows users to identify which file a URL belongs to more easily.


### Steps for Testing
Prerequisites:
- 1 User
- Course with communication enabled and some uploaded files

1. Open a conversation inside a course.
2. Verify that existing files can still be viewed/downloaded.
3. Upload a new file and ensure the URL includes the file name and no "Markdown_" prefix.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Filenames for conversation files now retain the original sanitized name with a timestamp prefix, instead of a generic "Markdown_" prefix or a random name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->