### PR TITLE
`Development`: Increase default concurrent result processing config

### DIFF
--- a/src/main/resources/config/application-localci.yml
+++ b/src/main/resources/config/application-localci.yml
@@ -13,8 +13,8 @@ artemis:
         concurrent-build-size: 1
         # If true, the CI jobs will be executed asynchronously. If false, the CI jobs will be executed synchronously (e.g. for debugging and tests).
         asynchronous: true
-        # The number of results that can be processed concurrently. This is used to speed up the processing of the results of the CI jobs. Increase for production setups according to your available cpu resources.
-        concurrent-result-processing-size: 1
+        # The number of results that can be processed concurrently. This is used to speed up the processing of the results of the CI jobs. Adapt according to your available hardware resources and expected load on the CI system.
+        concurrent-result-processing-size: 4
         # The prefix that is used for the Docker containers that are created by the local CI system.
         build-container-prefix: local-ci-
         # In case you need to use a proxy to access the internet from the Docker container (e.g., due to firewall constraints), set use-system-proxy to true and configure the proxy settings below.


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] config only change.

### Motivation and Context
Change config value for the max concurrent build job result to be processed in parallel to reasonable default. 

### Description
<!-- Describe your changes in detail -->
increase `artemis.continuous-integration.concurrent-result-processing-size` config default to 4


### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

