### PR TITLE
`Exam mode`: Fix wrong student points after unfinished second round correction

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ]
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamService.java
@@ -254,7 +254,7 @@ public class ExamService {
         if (latestSubmission.isPresent()) {
             var lastSubmission = latestSubmission.get();
             if (isStudentAllowedToSeeResult || isAtLeastInstructor) {
-                Result latestResult = lastSubmission.getLatestResult();
+                Result latestResult = lastSubmission.getLatestCompletedResult();
                 if (latestResult != null) {
                     latestResult.setSubmission(lastSubmission);
                     latestResult.filterSensitiveInformation();

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
@@ -142,6 +142,26 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     }
 
     /**
+     * Returns the most recent result that has been completed, i.e. has a non-null completion date.
+     * This ignores draft results that might exist when an assessment lock was created but not
+     * finished.
+     *
+     * @return the latest completed {@link Result} or {@code null} if none exists
+     */
+    @Nullable
+    @JsonIgnore
+    public Result getLatestCompletedResult() {
+        Result latestResult = Optional.ofNullable(results).orElse(Collections.emptyList()).stream().filter(result -> result != null && result.getCompletionDate() != null)
+                .max(Comparator.comparing(Result::getCompletionDate)).orElse(null);
+
+        if (latestResult != null) {
+            latestResult.setSubmission(this);
+        }
+
+        return latestResult;
+    }
+
+    /**
      * Used to get result by correction round (which ignores automatic results).
      * Works for all exercise types
      *


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When second corrections are enabled but remain unfinished, the latest draft result replaces the actual assessment. This leads to “No graded result” and zero points being shown to students once a correction round is incomplete. The affected issue is [#4793](https://github.com/ls1intum/Artemis/issues/4793).

### Description
<!-- Describe your changes in detail -->
- Introduced `Submission#getLatestCompletedResult()` to return the most recent completed result.
- Updated `ExamService` to display the latest completed result in student exam views, preventing draft second-correction results from hiding valid points.

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exam with a programming exercise: manual assessment mode, second correction round activated.

1. Login as instructor
2. Create the exam containing programming exercise with given specifications
3. Register student for the exam
4. Start the exam by setting start time to now
5. Login as student
6. Start and submit the relevant exam
7. Login as instructor
8. Finish the exam execution (by setting the end date to current time)
9. Grade the exercise using only the first correction round with a grade above 0 (go to exercise details -> scores)
10. Start the second correction round and don't submit
11. Log in as the student and check the exam overview
12. The student should see the originally graded points instead of 0


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Exam Mode Test
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExamService.java | 90% | ✅❌️                           |
| Submission.java  | 93% | ✅❌️              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a method to display only the latest completed result for exam submissions, ensuring students see the most up-to-date finalized assessment.
  * Introduced a new integration test to confirm students see the correct points from the first correction round if the second round is incomplete.

* **Tests**
  * Added comprehensive utility methods to simplify test setup for exams with multiple correction rounds and programming exercises.
  * Introduced a utility to create submissions with both completed and draft results for testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->