### PR TITLE
`Programming exercises`: Simplify participation deletion dialogs

### DIFF
--- a/src/main/webapp/app/exercise/participation/participation.component.html
+++ b/src/main/webapp/app/exercise/participation/participation.component.html
@@ -347,7 +347,7 @@
                                         jhiDeleteButton
                                         [entityTitle]="exercise.teamMode ? value.team?.name : value.student?.name"
                                         deleteQuestion="artemisApp.participation.delete.question"
-                                        (delete)="deleteParticipation(value.id, $event)"
+                                        (delete)="deleteParticipation(value.id)"
                                         [dialogError]="dialogError"
                                     >
                                         <fa-icon [icon]="faTrash" />

--- a/src/main/webapp/app/exercise/participation/participation.component.html
+++ b/src/main/webapp/app/exercise/participation/participation.component.html
@@ -349,11 +349,6 @@
                                         deleteQuestion="artemisApp.participation.delete.question"
                                         (delete)="deleteParticipation(value.id, $event)"
                                         [dialogError]="dialogError"
-                                        [additionalChecks]="
-                                            exercise.type === ExerciseType.PROGRAMMING
-                                                ? { deleteBuildPlan: 'artemisApp.participation.deleteBuildPlan', deleteRepository: 'artemisApp.participation.deleteRepository' }
-                                                : undefined
-                                        "
                                     >
                                         <fa-icon [icon]="faTrash" />
                                     </button>

--- a/src/main/webapp/app/exercise/participation/participation.component.spec.ts
+++ b/src/main/webapp/app/exercise/participation/participation.component.spec.ts
@@ -288,7 +288,7 @@ describe('ParticipationComponent', () => {
 
         const deleteStub = jest.spyOn(participationService, 'delete').mockReturnValue(of(new HttpResponse()));
 
-        component.deleteParticipation(1, {});
+        component.deleteParticipation(1);
         tick();
 
         expect(deleteStub).toHaveBeenCalledOnce();

--- a/src/main/webapp/app/exercise/participation/participation.component.ts
+++ b/src/main/webapp/app/exercise/participation/participation.component.ts
@@ -349,11 +349,10 @@ export class ParticipationComponent implements OnInit, OnDestroy {
     /**
      * Deletes participation
      * @param participationId the id of the participation that we want to delete
-     * @param event passed from delete dialog to represent if checkboxes were checked
      */
-    deleteParticipation(participationId: number, event: { [key: string]: boolean }) {
-        const deleteBuildPlan = event.deleteBuildPlan ? event.deleteBuildPlan : false;
-        const deleteRepository = event.deleteRepository ? event.deleteRepository : false;
+    deleteParticipation(participationId: number) {
+        const deleteBuildPlan = true;
+        const deleteRepository = true;
         this.participationService.delete(participationId, { deleteBuildPlan, deleteRepository }).subscribe({
             next: () => {
                 this.eventManager.broadcast({

--- a/src/main/webapp/app/programming/manage/reset/dialog/programming-exercise-reset-dialog.component.html
+++ b/src/main/webapp/app/programming/manage/reset/dialog/programming-exercise-reset-dialog.component.html
@@ -17,50 +17,6 @@
                                 <input
                                     class="form-check-input"
                                     type="checkbox"
-                                    name="deleteBuildPlans"
-                                    [(ngModel)]="this.programmingExerciseResetOptions.deleteBuildPlans"
-                                    (ngModelChange)="
-                                        this.programmingExerciseResetOptions.deleteRepositories =
-                                            this.programmingExerciseResetOptions.deleteBuildPlans && this.programmingExerciseResetOptions.deleteRepositories
-                                    "
-                                />
-                                <span jhiTranslate="artemisApp.programmingExercise.reset.deleteBuildPlans.title" [translateValues]="{ ciPlatform: continuousIntegrationName }">
-                                    Delete student build plans (on {{ continuousIntegrationName }})
-                                </span>
-                            </label>
-                        </div>
-                    </li>
-                }
-                @if (programmingExercise.isAtLeastInstructor && this.programmingExerciseResetOptions.deleteBuildPlans && !this.programmingExerciseResetOptions.deleteRepositories) {
-                    <div class="alert alert-info my-2">
-                        <span jhiTranslate="artemisApp.programmingExercise.reset.deleteBuildPlans.info"></span>
-                    </div>
-                }
-                @if (programmingExercise.isAtLeastInstructor) {
-                    <li>
-                        <div class="checkbox">
-                            <label class="control-label">
-                                <input
-                                    class="form-check-input"
-                                    type="checkbox"
-                                    name="deleteRepositories"
-                                    [(ngModel)]="this.programmingExerciseResetOptions.deleteRepositories"
-                                    (ngModelChange)="this.programmingExerciseResetOptions.deleteBuildPlans = !!$event || this.programmingExerciseResetOptions.deleteBuildPlans"
-                                />
-                                <span jhiTranslate="artemisApp.programmingExercise.reset.deleteRepositories.title" [translateValues]="{ vcPlatform: versionControlName }">
-                                    Delete student repositories (on {{ versionControlName }}).
-                                </span>
-                            </label>
-                        </div>
-                    </li>
-                }
-                @if (programmingExercise.isAtLeastInstructor) {
-                    <li>
-                        <div class="checkbox">
-                            <label class="control-label">
-                                <input
-                                    class="form-check-input"
-                                    type="checkbox"
                                     name="deleteParticipationsSubmissionsAndResults"
                                     [(ngModel)]="this.programmingExerciseResetOptions.deleteParticipationsSubmissionsAndResults"
                                 />
@@ -68,22 +24,6 @@
                             </label>
                         </div>
                     </li>
-                }
-                @if (
-                    programmingExercise.isAtLeastInstructor &&
-                    !this.programmingExerciseResetOptions.deleteRepositories &&
-                    this.programmingExerciseResetOptions.deleteParticipationsSubmissionsAndResults
-                ) {
-                    <div class="alert alert-warning my-2">
-                        <span
-                            jhiTranslate="artemisApp.programmingExercise.reset.artefactsWarning"
-                            [translateValues]="{ vcPlatform: versionControlName, ciPlatform: continuousIntegrationName }"
-                        >
-                            Deleting student participations, submissions, and results without removing the associated repositories and build plans may lead to undeleted artifacts
-                            on
-                            {{ versionControlName }} and {{ continuousIntegrationName }}. Please carefully review if this is the desired action before proceeding.
-                        </span>
-                    </div>
                 }
                 @if (programmingExercise.isAtLeastEditor) {
                     <li>

--- a/src/main/webapp/app/programming/manage/reset/dialog/programming-exercise-reset-dialog.component.spec.ts
+++ b/src/main/webapp/app/programming/manage/reset/dialog/programming-exercise-reset-dialog.component.spec.ts
@@ -97,6 +97,12 @@ describe('ProgrammingExerciseResetDialogComponent', () => {
 
         it('should not be called when there is an error in the reset response', fakeAsync(() => {
             const errorResponse = throwError({ status: 500 });
+            comp.programmingExerciseResetOptions = {
+                deleteBuildPlans: false,
+                deleteRepositories: false,
+                deleteParticipationsSubmissionsAndResults: true,
+                recreateBuildPlans: false,
+            };
             jest.spyOn(programmingExerciseService, 'reset').mockReturnValue(errorResponse);
             jest.spyOn(comp, 'handleResetResponse').mockImplementation();
 
@@ -114,9 +120,9 @@ describe('ProgrammingExerciseResetDialogComponent', () => {
             comp.confirmText = 'Programming Exercise';
             comp.resetInProgress = false;
             comp.programmingExerciseResetOptions = {
-                deleteBuildPlans: true,
+                deleteBuildPlans: false,
                 deleteRepositories: false,
-                deleteParticipationsSubmissionsAndResults: false,
+                deleteParticipationsSubmissionsAndResults: true,
                 recreateBuildPlans: false,
             };
         });
@@ -136,7 +142,7 @@ describe('ProgrammingExerciseResetDialogComponent', () => {
         });
 
         it('should return false when confirmation text is filled correctly, but no option is selected', () => {
-            comp.programmingExerciseResetOptions.deleteBuildPlans = false;
+            comp.programmingExerciseResetOptions.deleteParticipationsSubmissionsAndResults = false;
             expect(comp.canSubmit).toBeFalse();
         });
 
@@ -160,8 +166,6 @@ describe('ProgrammingExerciseResetDialogComponent', () => {
 
         it.each`
             option
-            ${'deleteBuildPlans'}
-            ${'deleteRepositories'}
             ${'deleteParticipationsSubmissionsAndResults'}
             ${'recreateBuildPlans'}
         `('should return true when $option is set to true', ({ option }) => {

--- a/src/main/webapp/app/programming/manage/reset/dialog/programming-exercise-reset-dialog.component.ts
+++ b/src/main/webapp/app/programming/manage/reset/dialog/programming-exercise-reset-dialog.component.ts
@@ -74,6 +74,11 @@ export class ProgrammingExerciseResetDialogComponent implements OnInit {
             return;
         }
 
+        if (this.programmingExerciseResetOptions.deleteParticipationsSubmissionsAndResults) {
+            this.programmingExerciseResetOptions.deleteBuildPlans = true;
+            this.programmingExerciseResetOptions.deleteRepositories = true;
+        }
+
         this.resetInProgress = true;
         this.programmingExerciseService.reset(this.programmingExercise.id, this.programmingExerciseResetOptions).subscribe({
             next: this.handleResetResponse,
@@ -105,11 +110,6 @@ export class ProgrammingExerciseResetDialogComponent implements OnInit {
      * @returns {boolean} true if at least one reset option is selected, false otherwise
      */
     get hasSelectedOptions(): boolean {
-        return (
-            this.programmingExerciseResetOptions.deleteBuildPlans ||
-            this.programmingExerciseResetOptions.deleteRepositories ||
-            this.programmingExerciseResetOptions.deleteParticipationsSubmissionsAndResults ||
-            this.programmingExerciseResetOptions.recreateBuildPlans
-        );
+        return this.programmingExerciseResetOptions.deleteParticipationsSubmissionsAndResults || this.programmingExerciseResetOptions.recreateBuildPlans;
     }
 }

--- a/src/main/webapp/i18n/de/programmingExercise.json
+++ b/src/main/webapp/i18n/de/programmingExercise.json
@@ -32,14 +32,6 @@
             },
             "reset": {
                 "pleaseSelectOperations": "Bitte wähle die durchzuführenden Operationen für <strong>{{ title }}</strong> aus:",
-                "deleteBuildPlans": {
-                    "title": "Lösche Build Pläne der Studierenden (auf {{ ciPlatform }}).",
-                    "info": "Die Build-Pläne werden automatisch neu erstellt, sobald Studierende erneut abgeben."
-                },
-                "deleteRepositories": {
-                    "title": "Lösche Repositories der Studierenden (auf {{ vcPlatform }}).",
-                    "warning": "Archivierung der Übung vor Aktivierung dieser Option wird empfohlen."
-                },
                 "deleteParticipationsSubmissionsAndResults": "Lösche Teilnahmen, Abgaben und Ergebnisse der Studierenden (in Artemis).",
                 "artefactsWarning": "Das Löschen von Teilnahmen, Abgaben und Ergebnissen von Studierenden, ohne dabei die zugehörigen Repositories und Build-Pläne zu entfernen, kann zu nicht gelöschten Artefakten auf {{ vcPlatform }} und {{ ciPlatform }} führen. Bitte überprüfe sorgfältig, ob dies die gewünschte Aktion ist, bevor du den Vorgang fortsetzt.",
                 "recreateBuildPlans": "Erstelle Build Pläne der Aufgabe (BASE und SOLUTION) erneut und überschreibe alle vorherigen Änderungen.",

--- a/src/main/webapp/i18n/en/programmingExercise.json
+++ b/src/main/webapp/i18n/en/programmingExercise.json
@@ -32,14 +32,6 @@
             },
             "reset": {
                 "pleaseSelectOperations": "Please select the operations you want to perform on <strong>{{ title }}</strong>:",
-                "deleteBuildPlans": {
-                    "title": "Delete student build plans (on {{ ciPlatform }}).",
-                    "info": "The build plans will be automatically recreated when students submit again."
-                },
-                "deleteRepositories": {
-                    "title": "Delete student repositories (on {{ vcPlatform }}).",
-                    "warning": "Before you activate this option, we recommend that you archive the repositories and build plans first."
-                },
                 "deleteParticipationsSubmissionsAndResults": "Delete all student participations, submissions and results (on Artemis).",
                 "artefactsWarning": "Deleting student participations, submissions, and results without removing the associated repositories and build plans may lead to undeleted artifacts on {{ vcPlatform }} and {{ ciPlatform }}. Please carefully review if this is the desired action before proceeding.",
                 "recreateBuildPlans": "Recreate the exercise build plans (BASE and SOLUTION) again from the latest exercise template, overwriting any previous changes.",


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

#### Changes affecting Programming Exercises
### Motivation and Context
Neither for Jenkins Setups, nor for the LocalVC setup the separation of participation deletion and deletion of repositories and build plans makes sense anymore (it used to make sense back when we supported the Atlassian Stack - Bamboo + Bitbucket)

### Description
Remove redundant questions about whether build plans and repositories of participations shall be deleted, but delete them by default instead.

### Steps for Testing
Prerequisites:
- 1 Programming exercise participation (can be the instructor in the online code editor)
- 1 Programming exercises
- Be logged in as instructor

1. Open the developer tools (you will need to inspect the network tab)
2. Delete the participation of a programming exercise, see that the delete request is sent with the params `deleteBuildPlan=true&deleteRepository=true`
3. `Reset` a Programming exercise with only toggling `Reset the customized build plans ...`
4. Inspect the body of the sent delete request, see that only recreateBuildPlans is true
```
{
    "deleteBuildPlans": false,
    "deleteRepositories": false,
    "deleteParticipationsSubmissionsAndResults": false,
    "recreateBuildPlans": true
}
```
5. `Reset` a Programming exercise with only toggling `Delete all student participations...`
6. Inspect the body of the sent delete request, see that only recreateBuildPlans is false and the others variables are true
```
{
    "deleteBuildPlans": true,
    "deleteRepositories": true,
    "deleteParticipationsSubmissionsAndResults": true,
    "recreateBuildPlans": false
}
```

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
No tests added 

### Screenshots
#### Before adjustment

##### Participation deletion
<img width="1161" height="432" alt="image" src="https://github.com/user-attachments/assets/e137aabd-da80-4034-8742-a7d490ec2463" />

##### Programming Exercise Reset
![resetProgrammingExerciseBefore](https://github.com/user-attachments/assets/2eee1b90-2d34-4aba-b3c8-8e32368d207c)


<details>
<summary>Higher resolution video</summary>


https://github.com/user-attachments/assets/8f017c53-7438-4aa6-ab0e-34a5b1527ec2


</details>

#### After adjustment
##### Participation deletion
<img width="1477" height="431" alt="image" src="https://github.com/user-attachments/assets/444b0a1a-9ac7-4b50-830b-91475795e2e6" />

##### Programming Exercise Reset
![resetProgrammingExerciseAfterAdjustment](https://github.com/user-attachments/assets/c6adb659-16a4-4e72-865a-17058fc235a6)


<details>
<summary>Higher resolution video</summary>


https://github.com/user-attachments/assets/c807e499-73f9-4af9-a07b-5b3ce8996d7d


</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Resetting a programming exercise now automatically deletes related build plans and repositories when participations, submissions, and results are deleted.

* **Bug Fixes**
  * Simplified the delete participation process to always remove associated build plans and repositories.

* **Style**
  * Removed UI options and alerts related to selectively deleting build plans and repositories from the reset dialog.

* **Documentation**
  * Updated localization files to remove unused entries for deleting build plans and repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->