### PR TITLE
`Programming exercises`: Fix submission creation at commit time

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingSubmissionService.java
@@ -185,7 +185,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
 
         // Instructors are allowed to submit to a programming exercise after the due date, if this happens we set the Submission to INSTRUCTOR
         // TODO: double check if the user contains the authoities and groups, if not, we need to load the user from the database again
-        if (authCheckService.isAtLeastInstructorForExercise(participation.getExercise(), user)) {
+        if (user != null && authCheckService.isAtLeastInstructorForExercise(participation.getExercise(), user)) {
             programmingSubmission.setType(SubmissionType.INSTRUCTOR);
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingSubmissionService.java
@@ -184,7 +184,8 @@ public class ProgrammingSubmissionService extends SubmissionService {
         programmingSubmission.setType(SubmissionType.MANUAL);
 
         // Instructors are allowed to submit to a programming exercise after the due date, if this happens we set the Submission to INSTRUCTOR
-        // TODO: double check if the user contains the authoities and groups, if not, we need to load the user from the database again
+        // TODO: double check if the user contains the authorities and groups, if not, we need to load the user from the database again
+        // TODO: the user can be null if the commit was made via git client so it can not be determined here if the user is a instructor for the exercise in that case
         if (user != null && authCheckService.isAtLeastInstructorForExercise(participation.getExercise(), user)) {
             programmingSubmission.setType(SubmissionType.INSTRUCTOR);
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixing a small issue that lead to submissions for programming exercises not being created at commit time, and a wrong error message in the git log.
Before the fix, the submission would not be created until the build job was processed. This can be reproduced best by pausing the build agents, committing to a programming exercise and checking if the submission got created while the job is still stuck in the queue.

### Description
<!-- Describe your changes in detail -->
in `processNewProgrammingSubmission` the null user (when pushing e.g. via https to the repo) causes an exception in `authCheckService.isAtLeastInstructorForExercise(participation.getExercise(), user))` before the submission is saved. This exception triggers also the wrong error message in` LocalVCPostPushHook->onPostReceive`

```
catch (VersionControlException e) {
            receivePack.sendError(wrongBranchMessage);
        }
```
### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Admin (use e.g. ts3)
- 1 Students
- 1 Programming Exercise

1. As admin, pause all build agents
2. As a user clone programming exercise repository on your local machine
3. commit and push a change to it
4. check the logs in your git client when committing, you should not see something like
    "remote: error: Only pushes to the default branch will be graded. Your changes were saved nonetheless.
To http://localhost:8080/git/LOCALCOURSEPROG/localcourseprog-artemis_test_user_3.git"
5. Check the submissions for that exercise, the submission should be immediately showing up after committing
e.g.: 
<img width="2056" height="387" alt="image" src="https://github.com/user-attachments/assets/b195a612-c6f6-4745-b324-e232c8fa81d9" />

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing errors when the user is not specified during submission processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->