### PR TITLE
`Programming exercises`: Keep history on import

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationService.java
@@ -422,7 +422,7 @@ public class ParticipationService {
             VersionControlService vcs = versionControlService.orElseThrow();
             String templateBranch = programmingExerciseRepository.findBranchByExerciseId(programmingExercise.getId());
             // the next action includes recovery, which means if the repository has already been copied, we simply retrieve the repository uri and do not copy it again
-            var newRepoUri = vcs.copyRepository(projectKey, templateRepoName, templateBranch, projectKey, repoName, participation.getAttempt());
+            var newRepoUri = vcs.copyRepositoryWithoutHistory(projectKey, templateRepoName, templateBranch, projectKey, repoName, participation.getAttempt());
             // add the userInfo part to the repoUri only if the participation belongs to a single student (and not a team of students)
             if (participation.getStudent().isPresent()) {
                 newRepoUri = newRepoUri.withUser(participation.getParticipantIdentifier());

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/GitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/GitService.java
@@ -13,15 +13,19 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -984,25 +988,7 @@ public class GitService extends AbstractGitService {
         log.debug("copy bare repository from {} to {} for source branch {}", sourceRepoUri, targetRepoUri, sourceBranch);
         Repository sourceRepo = getExistingBareRepository(sourceRepoUri, sourceBranch);
 
-        if (log.isDebugEnabled()) {
-            // Log how many commits the source repository has
-            try (RevWalk walk = new RevWalk(sourceRepo)) {
-                ObjectId debugCommitId = sourceRepo.resolve("refs/heads/" + sourceBranch + "^{commit}");
-                if (debugCommitId == null) {
-                    log.error("Source repo [{}] has no head commit in branch [{}]", sourceRepoUri, sourceBranch);
-                }
-                RevCommit headCommit = walk.parseCommit(debugCommitId);
-                walk.markStart(headCommit);
-                int commitCount = 0;
-                for (RevCommit ignored : walk) {
-                    commitCount++;
-                }
-                log.debug("Source repository {} has {} commits", sourceRepoUri, commitCount);
-                if (commitCount == 0) {
-                    log.error("Source repository {} is empty, no commits to copy. This operation will fail", sourceRepoUri);
-                }
-            }
-        }
+        logCommits(sourceRepoUri, sourceBranch, sourceRepo);
 
         // Initialize new bare repository
         var localTargetRepoUri = new LocalVCRepositoryUri(targetRepoUri.toString());
@@ -1052,6 +1038,96 @@ public class GitService extends AbstractGitService {
             refUpdate.update();
 
             return getBareRepository(targetRepoUri);
+        }
+    }
+
+    public Repository copyBareRepositoryWithHistory(VcsRepositoryUri sourceRepoUri, VcsRepositoryUri targetRepoUri, String sourceBranch) throws IOException {
+        log.debug("Copying full history from {} to {} for branch {}", sourceRepoUri, targetRepoUri, sourceBranch);
+        Repository sourceRepo = getExistingBareRepository(sourceRepoUri, sourceBranch);
+
+        logCommits(sourceRepoUri, sourceBranch, sourceRepo);
+
+        // Resolve the HEAD commit of the branch
+        ObjectId headCommitId = sourceRepo.resolve("refs/heads/" + sourceBranch + "^{commit}");
+        if (headCommitId == null) {
+            throw new IOException("Source branch " + sourceBranch + " not found in " + sourceRepoUri);
+        }
+
+        // Create new bare repository
+        var localTargetRepoUri = new LocalVCRepositoryUri(targetRepoUri.toString());
+        var localTargetPath = localTargetRepoUri.getLocalRepositoryPath(localVCBasePath);
+        try (org.eclipse.jgit.lib.Repository targetRepo = FileRepositoryBuilder.create(localTargetPath.toFile())) {
+            targetRepo.create(true); // bare = true
+
+            try (ObjectInserter inserter = targetRepo.newObjectInserter(); RevWalk revWalk = new RevWalk(sourceRepo)) {
+
+                Set<ObjectId> copiedObjects = new HashSet<>();
+                Deque<ObjectId> toProcess = new ArrayDeque<>();
+                toProcess.add(headCommitId);
+
+                while (!toProcess.isEmpty()) {
+                    ObjectId current = toProcess.poll();
+                    if (!copiedObjects.add(current)) {
+                        continue; // already processed
+                    }
+
+                    ObjectLoader loader = sourceRepo.open(current);
+                    inserter.insert(loader.getType(), loader.getSize(), loader.openStream());
+
+                    // If this is a commit, enqueue parents and tree
+                    if (loader.getType() == Constants.OBJ_COMMIT) {
+                        RevCommit commit = revWalk.parseCommit(current);
+                        toProcess.add(commit.getTree().getId());
+                        for (RevCommit parent : commit.getParents()) {
+                            toProcess.add(parent.getId());
+                        }
+                    }
+
+                    // If this is a tree, enqueue its entries (subtrees and blobs)
+                    if (loader.getType() == Constants.OBJ_TREE) {
+                        try (TreeWalk treeWalk = new TreeWalk(sourceRepo)) {
+                            treeWalk.addTree(current);
+                            treeWalk.setRecursive(false);
+                            while (treeWalk.next()) {
+                                toProcess.add(treeWalk.getObjectId(0));
+                            }
+                        }
+                    }
+                }
+
+                inserter.flush();
+
+                // Update target HEAD ref
+                RefUpdate refUpdate = targetRepo.updateRef("refs/heads/" + sourceBranch);
+                refUpdate.setNewObjectId(headCommitId);
+                refUpdate.setForceUpdate(true);
+                RefUpdate.Result result = refUpdate.update();
+                log.debug("RefUpdate result: {}", result);
+            }
+
+            return getBareRepository(targetRepoUri);
+        }
+    }
+
+    private static void logCommits(VcsRepositoryUri sourceRepoUri, String sourceBranch, Repository sourceRepo) throws IOException {
+        if (log.isDebugEnabled()) {
+            // Log how many commits the source repository has
+            try (RevWalk walk = new RevWalk(sourceRepo)) {
+                ObjectId debugCommitId = sourceRepo.resolve("refs/heads/" + sourceBranch + "^{commit}");
+                if (debugCommitId == null) {
+                    log.error("Source repo [{}] has no head commit in branch [{}]", sourceRepoUri, sourceBranch);
+                }
+                RevCommit headCommit = walk.parseCommit(debugCommitId);
+                walk.markStart(headCommit);
+                int commitCount = 0;
+                for (RevCommit ignored : walk) {
+                    commitCount++;
+                }
+                log.debug("Source repository {} has {} commits", sourceRepoUri, commitCount);
+                if (commitCount == 0) {
+                    log.error("Source repository {} is empty, no commits to copy. This operation will fail", sourceRepoUri);
+                }
+            }
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/GitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/GitService.java
@@ -984,8 +984,8 @@ public class GitService extends AbstractGitService {
      * @return a Repository object representing the newly created bare repository
      * @throws IOException if there is an error accessing the repositories or creating the new commit
      */
-    public Repository copyBareRepository(VcsRepositoryUri sourceRepoUri, VcsRepositoryUri targetRepoUri, String sourceBranch) throws IOException {
-        log.debug("copy bare repository from {} to {} for source branch {}", sourceRepoUri, targetRepoUri, sourceBranch);
+    public Repository copyBareRepositoryWithoutHistory(VcsRepositoryUri sourceRepoUri, VcsRepositoryUri targetRepoUri, String sourceBranch) throws IOException {
+        log.debug("copy bare repository without history from {} to {} for source branch {}", sourceRepoUri, targetRepoUri, sourceBranch);
         Repository sourceRepo = getExistingBareRepository(sourceRepoUri, sourceBranch);
 
         logCommits(sourceRepoUri, sourceBranch, sourceRepo);
@@ -1041,6 +1041,21 @@ public class GitService extends AbstractGitService {
         }
     }
 
+    /**
+     * Creates a new bare Git repository at the specified target location, copying all commits
+     * and history from the source repository.
+     * <p>
+     * This method efficiently duplicates the entire commit history from the source to the target
+     * repository by directly transferring Git objects (commits, trees, and blobs) without checking
+     * out any working tree. It is designed for bare repositories, ensuring that the complete
+     * history is preserved in the new repository.
+     *
+     * @param sourceRepoUri the URI of the source bare repository to copy from
+     * @param targetRepoUri the URI where the new bare repository will be created
+     * @param sourceBranch  the name of the branch to copy (e.g., "main" or "master")
+     * @return a Repository object representing the newly created bare repository
+     * @throws IOException if there is an error accessing the repositories or creating the new commit
+     */
     public Repository copyBareRepositoryWithHistory(VcsRepositoryUri sourceRepoUri, VcsRepositoryUri targetRepoUri, String sourceBranch) throws IOException {
         log.debug("Copying full history from {} to {} for branch {}", sourceRepoUri, targetRepoUri, sourceBranch);
         Repository sourceRepo = getExistingBareRepository(sourceRepoUri, sourceBranch);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportService.java
@@ -112,14 +112,15 @@ public class ProgrammingExerciseImportService {
         String sourceBranch = programmingExerciseRepository.findBranchByExerciseId(templateExercise.getId());
 
         // TODO: in case one of those operations fail, we should do error handling and revert all previous operations
-        versionControl.copyRepository(sourceProjectKey, templateRepoName, sourceBranch, targetProjectKey, RepositoryType.TEMPLATE.getName(), null);
-        versionControl.copyRepository(sourceProjectKey, solutionRepoName, sourceBranch, targetProjectKey, RepositoryType.SOLUTION.getName(), null);
-        versionControl.copyRepository(sourceProjectKey, testRepoName, sourceBranch, targetProjectKey, RepositoryType.TESTS.getName(), null);
+        versionControl.copyRepositoryWithHistory(sourceProjectKey, templateRepoName, sourceBranch, targetProjectKey, RepositoryType.TEMPLATE.getName(), null);
+        versionControl.copyRepositoryWithHistory(sourceProjectKey, solutionRepoName, sourceBranch, targetProjectKey, RepositoryType.SOLUTION.getName(), null);
+        versionControl.copyRepositoryWithHistory(sourceProjectKey, testRepoName, sourceBranch, targetProjectKey, RepositoryType.TESTS.getName(), null);
 
         List<AuxiliaryRepository> auxRepos = templateExercise.getAuxiliaryRepositories();
         for (int i = 0; i < auxRepos.size(); i++) {
             AuxiliaryRepository auxRepo = auxRepos.get(i);
-            var repoUri = versionControl.copyRepository(sourceProjectKey, auxRepo.getRepositoryName(), sourceBranch, targetProjectKey, auxRepo.getName(), null).toString();
+            var repoUri = versionControl.copyRepositoryWithHistory(sourceProjectKey, auxRepo.getRepositoryName(), sourceBranch, targetProjectKey, auxRepo.getName(), null)
+                    .toString();
             AuxiliaryRepository newAuxRepo = newExercise.getAuxiliaryRepositories().get(i);
             newAuxRepo.setRepositoryUri(repoUri);
             auxiliaryRepositoryRepository.save(newAuxRepo);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/AbstractVersionControlService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/AbstractVersionControlService.java
@@ -50,8 +50,8 @@ public abstract class AbstractVersionControlService implements VersionControlSer
     }
 
     @Override
-    public VcsRepositoryUri copyRepository(String sourceProjectKey, String sourceRepositoryName, String sourceBranch, String targetProjectKey, String targetRepositoryName,
-            Integer attempt) throws VersionControlException {
+    public VcsRepositoryUri copyRepositoryWithoutHistory(String sourceProjectKey, String sourceRepositoryName, String sourceBranch, String targetProjectKey,
+            String targetRepositoryName, Integer attempt) throws VersionControlException {
         return copyRepository(sourceProjectKey, sourceRepositoryName, sourceBranch, targetProjectKey, targetRepositoryName, attempt, false);
     }
 
@@ -73,7 +73,7 @@ public abstract class AbstractVersionControlService implements VersionControlSer
         final var sourceRepoUri = getCloneRepositoryUri(sourceProjectKey, sourceRepositoryName);
         final var targetRepoUri = getCloneRepositoryUri(targetProjectKey, targetRepoSlug);
         try (Repository targetRepo = withHistory ? gitService.copyBareRepositoryWithHistory(sourceRepoUri, targetRepoUri, sourceBranch)
-                : gitService.copyBareRepository(sourceRepoUri, targetRepoUri, sourceBranch)) {
+                : gitService.copyBareRepositoryWithoutHistory(sourceRepoUri, targetRepoUri, sourceBranch)) {
             return targetRepo.getRemoteRepositoryUri(); // should be the same as targetRepoUri
         }
         catch (IOException | LargeObjectException ex) {

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/AbstractVersionControlService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/AbstractVersionControlService.java
@@ -52,6 +52,17 @@ public abstract class AbstractVersionControlService implements VersionControlSer
     @Override
     public VcsRepositoryUri copyRepository(String sourceProjectKey, String sourceRepositoryName, String sourceBranch, String targetProjectKey, String targetRepositoryName,
             Integer attempt) throws VersionControlException {
+        return copyRepository(sourceProjectKey, sourceRepositoryName, sourceBranch, targetProjectKey, targetRepositoryName, attempt, false);
+    }
+
+    @Override
+    public VcsRepositoryUri copyRepositoryWithHistory(String sourceProjectKey, String sourceRepositoryName, String sourceBranch, String targetProjectKey,
+            String targetRepositoryName, Integer attempt) throws VersionControlException {
+        return copyRepository(sourceProjectKey, sourceRepositoryName, sourceBranch, targetProjectKey, targetRepositoryName, attempt, true);
+    }
+
+    private VcsRepositoryUri copyRepository(String sourceProjectKey, String sourceRepositoryName, String sourceBranch, String targetProjectKey, String targetRepositoryName,
+            Integer attempt, boolean withHistory) throws VersionControlException {
         sourceRepositoryName = sourceRepositoryName.toLowerCase();
         targetRepositoryName = targetRepositoryName.toLowerCase();
         String targetProjectKeyLowerCase = targetProjectKey.toLowerCase();
@@ -59,11 +70,10 @@ public abstract class AbstractVersionControlService implements VersionControlSer
             targetProjectKeyLowerCase = targetProjectKeyLowerCase + attempt;
         }
         final String targetRepoSlug = targetProjectKeyLowerCase + "-" + targetRepositoryName;
-        // get the remote url of the source repo
         final var sourceRepoUri = getCloneRepositoryUri(sourceProjectKey, sourceRepositoryName);
-        // get the remote url of the target repo
         final var targetRepoUri = getCloneRepositoryUri(targetProjectKey, targetRepoSlug);
-        try (Repository targetRepo = gitService.copyBareRepository(sourceRepoUri, targetRepoUri, sourceBranch)) {
+        try (Repository targetRepo = withHistory ? gitService.copyBareRepositoryWithHistory(sourceRepoUri, targetRepoUri, sourceBranch)
+                : gitService.copyBareRepository(sourceRepoUri, targetRepoUri, sourceBranch)) {
             return targetRepo.getRemoteRepositoryUri(); // should be the same as targetRepoUri
         }
         catch (IOException | LargeObjectException ex) {

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/VersionControlService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/VersionControlService.java
@@ -77,7 +77,7 @@ public interface VersionControlService {
      * @return The URL for cloning the repository
      * @throws VersionControlException if the repository could not be copied on the VCS server (e.g. because the source repo does not exist)
      */
-    VcsRepositoryUri copyRepository(String sourceProjectKey, String sourceRepositoryName, String sourceBranch, String targetProjectKey, String targetRepositoryName,
+    VcsRepositoryUri copyRepositoryWithoutHistory(String sourceProjectKey, String sourceRepositoryName, String sourceBranch, String targetProjectKey, String targetRepositoryName,
             Integer attempt) throws VersionControlException;
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/VersionControlService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/vcs/VersionControlService.java
@@ -66,7 +66,7 @@ public interface VersionControlService {
     boolean checkIfProjectExists(String projectKey, String projectName);
 
     /**
-     * Copies a repository from one project to another one. The project can be the same.
+     * Copies a repository from one project to another one. The project can be the same. The commit history is not preserved
      *
      * @param sourceProjectKey     The key of the template project (normally based on the course and exercise short name)
      * @param sourceRepositoryName The name of the repository which should be copied
@@ -78,5 +78,20 @@ public interface VersionControlService {
      * @throws VersionControlException if the repository could not be copied on the VCS server (e.g. because the source repo does not exist)
      */
     VcsRepositoryUri copyRepository(String sourceProjectKey, String sourceRepositoryName, String sourceBranch, String targetProjectKey, String targetRepositoryName,
+            Integer attempt) throws VersionControlException;
+
+    /**
+     * Copies a repository from one project to another one. The project can be the same. The commit history is preserved.
+     *
+     * @param sourceProjectKey     The key of the template project (normally based on the course and exercise short name)
+     * @param sourceRepositoryName The name of the repository which should be copied
+     * @param sourceBranch         The default branch of the source repository
+     * @param targetProjectKey     The key of the target project to which to copy the new repository to
+     * @param targetRepositoryName The desired name of the target repository
+     * @param attempt              The attempt number
+     * @return The URL for cloning the repository
+     * @throws VersionControlException if the repository could not be copied on the VCS server (e.g. because the source repo does not exist)
+     */
+    VcsRepositoryUri copyRepositoryWithHistory(String sourceProjectKey, String sourceRepositoryName, String sourceBranch, String targetProjectKey, String targetRepositoryName,
             Integer attempt) throws VersionControlException;
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
@@ -1946,7 +1946,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCTest {
 
     private void setupMocks() {
         doReturn(null).when(continuousIntegrationService).checkIfProjectExists(anyString(), anyString());
-        doReturn(new VcsRepositoryUri()).when(versionControlService).copyRepository(anyString(), anyString(), anyString(), anyString(), anyString(), isNull());
+        doReturn(new VcsRepositoryUri()).when(versionControlService).copyRepositoryWithoutHistory(anyString(), anyString(), anyString(), anyString(), anyString(), isNull());
         doNothing().when(continuousIntegrationService).createProjectForExercise(any(ProgrammingExercise.class));
         doReturn("build plan").when(continuousIntegrationService).copyBuildPlan(any(ProgrammingExercise.class), anyString(), any(ProgrammingExercise.class), anyString(),
                 anyString(), anyBoolean());

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
@@ -270,7 +270,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         userUtilService.createAndSaveUser(TEST_PREFIX + "student42");
         doReturn(new Repository("ab", new VcsRepositoryUri("uri"))).when(gitService).getOrCheckoutRepositoryIntoTargetDirectory(any(), any(), anyBoolean());
         doReturn(new Repository("ab", new VcsRepositoryUri("uri"))).when(gitService).getExistingCheckedOutRepositoryByLocalPath(any(), any(), any());
-        doReturn(new Repository("ab", new VcsRepositoryUri("uri"))).when(gitService).copyBareRepository(any(), any(), any());
+        doReturn(new Repository("ab", new VcsRepositoryUri("uri"))).when(gitService).copyBareRepositoryWithoutHistory(any(), any(), any());
         // TODO: all parts using programmingExerciseTestService should also be provided for LocalVC+Jenkins
         programmingExerciseTestService.setup(this, versionControlService);
         jenkinsRequestMockProvider.enableMockingOfRequests(jenkinsJobPermissionsService);

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
@@ -951,7 +951,7 @@ public class ParticipationUtilService {
     public void mockCreationOfExerciseParticipation(String templateRepoName, VersionControlService versionControlService, ContinuousIntegrationService continuousIntegrationService)
             throws URISyntaxException {
         var someURL = new VcsRepositoryUri("http://vcs.fake.fake");
-        doReturn(someURL).when(versionControlService).copyRepository(any(String.class), eq(templateRepoName), any(String.class), any(String.class), any(String.class),
+        doReturn(someURL).when(versionControlService).copyRepositoryWithoutHistory(any(String.class), eq(templateRepoName), any(String.class), any(String.class), any(String.class),
                 any(Integer.class));
         mockCreationOfExerciseParticipationInternal(continuousIntegrationService);
     }
@@ -966,7 +966,8 @@ public class ParticipationUtilService {
     public void mockCreationOfExerciseParticipation(VersionControlService versionControlService, ContinuousIntegrationService continuousIntegrationService)
             throws URISyntaxException {
         var someURL = new VcsRepositoryUri("http://vcs.fake.fake");
-        doReturn(someURL).when(versionControlService).copyRepository(any(String.class), any(), any(String.class), any(String.class), any(String.class), any(Integer.class));
+        doReturn(someURL).when(versionControlService).copyRepositoryWithoutHistory(any(String.class), any(), any(String.class), any(String.class), any(String.class),
+                any(Integer.class));
         mockCreationOfExerciseParticipationInternal(continuousIntegrationService);
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/ParticipationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/ParticipationServiceTest.java
@@ -206,7 +206,7 @@ class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsLocalVCTe
     }
 
     private void setUpProgrammingExerciseMocks() {
-        doReturn(new VcsRepositoryUri()).when(versionControlService).copyRepository(anyString(), anyString(), anyString(), anyString(), anyString(), anyInt());
+        doReturn(new VcsRepositoryUri()).when(versionControlService).copyRepositoryWithoutHistory(anyString(), anyString(), anyString(), anyString(), anyString(), anyInt());
         doReturn("fake-build-plan-id").when(continuousIntegrationService).copyBuildPlan(any(), anyString(), any(), anyString(), anyString(), anyBoolean());
         doNothing().when(continuousIntegrationService).configureBuildPlan(any(ProgrammingExerciseParticipation.class));
     }

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseTestService.java
@@ -2174,7 +2174,7 @@ public class ProgrammingExerciseTestService {
         var participantRepoTestUrl = new LocalVCRepositoryUri(convertToLocalVcUriString(studentTeamRepo));
         final var teamLocalPath = studentTeamRepo.workingCopyGitRepoFile.toPath();
         doReturn(teamLocalPath).when(gitService).getDefaultLocalPathOfRepo(participantRepoTestUrl);
-        doThrow(new IOException("Checkout got interrupted!")).when(gitService).copyBareRepository(any(), any(), anyString());
+        doThrow(new IOException("Checkout got interrupted!")).when(gitService).copyBareRepositoryWithoutHistory(any(), any(), anyString());
 
         // the local repo should exist before startExercise()
         assertThat(teamLocalPath).exists();
@@ -2212,7 +2212,7 @@ public class ProgrammingExerciseTestService {
     // TEST
     public void configureRepository_testBadRequestError() throws Exception {
         Team team = setupTeamForBadRequestForStartExercise();
-        doThrow(new IOException()).when(gitService).copyBareRepository(any(), any(), anyString());
+        doThrow(new IOException()).when(gitService).copyBareRepositoryWithoutHistory(any(), any(), anyString());
 
         // Start participation
         assertThatExceptionOfType(VersionControlException.class).isThrownBy(() -> participationService.startExercise(exercise, team, false))


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.


#### Changes affecting Programming Exercises
Only affects LocalVC


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The history is currently always lost when copying a repository. This is desirable when creating student participations but not when importing exercises between courses as instructors might want to look up older commits


### Description
<!-- Describe your changes in detail -->
We now keep the history when exercises are imported.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to the course you want to import the exercise from
4. Go to your desired exercise
5. Click on Edit in editor
6. Click on Go to repository
7. Click on View Commit History
8. If it only shows one commit, make another one by submitting something in the edit in editor view. This will show up as Changes by Online Editor in the commit history
9. Go to another course, import the exercise
10. Check the commit history again by repeating the steps 4-7. You should see all your previous commits + one commit Template adjusted by Artemis	

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->
Covered with the steps above

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
Test implemented in followup.
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository copies during programming exercise imports now preserve full commit history, ensuring all past changes are retained in the new repositories.
  * Added option to copy repositories with or without commit history, giving more control over repository duplication.

* **Documentation**
  * Updated documentation to clarify which repository copy operations retain commit history and which do not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->