### PR TITLE
`Development`: Fix tracking passkey authentication with events

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisPasskeyWebAuthnConfigurer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisPasskeyWebAuthnConfigurer.java
@@ -13,6 +13,7 @@ import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -44,6 +45,8 @@ import de.tum.cit.aet.artemis.core.util.AndroidApkKeyHashUtil;
 public class ArtemisPasskeyWebAuthnConfigurer {
 
     private static final Logger log = LoggerFactory.getLogger(ArtemisPasskeyWebAuthnConfigurer.class);
+
+    private final AuditEventRepository auditEventRepository;
 
     private final HttpMessageConverter<Object> converter;
 
@@ -85,12 +88,13 @@ public class ArtemisPasskeyWebAuthnConfigurer {
 
     private final String relyingPartyName = "Artemis";
 
-    public ArtemisPasskeyWebAuthnConfigurer(MappingJackson2HttpMessageConverter converter, JWTCookieService jwtCookieService, UserRepository userRepository,
-            PublicKeyCredentialUserEntityRepository publicKeyCredentialUserEntityRepository, UserCredentialRepository userCredentialRepository,
+    public ArtemisPasskeyWebAuthnConfigurer(AuditEventRepository auditEventRepository, MappingJackson2HttpMessageConverter converter, JWTCookieService jwtCookieService,
+            UserRepository userRepository, PublicKeyCredentialUserEntityRepository publicKeyCredentialUserEntityRepository, UserCredentialRepository userCredentialRepository,
             PublicKeyCredentialCreationOptionsRepository publicKeyCredentialCreationOptionsRepository,
             PublicKeyCredentialRequestOptionsRepository publicKeyCredentialRequestOptionsRepository, AndroidFingerprintService androidFingerprintService,
             MailSendingService mailSendingService, ArtemisSuccessfulLoginService artemisSuccessfulLoginService,
             GlobalNotificationSettingRepository globalNotificationSettingRepository) {
+        this.auditEventRepository = auditEventRepository;
         this.converter = converter;
         this.jwtCookieService = jwtCookieService;
         this.userRepository = userRepository;
@@ -164,9 +168,9 @@ public class ArtemisPasskeyWebAuthnConfigurer {
             return false;
         }
 
-        WebAuthnConfigurer<HttpSecurity> webAuthnConfigurer = new ArtemisWebAuthnConfigurer<>(converter, jwtCookieService, userRepository, publicKeyCredentialUserEntityRepository,
-                userCredentialRepository, publicKeyCredentialCreationOptionsRepository, publicKeyCredentialRequestOptionsRepository, mailSendingService,
-                artemisSuccessfulLoginService, globalNotificationSettingRepository);
+        WebAuthnConfigurer<HttpSecurity> webAuthnConfigurer = new ArtemisWebAuthnConfigurer<>(auditEventRepository, converter, jwtCookieService, userRepository,
+                publicKeyCredentialUserEntityRepository, userCredentialRepository, publicKeyCredentialCreationOptionsRepository, publicKeyCredentialRequestOptionsRepository,
+                mailSendingService, artemisSuccessfulLoginService, globalNotificationSettingRepository);
 
         http.with(webAuthnConfigurer, configurer -> {
             configurer.allowedOrigins(allowedOrigins).rpId(relyingPartyId).rpName(relyingPartyName);

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisWebAuthnAuthenticationFilter.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/passkey/ArtemisWebAuthnAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.artemis.core.security.passkey;
 
+import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.security.web.authentication.AuthenticationEntryPointFailureHandler;
@@ -18,13 +19,14 @@ import de.tum.cit.aet.artemis.core.service.ArtemisSuccessfulLoginService;
  */
 public class ArtemisWebAuthnAuthenticationFilter extends WebAuthnAuthenticationFilter {
 
-    public ArtemisWebAuthnAuthenticationFilter(HttpMessageConverter<Object> converter, JWTCookieService jwtCookieService,
+    public ArtemisWebAuthnAuthenticationFilter(AuditEventRepository auditEventRepository, HttpMessageConverter<Object> converter, JWTCookieService jwtCookieService,
             PublicKeyCredentialRequestOptionsRepository publicKeyCredentialRequestOptionsRepository, ArtemisSuccessfulLoginService artemisSuccessfulLoginService) {
         super();
         setSecurityContextRepository(new HttpSessionSecurityContextRepository());
         setRequestOptionsRepository(publicKeyCredentialRequestOptionsRepository);
         setAuthenticationFailureHandler(new AuthenticationEntryPointFailureHandler(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
-        setAuthenticationSuccessHandler(new ArtemisHttpMessageConverterAuthenticationSuccessHandler(converter, jwtCookieService, artemisSuccessfulLoginService));
+        setAuthenticationSuccessHandler(
+                new ArtemisHttpMessageConverterAuthenticationSuccessHandler(auditEventRepository, converter, jwtCookieService, artemisSuccessfulLoginService));
     }
 
 }


### PR DESCRIPTION
### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I documented the Java code using JavaDoc style.


### Motivation and Context


### Description


### Steps for Testing
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
Tests are rather complicated as we do not have integration tests for passkey yet (we need to register passkey and simulate the client challenge solving for the integration test -> will be done in a follow up but out of scope for this PR)

### Screenshots

