### PR TITLE
`Programming Exercises`: Add problem statement as a selectable file in the editor with live preview

### DIFF
--- a/src/main/webapp/app/exam/overview/exercises/programming/programming-exam-submission.component.html
+++ b/src/main/webapp/app/exam/overview/exercises/programming/programming-exam-submission.component.html
@@ -16,6 +16,7 @@
 @if (exercise().allowOnlineEditor) {
     <div>
         <jhi-code-editor-container
+            [forRepositoryView]="true"
             [editable]="!repositoryIsLocked"
             [participation]="studentParticipation()"
             [showEditorInstructions]="showEditorInstructions"

--- a/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-container/code-editor-tutor-assessment-container.component.html
+++ b/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-container/code-editor-tutor-assessment-container.component.html
@@ -53,6 +53,7 @@
     <ng-template #assessment>
         @if (!loadingParticipation && !participationCouldNotBeFetched) {
             <jhi-code-editor-container
+                [forRepositoryView]="true"
                 [editable]="false"
                 [participation]="participation"
                 [feedbackSuggestions]="feedbackSuggestions"

--- a/src/main/webapp/app/programming/manage/code-editor/container/code-editor-container.component.html
+++ b/src/main/webapp/app/programming/manage/code-editor/container/code-editor-container.component.html
@@ -45,30 +45,43 @@
         (onToggleCollapse)="onToggleCollapse($event, CollapsableCodeEditorElement.FileBrowser)"
     />
     <ng-container editorCenter>
-        <jhi-code-editor-monaco
-            [commitState]="commitState"
-            [editorState]="editorState"
-            [course]="course"
-            [feedbacks]="feedbackForSubmission()"
-            [feedbackSuggestions]="feedbackSuggestions"
-            [readOnlyManualFeedback]="readOnlyManualFeedback"
-            [disableActions]="!editable"
-            [isTutorAssessment]="isTutorAssessment"
-            [highlightDifferences]="highlightDifferences"
-            [selectedFile]="selectedFile"
-            [buildAnnotations]="annotations"
-            [sessionId]="participation?.id ?? 'test'"
-            (onFileContentChange)="onFileContentChange($event)"
-            (onUpdateFeedback)="onUpdateFeedback.emit($event)"
-            (onAcceptSuggestion)="onAcceptSuggestion.emit($event)"
-            (onDiscardSuggestion)="onDiscardSuggestion.emit($event)"
-            (onError)="onError($event)"
-            (onFileLoad)="fileLoad($event)"
-        />
+        @if (selectedFile === PROBLEM_STATEMENT_IDENTIFIER && showEditorInstructions) {
+            <jhi-code-editor-instructions
+                (onToggleCollapse)="onToggleCollapse($event, CollapsableCodeEditorElement.Instructions)"
+                (onError)="onError($event)"
+                [isAssessmentMode]="isTutorAssessment"
+                [disableCollapse]="true"
+            >
+                <ng-content select="[editorCenter]" />
+            </jhi-code-editor-instructions>
+        } @else {
+            <!-- Regular Code Editor -->
+            <jhi-code-editor-monaco
+                [commitState]="commitState"
+                [editorState]="editorState"
+                [course]="course"
+                [feedbacks]="feedbackForSubmission()"
+                [feedbackSuggestions]="feedbackSuggestions"
+                [readOnlyManualFeedback]="readOnlyManualFeedback"
+                [disableActions]="!editable"
+                [isTutorAssessment]="isTutorAssessment"
+                [highlightDifferences]="highlightDifferences"
+                [selectedFile]="selectedFile"
+                [buildAnnotations]="annotations"
+                [sessionId]="participation?.id ?? 'test'"
+                (onFileContentChange)="onFileContentChange($event)"
+                (onUpdateFeedback)="onUpdateFeedback.emit($event)"
+                (onAcceptSuggestion)="onAcceptSuggestion.emit($event)"
+                (onDiscardSuggestion)="onDiscardSuggestion.emit($event)"
+                (onError)="onError($event)"
+                (onFileLoad)="fileLoad($event)"
+            />
+        }
     </ng-container>
     <ng-container editorSidebarRight>
         @if (showEditorInstructions) {
             <jhi-code-editor-instructions
+                #rightInstructions
                 (onToggleCollapse)="onToggleCollapse($event, CollapsableCodeEditorElement.Instructions)"
                 (onError)="onError($event)"
                 [isAssessmentMode]="isTutorAssessment"

--- a/src/main/webapp/app/programming/manage/code-editor/file-browser/code-editor-file-browser.component.html
+++ b/src/main/webapp/app/programming/manage/code-editor/file-browser/code-editor-file-browser.component.html
@@ -80,8 +80,25 @@
 </div>
 <!--Treeview Item Template-->
 <ng-template #itemTemplate let-item="item" let-onCollapseExpand="onCollapseExpand">
+    <!--Problem Statement-->
+    @if (item.value === problemStatementId) {
+        <div
+            class="problem-statement-entry"
+            [class.selected]="item.checked"
+            role="button"
+            tabindex="0"
+            [attr.aria-selected]="item.checked"
+            [attr.aria-label]="'Problem Statement'"
+            (click)="handleNodeSelected(item)"
+            (keydown.enter)="handleNodeSelected(item)"
+            (keydown.space)="handleNodeSelected(item)"
+        >
+            <fa-icon [icon]="faListAlt" class="problem-statement-icon" aria-hidden="true" />
+            <span class="problem-statement-text">{{ item.text }}</span>
+        </div>
+    }
     <!--folder-->
-    @if (repositoryFiles[item.value] === FileType.FOLDER) {
+    @if (repositoryFiles?.[item.value] === FileType.FOLDER) {
         <jhi-code-editor-file-browser-folder
             [item]="item"
             [isBeingRenamed]="!!renamingFile && renamingFile![0] === item.value"
@@ -100,11 +117,11 @@
         />
     }
     <!--file-->
-    @if (repositoryFiles[item.value] === FileType.FILE) {
+    @if (repositoryFiles?.[item.value] === FileType.FILE) {
         <jhi-code-editor-file-browser-file
             [item]="item"
-            [hasChanges]="repositoryFilesWithInformationAboutChange ? repositoryFilesWithInformationAboutChange[item.value] : false"
-            [badges]="fileBadges[item.value] || []"
+            [hasChanges]="repositoryFilesWithInformationAboutChange?.[item.value] ?? false"
+            [badges]="fileBadges?.[item.value] ?? []"
             [isBeingRenamed]="!!renamingFile && renamingFile![0] === item.value"
             [hasUnsavedChanges]="unsavedFiles && unsavedFiles.includes(item.value)"
             [hasError]="errorFiles && errorFiles.includes(item.value)"

--- a/src/main/webapp/app/programming/manage/code-editor/file-browser/code-editor-file-browser.scss
+++ b/src/main/webapp/app/programming/manage/code-editor/file-browser/code-editor-file-browser.scss
@@ -19,6 +19,47 @@ File browser
             width: 60px;
         }
     }
+
+    // Problem Statement Entry Styles
+    .problem-statement-entry {
+        display: flex;
+        align-items: center;
+        padding: 0.3rem 0.5rem 0.3rem 1rem;
+        margin-bottom: 2px;
+        border: none;
+        background: linear-gradient(135deg, var(--bs-primary-bg-subtle), var(--bs-info-bg-subtle));
+        border-left: 3px solid var(--bs-primary);
+        border-radius: 4px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s ease;
+
+        &:hover {
+            background: linear-gradient(135deg, var(--bs-primary-bg-subtle), var(--bs-info-bg-subtle));
+            transform: translateX(2px);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        &.selected {
+            background-color: var(--code-editor-file-browser-selected-file-background) !important;
+            border-left: 3px solid var(--bs-success);
+            transform: none;
+            box-shadow: none;
+        }
+
+        .problem-statement-icon {
+            color: var(--bs-primary);
+            margin-right: 12px;
+            font-size: 1.1em;
+        }
+
+        .problem-statement-text {
+            color: var(--bs-primary);
+            font-weight: 600;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    }
 }
 
 /*!* ==========================================================================

--- a/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-and-editor-container.component.html
+++ b/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-and-editor-container.component.html
@@ -148,13 +148,24 @@
             }
         </div>
         <jhi-programming-exercise-editable-instructions
-            editorSidebar
+            editorCenter
             [(exercise)]="exercise"
             [(participation)]="selectedParticipation!"
             [templateParticipation]="exercise.templateParticipation!"
             [initialEditorHeight]="'external'"
             [enableResize]="false"
             class="instructions-wrapper__content card-body p-0"
+            (instructionChange)="onInstructionChanged($event)"
+        />
+        <!-- Preview-only component for right sidebar -->
+        <jhi-programming-exercise-instructions
+            editorSidebar
+            id="previewMonaco"
+            class="editable-instruction-container__instructions"
+            [exercise]="exercise"
+            [participation]="selectedParticipation!"
+            [personalParticipation]="false"
+            [generateHtmlEvents]="previewEvents$"
         />
     </jhi-code-editor-container>
 }

--- a/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-and-editor-container.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-and-editor-container.component.ts
@@ -5,6 +5,7 @@ import { IncludedInScoreBadgeComponent } from 'app/exercise/exercise-headers/inc
 import { UpdatingResultComponent } from 'app/exercise/result/updating-result/updating-result.component';
 import { CodeEditorInstructorBaseContainerComponent } from 'app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-base-container.component';
 import { ProgrammingExerciseEditableInstructionComponent } from 'app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component';
+import { ProgrammingExerciseInstructionComponent } from 'app/programming/shared/instructions-render/programming-exercise-instruction.component';
 import { IncludedInOverallScore } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { faCircleNotch, faPlus, faTimes, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 import { IrisSettings } from 'app/iris/shared/entities/settings/iris-settings.model';
@@ -33,6 +34,7 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
         UpdatingResultComponent,
         ProgrammingExerciseStudentTriggerBuildButtonComponent,
         ProgrammingExerciseEditableInstructionComponent,
+        ProgrammingExerciseInstructionComponent,
         NgbTooltip,
         ArtemisTranslatePipe,
     ],

--- a/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-base-container.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-base-container.component.ts
@@ -19,6 +19,9 @@ import { DomainChange, DomainType, RepositoryType } from 'app/programming/shared
 import { Course } from 'app/core/course/shared/entities/course.model';
 import { CourseExerciseService } from 'app/exercise/course-exercises/course-exercise.service';
 import { isExamExercise } from 'app/shared/util/utils';
+import { OnChanges, SimpleChanges } from '@angular/core';
+import { Subject } from 'rxjs';
+import { debounceTime, shareReplay } from 'rxjs/operators';
 /**
  * Enumeration specifying the loading state
  */
@@ -33,7 +36,7 @@ export enum LOADING_STATE {
 @Component({
     template: '',
 })
-export abstract class CodeEditorInstructorBaseContainerComponent implements OnInit, OnDestroy {
+export abstract class CodeEditorInstructorBaseContainerComponent implements OnInit, OnDestroy, OnChanges {
     @ViewChild(CodeEditorContainerComponent, { static: false }) codeEditorContainer: CodeEditorContainerComponent;
 
     private router = inject(Router);
@@ -44,6 +47,8 @@ export abstract class CodeEditorInstructorBaseContainerComponent implements OnIn
     private participationService = inject(ParticipationService);
     private route = inject(ActivatedRoute);
     private alertService = inject(AlertService);
+    /** Raw markdown changes from the center editor for debounce logic */
+    private problemStatementChanges$ = new Subject<string>();
 
     ButtonSize = ButtonSize;
     LOADING_STATE = LOADING_STATE;
@@ -74,12 +79,22 @@ export abstract class CodeEditorInstructorBaseContainerComponent implements OnIn
     loadingState = LOADING_STATE.CLEAR;
 
     protected isCreateAssignmentRepoDisabled: boolean;
+    /** Debounced tick stream consumed by the sidebar preview */
+    previewEvents$ = this.problemStatementChanges$.pipe(
+        debounceTime(200), // TODO: consider to prune to 300–500ms for PlantUML-heavy content
+        map(() => void 0), // Observable<void>
+        shareReplay({ bufferSize: 1, refCount: true }), // replay latest for late subscribers
+    );
 
     /**
      * Initialize the route params subscription.
      * On route param change load the exercise and the selected participation OR the test repository.
      */
     ngOnInit(): void {
+        /** Initial render if we already have content */
+        if (this.exercise?.problemStatement != null) {
+            this.problemStatementChanges$.next(this.exercise.problemStatement);
+        }
         if (this.paramSub) {
             this.paramSub.unsubscribe();
         }
@@ -137,6 +152,17 @@ export abstract class CodeEditorInstructorBaseContainerComponent implements OnIn
                     },
                 });
         });
+    }
+    /** Debounce logic */
+    ngOnChanges(changes: SimpleChanges): void {
+        // Re-trigger when a new exercise is loaded/switched
+        if ('exercise' in changes && this.exercise?.problemStatement != null) {
+            this.problemStatementChanges$.next(this.exercise.problemStatement);
+        }
+    }
+    /** Called by the center editor on every markdown change */
+    onInstructionChanged(markdown: string) {
+        this.problemStatementChanges$.next(markdown);
     }
 
     /**

--- a/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.html
+++ b/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.html
@@ -10,18 +10,11 @@
             [enableResize]="enableResize"
             [markdown]="exercise.problemStatement"
             [showDefaultPreview]="false"
-            (onPreviewSelect)="generateHtml()"
+            [showPreviewButton]="false"
+            [showVisualButton]="false"
+            [showEditButton]="false"
             (markdownChange)="updateProblemStatement($event)"
-        >
-            <jhi-programming-exercise-instructions
-                id="previewMonaco"
-                class="editable-instruction-container__instructions"
-                [participation]="participation"
-                [exercise]="exercise"
-                [generateHtmlEvents]="generateHtmlSubject.asObservable()"
-                [personalParticipation]="false"
-            />
-        </jhi-markdown-editor-monaco>
+        />
     }
     @if (editMode) {
         <button

--- a/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.scss
+++ b/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.scss
@@ -5,7 +5,7 @@
     flex: 1 1 auto;
     height: 100%;
 
-    // Override bootstrap tooltip width.
+    /* Wider Bootstrap tooltip */
     .tooltip-inner {
         width: 500px;
     }
@@ -29,24 +29,23 @@
     }
 
     .markdown-editor-wrapper {
-        // Important needed here to override scoped styling
+        /* override scoped styling */
         background-color: var(--markdown-preview-editor-background) !important;
+
+        .nav {
+            position: sticky;
+            top: 0;
+            z-index: 1;
+            background-color: var(--markdown-preview-editor-background);
+        }
     }
 
-    .markdown-editor-wrapper .nav {
-        position: sticky;
-        top: 0;
-        z-index: 1;
+    .instructions__content__markdown,
+    .card-second-header {
         background-color: var(--markdown-preview-editor-background);
     }
-
-    .instructions__content__markdown {
-        background-color: var(--markdown-preview-editor-background);
-    }
-
     .card-second-header {
         padding: 10px 15px;
-        background-color: var(--markdown-preview-editor-background);
     }
 
     &__save {
@@ -60,24 +59,33 @@
 
     &__status {
         display: grid;
-        grid-template-columns: repeat(2, minmax(max-content, 1fr));
+        grid-template-columns: 1fr 2fr; /* left | right */
+        align-items: center;
 
-        > :not(:first-child) {
-            border-left: 1px solid rgba(0, 0, 0, 0.125);
-        }
-
-        &__container {
+        .instructions-status {
+            grid-column: 1;
             display: flex;
-            text-align: center;
-
-            > :not(:first-child) {
-                border-left: 1px solid rgba(0, 0, 0, 0.125);
-                flex: 1;
-            }
+            align-items: center;
+            justify-content: center;
+            min-width: 0;
         }
 
-        &__item {
-            flex: 1;
+        &__testcase {
+            grid-column: 2;
+            min-width: 0;
+
+            & > .editable-instruction-container__status__container {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                align-items: center;
+                border-left: 1px solid rgba(0, 0, 0, 0.125);
+                padding-left: 0.75rem;
+
+                > * {
+                    justify-self: center;
+                    text-align: center;
+                }
+            }
         }
     }
 }

--- a/src/main/webapp/app/programming/overview/code-editor-student-container/code-editor-student-container.component.html
+++ b/src/main/webapp/app/programming/overview/code-editor-student-container/code-editor-student-container.component.html
@@ -20,6 +20,7 @@
 
     @if (!loadingParticipation && !participationCouldNotBeFetched) {
         <jhi-code-editor-container
+            [forRepositoryView]="true"
             [editable]="!repositoryIsLocked"
             [participation]="participation"
             [showEditorInstructions]="showEditorInstructions"
@@ -55,28 +56,28 @@
             </div>
             <!-- prettier-ignore -->
             <div editorToolbar class="d-inline-flex align-items-center">
-              @if (repositoryIsLocked) {
-                <jhi-code-editor-repository-is-locked class="me-3" />
-              }
-              @if (participation) {
-                <jhi-updating-result
-                  [exercise]="exercise"
-                  [showUngradedResults]="true"
-                  [showBadge]="true"
-                  [participation]="participation"
-                  [personalParticipation]="true"
-                  (onParticipationChange)="receivedNewResult()"
-                  [showProgressBar]="true"
-                  [showProgressBarBorder]="true"
-                  class="me-2"
+                @if (repositoryIsLocked) {
+                    <jhi-code-editor-repository-is-locked class="me-3" />
+                }
+                @if (participation) {
+                    <jhi-updating-result
+                        [exercise]="exercise"
+                        [showUngradedResults]="true"
+                        [showBadge]="true"
+                        [participation]="participation"
+                        [personalParticipation]="true"
+                        (onParticipationChange)="receivedNewResult()"
+                        [showProgressBar]="true"
+                        [showProgressBarBorder]="true"
+                        class="me-2"
+                    />
+                }
+                <jhi-programming-exercise-student-trigger-build-button
+                    class="me-2"
+                    [exercise]="exercise"
+                    [participation]="participation"
+                    [btnSize]="ButtonSize.MEDIUM"
                 />
-              }
-              <jhi-programming-exercise-student-trigger-build-button
-                class="me-2"
-                [exercise]="exercise"
-                [participation]="participation"
-                [btnSize]="ButtonSize.MEDIUM"
-              />
             </div>
             <jhi-programming-exercise-instructions
                 editorSidebar

--- a/src/main/webapp/app/programming/shared/code-editor/instructions/code-editor-instructions.component.html
+++ b/src/main/webapp/app/programming/shared/code-editor/instructions/code-editor-instructions.component.html
@@ -18,7 +18,9 @@
             }
             @if (collapsed) {
                 <span class="collapsed-instructions-card">
-                    <fa-icon class="top-icon" [icon]="faChevronLeft" />
+                    @if (!disableCollapse) {
+                        <fa-icon class="top-icon" [icon]="faChevronLeft" />
+                    }
                     <fa-icon [icon]="farListAlt" class="fa-rotate-90" id="panel-symbol" />
                     @if (!isAssessmentMode) {
                         <span class="header" jhiTranslate="artemisApp.exercise.problemStatement"></span>
@@ -26,15 +28,17 @@
                     @if (isAssessmentMode) {
                         <span class="header" jhiTranslate="artemisApp.exercise.instructions"></span>
                     }
-                    <fa-icon class="bottom-icon" [icon]="faChevronLeft" />
+                    @if (!disableCollapse) {
+                        <fa-icon class="bottom-icon" [icon]="faChevronLeft" />
+                    }
                 </span>
             }
         </h3>
-        @if (!collapsed) {
+        @if (!collapsed && !disableCollapse) {
             <fa-icon class="ms-auto clickable" [icon]="faChevronRight" />
         }
     </div>
-    <div style="display: contents" [hidden]="collapsed">
+    <div class="instructions-wrapper__content" [hidden]="collapsed">
         <ng-content />
     </div>
     <!-- Required for resizing; don't remove empty span -->

--- a/src/main/webapp/app/programming/shared/code-editor/instructions/code-editor-instructions.component.ts
+++ b/src/main/webapp/app/programming/shared/code-editor/instructions/code-editor-instructions.component.ts
@@ -20,6 +20,10 @@ export class CodeEditorInstructionsComponent implements AfterViewInit {
     @Input()
     isAssessmentMode = true;
 
+    // make instructions monaco editor in the main editor not collapsible
+    @Input()
+    disableCollapse = false;
+
     /** Resizable constants **/
     initialInstructionsWidth: number;
     minInstructionsWidth: number;
@@ -47,6 +51,13 @@ export class CodeEditorInstructionsComponent implements AfterViewInit {
      * @param event - any event
      */
     toggleEditorCollapse(event: any) {
+        // make instructions monaco editor in the main editor not collapsible
+        if (this.disableCollapse) {
+            if (event?.stopPropagation) {
+                event.stopPropagation();
+            }
+            return;
+        }
         this.collapsed = !this.collapsed;
         this.onToggleCollapse.emit({ event, horizontal: true, interactable: this.interactResizable, resizableMinWidth: this.minInstructionsWidth });
     }

--- a/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.scss
+++ b/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.scss
@@ -1,6 +1,6 @@
-/*!* ==========================================================================
-Code-Editor Layout Styles
-========================================================================== *!*/
+/* ==========================================================================
+   Code-Editor Layout
+   ========================================================================== */
 
 .editor-wrapper {
     display: grid;
@@ -27,6 +27,7 @@ Code-Editor Layout Styles
         &__content {
             display: flex;
             height: inherit;
+            min-width: 0; /* allow middle strip to shrink */
 
             .editor-sidebar-left {
                 flex: 0 1 auto;
@@ -42,11 +43,13 @@ Code-Editor Layout Styles
 
         .editor-center {
             flex: 1 1 auto;
+            min-width: 0; /* let center shrink */
 
             .card {
                 height: 100%;
             }
         }
+
         .editor-sidebar-right {
             flex: 0 1 auto;
             display: flex;
@@ -73,7 +76,7 @@ Code-Editor Layout Styles
         flex-flow: column nowrap;
         height: 200px;
 
-        // Hide the grip lines if the editor-bottom content template is empty.
+        /* Hide grip when bottom area is empty */
         .rg-bottom-bottom {
             display: none;
         }
@@ -87,13 +90,14 @@ Code-Editor Layout Styles
     }
 }
 
-/*!* ==========================================================================
-Collapsable styling
-========================================================================== *!*/
+/* ==========================================================================
+   Collapsible styling
+   ========================================================================== */
 
-// File browser
+/* File browser */
 .editor-sidebar-left.collapsed--horizontal {
     flex: none !important;
+
     .card-header {
         height: 100%;
         width: 100%;
@@ -123,55 +127,49 @@ Collapsable styling
             position: absolute;
             left: 15px;
         }
-
         .top-icon {
             top: 15px;
         }
-
         #panel-symbol {
-            padding-right: 0 !important;
             position: absolute;
             top: 66%;
             left: 25%;
+            padding-right: 0 !important;
         }
-
         .bottom-icon {
             bottom: 15px;
         }
     }
 }
 
-.editor-sidebar-left:not(.collapsed--horizontal) {
-    .code-editor-status {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(max-content, 1fr));
-        grid-column-gap: 10px;
+.editor-sidebar-left:not(.collapsed--horizontal) .code-editor-status {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(max-content, 1fr));
+    grid-column-gap: 10px;
 
-        > :not(:first-child) {
-            border-left: 1px solid rgba(0, 0, 0, 0.125);
-            padding-left: 20px;
-        }
+    > :not(:first-child) {
+        border-left: 1px solid rgba(0, 0, 0, 0.125);
+        padding-left: 20px;
     }
 }
 
-.editor-sidebar-left.collapsed--horizontal {
-    .code-editor-status {
-        > :not(:last-child) {
-            padding-bottom: 5px;
-        }
-        > :not(:first-child) {
-            padding-top: 5px;
-            border-top: 1px solid rgba(0, 0, 0, 0.125);
-        }
-        span {
-            display: none !important;
-        }
+.editor-sidebar-left.collapsed--horizontal .code-editor-status {
+    > :not(:last-child) {
+        padding-bottom: 5px;
+    }
+    > :not(:first-child) {
+        padding-top: 5px;
+        border-top: 1px solid rgba(0, 0, 0, 0.125);
+    }
+    span {
+        display: none !important;
     }
 }
 
-// Instructions
+/* Instructions (right pane) */
 .editor-sidebar-right.collapsed--horizontal {
     flex: none !important;
+
     .card-header {
         height: 100%;
         width: 100%;
@@ -179,6 +177,7 @@ Collapsable styling
             display: none;
         }
     }
+
     .instructions-wrapper__content {
         height: auto !important;
 
@@ -207,89 +206,38 @@ Collapsable styling
             position: absolute;
             right: 15px;
         }
-
         .top-icon {
             top: 15px;
         }
-
         #panel-symbol {
-            padding-right: 0 !important;
             position: absolute;
             top: 18%;
             left: 40%;
+            padding-right: 0 !important;
         }
-
         .bottom-icon {
             bottom: 15px;
         }
     }
 
+    /* Hide status area when collapsed */
     .editable-instruction-container__status {
         display: none !important;
     }
-}
 
-.editor-sidebar-right:not(.collapsed--horizontal) {
-    .editable-instruction-container__status {
-        display: grid;
-        grid-template-columns: minmax(max-content, 1fr) minmax(max-content, 2fr);
-
-        > :not(:first-child) {
-            border-left: 1px solid rgba(0, 0, 0, 0.125);
-            padding-left: 20px;
-        }
-
-        &__item:not(:last-child) {
-            margin-right: 15px;
-        }
-
-        .instructions-status {
-            display: flex;
-            justify-content: center;
-        }
-    }
-}
-
-.editor-sidebar-right.collapsed--horizontal {
     .instructions__content {
         height: auto;
     }
-    .editable-instruction-container__status {
-        display: flex;
-        flex-flow: column;
-
-        > :not(:last-child) {
-            padding-bottom: 5px;
-        }
-
-        > :not(:first-child) {
-            padding-left: 0 !important;
-            padding-top: 5px;
-            border-top: 1px solid rgba(0, 0, 0, 0.125);
-            border-left: none !important;
-        }
-
-        span {
-            display: none !important;
-        }
-
-        .editable-instruction-container__status__testcase span,
-        .instructions-status span {
-            display: none !important;
-        }
-    }
 }
 
-// build-output
-.editor-bottom.collapsed--vertical {
-    .card-body {
-        display: none;
-    }
+/* Build output */
+.editor-bottom.collapsed--vertical .card-body {
+    display: none;
 }
 
-/*!* ==========================================================================
-Resizable drag elements
-========================================================================== *!*/
+/* ==========================================================================
+   Resizable drag elements
+   ========================================================================== */
 
 .rg-main-bottom,
 .rg-bottom-bottom,
@@ -309,8 +257,59 @@ Resizable drag elements
     cursor: col-resize;
     margin-left: 4px;
     margin-right: 4px;
+
+    /* easier to grab + avoid selecting editor text while dragging */
+    padding: 6px 6px;
+    -webkit-user-select: none;
+    user-select: none;
+    touch-action: none;
+    z-index: 3;
 }
 
 .separator {
     margin: 5px;
+}
+
+/* ==========================================================================
+   Problem Statement (center) – keep content inside the card and allow shrink
+   ========================================================================== */
+
+/* allow all layers in the center to shrink instead of pushing the right pane */
+.editor-center .instructions-wrapper,
+.editor-center .instructions-wrapper__content,
+.editor-center .editable-instruction-container,
+.editor-center .editable-instruction-container > jhi-markdown-editor-monaco {
+    min-width: 0;
+}
+
+/* contain the markdown editor’s inner flow (it defaults to overflow: visible) */
+.editor-center jhi-markdown-editor-monaco .markdown-editor-wrapper {
+    overflow: hidden !important;
+}
+
+/* vertical sizing for the editable-instructions stack */
+.editor-center .instructions-wrapper {
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.editor-center .instructions-wrapper__content {
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.editor-center .editable-instruction-container {
+    height: 100%;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.editor-center .editable-instruction-container jhi-markdown-editor-monaco {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
 }


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented unnecessary REST calls, and kept the UI responsive (debounced preview updates).
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only via theme variables and verified light/dark consistency.
- [x] I added integration/unit tests (Jest) for the affected components (file tree entry + smart preview behavior).
- [x] I documented the TypeScript code using JSDoc style where appropriate.
- [x] I added screenshots/screencasts of the UI changes.
- [x] I translated newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [x] Client-side changes only; CI/VC and server behavior are unchanged.



### Motivation and Context
Instructors editing programming exercises previously had to switch contexts to modify the problem statement. This PR addresses the issue https://github.com/ls1intum/Artemis/issues/10968 and integrates the **Problem Statement** directly into the editor’s file tree as a selectable item, enabling a unified editing experience in Monaco with a live preview.


### Description
- **File tree**
  - Adds a persistent **“Problem Statement”** pseudo-file pinned at the top.
  - Distinct icon and visual styling to differentiate it from repository files (template/solution/tests).
  - Always visible (also when the repository is empty or loading), hidden only in explicit *repository-only* views.
- **Main editor**
  - Selecting **Problem Statement** opens markdown in **Monaco** with syntax highlighting.
  - Right preview pane **auto-expands** for the problem statement and **auto-collapses** when switching to repository files.
  - Live preview updates with a short **debounce** to handle large content (e.g., PlantUML).
- **Persistence**
  - Saving (button or Ctrl/Cmd+S) persists content via the existing mechanism; **no** model changes.


### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise which allows online code editor

I. Test 1:
1. Log in as instructor and open **Edit in Editor** for the exercise.
2. Verify the file tree shows **Problem Statement** at the top with distinct styling.
3. Click **Problem Statement**:
   - Monaco displays markdown with proper syntax highlighting.
   - The right preview pane **auto-expands** and shows the rendered HTML.
4. Type in the markdown:
   - Preview updates after a short debounce.
5. Click a repository file (e.g., `.java`):
   - Preview pane **auto-collapses**, code opens in Monaco.
6. Click **Problem Statement** again:
   - Preview pane **re-expands** and shows the current content.
7. Save via button or Ctrl/Cmd+S:
   - Reload to confirm persistence.

II. Test 2:
1. Log in as student/instructor and open any programming exercise which allows online editor.
2. Start the exercise and click on **Open code editor**
3. Verify the file tree does not contain **Problem Statement** entry.
4. Solve the exercise
5. Log in again as an instructor and assess the exercise
6. Verify that the file tree does not contain **Problem Statement** entry.

#### Exam Mode Testing
Prerequisites:
- 1 Instructor
- 1 Students
- 1 Exam with a Programming Exercise which allows online code editor

1. Log in to Artemis
2. Participate in the exam as a student
3. Start the exercise and click on **Open code editor**
4. Wait till the exam is finished
5. Log in again as an instructor and assess the exercise
6. Verify that the file tree does not contain **Problem Statement** entry.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
### Screenshots
1. Problem statement entry on top of the file tree (when click on **Edit in Editor**)
<img width="2541" height="871" alt="image" src="https://github.com/user-attachments/assets/8478f2bf-e7ba-46bd-919f-44b127424003" />

2. Problem statement entry should not be visible when clicking on **Go to Repository**
<img width="2542" height="826" alt="image" src="https://github.com/user-attachments/assets/1a9de54f-395e-4dbd-9fd8-7965dbe58d83" />

3. Problem statement entry should not be visible when solving the exercise via the online editor
<img width="2543" height="896" alt="image" src="https://github.com/user-attachments/assets/06b6a9cf-3b8f-4880-b262-f0a574e15fbf" />

4. Problem statement entry should not be visible when assessing students' submissions

5. All of the above requirements should be applicable for programming exercise in exam



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Repository-view mode enabled for the code editor in exams, tutor assessment, and student views.
  * Problem Statement appears as a dedicated, clickable item in the file browser.
  * Live instructions preview alongside the editor for instructors with debounced updates.

* Improvements
  * Smart auto-collapse/expand of the instructions pane based on the selected file.
  * Option to disable collapsing of the instructions pane.
  * More responsive editor layout with improved resizing and drag interactions.
  * Safer handling of empty/failed repository states and improved keyboard accessibility.

* Style
  * Enhanced visual styling for the Problem Statement entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->