### PR TITLE
`Modeling exercises`: Fix Enter key triggering help modal in exercise forms

### DIFF
--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.html
@@ -1,4 +1,6 @@
 <form name="editForm markdown-preview" role="form" novalidate #editForm="ngForm">
+    <!-- OPTION 2: Hidden submit button to intercept Enter key and provide custom navigation -->
+    <button type="submit" style="display: none" (click)="handleEnterKeyNavigation($event)"></button>
     <div class="d-flex align-items-center gap-2">
         @if (!modelingExercise.id) {
             <h2 id="jhi-modeling-exercise-heading-create" jhiTranslate="artemisApp.modelingExercise.home.createLabel"></h2>

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.html
@@ -1,5 +1,5 @@
 <form name="editForm markdown-preview" role="form" novalidate #editForm="ngForm">
-    <!-- OPTION 2: Hidden submit button to intercept Enter key and provide custom navigation -->
+    <!-- Hidden submit button to intercept Enter key and provide custom navigation -->
     <button type="submit" style="display: none" (click)="handleEnterKeyNavigation($event)"></button>
     <div class="d-flex align-items-center gap-2">
         @if (!modelingExercise.id) {

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.spec.ts
@@ -356,37 +356,30 @@ describe('ModelingExerciseUpdateComponent', () => {
         });
 
         it('should have hidden submit button to intercept Enter key', () => {
-            // GIVEN
             comp.ngOnInit();
             fixture.detectChanges();
 
-            // WHEN
             const form = fixture.debugElement.nativeElement.querySelector('form');
             const hiddenButton = form.querySelector('button[type="submit"][style*="display: none"]');
 
-            // THEN
             expect(hiddenButton).toBeTruthy();
             expect(hiddenButton.style.display).toBe('none');
             expect(hiddenButton.type).toBe('submit');
         });
 
         it('should always prevent default form submission and stop propagation', () => {
-            // GIVEN
             const mockEvent = {
                 preventDefault: jest.fn(),
                 stopPropagation: jest.fn(),
             } as any as Event;
 
-            // WHEN
             comp.handleEnterKeyNavigation(mockEvent);
 
-            // THEN
             expect(mockEvent.preventDefault).toHaveBeenCalledOnce();
             expect(mockEvent.stopPropagation).toHaveBeenCalledOnce();
         });
 
         it('should prevent Enter key from triggering unwanted modals or form submissions', () => {
-            // GIVEN - Simulate real Enter key event that would trigger modal
             const realEnterEvent = new KeyboardEvent('keydown', {
                 key: 'Enter',
                 bubbles: true,
@@ -395,10 +388,8 @@ describe('ModelingExerciseUpdateComponent', () => {
             const preventDefaultSpy = jest.spyOn(realEnterEvent, 'preventDefault');
             const stopPropagationSpy = jest.spyOn(realEnterEvent, 'stopPropagation');
 
-            // WHEN - Our handler processes the event
             comp.handleEnterKeyNavigation(realEnterEvent);
 
-            // THEN - Event is blocked from causing unwanted behavior
             expect(preventDefaultSpy).toHaveBeenCalledOnce();
             expect(stopPropagationSpy).toHaveBeenCalledOnce();
             expect(realEnterEvent.defaultPrevented).toBeTrue();
@@ -407,17 +398,14 @@ describe('ModelingExerciseUpdateComponent', () => {
 
     describe('Component cleanup', () => {
         it('should unsubscribe from teamSubscription on destroy', () => {
-            // GIVEN
             const mockSubscription = {
                 unsubscribe: jest.fn(),
                 closed: false,
             };
             comp.teamSubscription = mockSubscription as any;
 
-            // WHEN
             comp.ngOnDestroy();
 
-            // THEN
             expect(mockSubscription.unsubscribe).toHaveBeenCalledOnce();
         });
     });

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.spec.ts
@@ -349,4 +349,76 @@ describe('ModelingExerciseUpdateComponent', () => {
         expect(comp.bonusPointsSubscription?.closed).toBeTrue();
         expect(comp.pointsSubscription?.closed).toBeTrue();
     });
+
+    describe('Enter key navigation handling', () => {
+        beforeEach(() => {
+            jest.spyOn(console, 'error').mockImplementation(); // Suppress console errors
+        });
+
+        it('should have hidden submit button to intercept Enter key', () => {
+            // GIVEN
+            comp.ngOnInit();
+            fixture.detectChanges();
+
+            // WHEN
+            const form = fixture.debugElement.nativeElement.querySelector('form');
+            const hiddenButton = form.querySelector('button[type="submit"][style*="display: none"]');
+
+            // THEN
+            expect(hiddenButton).toBeTruthy();
+            expect(hiddenButton.style.display).toBe('none');
+            expect(hiddenButton.type).toBe('submit');
+        });
+
+        it('should always prevent default form submission and stop propagation', () => {
+            // GIVEN
+            const mockEvent = {
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn(),
+            } as any as Event;
+
+            // WHEN
+            comp.handleEnterKeyNavigation(mockEvent);
+
+            // THEN
+            expect(mockEvent.preventDefault).toHaveBeenCalledOnce();
+            expect(mockEvent.stopPropagation).toHaveBeenCalledOnce();
+        });
+
+        it('should prevent Enter key from triggering unwanted modals or form submissions', () => {
+            // GIVEN - Simulate real Enter key event that would trigger modal
+            const realEnterEvent = new KeyboardEvent('keydown', {
+                key: 'Enter',
+                bubbles: true,
+                cancelable: true,
+            });
+            const preventDefaultSpy = jest.spyOn(realEnterEvent, 'preventDefault');
+            const stopPropagationSpy = jest.spyOn(realEnterEvent, 'stopPropagation');
+
+            // WHEN - Our handler processes the event
+            comp.handleEnterKeyNavigation(realEnterEvent);
+
+            // THEN - Event is blocked from causing unwanted behavior
+            expect(preventDefaultSpy).toHaveBeenCalledOnce();
+            expect(stopPropagationSpy).toHaveBeenCalledOnce();
+            expect(realEnterEvent.defaultPrevented).toBeTrue();
+        });
+    });
+
+    describe('Component cleanup', () => {
+        it('should unsubscribe from teamSubscription on destroy', () => {
+            // GIVEN
+            const mockSubscription = {
+                unsubscribe: jest.fn(),
+                closed: false,
+            };
+            comp.teamSubscription = mockSubscription as any;
+
+            // WHEN
+            comp.ngOnDestroy();
+
+            // THEN
+            expect(mockSubscription.unsubscribe).toHaveBeenCalledOnce();
+        });
+    });
 });

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
@@ -294,6 +294,34 @@ export class ModelingExerciseUpdateComponent implements AfterViewInit, OnDestroy
         this.calculateFormSectionStatus();
     }
 
+    /**
+     * Handles Enter key navigation - moves to next input field
+     * Only applies to form inputs, not Apollon Editor elements
+     */
+    handleEnterKeyNavigation(event: Event): void {
+        event.preventDefault();
+
+        const activeElement = document.activeElement as HTMLElement;
+
+        // Check if we're inside Apollon Editor - if so, don't interfere
+        const apollonContainer = document.querySelector('.apollon-container');
+        if (apollonContainer?.contains(activeElement)) {
+            return; // Let Apollon handle its own navigation
+        }
+
+        // Only handle navigation for regular form inputs outside Apollon
+        const focusableElements = Array.from(
+            document.querySelectorAll('input:not([disabled]):not([readonly]), textarea:not([disabled]):not([readonly]), select:not([disabled])'),
+        ) as HTMLElement[];
+
+        const currentIndex = focusableElements.indexOf(activeElement);
+
+        // Move to next element, or stay on current if it's the last
+        if (currentIndex >= 0 && currentIndex < focusableElements.length - 1) {
+            focusableElements[currentIndex + 1].focus();
+        }
+    }
+
     save() {
         this.modelingExercise.exampleSolutionModel = JSON.stringify(this.modelingEditor?.getCurrentModel());
         this.isSaving = true;

--- a/src/main/webapp/app/modeling/shared/modeling-editor/modeling-editor.component.html
+++ b/src/main/webapp/app/modeling/shared/modeling-editor/modeling-editor.component.html
@@ -69,7 +69,7 @@
     @if (!readOnly && !isFullScreen) {
         <div class="help-and-status">
             @if (!readOnly && showHelpButton) {
-                <button class="btn btn-warning" (click)="open(help)">
+                <button type="button" class="btn btn-warning" (click)="open(help)">
                     <fa-icon [icon]="farQuestionCircle" />&nbsp;
                     <span jhiTranslate="artemisApp.modelingEditor.helpModal.help"></span>
                 </button>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #9641 - Issue where pressing Enter key in form input fields or Apollon Editor unexpectedly opens the help modal instead of providing normal field navigation behavior.

**Root Cause**: HTML forms without explicit submit buttons automatically trigger the first `<button>` element when Enter is pressed. The modeling exercise form's first button was the help button, causing unwanted modal activation.


### Description
<!-- Describe your changes in detail -->
Implemented hidden submit button solution that intercepts Enter key events and provides appropriate navigation behavior:

- **Form inputs**: Enter key moves focus to next input field (Tab-like behavior)
- **Apollon Editor**: Enter key works normally, respecting component boundaries
- **Help modal**: Only opens when explicitly clicked by user

**Technical Implementation**:
- Added hidden submit button to `modeling-exercise-update.component.html` 
- Added `handleEnterKeyNavigation()` method with smart component boundary detection
- Preserves all existing functionality (form validation, Angular directives, etc.)

**Files Changed**:
- `modeling-exercise-update.component.html`: Added hidden submit button
- `modeling-exercise-update.component.ts`: Added Enter key navigation logic


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor account
- 1 Course with modeling exercise capability

1. Login to Artemis
2. Navigate to Course Management > Exercises > Create New Modeling Exercise
3. **Form Input Test**: 
   - Press Enter in various input fields (exercise title, points, description, dates)
   - **Expected**: Focus moves to next field smoothly, no help modal appears
   - **Before fix**: Help modal would open unexpectedly
4. **Apollon Editor Test**: 
   - Click inside the UML diagram editor area
   - Press Enter key while focused in Apollon
   - **Expected**: Apollon handles Enter normally for its internal functionality
   - **Before fix**: Help modal would open, disrupting UML editing workflow
5. **Help Button Test**: 
   - Click the help button (?) manually with mouse
   - **Expected**: Help modal opens normally as intended
6. **Form Validation Test**: 
   - Leave required fields empty and try to save
   - **Expected**: Validation errors appear normally
7. **Save Functionality Test**: 
   - Complete the form properly and click Save
   - **Expected**: Exercise saves successfully

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

https://github.com/user-attachments/assets/dc78d485-5b65-4dd3-96be-79d12e8e5d3f




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Pressing Enter advances focus to the next field in the modeling exercise update form for improved keyboard navigation.

- Bug Fixes
  - Prevented unintended form submissions by routing Enter to controlled navigation.
  - Help button in the modeling editor no longer triggers form submission.
  - Enter-based navigation ignores textareas, content-editable areas, and the embedded editor; fixed subscription cleanup to avoid leaks.

- Tests
  - Added tests for Enter-navigation behavior and component cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->