### PR TITLE
`Development`: Fix percentiles histogram metrics

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -166,11 +166,10 @@ management:
             export:
                 enabled: true
                 step: 60
+    metrics:
         distribution:
             percentiles-histogram:
                 all: true
-            percentiles:
-                all: 0, 0.5, 0.75, 0.95, 0.99, 1.0
         tags:
             application: ${spring.application.name}
     observations:


### PR DESCRIPTION

### Checklist
#### General

- [x] I tested **all** changes and their related features locally.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context

fixes #11286


### Description


The key `distribution` and `tags` have their own top-level key `metrics`. See: https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.customizing.per-meter-properties

Also, `percentiles-histogram` and `percentiles` can't be used together (https://docs.micrometer.io/micrometer/reference/concepts/histogram-quantiles.html). `percentiles-histogram` takes precedence.

We moved the `distribution` and `tags` keys to the top-level key `metrics` and removed `percentiles`.


### Steps for Testing

1. Add the following configuration to your application-local.yml:
```yml
spring:
  prometheus:
    monitoringIp: 127.0.0.1
```
2. Start `develop`, run `curl 127.0.0.1:8080/management/prometheus`, and check that no percentiles-histogram is returned (e.g. `curl 127.0.0.1:8080/management/prometheus | grep "le="`)
3. Start this branch and run `curl 127.0.0.1:8080/management/prometheus | grep "le="` to check the percentiles-histogram.


### Review Progress


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2