### PR TITLE
Initial code.

### DIFF
--- a/src/main/webapp/app/programming/manage/programming-exercise-management.route.ts
+++ b/src/main/webapp/app/programming/manage/programming-exercise-management.route.ts
@@ -5,7 +5,10 @@ import { Authority } from 'app/shared/constants/authority.constants';
 
 import { ProgrammingExerciseResolve } from 'app/programming/manage/services/programming-exercise-resolve.service';
 import { repositorySubRoutes } from 'app/programming/shared/routes/programming-exercise-repository.route';
-import { CodeEditorTutorAssessmentContainerComponent } from 'app/programming/manage/assess/code-editor-tutor-assessment-container/code-editor-tutor-assessment-container.component';
+import {
+    CodeEditorTutorAssessmentContainerComponent,
+    canLeaveCodeEditorTutorAssessmentContainer,
+} from 'app/programming/manage/assess/code-editor-tutor-assessment-container/code-editor-tutor-assessment-container.component';
 
 export const routes: Routes = [
     {
@@ -134,5 +137,6 @@ export const routes: Routes = [
             pageTitle: 'artemisApp.programmingExercise.home.title',
         },
         canActivate: [UserRouteAccessService],
+        canDeactivate: [canLeaveCodeEditorTutorAssessmentContainer],
     },
 ];


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->


### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation, Context and Description
`ngx-datatable` caches its dimensions in inline styles and does not automatically recalculate when the container is resized.  
This causes layout issues when the browser window is resized or the device orientation changes.

This PR ensures that the table recalculates its size after Angular’s change detection runs by dispatching a `resize` event in the `ngAfterViewChecked` lifecycle hook of `DataTableComponent`.  
This triggers `ngx-datatable`’s internal resize handling, keeping the table responsive without requiring manual recalculation calls.

This fixes issue https://github.com/ls1intum/Artemis/issues/11091.

### Steps for Testing
Prerequisites: 1 Instructor

1. Log in to Artemis, create a programming exercise and make a submission using the same account.
2. Open the "Scores" page that lists all student submissions.
3. Resize the browser window to a smaller width.
4. Resize it back to a larger width.
5. Observe how the table correctly adjusts its width and column layout without a manual refresh.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots
Before (resizing causes stale table width):
<img width="1855" height="586" alt="image" src="https://github.com/user-attachments/assets/75fbb294-4a20-453c-8a0c-65c0d24d05be" />

After (resizing updates table width correctly):
<img width="1700" height="691" alt="image" src="https://github.com/user-attachments/assets/14dd8577-40ba-4d00-8de4-59374abcc409" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Data tables now reliably adjust their layout after window resizing or device orientation changes, improving responsiveness across screens.
  - Resolves issues where table content could appear clipped or misaligned until a manual refresh.
  - Enhances usability on mobile and desktop by ensuring columns and scroll areas update immediately with size changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->