### PR TITLE
`Quiz Exercises`: Fix importing quiz exercises with short answer questions

### DIFF
--- a/src/test/playwright/e2e/exercise/ExerciseImport.spec.ts
+++ b/src/test/playwright/e2e/exercise/ExerciseImport.spec.ts
@@ -130,6 +130,13 @@ test.describe('Import exercises', () => {
                 const submission: QuizSubmission = await submitResponse.json();
                 expect(submission.submitted).toBe(true);
                 expect(submitResponse.status()).toBe(200);
+
+                await login(instructor, `/course-management/${secondCourse.id}/exercises`);
+                await courseManagementExercises.endQuiz(exercise.id!);
+
+                await login(studentOne, `/courses/${secondCourse.id}/exercises/${exercise.id}`);
+                await page.reload();
+                await expect(page.getByText('Your score: 1/1 (100%)')).toBeVisible();
             },
         );
 


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
This PR addresses a bug (Closes #11245) in the `QuizExerciseImportService` that causes imported quiz exercises containing short answer questions to be saved in an invalid state, with broken associations between short answer spots and solutions.

The issue stems from the service's outdated reliance on `shortAnswerSpotIndex` and `shortAnswerSolutionIndex` fields in the `correctMappings` . However, the current quiz exercise object transmitted from the client to the server no longer includes these index fields.

As a result, during import, the service fails to correctly relink the mappings, leading to incomplete or null associations in the persisted short answer question.

### Description

- Modified the `setUpShortAnswerQuestionForImport()` function in `QuizExerciseImportService` to create new spots/ solutions/ mappings and relink them using `id` or `tempId`, replacing the old index based approach.
- Added a new e2e test, to verify that a quiz with a ShortAnswerQuestion can be imported and users can participate

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Students
- 1 Quiz Exercise containing a short answer question.

1. Log in to Artemis as the Instructor
2. Navigate to the exercise management
3. Under "Quiz Exercises" click "Import Quiz"
4. Select the quiz containing the short answer question to import
5. Select a due date and save the new quiz
6. Log in to Artemis as a Student
7. Participate in the quiz
8. Wait for the quiz to end
9. Verify that you have been awarded the correct amount of points

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2