### PR TITLE
`Development`: Fixed flaky StudentExamIntegration test

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/ParticipantScore.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/ParticipantScore.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.assessment.domain;
 
 import java.time.Instant;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorType;
@@ -67,14 +68,14 @@ public abstract class ParticipantScore extends DomainObject {
     /**
      * Last result of the participant for the exercise no matter if the result is rated or not
      */
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "last_result_id")
     private Result lastResult;
 
     /**
      * Last rated result of the participant for the exercise
      */
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "last_rated_result_id")
     private Result lastRatedResult;
 


### PR DESCRIPTION
### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
We have a bunch of flaky tests. Flaky tests are annoying. 


### Description
Fix one of the most flaky tests, `testDeleteExamWithStudentExamsAfterConductionAndEvaluation` in `StudentExamIntegrationTest`. \
This is done by adding cascades to the `lastResult` and `lastRatedResult` fields of `ParticipantScore.java`.\
The PR does some additional QoL changes that should improve the test's performance and eliminates another possible source of flakiness. It also makes reading the logs a bit easier. 


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
