### PR TITLE
change TutorParticipationResource to use TutorParticipationDTO

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/dto/TutorParticipationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/dto/TutorParticipationDTO.java
@@ -1,0 +1,19 @@
+package de.tum.cit.aet.artemis.assessment.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.TutorParticipation;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record TutorParticipationDTO(long id, long exerciseId, long tutorId, String status, int trainedCount) {
+
+    /**
+     * Convert a TutorParticipation entity to a TutorParticipationDTO.
+     *
+     * @param tutorParticipation the TutorParticipation to convert
+     */
+    public TutorParticipationDTO(TutorParticipation tutorParticipation) {
+        this(tutorParticipation.getId(), tutorParticipation.getAssessedExercise().getId(), tutorParticipation.getTutor().getId(), tutorParticipation.getStatus().name(),
+                tutorParticipation.getTrainedExampleSubmissions().size());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/web/TutorParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/web/TutorParticipationResource.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.artemis.assessment.domain.ExampleSubmission;
 import de.tum.cit.aet.artemis.assessment.domain.TutorParticipation;
+import de.tum.cit.aet.artemis.assessment.dto.TutorParticipationDTO;
 import de.tum.cit.aet.artemis.assessment.repository.TutorParticipationRepository;
 import de.tum.cit.aet.artemis.assessment.service.TutorParticipationService;
 import de.tum.cit.aet.artemis.core.domain.User;
@@ -76,7 +77,7 @@ public class TutorParticipationResource {
      */
     @PostMapping("exercises/{exerciseId}/tutor-participations")
     @EnforceAtLeastTutor
-    public ResponseEntity<TutorParticipation> initTutorParticipation(@PathVariable Long exerciseId) throws URISyntaxException {
+    public ResponseEntity<TutorParticipationDTO> initTutorParticipation(@PathVariable Long exerciseId) throws URISyntaxException {
         log.debug("REST request to start tutor participation : {}", exerciseId);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
@@ -89,7 +90,8 @@ public class TutorParticipationResource {
         }
 
         TutorParticipation tutorParticipation = tutorParticipationService.createNewParticipation(exercise, user);
-        return ResponseEntity.created(new URI("/api/assessment/exercises/" + exerciseId + "tutor-participations/" + tutorParticipation.getId())).body(tutorParticipation);
+        TutorParticipationDTO dto = new TutorParticipationDTO(tutorParticipation);
+        return ResponseEntity.created(new URI("/api/assessment/exercises/" + exerciseId + "tutor-participations/" + tutorParticipation.getId())).body(dto);
     }
 
     /**
@@ -104,7 +106,7 @@ public class TutorParticipationResource {
      */
     @PostMapping("exercises/{exerciseId}/assess-example-submission")
     @EnforceAtLeastTutor
-    public ResponseEntity<TutorParticipation> assessExampleSubmissionForTutorParticipation(@PathVariable Long exerciseId, @RequestBody ExampleSubmission exampleSubmission) {
+    public ResponseEntity<TutorParticipationDTO> assessExampleSubmissionForTutorParticipation(@PathVariable Long exerciseId, @RequestBody ExampleSubmission exampleSubmission) {
         log.debug("REST request to add example submission to exercise id : {}", exerciseId);
         Exercise exercise = this.exerciseRepository.findByIdElseThrow(exerciseId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
@@ -118,6 +120,7 @@ public class TutorParticipationResource {
             trainedExampleSubmission.setExercise(null);
         });
 
-        return ResponseEntity.ok().body(resultTutorParticipation);
+        TutorParticipationDTO dto = new TutorParticipationDTO(resultTutorParticipation);
+        return ResponseEntity.ok().body(dto);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Description
<!-- Describe your changes in detail -->
This change refactors the TutorParticipation REST endpoints to use TutorParticipationDTO instead of exposing the domain entity directly.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a Programming Exercise

1. Log in to Artemis
2. Participate in the exam as a student
3. Make sure that the UI of the programming exercise in the exam mode stays unchanged. You can use the [exam mode documentation](https://docs.artemis.cit.tum.de/user/exam_mode/) as reference.
4. ...

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2