### PR TITLE
`Communication`: Fix refresh button to clear search results

### DIFF
--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
@@ -697,4 +697,15 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
             }
         }
     }
+
+    /**
+     * Clears search state and reverts to original view when refresh button is clicked
+     */
+    clearSearchAndRevertToOriginalView(): void {
+        // Clear the global search component UI state
+        this.globalSearchComponent()?.clearSearch();
+        // Delegate to the wrapper to reset component state and handle mobile sidebar consistently
+        const emptySearch: ConversationGlobalSearchConfig = { searchTerm: '', selectedConversations: [], selectedAuthors: [] };
+        this.onSearch(emptySearch);
+    }
 }

--- a/src/main/webapp/app/core/course/overview/course-overview/course-overview.component.ts
+++ b/src/main/webapp/app/core/course/overview/course-overview/course-overview.component.ts
@@ -215,6 +215,12 @@ export class CourseOverviewComponent extends BaseCourseContainerComponent implem
      */
     loadCourse(refresh = false): Observable<void> {
         this.refreshingCourse.set(refresh);
+
+        // Clear search state if we're refreshing and currently in conversations view
+        if (refresh && this.activatedComponentReference() instanceof CourseConversationsComponent) {
+            (this.activatedComponentReference() as CourseConversationsComponent).clearSearchAndRevertToOriginalView();
+        }
+
         const observable = this.courseManagementService.findOneForDashboard(this.courseId()).pipe(
             map((res: HttpResponse<Course>) => {
                 if (res.body) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This change fixes issue #9643 where the refresh button in communication channels would only reload course data but maintain search results. Users had to navigate away from the channel and back to clear search results and see the original messages view, which was time-consuming and unintuitive.

Fixes #9643

### Description
<!-- Describe your changes in detail -->
The fix adds a `clearSearchAndRevertToOriginalView()` method to the `CourseConversationsComponent` that:
- Clears the global search component state
- Resets the course-wide search configuration (searchTerm, selectedConversations, selectedAuthors)  
- Triggers a search with empty config to show original messages
- Updates query parameters to reflect the cleared state

The `CourseOverviewComponent.loadCourse()` method is modified to detect when refreshing the communication page and automatically call this clear method, ensuring the refresh button properly resets the search state.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Course with communication enabled
- Multiple messages in different channels
- At least 1 Student account

1. Log in to Artemis as a student
2. Navigate to a course with communication enabled
3. Go to the Communication tab
4. Post several messages in a channel
5. Use the search functionality to search for a specific message
6. Verify search results are displayed
7. Click the refresh button in the top toolbar
8. **Expected**: Search results are cleared and the original messages view is restored
9. **Previously**: Search results remained visible after refresh



### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2



### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->



https://github.com/user-attachments/assets/cf19033c-1b20-451a-8e60-c8d9fc31def5





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Clear search action in Course Conversations to instantly reset filters and return to the default conversation list across devices.
  * Course refresh now automatically clears any active conversation search and restores the default view, providing a consistent starting point after reloads and reducing confusion when switching between sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->