### PR TITLE
`General`: Hide cleanup on localCI setups

### DIFF
--- a/src/main/webapp/app/exercise/participation/participation.component.html
+++ b/src/main/webapp/app/exercise/participation/participation.component.html
@@ -144,7 +144,7 @@
                         <ng-template ngx-datatable-cell-template let-row="row">
                             @if (row) {
                                 <span>
-                                    @if (!localCIEnabled) {
+                                    @if (!isLocalCIEnabled) {
                                         <a href="{{ row.buildPlanUrl }}" target="_blank" rel="noreferrer">
                                             {{ row.buildPlanId }}
                                         </a>
@@ -353,7 +353,7 @@
                                         <fa-icon [icon]="faTrash" />
                                     </button>
                                 }
-                                @if (exercise?.type === ExerciseType.PROGRAMMING && value.buildPlanId !== null && exercise.isAtLeastInstructor) {
+                                @if (exercise?.type === ExerciseType.PROGRAMMING && !isLocalCIEnabled && value.buildPlanId !== null && exercise.isAtLeastInstructor) {
                                     <button
                                         [jhiFeatureToggle]="FeatureToggle.ProgrammingExercises"
                                         jhiDeleteButton

--- a/src/main/webapp/app/exercise/participation/participation.component.spec.ts
+++ b/src/main/webapp/app/exercise/participation/participation.component.spec.ts
@@ -29,6 +29,8 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { EventManager } from 'app/shared/service/event-manager.service';
+import { PROFILE_LOCALCI } from 'app/app.constants';
+import { By } from '@angular/platform-browser';
 
 describe('ParticipationComponent', () => {
     let component: ParticipationComponent;
@@ -78,6 +80,42 @@ describe('ParticipationComponent', () => {
 
     afterEach(() => {
         jest.restoreAllMocks();
+    });
+
+    describe('cleanup button', () => {
+        it('should be displayed when not localCI', () => {
+            const profileServiceSpy = jest.spyOn(component['profileService'], 'isProfileActive').mockReturnValue(false);
+
+            component.isLoading = false;
+            // Set up the exercise as a programming exercise with the required conditions
+            component.exercise = {
+                ...exercise,
+                type: ExerciseType.PROGRAMMING,
+                isAtLeastInstructor: true,
+                teamMode: false,
+            };
+            component.isLocalCIEnabled = false;
+
+            // Mock a participation with a buildPlanId
+            const participation = {
+                id: 1,
+                buildPlanId: 'buildPlan123',
+                student: { name: 'Student Name' },
+            };
+            component.participations = [participation];
+
+            componentFixture.detectChanges();
+
+            // const cleanupButton = componentFixture.debugElement.query(
+            //     By.css('button[jhiDeleteButton][deleteQuestion="artemisApp.participation.cleanupBuildPlan.question"]')
+            // )?.nativeElement;
+            const cleanupButton = componentFixture.debugElement.query(By.css('#test'))?.nativeElement;
+
+            expect(profileServiceSpy).toHaveBeenCalledOnce();
+            expect(profileServiceSpy).toHaveBeenCalledWith(PROFILE_LOCALCI);
+            expect(cleanupButton).toBeTruthy();
+            expect(cleanupButton.querySelector('fa-icon')).toBeTruthy();
+        });
     });
 
     it('should initialize with exerciseId from route', () => {

--- a/src/main/webapp/app/exercise/participation/participation.component.ts
+++ b/src/main/webapp/app/exercise/participation/participation.component.ts
@@ -66,21 +66,27 @@ enum FilterProp {
     ],
 })
 export class ParticipationComponent implements OnInit, OnDestroy {
-    private route = inject(ActivatedRoute);
-    private participationService = inject(ParticipationService);
-    private alertService = inject(AlertService);
-    private eventManager = inject(EventManager);
-    private exerciseService = inject(ExerciseService);
-    private programmingSubmissionService = inject(ProgrammingSubmissionService);
-    private accountService = inject(AccountService);
-    private profileService = inject(ProfileService);
-    private gradingSystemService = inject(GradingSystemService);
+    private readonly route = inject(ActivatedRoute);
+    private readonly participationService = inject(ParticipationService);
+    private readonly alertService = inject(AlertService);
+    private readonly eventManager = inject(EventManager);
+    private readonly exerciseService = inject(ExerciseService);
+    private readonly programmingSubmissionService = inject(ProgrammingSubmissionService);
+    private readonly accountService = inject(AccountService);
+    private readonly profileService = inject(ProfileService);
+    private readonly gradingSystemService = inject(GradingSystemService);
 
-    // make constants available to html for comparison
-    readonly FilterProp = FilterProp;
-    readonly ExerciseType = ExerciseType;
-    readonly ActionType = ActionType;
-    readonly FeatureToggle = FeatureToggle;
+    protected readonly faTable = faTable;
+    protected readonly faTimes = faTimes;
+    protected readonly faTrash = faTrash;
+    protected readonly faCircleNotch = faCircleNotch;
+    protected readonly faEraser = faEraser;
+    protected readonly faFilePowerpoint = faFilePowerpoint;
+
+    protected readonly FilterProp = FilterProp;
+    protected readonly ExerciseType = ExerciseType;
+    protected readonly ActionType = ActionType;
+    protected readonly FeatureToggle = FeatureToggle;
     protected readonly RepositoryType = RepositoryType;
 
     participations: StudentParticipation[] = [];
@@ -111,14 +117,6 @@ export class ParticipationComponent implements OnInit, OnDestroy {
     isLoading: boolean;
     isSaving: boolean;
     afterDueDate = false;
-
-    // Icons
-    faTable = faTable;
-    faTimes = faTimes;
-    faTrash = faTrash;
-    faCircleNotch = faCircleNotch;
-    faEraser = faEraser;
-    faFilePowerpoint = faFilePowerpoint;
 
     constructor() {
         this.participationCriteria = {

--- a/src/main/webapp/app/exercise/participation/participation.component.ts
+++ b/src/main/webapp/app/exercise/participation/participation.component.ts
@@ -112,7 +112,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
 
     exerciseSubmissionState: ExerciseSubmissionState;
 
-    localCIEnabled = true;
+    isLocalCIEnabled = true;
     isAdmin = false;
     isLoading: boolean;
     isSaving: boolean;
@@ -131,7 +131,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
         this.paramSub = this.route.params.subscribe((params) => this.loadExercise(+params['exerciseId']));
         this.registerChangeInParticipations();
         this.isAdmin = this.accountService.isAdmin();
-        this.localCIEnabled = this.profileService.isProfileActive(PROFILE_LOCALCI);
+        this.isLocalCIEnabled = this.profileService.isProfileActive(PROFILE_LOCALCI);
     }
 
     /**


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally 
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context


### Description
Cleanup for single participations is not necessary on LocalCI, only with external CI management.

### Steps for Testing
1. Deploy to ts1 - ts4
2. Go to a programming exercise participation and see that the cleanup button **is not** displayed
3. Deploy to ts5 or ts6
4. Go to a programming exercise participation and see that the cleanup button **is** displayed

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
Tried to write a test for an hour, did not get it to work, the component is too big to handle for me.

### Screenshots

