### PR TITLE
`Development`: Add nginx rate limit for passkey logins

### DIFF
--- a/docker/nginx/artemis-server.conf
+++ b/docker/nginx/artemis-server.conf
@@ -38,6 +38,17 @@ location /api/authenticate {
    limit_req zone=loginlimit burst=3 delay=2;
 }
 
+location /login/webauthn {
+    proxy_pass http://artemis/login/webauthn;
+    # For a given violation of the rate limit defined in the zone
+	# * the first 2 (delay) requests will be allowed without delay
+	# * the next (burst - delay) request waits until it fits in the rate limit
+	# * the rest will be denied
+	# If an attacker spams this endpoint, only the first three requests will come through.
+	# This only resets if the violation of the rate limit stops.
+   limit_req zone=loginlimit burst=3 delay=2;
+}
+
 location /favicon.ico {
     return 404;
 }


### PR DESCRIPTION

### Checklist
#### General

- [x] This is a small issue that I tested on production.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



### Motivation and Context


### Description

Add rate limit for passkey and git endpoints.


### Steps for Testing

- Login on production with a passkey
- Clone a repository from production with HTTPS

### Review Progress

#### Manual Tests
- [ ] Test 1
- [ ] Test 2
- [ ] 