### PR TITLE
`General`: Fixing internal server error when starting Artemis Locally

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/GitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/GitService.java
@@ -109,7 +109,7 @@ public class GitService extends AbstractGitService {
 
     private final ProfileService profileService;
 
-    @Value("${artemis.version-control.local-vcs-repo-path}")
+    @Value("${artemis.version-control.local-vcs-repo-path:#{null}}")
     private Path localVCBasePath;
 
     @Value("${artemis.repo-clone-path}")


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests)

### Motivation and Context
When starting Artemis locally using the Server & Client Profile, spring fails to create several beans, leading to internal server errors.

### Description
I re-added the `#{null}` to the localVCBasePath in `GitService.java` which was recently removed. This fixes the problem.


### Steps for Testing
1. Start Artemis locally using the Server & Client Profile in IntelliJ
2. Verify that no Exceptions are logged in the console during startup

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

