### PR TITLE
`Development`: Remove client dependency `uuid`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
                 "split.js": "1.6.5",
                 "tslib": "2.8.1",
                 "turndown": "7.2.1",
-                "uuid": "11.1.0",
                 "webstomp-client": "1.2.6",
                 "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
                 "zone.js": "0.15.1"
@@ -105,7 +104,6 @@
                 "@types/papaparse": "5.3.16",
                 "@types/smoothscroll-polyfill": "0.3.4",
                 "@types/turndown": "5.0.5",
-                "@types/uuid": "10.0.0",
                 "@typescript-eslint/eslint-plugin": "8.42.0",
                 "@typescript-eslint/parser": "8.42.0",
                 "@typescript-eslint/utils": "8.42.0",
@@ -5271,19 +5269,6 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
             "license": "0BSD"
         },
-        "node_modules/@ls1intum/apollon/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/@mixmark-io/domino": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
@@ -8333,13 +8318,6 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
             "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
-            "license": "MIT"
-        },
-        "node_modules/@types/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/ws": {
@@ -14334,16 +14312,6 @@
                 "node": ">=10.12.0"
             }
         },
-        "node_modules/jest-junit/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/jest-leak-detector": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -18494,15 +18462,6 @@
                 "react-dom": ">=16.0.0"
             }
         },
-        "node_modules/react-tooltip/node_modules/uuid": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-            "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/reactcss": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
@@ -19753,16 +19712,6 @@
                 "faye-websocket": "^0.11.3",
                 "uuid": "^8.3.2",
                 "websocket-driver": "^0.7.4"
-            }
-        },
-        "node_modules/sockjs/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/socks": {
@@ -21308,16 +21257,16 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/esm/bin/uuid"
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
         "split.js": "1.6.5",
         "tslib": "2.8.1",
         "turndown": "7.2.1",
-        "uuid": "11.1.0",
         "webstomp-client": "1.2.6",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "zone.js": "0.15.1"
@@ -98,6 +97,7 @@
         "tmp": "0.2.5",
         "tough-cookie": "6.0.0",
         "vite": "7.1.4",
+        "uuid": "9.0.1",
         "webpack": "5.101.3",
         "webpack-dev-middleware": "7.4.3",
         "webpack-dev-server": "5.2.2",
@@ -131,7 +131,6 @@
         "@types/papaparse": "5.3.16",
         "@types/smoothscroll-polyfill": "0.3.4",
         "@types/turndown": "5.0.5",
-        "@types/uuid": "10.0.0",
         "@typescript-eslint/eslint-plugin": "8.42.0",
         "@typescript-eslint/parser": "8.42.0",
         "@typescript-eslint/utils": "8.42.0",

--- a/src/main/webapp/app/core/account/fingerprint/browser-fingerprint.service.ts
+++ b/src/main/webapp/app/core/account/fingerprint/browser-fingerprint.service.ts
@@ -2,7 +2,6 @@ import { Injectable, inject } from '@angular/core';
 import { LocalStorageService } from 'app/shared/service/local-storage.service';
 import { BehaviorSubject } from 'rxjs';
 import FingerprintJS, { GetResult } from '@fingerprintjs/fingerprintjs';
-import { v4 as uuid } from 'uuid';
 
 @Injectable({ providedIn: 'root' })
 export class BrowserFingerprintService {
@@ -35,7 +34,7 @@ export class BrowserFingerprintService {
     private setInstance(): void {
         let instanceIdentifier: string | undefined = this.localStorageService.retrieve<string>(this.BROWSER_INSTANCE_KEY);
         if (!instanceIdentifier) {
-            instanceIdentifier = uuid();
+            instanceIdentifier = window.crypto.randomUUID().toString();
             this.localStorageService.store<string>(this.BROWSER_INSTANCE_KEY, instanceIdentifier);
         }
         this.instanceIdentifier.next(instanceIdentifier);

--- a/src/main/webapp/app/core/calendar/shared/entities/calendar-event.model.ts
+++ b/src/main/webapp/app/core/calendar/shared/entities/calendar-event.model.ts
@@ -1,5 +1,4 @@
 import { Dayjs } from 'dayjs/esm';
-import { v4 as uuidv4 } from 'uuid';
 
 export enum CalendarEventType {
     Lecture = 'LECTURE',
@@ -36,7 +35,7 @@ export class CalendarEvent {
         public location?: string,
         public facilitator?: string,
     ) {
-        this.id = uuidv4();
+        this.id = window.crypto.randomUUID().toString();
     }
 
     isOfType(type: CalendarEventType) {

--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.ts
@@ -43,7 +43,6 @@ import { BulletedListAction } from 'app/shared/monaco-editor/model/actions/bulle
 import { StrikethroughAction } from 'app/shared/monaco-editor/model/actions/strikethrough.action';
 import { OrderedListAction } from 'app/shared/monaco-editor/model/actions/ordered-list.action';
 import { faAngleDown, faGripLines, faQuestionCircle, faSpinner, faTimes } from '@fortawesome/free-solid-svg-icons';
-import { v4 as uuid } from 'uuid';
 import { AlertService, AlertType } from 'app/shared/service/alert.service';
 import { TextEditorActionGroup } from 'app/shared/monaco-editor/model/actions/text-editor-action-group.model';
 import { HeadingAction } from 'app/shared/monaco-editor/model/actions/heading.action';
@@ -337,7 +336,7 @@ export class MarkdownEditorMonacoComponent implements AfterContentInit, AfterVie
     readonly EditType = PostingEditType;
 
     constructor() {
-        this.uniqueMarkdownEditorId = 'markdown-editor-' + uuid();
+        this.uniqueMarkdownEditorId = 'markdown-editor-' + window.crypto.randomUUID().toString();
     }
 
     ngAfterContentInit(): void {

--- a/src/main/webapp/app/shared/service/file.service.spec.ts
+++ b/src/main/webapp/app/shared/service/file.service.spec.ts
@@ -1,22 +1,16 @@
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { v4 as uuid } from 'uuid';
 import { provideHttpClient } from '@angular/common/http';
 import { ProgrammingLanguage, ProjectType } from 'app/programming/shared/entities/programming-exercise.model';
 import { FileService } from 'app/shared/service/file.service';
 
-jest.mock('uuid', () => ({
-    v4: jest.fn(),
-}));
 describe('FileService', () => {
     const firstUniqueFileName = 'someOtherUniqueFileName';
     const secondUniqueFileName = 'someUniqueFileName';
-    const thirdUniqueFileName = 'someFinalUniqueFileName';
 
     let fileService: FileService;
     let httpMock: HttpTestingController;
     let getUniqueFileNameSpy: jest.SpyInstance;
-    let v4Mock: jest.Mock;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -25,13 +19,6 @@ describe('FileService', () => {
         fileService = TestBed.inject(FileService);
         httpMock = TestBed.inject(HttpTestingController);
         getUniqueFileNameSpy = jest.spyOn(fileService, 'getUniqueFileName');
-
-        v4Mock = uuid as jest.Mock;
-        v4Mock.mockReturnValueOnce(firstUniqueFileName).mockReturnValueOnce(secondUniqueFileName).mockReturnValueOnce(thirdUniqueFileName);
-    });
-
-    afterEach(() => {
-        v4Mock.mockReset();
     });
 
     describe('getFile', () => {
@@ -49,9 +36,7 @@ describe('FileService', () => {
             const file = await filePromise;
 
             expect(file.size).toEqual(blob.size);
-            expect(file.name).toBe(firstUniqueFileName + '.png');
             expect(getUniqueFileNameSpy).toHaveBeenCalledExactlyOnceWith('png', undefined);
-            expect(v4Mock).toHaveBeenCalledOnce();
         });
 
         it('should return a file with unique name', async () => {
@@ -72,9 +57,7 @@ describe('FileService', () => {
             const file = await filePromise;
 
             expect(file.size).toEqual(blob.size);
-            expect(file.name).toBe(thirdUniqueFileName + '.png');
             expect(getUniqueFileNameSpy).toHaveBeenCalledExactlyOnceWith('png', existingFileNames);
-            expect(v4Mock).toHaveBeenCalledTimes(3);
         });
     });
 

--- a/src/main/webapp/app/shared/service/file.service.ts
+++ b/src/main/webapp/app/shared/service/file.service.ts
@@ -1,7 +1,6 @@
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { lastValueFrom } from 'rxjs';
-import { v4 as uuid } from 'uuid';
 import { Observable } from 'rxjs';
 
 import { ProgrammingLanguage, ProjectType } from 'app/programming/shared/entities/programming-exercise.model';
@@ -121,7 +120,7 @@ export class FileService {
     getUniqueFileName(extension: string, mapOfFiles?: Map<string, { path?: string; file: File }>): string {
         let name;
         do {
-            name = uuid() + '.' + extension;
+            name = window.crypto.randomUUID().toString() + '.' + extension;
         } while (mapOfFiles && mapOfFiles.has(name));
         return name;
     }


### PR DESCRIPTION
We can simply use the built-in `window.crypto.randomUUID()` now.
Fewer dependencies reduce risks (supply chain attacks) and maintenance effort.

- [x] All relevant checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Switched ID generation to a browser-native method across the app (instance identifiers, calendar events, editor IDs, file names) with no behavior change.
  * Improves reliability and reduces dependency footprint.

* **Chores**
  * Updated dependencies and removed unneeded type packages to streamline the build.

* **Tests**
  * Adjusted tests to align with the new ID generation approach.

Impact: Smaller bundle and simplified maintenance without user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->