### PR TITLE
`Exam mode`: Adjust test-run layout and ribbon position

### DIFF
--- a/src/main/webapp/app/core/course/manage/course-management-container/course-management-container.component.html
+++ b/src/main/webapp/app/core/course/manage/course-management-container/course-management-container.component.html
@@ -65,8 +65,8 @@
                         id="course-body-container"
                         [ngClass]="{
                             'module-bg rounded rounded-3 scrollable-content': !hasSidebar(),
+                            'p-3': !hasSidebar() && !removePadding,
                             'content-height-dev': !isProduction || isTestServer,
-                            'p-3': !removePadding,
                         }"
                     >
                         @if (!hasSidebar()) {

--- a/src/main/webapp/app/core/course/manage/course-management-container/course-management-container.component.html
+++ b/src/main/webapp/app/core/course/manage/course-management-container/course-management-container.component.html
@@ -64,8 +64,9 @@
                         class="course-body-container mx-2"
                         id="course-body-container"
                         [ngClass]="{
-                            'module-bg p-3 rounded rounded-3 scrollable-content': !hasSidebar(),
+                            'module-bg rounded rounded-3 scrollable-content': !hasSidebar(),
                             'content-height-dev': !isProduction || isTestServer,
+                            'p-3': !removePadding,
                         }"
                     >
                         @if (!hasSidebar()) {

--- a/src/main/webapp/app/core/course/manage/course-management-container/course-management-container.component.ts
+++ b/src/main/webapp/app/core/course/manage/course-management-container/course-management-container.component.ts
@@ -103,10 +103,14 @@ export class CourseManagementContainerComponent extends BaseCourseContainerCompo
     private featureToggleSub: Subscription;
     private courseSub?: Subscription;
     private urlSubscription?: Subscription;
+    private routeSubscription?: Subscription;
+
     private learningPathsActive = signal(false);
     courseBody = viewChild<ElementRef<HTMLElement>>('courseBodyContainer');
     isSettingsPage = signal(false);
     studentViewLink = signal<string[]>([]);
+
+    removePadding = false;
 
     // we cannot use signals here because the child component doesn't expect it
     dialogErrorSource = new Subject<string>();
@@ -135,6 +139,11 @@ export class CourseManagementContainerComponent extends BaseCourseContainerCompo
             const id = Number(params.courseId);
             this.handleCourseIdChange(id);
             this.checkIfSettingsPage();
+        });
+
+        this.routeSubscription = this.router.events.subscribe(() => {
+            // we do not want to have the padding to the left and right during test runs, see https://github.com/ls1intum/Artemis/pull/11235
+            this.removePadding = this.router.url.includes('test-runs') && this.router.url.includes('conduction');
         });
 
         this.featureToggleSub = this.featureToggleService.getFeatureToggleActive(FeatureToggle.LearningPaths).subscribe((isActive) => {
@@ -376,6 +385,7 @@ export class CourseManagementContainerComponent extends BaseCourseContainerCompo
         this.featureToggleSub?.unsubscribe();
         this.urlSubscription?.unsubscribe();
         this.courseSub?.unsubscribe();
+        this.routeSubscription?.unsubscribe();
     }
 
     fetchCourseDeletionSummary(): Observable<EntitySummary> {

--- a/src/main/webapp/app/core/layouts/profiles/page-ribbon.component.ts
+++ b/src/main/webapp/app/core/layouts/profiles/page-ribbon.component.ts
@@ -8,7 +8,7 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
     template: `
         <div class="box">
             @if (ribbonEnv) {
-                <div class="ribbon ribbon-top-left">
+                <div class="ribbon ribbon-top-left ribbon-rotate">
                     <span jhiTranslate="global.ribbon.{{ ribbonEnv }}">{{ ribbonEnv }}</span>
                 </div>
             }

--- a/src/main/webapp/app/core/layouts/profiles/page-ribbon.scss
+++ b/src/main/webapp/app/core/layouts/profiles/page-ribbon.scss
@@ -46,7 +46,7 @@ Developement Ribbon
     border-left-color: transparent;
 }
 
-.ribbon-top-left span {
+.ribbon-rotate span {
     right: -25px;
     top: 45px;
     transform: rotate(-45deg);

--- a/src/main/webapp/app/exam/manage/test-runs/test-run-management/test-run-management.component.html
+++ b/src/main/webapp/app/exam/manage/test-runs/test-run-management/test-run-management.component.html
@@ -96,9 +96,8 @@
                                                     <a class="start-testrun btn btn-primary btn-sm me-1 mb-1" [routerLink]="['../test-runs/' + testRun.id + '/conduction']">
                                                         @if (!testRun.started) {
                                                             <span jhiTranslate="artemisApp.course.startDate"></span>
-                                                        }
-                                                        @if (testRun.started) {
-                                                            <span jhiTranslate="artemisApp.examParticipation.continueAfterHandInEarly"></span>
+                                                        } @else {
+                                                            <span jhiTranslate="artemisApp.examParticipation.continue"></span>
                                                         }
                                                     </a>
                                                 } @else {

--- a/src/main/webapp/app/exam/manage/test-runs/test-run-ribbon.component.ts
+++ b/src/main/webapp/app/exam/manage/test-runs/test-run-ribbon.component.ts
@@ -5,7 +5,7 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
     selector: 'jhi-test-run-ribbon',
     template: `
         <div class="box">
-            <div class="ribbon ribbon-top-left">
+            <div class="ribbon ribbon-rotate">
                 <span jhiTranslate="artemisApp.examManagement.testRun.testRun"></span>
             </div>
         </div>

--- a/src/main/webapp/app/exam/overview/exam-bar/exam-bar.component.html
+++ b/src/main/webapp/app/exam/overview/exam-bar/exam-bar.component.html
@@ -1,4 +1,4 @@
-<div class="h5 module-bg exam-bar mt-0 px-3 py-2 rounded rounded-3 sticky-top" [ngClass]="{ 'end-view': isEndView, 'mx-3': !isEndView }">
+<div class="h5 module-bg exam-bar mt-0 px-3 py-2 rounded rounded-3 sticky-top" [ngClass]="{ 'end-view': isEndView, 'mx-3': !isEndView && !isTestRun }">
     <div class="d-flex justify-content-between">
         <h3 class="align-self-center mb-0 me-3">
             {{ examTitle }}

--- a/src/main/webapp/app/exam/overview/exam-bar/exam-bar.component.ts
+++ b/src/main/webapp/app/exam/overview/exam-bar/exam-bar.component.ts
@@ -19,7 +19,9 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
     styleUrl: './exam-bar.component.scss',
 })
 export class ExamBarComponent implements AfterViewInit, OnInit {
-    private elementRef = inject(ElementRef);
+    private readonly elementRef = inject(ElementRef);
+
+    protected readonly faDoorClosed = faDoorClosed;
 
     @Output() onExamHandInEarly = new EventEmitter<void>();
     @Output() examAboutToEnd = new EventEmitter<void>();
@@ -34,11 +36,10 @@ export class ExamBarComponent implements AfterViewInit, OnInit {
     @Input() studentExam: StudentExam;
     @Input() examStartDate: dayjs.Dayjs;
 
-    readonly faDoorClosed = faDoorClosed;
     criticalTime = dayjs.duration(5, 'minutes');
     criticalTimeEndView = dayjs.duration(30, 'seconds');
     testExam: boolean;
-    testRun: boolean;
+    isTestRun: boolean;
 
     private previousHeight: number;
     examTitle: string;
@@ -48,7 +49,7 @@ export class ExamBarComponent implements AfterViewInit, OnInit {
         this.examTitle = this.exam.title ?? '';
         this.exercises = this.studentExam.exercises ?? [];
         this.testExam = this.exam.testExam ?? false;
-        this.testRun = this.studentExam.testRun ?? false;
+        this.isTestRun = this.studentExam.testRun ?? false;
     }
 
     /**

--- a/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.html
+++ b/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.html
@@ -30,7 +30,7 @@
                 />
 
                 <div class="d-flex justify-content-between gap-3">
-                    <div class="ms-3 bg-body">
+                    <div class="bg-body" [class.ms-3]="!testRunId">
                         <jhi-exam-navigation-sidebar
                             [sidebarData]="sidebarData"
                             [exercises]="studentExam.exercises!"
@@ -43,8 +43,8 @@
                     </div>
                     <!-- exercises -->
                     <div
-                        class="vw-100 module-bg rounded-3 me-3 px-3 pt-3 content-exam-height"
-                        [ngClass]="{ 'content-exam-height-testRun-dev': !isProduction || isTestServer, 'content-exam-height-testRun': testRunId }"
+                        class="vw-100 module-bg rounded-3 px-3 pt-3 content-exam-height"
+                        [ngClass]="{ 'content-exam-height-testRun-dev': !isProduction || isTestServer, 'content-exam-height-testRun': testRunId, 'me-3': !testRunId }"
                     >
                         <div [ngClass]="{ 'd-flex h-100 justify-content-between flex-column': !checkVerticalOverflow() }">
                             <div [hidden]="activePageIndex !== -1">

--- a/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.ts
@@ -108,6 +108,9 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
     private examManagementService = inject(ExamManagementService);
     private profileService = inject(ProfileService);
 
+    protected readonly faCheckCircle = faCheckCircle;
+    protected readonly faGraduationCap = faGraduationCap;
+
     @ViewChildren(ExamSubmissionComponent)
     currentPageComponents: QueryList<ExamSubmissionComponent>;
 
@@ -164,9 +167,6 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
     sidebarData: SidebarData;
     sidebarExercises: SidebarCardElement[] = [];
 
-    // Icons
-    faCheckCircle = faCheckCircle;
-
     isProgrammingExercise() {
         return !this.activeExamPage.isOverviewPage && this.activeExamPage.exercise!.type === ExerciseType.PROGRAMMING;
     }
@@ -194,9 +194,6 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
     isAtLeastInstructor?: boolean;
 
     generateParticipationStatus: BehaviorSubject<GenerateParticipationStatus> = new BehaviorSubject('success');
-
-    // Icons
-    faGraduationCap = faGraduationCap;
 
     constructor() {
         // show only one synchronization error every 5s

--- a/src/main/webapp/app/exam/overview/summary/exam-result-summary.component.html
+++ b/src/main/webapp/app/exam/overview/summary/exam-result-summary.component.html
@@ -1,3 +1,6 @@
+@if (isTestRun) {
+    <jhi-test-run-ribbon id="testRunRibbon" />
+}
 <div id="exam-results-title">
     <h2>
         <ng-container>

--- a/src/main/webapp/app/exam/overview/summary/exam-result-summary.component.ts
+++ b/src/main/webapp/app/exam/overview/summary/exam-result-summary.component.ts
@@ -42,6 +42,7 @@ import { ComplaintsStudentViewComponent } from 'app/assessment/overview/complain
 import { ProgrammingExamSummaryComponent } from 'app/exam/overview/summary/exercises/programming-exam-summary/programming-exam-summary.component';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ExampleSolutionComponent } from 'app/exercise/example-solution/example-solution.component';
+import { TestRunRibbonComponent } from 'app/exam/manage/test-runs/test-run-ribbon.component';
 
 export type ResultSummaryExerciseInfo = {
     icon: IconProp;
@@ -86,6 +87,7 @@ type StateBeforeResetting = {
         ComplaintsStudentViewComponent,
         ProgrammingExamSummaryComponent,
         ArtemisTranslatePipe,
+        TestRunRibbonComponent,
     ],
 })
 export class ExamResultSummaryComponent implements OnInit {

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -327,6 +327,7 @@
             "pendingChanges": "Alle ungespeicherten Änderungen gehen beim Verlassen der Klausur verloren. Bist du sicher, dass du fortfahren möchtest?",
             "handInEarly": "Vorzeitig Abgeben",
             "continueAfterHandInEarly": "Zurück",
+            "continue": "Fortsetzen",
             "attendanceCheck": "Anwesenheitskontrolle",
             "continueAfterHandInEarlyDescription": "Um mit der Klausur fortzufahren, klicke auf den Button 'Zurück'.",
             "handInEarlyNotice": "Du bist dabei die Klausur vorzeitig abzugeben. Du kannst danach nicht mehr an der Klausur teilnehmen.",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -327,6 +327,7 @@
             "pendingChanges": "All unsaved changes will be lost when leaving the exam! Are you sure that you want to continue?",
             "handInEarly": "Hand in Early",
             "continueAfterHandInEarly": "Back",
+            "continue": "Continue",
             "attendanceCheck": "Attendance check",
             "continueAfterHandInEarlyDescription": "To continue working on the exam, click on the 'Back' button.",
             "handInEarlyNotice": "You are about to hand in your submission before the end of the exam. After finishing the exam you cannot participate any longer.",


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
- On develop the test run ribbon overlaps and is hidden behind the sidebar

   <img width="690" height="484" alt="image" src="https://github.com/user-attachments/assets/18807fb9-6649-4b4e-a523-01fd1aaa2acd" />

    <img width="671" height="647" alt="image" src="https://github.com/user-attachments/assets/392529e9-1832-4968-bf00-adfc148b4c4d" />

- Also the spacing was not good, see the white and grey border around the actual content 
   <img width="1925" height="1088" alt="Screenshot 2025-07-31 at 18 03 01" src="https://github.com/user-attachments/assets/d7eddc8e-b3f0-4de5-a9a5-c9cc5737cc9e" />


### Description
- Adjusted ribbon position, instead of placing it in the upper left corner of the browser we place it in the upper left corner of the participation component
- `Continue` makes more sense in the test run view than `Back` -> adjusted translation
- Improved the spacing for test runs

### Steps for Testing
- 1 existing exam

1. Create a Test Run
2. Start the test run
3. Go back to the test run overview
4. See that `Continue` is written there and not `Back`
5. Continue the test run
6. Submit the test run
7. Verify that the test run ribbon was displayed properly during the whole test run
8. Verify the test run ribbon is not displayed in the actual exam mode
9. Verify the layout did not break in real exam participation (especially padding to left and right)

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
No tests added

### Screenshots

![testRunsWithImprovedSpacing](https://github.com/user-attachments/assets/ce53bb43-cf23-4645-9940-a6eae9a459d9)

<details>
<summary>Higher resolution video</summary>


https://github.com/user-attachments/assets/9deeed0a-5dd4-4520-af48-ca876f500908


</details>


<img width="1915" height="1043" alt="image" src="https://github.com/user-attachments/assets/e2f4041c-5f3a-4e35-9e8f-eab550d3bc9a" />


<img width="1684" height="390" alt="Screenshot 2025-07-31 at 13 17 28" src="https://github.com/user-attachments/assets/362c9f5f-4eb2-4aaf-9584-debda564f14d" />


Improved spacing during exam mode
<img width="1921" height="1088" alt="image" src="https://github.com/user-attachments/assets/c1e23dbc-09a6-4685-bfa8-0850bbfb3343" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a visual ribbon indicator for test runs in the exam result summary view.

* **Style**
  * Updated ribbon styling and positioning for environment and test run ribbons to use a rotated appearance.
  * Refined layout spacing and padding in course management and exam participation views based on test run context.

* **Bug Fixes**
  * Improved the display logic for starting or continuing test runs, ensuring the correct label is shown.

* **Documentation**
  * Added new translation keys for "Continue" in English and German exam participation sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->