### PR TITLE
`Modeling exercises`: Remove no longer required MacOS Safari setup

### DIFF
--- a/src/main/webapp/app/modeling/shared/modeling-editor/modeling-editor.component.ts
+++ b/src/main/webapp/app/modeling/shared/modeling-editor/modeling-editor.component.ts
@@ -41,7 +41,6 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
     private modelSubscription: number;
     private modelPatchSubscription: number;
 
-    htmlScroll = 0;
     mouseDownListener: ((this: Document, ev: MouseEvent) => any) | undefined;
     scrollListener: ((this: Document, ev: Event) => any) | undefined;
 
@@ -69,7 +68,6 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
             this.destroyApollonEditor();
         } else {
             this.setupInteract();
-            this.setupSafariScrollFix();
         }
     }
 
@@ -103,41 +101,6 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
                 this.onModelPatch.emit(patch);
             });
         }
-    }
-
-    /**
-     * This is a hack to prevent the UI jumping to bottom when using popovers in Apollon while using Safari.
-     * Other browsers do not show this behavior.
-     */
-    private setupSafariScrollFix() {
-        // Detect Safari desktop: https://stackoverflow.com/a/52205049/7441850
-        const isSafariDesktop = /Safari/i.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor) && !/Mobi|Android/i.test(navigator.userAgent);
-
-        if (this.readOnly || !isSafariDesktop) {
-            return;
-        }
-
-        // eslint-disable-next-line no-undef
-        console.log('Warning: Installing hack to prevent UI scroll jumps in Safari while using Apollon!');
-        // eslint-disable-next-line no-undef
-        console.log('Warning: If you experience problems regarding the scrolling behavior, please report them at https://github.com/ls1intum/Artemis');
-
-        this.mouseDownListener = () => {
-            const newScroll = document.getElementsByTagName('html')[0].scrollTop;
-            if (newScroll !== this.htmlScroll) {
-                const copy = this.htmlScroll;
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore (behavior 'instant' works with safari)
-                requestAnimationFrame(() => window.scrollTo({ top: copy, left: 0, behavior: 'instant' }));
-            }
-        };
-
-        this.scrollListener = () => {
-            this.htmlScroll = document.getElementsByTagName('html')[0].scrollTop;
-        };
-
-        document.addEventListener('mousedown', this.mouseDownListener);
-        document.addEventListener('scroll', this.scrollListener);
     }
 
     /**


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.



### Motivation and Context
Reducing number of warnings. Instead of replacing the deprecated method call to `vendor` it seems like we do not need the logic at all anymore.

<img width="1544" height="375" alt="image" src="https://github.com/user-attachments/assets/9bd0391f-1bd4-41f9-81bf-ed08f67707d5" />


### Description



### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://docs.artemis.cit.tum.de/user/exam_mode/) as reference.
4. ...

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage


### Screenshots

