### PR TITLE
`Development`: QoL improvement for time formatting

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/util/TimeLogUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/TimeLogUtil.java
@@ -23,12 +23,19 @@ public class TimeLogUtil {
         if (durationInSeconds < 60) {
             return roundOffTo2DecPlaces(durationInSeconds) + "sec";
         }
+
+        /*
+         * Minutes and hours need a special treatment to prevent formats like this:
+         * '1.58min': Is this supposed to mean 1 min and 58 seconds or 1 min and 35 seconds?
+         * '1.94hours': Here it would be obvious that something is off, but how long is that really?
+         * This happens because there's not 100 seconds in a minute and also not 100 hours in a day.
+         */
         double durationInMinutes = durationInSeconds / 60.0;
         if (durationInMinutes < 60) {
-            return roundOffTo2DecPlaces(durationInMinutes) + "min";
+            return durationInMinutes + ":" + (durationInSeconds % 60) + "min";
         }
         double durationInHours = durationInMinutes / 60.0;
-        return roundOffTo2DecPlaces(durationInHours) + "hours";
+        return durationInHours + ":" + (durationInMinutes % 60) + "hours";
     }
 
     public static String formatDuration(long durationInSeconds) {


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
When I started Artemis yesterday, I noticed this, rather odd, startup notification (shortened version):
```
'Artemis' is running! Access URLs:
...

Full startup: 1.94min
```
`1.94` minutes is very odd to read, and rather confusing.


### Description
Made it so that for minutes and hours, it now displays them in `<min>:<sec>` and `<hour>:<min>`, respectively, rather than the old `<min>.<sec * 10/6>` and `<hour>.<min * 10/6>`. 
For example, instead of the
> Full startup: 1.94min
message I would now get 
> Full startup: 1:56min
which is much easier to intuitively understand.


### Review Process 
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


