### PR TITLE
`Development`: Do not use system temp dir for server tests

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/service/ResourceLoaderService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/ResourceLoaderService.java
@@ -44,6 +44,8 @@ public class ResourceLoaderService {
     @Value("${artemis.template-path:#{null}}")
     private Optional<Path> templateFileSystemPath;
 
+    private final Path tempPath;
+
     private final ResourcePatternResolver resourceLoader;
 
     /**
@@ -51,8 +53,9 @@ public class ResourceLoaderService {
      */
     private static final List<Path> ALLOWED_OVERRIDE_PREFIXES = List.of(Path.of("templates"));
 
-    public ResourceLoaderService(ResourceLoader resourceLoader) {
+    public ResourceLoaderService(ResourceLoader resourceLoader, @Value("${artemis.temp-path}") Path tempPath) {
         this.resourceLoader = ResourcePatternUtils.getResourcePatternResolver(resourceLoader);
+        this.tempPath = tempPath;
     }
 
     /**
@@ -221,7 +224,7 @@ public class ResourceLoaderService {
         }
         else if ("jar".equals(resourceUrl.getProtocol())) {
             // Resource is in a jar file.
-            Path resourcePath = Files.createTempFile(UUID.randomUUID().toString(), "");
+            Path resourcePath = Files.createTempFile(tempPath, UUID.randomUUID().toString(), "");
             File file = resourcePath.toFile();
             file.deleteOnExit();
             FileUtils.copyInputStreamToFile(resource.getInputStream(), file);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/PlantUmlService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/PlantUmlService.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
@@ -36,13 +37,13 @@ public class PlantUmlService {
 
     private static final String LIGHT_THEME_FILE_NAME = "puml-theme-artemislight.puml";
 
-    // TODO: we should use a different directory and not the tmp directory
-    private static final Path PATH_TMP_THEME = Path.of(System.getProperty("java.io.tmpdir"), "artemis-puml-theme");
+    private final Path PATH_TMP_THEME;
 
     private final ResourceLoaderService resourceLoaderService;
 
-    public PlantUmlService(ResourceLoaderService resourceLoaderService) {
+    public PlantUmlService(ResourceLoaderService resourceLoaderService, @Value("${artemis.temp-path}") Path tempPath) {
         this.resourceLoaderService = resourceLoaderService;
+        this.PATH_TMP_THEME = tempPath.resolve("artemis-puml-theme");
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportFromFileService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportFromFileService.java
@@ -20,6 +20,7 @@ import org.apache.commons.io.filefilter.NotFileFilter;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -69,6 +70,9 @@ public class ProgrammingExerciseImportFromFileService {
 
     private final BuildPlanRepository buildPlanRepository;
 
+    @Value("${artemis.temp-path}")
+    private Path tempPath;
+
     public ProgrammingExerciseImportFromFileService(ProgrammingExerciseCreationUpdateService programmingExerciseCreationUpdateService,
             ProgrammingExerciseValidationService programmingExerciseValidationService, ZipFileService zipFileService, StaticCodeAnalysisService staticCodeAnalysisService,
             ProgrammingExerciseRepositoryService programmingExerciseRepositoryService, RepositoryService repositoryService, GitService gitService, FileService fileService,
@@ -104,7 +108,7 @@ public class ProgrammingExerciseImportFromFileService {
         Path importExerciseDir = null;
         ProgrammingExercise newProgrammingExercise;
         try {
-            importExerciseDir = Files.createTempDirectory("imported-exercise-dir");
+            importExerciseDir = Files.createTempDirectory(tempPath, "imported-exercise-dir");
             Path exerciseFilePath = Files.createTempFile(importExerciseDir, "exercise-for-import", ".zip");
 
             zipFile.transferTo(exerciseFilePath);

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -9,6 +9,7 @@ artemis:
   repo-download-clone-path: ./repos-download      # a temporary folder, in which git repos are downloaded that are immediately deleted afterwards (e.g. exports, plagiarism checks), should NOT be in a shared file system area
   data-export-path: ./data-exports                # a folder in which data exports are stored
   build-logs-path: ./build-logs                   # a folder in which build logs are stored
+  temp-path: ${java.io.tmpdir}                           # a folder in which temporary files are stored, e.g. for the online code editor
   bcrypt-salt-rounds: 11  # The number of salt rounds for the bcrypt password hashing. Lower numbers make it faster but more unsecure and vice versa.
   # Please use the bcrypt benchmark tool to determine the best number of rounds for your system. https://github.com/ls1intum/bcrypt-Benchmark
   user-management:

--- a/src/test/java/de/tum/cit/aet/artemis/core/FileIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/FileIntegrationTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -85,6 +86,9 @@ class FileIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Value("${artemis.temp-path}")
+    private Path tempPath;
 
     @BeforeEach
     void initTestCase() {
@@ -387,7 +391,7 @@ class FileIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     }
 
     private void testGetAttachmentVideoUnit(boolean isTutor) throws Exception {
-        Path tempFile = Files.createTempFile("dummy", ".pdf");
+        Path tempFile = Files.createTempFile(tempPath, "dummy", ".pdf");
         byte[] dummyContent = "dummy pdf content".getBytes();
         FileUtils.writeByteArrayToFile(tempFile.toFile(), dummyContent);
         tempFile.toFile().deleteOnExit();

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/ResourceLoaderServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/ResourceLoaderServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 
@@ -40,6 +41,9 @@ class ResourceLoaderServiceTest extends AbstractSpringIntegrationIndependentTest
     private final Path jenkinsPath = Path.of("templates", "jenkins", "jenkins.txt");
 
     private final List<Path> jenkinsFilesystemPaths = List.of(Path.of("templates", "jenkins", "p1.txt"), Path.of("templates", "jenkins", "p2.txt"));
+
+    @Value("${artemis.temp-path}")
+    private Path tempPath;
 
     @AfterEach
     void cleanup() throws IOException {
@@ -173,7 +177,7 @@ class ResourceLoaderServiceTest extends AbstractSpringIntegrationIndependentTest
         doReturn(resource).when(resourceLoader).getResource(anyString());
 
         // Instantiate the class under test and invoke the method.
-        ResourceLoaderService resourceLoaderService = new ResourceLoaderService(resourceLoader);
+        ResourceLoaderService resourceLoaderService = new ResourceLoaderService(resourceLoader, tempPath);
         Path path = Path.of("path", "to", "resource.txt");
         Path resourceFilePath = resourceLoaderService.getResourceFilePath(path);
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/ZipFileServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/ZipFileServiceTest.java
@@ -11,6 +11,7 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
@@ -19,10 +20,13 @@ class ZipFileServiceTest extends AbstractSpringIntegrationIndependentTest {
     @Autowired
     private ZipFileService zipFileService;
 
+    @Value("${artemis.temp-path}")
+    private Path tempPath;
+
     @Test
     void testExtractZipFileRecursively_unzipsNestedZipCorrectly() throws IOException {
-        Path testDir = Files.createTempDirectory("test-dir");
-        Path zipDir = Files.createTempDirectory("zip-dir");
+        Path testDir = Files.createTempDirectory(tempPath, "test-dir");
+        Path zipDir = Files.createTempDirectory(tempPath, "zip-dir");
 
         Path rootDir = Files.createTempDirectory(testDir, "root-dir");
         Path subDir = Files.createTempDirectory(rootDir, "sub-dir");
@@ -47,7 +51,7 @@ class ZipFileServiceTest extends AbstractSpringIntegrationIndependentTest {
 
     @Test
     void testCreateTemporaryZipFileSchedulesFileForDeletion() throws IOException {
-        var tempZipFile = Files.createTempFile("test", ".zip");
+        var tempZipFile = Files.createTempFile(tempPath, "test", ".zip");
         zipFileService.createTemporaryZipFile(tempZipFile, List.of(), 5);
         assertThat(tempZipFile).exists();
         verify(fileService).schedulePathForDeletion(tempZipFile, 5L);

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/SlideSplitterServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/SlideSplitterServiceTest.java
@@ -28,6 +28,7 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.cit.aet.artemis.core.FilePathType;
@@ -62,6 +63,9 @@ class SlideSplitterServiceTest extends AbstractSpringIntegrationIndependentTest 
     private AttachmentVideoUnit testAttachmentVideoUnit;
 
     private PDDocument testDocument;
+
+    @Value("${artemis.temp-path}")
+    private Path tempPath;
 
     @BeforeEach
     void initTestCase() {
@@ -645,7 +649,7 @@ class SlideSplitterServiceTest extends AbstractSpringIntegrationIndependentTest 
         slideRepository.deleteAll(existingSlides);
 
         // Create a mock PDF file with 3 pages
-        Path tempDir = Files.createTempDirectory("test-slides");
+        Path tempDir = Files.createTempDirectory(tempPath, "test-slides");
         Path tempPdfPath = tempDir.resolve("test-slides.pdf");
         try (PDDocument doc = new PDDocument()) {
             // Add 3 pages to the document
@@ -772,7 +776,7 @@ class SlideSplitterServiceTest extends AbstractSpringIntegrationIndependentTest 
         slideRepository.deleteAll(existingSlides);
 
         // Create a mock PDF file
-        Path tempDir = Files.createTempDirectory("test-slides");
+        Path tempDir = Files.createTempDirectory(tempPath, "test-slides");
         Path tempPdfPath = tempDir.resolve("test-slides.pdf");
         try (PDDocument doc = new PDDocument()) {
             doc.addPage(new PDPage());
@@ -821,7 +825,7 @@ class SlideSplitterServiceTest extends AbstractSpringIntegrationIndependentTest 
         slideRepository.deleteAll(existingSlides);
 
         // Create a mock PDF file with 3 pages
-        Path tempDir = Files.createTempDirectory("test-slides");
+        Path tempDir = Files.createTempDirectory(tempPath, "test-slides");
         Path tempPdfPath = tempDir.resolve("test-slides.pdf");
         try (PDDocument doc = new PDDocument()) {
             // Add 3 pages to the document

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
@@ -16,6 +16,7 @@ import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
@@ -33,6 +34,9 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractProgrammingIntegrati
 
     private Git localGit;
 
+    @Value("${artemis.temp-path}")
+    private Path tempPath;
+
     @BeforeEach
     void initTestCase() throws Exception {
         userUtilService.addUsers(TEST_PREFIX, 3, 2, 0, 2);
@@ -43,7 +47,7 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractProgrammingIntegrati
         participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, TEST_PREFIX + "student1");
         participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, TEST_PREFIX + "student2");
 
-        localRepoPath = Files.createTempDirectory("repo");
+        localRepoPath = Files.createTempDirectory(tempPath, "repo");
         localGit = LocalRepository.initialize(localRepoPath, defaultBranch, false);
 
         // create commits

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
@@ -147,6 +147,9 @@ public class ProgrammingExerciseIntegrationTestService {
     @Value("${artemis.version-control.local-vcs-repo-path}")
     private Path localVCRepoPath;
 
+    @Value("${artemis.temp-path}")
+    private Path tempPath;
+
     @Autowired
     // this will be a MockitoSpyBean because it was configured as MockitoSpyBean in the super class of the actual test class (see AbstractArtemisIntegrationTest)
     private FileService fileService;
@@ -281,17 +284,17 @@ public class ProgrammingExerciseIntegrationTestService {
         participationUtilService.addStudentParticipationForProgrammingExercise(programmingExerciseInExam, userPrefix + "student1");
         participationUtilService.addStudentParticipationForProgrammingExercise(programmingExerciseInExam, userPrefix + "student2");
 
-        localRepoPath = Files.createTempDirectory("repo");
+        localRepoPath = Files.createTempDirectory(tempPath, "repo");
         localGit = LocalRepository.initialize(localRepoPath, defaultBranch, false);
-        remoteRepoPath = Files.createTempDirectory("repoOrigin");
+        remoteRepoPath = Files.createTempDirectory(tempPath, "repoOrigin");
         remoteGit = LocalRepository.initialize(remoteRepoPath, defaultBranch, true);
         StoredConfig config = localGit.getRepository().getConfig();
         config.setString("remote", "origin", "url", remoteRepoPath.toFile().getAbsolutePath());
         config.save();
 
-        localRepoPath2 = Files.createTempDirectory("repo2");
+        localRepoPath2 = Files.createTempDirectory(tempPath, "repo2");
         localGit2 = LocalRepository.initialize(localRepoPath2, defaultBranch, false);
-        remoteRepoPath2 = Files.createTempDirectory("repoOrigin");
+        remoteRepoPath2 = Files.createTempDirectory(tempPath, "repoOrigin");
         remoteGit2 = LocalRepository.initialize(remoteRepoPath2, defaultBranch, true);
         StoredConfig config2 = localGit2.getRepository().getConfig();
         config2.setString("remote", "origin", "url", remoteRepoPath2.toFile().getAbsolutePath());
@@ -307,7 +310,7 @@ public class ProgrammingExerciseIntegrationTestService {
         GitService.commit(localGit).setMessage("empty").setAllowEmpty(true).setSign(false).setAuthor("test", "test@test.com").call();
         localGit.push().call();
 
-        this.plagiarismChecksTestReposDir = Files.createTempDirectory("jplag-repos").toFile();
+        this.plagiarismChecksTestReposDir = Files.createTempDirectory(tempPath, "jplag-repos").toFile();
     }
 
     void tearDown() throws IOException {
@@ -1752,7 +1755,7 @@ public class ProgrammingExerciseIntegrationTestService {
                 """;
 
         // Create temporary directories for the mock repositories with proper JPlag structure
-        Path tempDir = Files.createTempDirectory("plagiarism-test-repos");
+        Path tempDir = Files.createTempDirectory(tempPath, "plagiarism-test-repos");
         Path projectDir = tempDir.resolve(projectKey);
         Files.createDirectories(projectDir);
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalVCIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalVCIntegrationTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.cit.aet.artemis.core.service.ldap.LdapUserDto;
@@ -48,6 +49,9 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
     private LocalRepository solutionRepository;
 
     private LocalRepository testsRepository;
+
+    @Value("${artemis.temp-path}")
+    private Path tempPath;
 
     @BeforeEach
     void initRepositories() throws GitAPIException, IOException, URISyntaxException {
@@ -292,7 +296,7 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
             throws Exception {
 
         // Create a second local repository and push a file from there
-        Path tempDirectory = Files.createTempDirectory("tempDirectory");
+        Path tempDirectory = Files.createTempDirectory(tempPath, "tempDirectory");
         Git secondLocalGit = Git.cloneRepository().setURI(repositoryUri).setDirectory(tempDirectory.toFile()).call();
         localVCLocalCITestService.commitFile(tempDirectory, secondLocalGit);
         localVCLocalCITestService.testPushSuccessful(secondLocalGit, login, projectKey, repositorySlug);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/GitUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/GitUtilService.java
@@ -13,6 +13,8 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
 
+import jakarta.annotation.PostConstruct;
+
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -46,9 +48,20 @@ public class GitUtilService {
     @Value("${artemis.repo-clone-path}")
     private String repoClonePath;
 
-    private final Path remotePath = Files.createTempDirectory("remotegittest").resolve("scm/test-repository");
+    @Value("${artemis.temp-path}")
+    private Path tempPath;
 
-    public GitUtilService() throws IOException {
+    private Path remotePath;
+
+    public GitUtilService() {
+    }
+
+    // we have to create the path in a @PostConstruct to make sure that the tempPath is set
+    @PostConstruct
+    void init() throws IOException {
+        Path base = Files.createTempDirectory(tempPath, "remotegittest");
+        this.remotePath = base.resolve("scm").resolve("test-repository").toAbsolutePath();
+        Files.createDirectories(remotePath);
     }
 
     private Path getLocalPath() {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseResultTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseResultTestService.java
@@ -131,13 +131,13 @@ public class ProgrammingExerciseResultTestService {
     private ProgrammingExerciseUtilService programmingExerciseUtilService;
 
     @Autowired
-    private ExerciseUtilService exerciseUtilService;
-
-    @Autowired
     private ParticipationUtilService participationUtilService;
 
     @Autowired
     private ParticipationVCSAccessTokenRepository participationVCSAccessTokenRepository;
+
+    @Value("${artemis.temp-path}")
+    private Path tempPath;
 
     private Course course;
 
@@ -168,7 +168,7 @@ public class ProgrammingExerciseResultTestService {
         programmingExerciseStudentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, userPrefix + "student1");
         programmingExerciseStudentParticipationStaticCodeAnalysis = participationUtilService
                 .addStudentParticipationForProgrammingExercise(programmingExerciseWithStaticCodeAnalysis, userPrefix + "student2");
-        var localRepoFile = Files.createTempDirectory("repo").toFile();
+        var localRepoFile = Files.createTempDirectory(tempPath, "repo").toFile();
         var repository = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), null);
         doReturn(repository).when(gitService).getOrCheckoutRepositoryWithTargetPath(any(), any(Path.class), anyBoolean());
     }

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
@@ -11,6 +12,8 @@ import java.util.Optional;
 
 import jakarta.mail.internet.MimeMessage;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -219,6 +222,17 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
     @AfterEach
     void stopRunningTasks() {
         participantScoreScheduleService.shutdown();
+    }
+
+    // Comment this out if you need the results of some test files for debugging purposes.
+    @AfterAll
+    static void deleteTestFiles() {
+        try {
+            FileUtils.deleteDirectory(Path.of("local", "server-integration-test").toFile());
+        }
+        catch (IOException ignored) {
+            // test should still succeed if directory deletion fails
+        }
     }
 
     protected void resetSpyBeans() {

--- a/src/test/resources/config/application-artemis.yml
+++ b/src/test/resources/config/application-artemis.yml
@@ -12,6 +12,7 @@ artemis:
     file-upload-path: ./local/server-integration-test/uploads
     submission-export-path: ./local/server-integration-test/exports
     checked-out-repos-path: ./local/server-integration-test/checked-out-repos
+    temp-path: ./local/server-integration-test/temp
     bcrypt-salt-rounds: 4  # We don't need secure passwords for testing. Lower rounds will speed up tests. 4 ist the lowest allowed round count.
     user-management:
         use-external: true


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [ ] I **strictly** followed the principle of **data economy** for all database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Our server tests produce temp dirs that pollute the system temp dir and are difficult to clean up.

### Description
<!-- Describe your changes in detail -->
Introduced `artemis.temp-path`. In production setups it still defaults to java.io.tmpdir but for server tests it set to local/server-integration-test/temp
local/server-integration-test is deleted after all tests ran.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Make sure all checks pass


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

