### PR TITLE
`Integrated code lifecycle`: Split log chunk per line to ensure the log limit

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -528,13 +528,15 @@ public class BuildJobContainerService {
                         String[] logLines = splitBehindNewLines(payload);
                         ZonedDateTime now = ZonedDateTime.now();
 
-                        if (buildJobId != null) {
-                            for (String line : logLines) {
-                                if (!line.isEmpty()) {
-                                    BuildLogDTO buildLogEntry = new BuildLogDTO(now, line);
-                                    buildLogsMap.appendBuildLogEntry(buildJobId, buildLogEntry);
-                                }
+                        if (buildJobId == null) {
+                            return;
+                        }
+                        for (String line : logLines) {
+                            if (line.isEmpty()) {
+                                continue;
                             }
+                            BuildLogDTO buildLogEntry = new BuildLogDTO(now, line);
+                            buildLogsMap.appendBuildLogEntry(buildJobId, buildLogEntry);
                         }
                     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The current build log line limit is not working as expected since we treat every incoming chunk of the container stdout as a log entry, while it could be up to 10-15 lines depending on speed of log output. 

I conducted experiments with 500 build jobs that spam the build log and this can currently congest network and lead to inconsistencies in build job processing and even artemis crash.

### Description
<!-- Describe your changes in detail -->
Splitting incoming stdout payload by newlines and treating every row as a build log row leads to the configured limits working as intended. 
This prevents unreasonable large logs (with our standard config of 10.000 rows x 1024 chars max) that can cause above mentioned issues. 


### Steps for Testing
- 1 Instructor
2. Edit or create a programming exercise (or use https://artemis-test3.artemis.cit.tum.de/course-management/59/programming-exercises/289 on TS3 and skip to step 4)
3. Customize the build plan (check _Customize Build Configuration_) and add script that will spam the log output e.g. for Java gradle exercise I used something like :
```
#!/usr/bin/env bash
    set -e

    spam_logs() {
        log_line="This is a test log message meant to spam the output."
        for ((i = 1; i <= 50000; i++)); do
            printf "Log line %d: %s\n" "$i" "$log_line"
        done
    echo "✅ Finished printing log lines."
    }

    gradle_build() {
        echo '⚙️ Executing Gradle build...'
        chmod +x ./gradlew
        ./gradlew clean test
    }

    main() {
        spam_logs
        gradle_build
    }

    main "$@"
```
4. Trigger the template and solution repository build
5. Check the build log output for the solution and template repository. It should only contain 10.000 lines in total (e.g. command F for the timezone of the timestamp thats added for every row to verify)

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build logs now split command output into separate entries per line (preserving line endings and original timestamps), improving readability and making logs clearer and easier to follow during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->