### PR TITLE
`Programming exercises`: Prevent pushing large files

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/BinaryFileExtensionConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/BinaryFileExtensionConfiguration.java
@@ -28,7 +28,7 @@ public class BinaryFileExtensionConfiguration {
             ".jar", ".class", ".war", ".ear",
 
             // Compiled Python files
-            ".pyc", ".pyo", ".pyd",
+            ".pyc", ".pyo", ".pyd", ".npy",
 
             // Compiled C/C++/.NET/Go files
             ".o", ".so", ".a", ".dylib", ".lib", ".dll", ".exp", ".pdb",

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationResource.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 
+import org.eclipse.jgit.errors.LargeObjectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,6 +52,8 @@ import de.tum.cit.aet.artemis.core.exception.AccessForbiddenAlertException;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.exception.ConflictException;
+import de.tum.cit.aet.artemis.core.exception.InternalServerErrorException;
+import de.tum.cit.aet.artemis.core.exception.VersionControlException;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.security.Role;
 import de.tum.cit.aet.artemis.core.security.allowedTools.AllowedTools;
@@ -233,8 +236,19 @@ public class ParticipationResource {
             participant = teamRepository.findOneByExerciseIdAndUserId(exercise.getId(), user.getId())
                     .orElseThrow(() -> new BadRequestAlertException("Team exercise cannot be started without assigned team.", "participation", "teamExercise.cannotStart"));
         }
-
-        StudentParticipation participation = participationService.startExercise(exercise, participant, true);
+        StudentParticipation participation = null;
+        try {
+            participation = participationService.startExercise(exercise, participant, true);
+        }
+        catch (Exception e) {
+            if (e instanceof VersionControlException && e.getCause() instanceof LargeObjectException) {
+                throw new InternalServerErrorException("Failed to start exercise because repository contains files that are too large. Please contact your instructor.");
+            }
+            else {
+                log.error("Failed to start exercise participation for exercise {} and user {}", exerciseId, user.getLogin(), e);
+                throw new InternalServerErrorException("Failed to start exercise participation.");
+            }
+        }
 
         // remove sensitive information before sending participation to the client
         participation.getExercise().filterSensitiveInformation();

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/localvc/LocalVCPrePushHook.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/localvc/LocalVCPrePushHook.java
@@ -128,9 +128,7 @@ public class LocalVCPrePushHook implements PreReceiveHook {
                 if (loader.getType() == Constants.OBJ_BLOB && loader.getSize() > MAX_BLOB_SIZE_BYTES) {
                     command.setResult(ReceiveCommand.Result.REJECTED_OTHER_REASON,
                             String.format("File '%s' exceeds 10MB size limit (%.2f MB)", treeWalk.getPathString(), loader.getSize() / (1024.0 * 1024.0)));
-                    reader.close();
-                    revWalk.close();
-                    return;
+                    break;
                 }
             }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/AbstractVersionControlService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/AbstractVersionControlService.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.errors.LargeObjectException;
 import org.eclipse.jgit.internal.JGitText;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,7 +66,7 @@ public abstract class AbstractVersionControlService implements VersionControlSer
         try (Repository targetRepo = gitService.copyBareRepository(sourceRepoUri, targetRepoUri, sourceBranch)) {
             return targetRepo.getRemoteRepositoryUri(); // should be the same as targetRepoUri
         }
-        catch (IOException ex) {
+        catch (IOException | LargeObjectException ex) {
             Path localPath = gitService.getDefaultLocalPathOfRepo(targetRepoUri);
             // clean up in case of an error
             try {
@@ -75,6 +76,10 @@ public abstract class AbstractVersionControlService implements VersionControlSer
             catch (IOException ioException) {
                 // ignore
                 log.error("Could not delete directory of the failed cloned repository in: {}", localPath);
+            }
+            if (ex instanceof LargeObjectException) {
+                throw new VersionControlException("Could not copy repository " + sourceRepositoryName + " to the target repository " + targetRepositoryName
+                        + " due to a file in the repository being too large.");
             }
             throw new VersionControlException("Could not copy repository " + sourceRepositoryName + " to the target repository " + targetRepositoryName, ex);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/AbstractVersionControlService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/AbstractVersionControlService.java
@@ -79,7 +79,8 @@ public abstract class AbstractVersionControlService implements VersionControlSer
             }
             if (ex instanceof LargeObjectException) {
                 throw new VersionControlException(
-                        "Could not copy repository " + sourceRepositoryName + " to the target repository " + targetRepositoryName + " because a file in the repo is too large.");
+                        "Could not copy repository " + sourceRepositoryName + " to the target repository " + targetRepositoryName + " because a file in the repo is too large.",
+                        ex);
             }
             throw new VersionControlException("Could not copy repository " + sourceRepositoryName + " to the target repository " + targetRepositoryName, ex);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/AbstractVersionControlService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/AbstractVersionControlService.java
@@ -78,8 +78,8 @@ public abstract class AbstractVersionControlService implements VersionControlSer
                 log.error("Could not delete directory of the failed cloned repository in: {}", localPath);
             }
             if (ex instanceof LargeObjectException) {
-                throw new VersionControlException("Could not copy repository " + sourceRepositoryName + " to the target repository " + targetRepositoryName
-                        + " due to a file in the repository being too large.");
+                throw new VersionControlException(
+                        "Could not copy repository " + sourceRepositoryName + " to the target repository " + targetRepositoryName + " because a file in the repo is too large.");
             }
             throw new VersionControlException("Could not copy repository " + sourceRepositoryName + " to the target repository " + targetRepositoryName, ex);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseExportImportResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseExportImportResource.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import jakarta.validation.constraints.NotNull;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.LargeObjectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,6 +55,7 @@ import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.core.exception.HttpStatusException;
 import de.tum.cit.aet.artemis.core.exception.InternalServerErrorAlertException;
 import de.tum.cit.aet.artemis.core.exception.InternalServerErrorException;
+import de.tum.cit.aet.artemis.core.exception.VersionControlException;
 import de.tum.cit.aet.artemis.core.repository.CourseRepository;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.security.Role;
@@ -277,6 +279,9 @@ public class ProgrammingExerciseExportImportResource {
             boolean isExceptionWithTranslationKeys = exception instanceof HttpStatusException;
             if (isExceptionWithTranslationKeys) {
                 throw exception;
+            }
+            if (exception instanceof VersionControlException && exception.getCause() instanceof LargeObjectException) {
+                throw new InternalServerErrorException("The import of the programming exercise failed because a file in the repository is too large.");
             }
 
             throw new InternalServerErrorAlertException("Unable to import programming exercise: " + exception.getMessage(), ENTITY_NAME, "unableToImportProgrammingExercise");

--- a/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalVCIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalVCIntegrationTest.java
@@ -25,7 +25,6 @@ import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.test.context.support.WithMockUser;
 
@@ -108,7 +107,6 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         someRepository.resetLocalRepo();
     }
 
-    @Disabled
     @Test
     void testFetchPush_usingVcsAccessToken() {
         var programmingParticipation = localVCLocalCITestService.createParticipation(programmingExercise, student1Login);
@@ -178,7 +176,6 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         someRepository.resetLocalRepo();
     }
 
-    @Disabled
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testFetchPush_offlineIDENotAllowed() {
@@ -230,7 +227,6 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         localVCLocalCITestService.testPushReturnsError(solutionRepository.workingCopyGitRepo, instructor1Login, projectKey1, solutionRepositorySlug, INTERNAL_SERVER_ERROR);
     }
 
-    @Disabled
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testUserTriesToDeleteBranch() throws GitAPIException {
@@ -245,7 +241,6 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         assertThat(remoteRefUpdate.getMessage()).isEqualTo("You cannot delete a branch.");
     }
 
-    @Disabled
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testStudentTriesToForcePush() throws Exception {
@@ -259,7 +254,7 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
     }
 
     // TODO add test for force push over ssh, which should work
-    @Disabled
+
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testInstructorTriesToForcePushOverHttp() throws Exception {
@@ -270,22 +265,22 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         String solutionRepoUri = localVCLocalCITestService.constructLocalVCUrl(instructor1Login, projectKey1, solutionRepositorySlug);
         String testsRepoUri = localVCLocalCITestService.constructLocalVCUrl(instructor1Login, projectKey1, testsRepositorySlug);
 
-        // Force push to assignment repository (should not be possible)
+        // Force push to assignment repository is allowed for instructors
         RemoteRefUpdate remoteRefUpdate = setupAndTryForcePush(assignmentRepository, assignmentRepoUri, instructor1Login, projectKey1, assignmentRepositorySlug);
         assertThat(remoteRefUpdate.getStatus()).isEqualTo(RemoteRefUpdate.Status.REJECTED_OTHER_REASON);
         assertThat(remoteRefUpdate.getMessage()).isEqualTo("You cannot force push.");
 
-        // Force push to template repository (should not be possible)
+        // Force push to template repository is allowed for instructors
         remoteRefUpdate = setupAndTryForcePush(templateRepository, templateRepoUri, instructor1Login, projectKey1, templateRepositorySlug);
-        assertThat(remoteRefUpdate.getStatus()).isEqualTo(RemoteRefUpdate.Status.REJECTED_OTHER_REASON);
+        assertThat(remoteRefUpdate.getStatus()).isEqualTo(RemoteRefUpdate.Status.OK);
 
-        // Force push to solution repository (should not be possible)
+        // Force push to solution repository is allowed for instructors
         remoteRefUpdate = setupAndTryForcePush(solutionRepository, solutionRepoUri, instructor1Login, projectKey1, solutionRepositorySlug);
-        assertThat(remoteRefUpdate.getStatus()).isEqualTo(RemoteRefUpdate.Status.REJECTED_OTHER_REASON);
+        assertThat(remoteRefUpdate.getStatus()).isEqualTo(RemoteRefUpdate.Status.OK);
 
-        // Force push to rests repository (should not be possible)
+        // Force push to rests repository is allowed for instructors
         remoteRefUpdate = setupAndTryForcePush(testsRepository, testsRepoUri, instructor1Login, projectKey1, testsRepositorySlug);
-        assertThat(remoteRefUpdate.getStatus()).isEqualTo(RemoteRefUpdate.Status.REJECTED_OTHER_REASON);
+        assertThat(remoteRefUpdate.getStatus()).isEqualTo(RemoteRefUpdate.Status.OK);
     }
 
     private RemoteRefUpdate setupAndTryForcePush(LocalRepository originalRepository, String repositoryUri, String login, String projectKey, String repositorySlug)
@@ -316,7 +311,6 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         return remoteRefUpdate;
     }
 
-    @Disabled
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testUserCreatesNewBranch() throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalVCIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalVCIntegrationTest.java
@@ -30,6 +30,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.cit.aet.artemis.core.service.ldap.LdapUserDto;
 import de.tum.cit.aet.artemis.programming.AbstractProgrammingIntegrationLocalCILocalVCTestBase;
+import de.tum.cit.aet.artemis.programming.service.GitService;
 import de.tum.cit.aet.artemis.programming.service.localvc.LocalVCRepositoryUri;
 import de.tum.cit.aet.artemis.programming.util.LocalRepository;
 
@@ -352,10 +353,10 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         localVCLocalCITestService.createParticipation(programmingExercise, student1Login);
 
         Path largeFile = assignmentRepository.workingCopyGitRepoFile.toPath().resolve("large-file.txt");
-        Files.write(largeFile, new byte[11 * 1024 * 1024]); // 11 MB
+        FileUtils.writeByteArrayToFile(largeFile.toFile(), new byte[11 * 1024 * 1024]); // 11 MB
 
         assignmentRepository.workingCopyGitRepo.add().addFilepattern("large-file.txt").call();
-        assignmentRepository.workingCopyGitRepo.commit().setMessage("Add large file").call();
+        GitService.commit(assignmentRepository.workingCopyGitRepo).setMessage("Add large file").call();
 
         String repositoryUri = localVCLocalCITestService.constructLocalVCUrl(student1Login, projectKey1, assignmentRepositorySlug);
         PushResult pushResult = assignmentRepository.workingCopyGitRepo.push().setRemote(repositoryUri)


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.




#### Changes affecting Programming Exercises
VCS is the same for all setups.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
On production, we encountered an issue when a student starts an exercise that contains a large file (in this case >90MB) as JGit throws an exception. So large files i a git repository are usually not necessary in the Artemis context.


### Description
<!-- Describe your changes in detail -->

1. Limit the file size to 10 MB
2. Wrote a server integration test to verify this
3. Improved the log message when the exception occurs because a repository contains too large files.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:

1. Log in to Artemis
2. Go to any programming exercise
3. Start it
4. Clone it
5. Try to stage, commit and push a file > 10 MB
6. Check that the push is rejected and you get a descriptive error message


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
the change in LocalVCPrePushHook is covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pushes containing files larger than 10MB are now automatically rejected, with clear error messages indicating the file and its size.
  * The ".npy" file extension is now recognized as a binary file type.

* **Bug Fixes**
  * Improved error messages and handling when starting an exercise or importing a programming exercise fails due to large files in the repository.

* **Tests**
  * Enabled several previously disabled integration tests.
  * Added a new test to verify that files larger than 10MB are rejected during push attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->