### PR TITLE
`Exam mode`: Fix visual bug indicating no commit was made in exam summary

### DIFF
--- a/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.spec.ts
+++ b/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.spec.ts
@@ -114,7 +114,6 @@ describe('ProgrammingExamSummaryComponent', () => {
                 component = fixture.componentInstance;
 
                 component.exercise = programmingExercise;
-                programmingSubmission.results = [result];
                 programmingSubmission.participation = programmingParticipation;
                 programmingParticipation.submissions = [programmingSubmission];
                 component.participation = programmingParticipation;
@@ -127,15 +126,16 @@ describe('ProgrammingExamSummaryComponent', () => {
         jest.restoreAllMocks();
     });
 
-    it('should initialize', () => {
+    it('should initialize and set commit hash', () => {
         fixture.detectChanges();
 
         expect(component).toBeTruthy();
+        expect(component.commitHash).toBe('123456789ab');
     });
 
     it('should show result if present and results are published', () => {
         component.isAfterResultsArePublished = true;
-
+        programmingSubmission.results = [result];
         fixture.detectChanges();
 
         expect(component.feedbackComponentParameters.exercise).toEqual(programmingExercise);
@@ -148,7 +148,7 @@ describe('ProgrammingExamSummaryComponent', () => {
 
     it('should not show results if not yet published', () => {
         component.isAfterResultsArePublished = false;
-
+        programmingSubmission.results = [result];
         fixture.detectChanges();
 
         const feedbackComponent = fixture.debugElement.query(By.directive(FeedbackComponent))?.componentInstance;

--- a/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component.ts
@@ -17,6 +17,8 @@ import { FeedbackComponent } from 'app/exercise/feedback/feedback.component';
 import { ProgrammingExerciseInstructionComponent } from 'app/programming/shared/instructions-render/programming-exercise-instruction.component';
 import { ComplaintsStudentViewComponent } from 'app/assessment/overview/complaints-for-students/complaints-student-view.component';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { getLatestSubmission } from 'app/exercise/shared/entities/participation/participation.model';
+import { getLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
 
 @Component({
     selector: 'jhi-programming-exam-summary',
@@ -57,10 +59,12 @@ export class ProgrammingExamSummaryComponent implements OnInit {
     ngOnInit() {
         this.routerLink = this.router.url;
         this.participation.exercise = this.exercise;
-        this.result = this.participation.submissions![0].results![0];
-        // TODO this is not a a perfect solution.
-        this.result.submission = this.submission;
-        this.result.submission.participation = this.participation;
+        this.submission = getLatestSubmission(this.participation) as ProgrammingSubmission;
+        this.result = getLatestSubmissionResult(this.submission);
+        if (this.result && this.submission) {
+            this.result.submission = this.submission;
+            this.result.submission.participation = this.participation;
+        }
         this.commitHash = this.submission?.commitHash?.slice(0, 11);
         this.isInCourseManagement = this.router.url.includes('course-management');
         const isBuilding = false;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).




#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Students in the EIST exam encountered a bug that showed them a message in the exam summary that no commit was made which was incorrect.
The issue is only present when no result for a submission exists.


### Description
<!-- Describe your changes in detail -->
Due to an access of undefined objects, the ngOnInit didn't complete and the commit hash was never initialized causing the issue.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Admin (to pause the build agents)
- 1 Student
- 1 Exam with a programming exercise

1. Log in to Artemis
2. Navigate to Course Administration
3. Create the exam with the programming exercise
4. As admin, pause all build agents (this simulates that the submission was not yet built because it's in the queue
5. Participate in the exam and submit something as student
6. Hand in the exam
7. Check that on the exam summary page for the programming exercise `The submission is linked to commit <commit-hash>` is shown
8. Activate all build agents again

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->
Covered with the steps above
### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
my changes are covered
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in displaying the latest submission and result for programming exam summaries. The component now reliably shows the most recent data for each participation.
  * Enhanced test coverage to ensure correct commit hash display and localized test data setup for programming exam summary components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->