### PR TITLE
`Development`: Split method in exam service

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamService.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.Nullable;
@@ -90,6 +91,7 @@ import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.IncludedInOverallScore;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.SubmissionType;
+import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.exercise.dto.ExamGradeScoreDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
@@ -314,67 +316,142 @@ public class ExamService {
     }
 
     /**
-     * Get one exam with exercise groups, exercises and additional details.
-     * Additional details are:
-     * - template and solution participation for programming exercises with latest submission and result
-     * - questions for quiz exercises
+     * Loads an {@link Exam} with its exercise groups, exercises, and exercise-specific details.
+     * <p>
+     * For quiz exercises, this also loads and attaches their {@link QuizQuestion}s.
+     * For programming exercises, this loads and attaches template/solution participations along with
+     * the latest {@link Result} for each participation's latest submission.
      *
-     * @param examId the id of the entity
-     * @return the exam with exercise groups and additional details
+     * @param examId the id of the exam
+     * @return the fully populated exam
+     * @throws EntityNotFoundException if the exam does not exist
      */
     private Exam findWithExerciseGroupsAndExercisesAndDetailsByIdElseThrow(long examId) {
         Exam exam = examRepository.findWithExerciseGroupsAndExercisesByIdOrElseThrow(examId);
+
         Set<QuizExercise> quizExercises = getAllExercisesForExamByType(exam, QuizExercise.class);
         Set<ProgrammingExercise> programmingExercises = getAllExercisesForExamByType(exam, ProgrammingExercise.class);
-        Set<Long> quizExerciseIds = quizExercises.stream().map(DomainObject::getId).collect(Collectors.toSet());
-        Set<Long> programmingExerciseIds = programmingExercises.stream().map(DomainObject::getId).collect(Collectors.toSet());
-        if (!quizExerciseIds.isEmpty()) {
-            Set<QuizQuestion> quizQuestions = quizQuestionRepository.findAllByExerciseIds(quizExerciseIds);
-            quizExercises.forEach(quizExercise -> quizExercise.setQuizQuestions(
-                    quizQuestions.stream().filter(quizQuestion -> quizQuestion.getExercise() != null && quizQuestion.getExercise().getId().equals(quizExercise.getId())).toList()));
-        }
-        if (!programmingExerciseIds.isEmpty()) {
-            Set<TemplateProgrammingExerciseParticipation> templateProgrammingExerciseParticipations = templateProgrammingExerciseParticipationRepository
-                    .findAllWithLatestSubmissionByExerciseIds(programmingExerciseIds);
-            Set<SolutionProgrammingExerciseParticipation> solutionProgrammingExerciseParticipations = solutionProgrammingExerciseParticipationRepository
-                    .findAllWithLatestSubmissionByExerciseIds(programmingExerciseIds);
 
-            programmingExercises.forEach(programmingExercise -> {
-                templateProgrammingExerciseParticipations.stream().filter(
-                        participation -> participation.getProgrammingExercise() != null && participation.getProgrammingExercise().getId().equals(programmingExercise.getId()))
-                        .findAny().ifPresent(programmingExercise::setTemplateParticipation);
-                solutionProgrammingExerciseParticipations.stream().filter(
-                        participation -> participation.getProgrammingExercise() != null && participation.getProgrammingExercise().getId().equals(programmingExercise.getId()))
-                        .findAny().ifPresent(programmingExercise::setSolutionParticipation);
-            });
-            Map<Long, Result> latestResultsForTemplateSubmissions = resultRepository
-                    .findLatestResultsByParticipationIds(templateProgrammingExerciseParticipations.stream().map(DomainObject::getId).collect(Collectors.toSet())).stream()
-                    .collect(Collectors.toMap(result -> result.getSubmission().getId(), result -> result, (r1, r2) -> r1));
-            Map<Long, Result> latestResultsForSolutionSubmissions = resultRepository
-                    .findLatestResultsByParticipationIds(solutionProgrammingExerciseParticipations.stream().map(DomainObject::getId).collect(Collectors.toSet())).stream()
-                    .collect(Collectors.toMap(result -> result.getSubmission().getId(), result -> result, (r1, r2) -> r1));
+        populateQuizQuestions(quizExercises);
+        populateProgrammingExerciseParticipationsAndResults(programmingExercises);
 
-            programmingExercises.forEach(programmingExercise -> {
-                if (programmingExercise.getSolutionParticipation() != null) {
-                    programmingExercise.getSolutionParticipation().getSubmissions().forEach(submission -> {
-                        Result result = latestResultsForSolutionSubmissions.get(submission.getId());
-                        if (result != null) {
-                            submission.setResults(List.of(result));
-                        }
-                    });
-                }
-                if (programmingExercise.getTemplateParticipation() != null) {
-                    programmingExercise.getTemplateParticipation().getSubmissions().forEach(submission -> {
-                        Result result = latestResultsForTemplateSubmissions.get(submission.getId());
-                        if (result != null) {
-                            submission.setResults(List.of(result));
-                        }
-                    });
-                }
-            });
-
-        }
         return exam;
+    }
+
+    /**
+     * Loads all {@link QuizQuestion}s for the provided quiz exercises and attaches them
+     * to their respective {@link QuizExercise}.
+     *
+     * @param quizExercises the quiz exercises to enrich
+     */
+    private void populateQuizQuestions(Set<QuizExercise> quizExercises) {
+        if (quizExercises == null || quizExercises.isEmpty()) {
+            return;
+        }
+
+        Set<Long> quizExerciseIds = quizExercises.stream().map(DomainObject::getId).collect(Collectors.toSet());
+
+        Set<QuizQuestion> quizQuestions = quizQuestionRepository.findAllByExerciseIds(quizExerciseIds);
+
+        Map<Long, List<QuizQuestion>> questionsByExerciseId = quizQuestions.stream().filter(q -> q.getExercise() != null && q.getExercise().getId() != null)
+                .collect(Collectors.groupingBy(q -> q.getExercise().getId()));
+
+        quizExercises.forEach(qe -> qe.setQuizQuestions(questionsByExerciseId.getOrDefault(qe.getId(), List.of())));
+    }
+
+    /**
+     * For each {@link ProgrammingExercise}:
+     * <ul>
+     * <li>Loads and attaches template and solution participations (with their latest submission).</li>
+     * <li>Loads the latest {@link Result} for each participation's latest submission and attaches it to the submission.</li>
+     * </ul>
+     *
+     * @param programmingExercises the programming exercises to enrich
+     */
+    private void populateProgrammingExerciseParticipationsAndResults(Set<ProgrammingExercise> programmingExercises) {
+        if (programmingExercises == null || programmingExercises.isEmpty()) {
+            return;
+        }
+
+        Set<Long> programmingExerciseIds = programmingExercises.stream().map(DomainObject::getId).collect(Collectors.toSet());
+
+        Set<TemplateProgrammingExerciseParticipation> templateParticipations = templateProgrammingExerciseParticipationRepository
+                .findAllWithLatestSubmissionByExerciseIds(programmingExerciseIds);
+
+        Set<SolutionProgrammingExerciseParticipation> solutionParticipations = solutionProgrammingExerciseParticipationRepository
+                .findAllWithLatestSubmissionByExerciseIds(programmingExerciseIds);
+
+        attachParticipationsToExercises(programmingExercises, templateParticipations, solutionParticipations);
+
+        Map<Long, Result> latestTemplateResults = loadLatestResultsBySubmissionIdForParticipations(templateParticipations);
+        Map<Long, Result> latestSolutionResults = loadLatestResultsBySubmissionIdForParticipations(solutionParticipations);
+
+        attachResultsToSubmissions(programmingExercises, latestTemplateResults, latestSolutionResults);
+    }
+
+    /**
+     * Attaches template and solution participations to their corresponding programming exercises.
+     */
+    private void attachParticipationsToExercises(Set<ProgrammingExercise> programmingExercises, Set<TemplateProgrammingExerciseParticipation> templateParticipations,
+            Set<SolutionProgrammingExerciseParticipation> solutionParticipations) {
+        Map<Long, TemplateProgrammingExerciseParticipation> templateByExerciseId = templateParticipations.stream()
+                .filter(p -> p.getProgrammingExercise() != null && p.getProgrammingExercise().getId() != null)
+                .collect(Collectors.toMap(p -> p.getProgrammingExercise().getId(), Function.identity(), (a, b) -> a));
+
+        Map<Long, SolutionProgrammingExerciseParticipation> solutionByExerciseId = solutionParticipations.stream()
+                .filter(p -> p.getProgrammingExercise() != null && p.getProgrammingExercise().getId() != null)
+                .collect(Collectors.toMap(p -> p.getProgrammingExercise().getId(), Function.identity(), (a, b) -> a));
+
+        programmingExercises.forEach(ex -> {
+            if (templateByExerciseId.containsKey(ex.getId())) {
+                ex.setTemplateParticipation(templateByExerciseId.get(ex.getId()));
+            }
+            if (solutionByExerciseId.containsKey(ex.getId())) {
+                ex.setSolutionParticipation(solutionByExerciseId.get(ex.getId()));
+            }
+        });
+    }
+
+    /**
+     * Attaches the latest results to submissions of both template and solution participations.
+     */
+    private void attachResultsToSubmissions(Set<ProgrammingExercise> programmingExercises, Map<Long, Result> latestTemplateResults, Map<Long, Result> latestSolutionResults) {
+        programmingExercises.forEach(ex -> {
+            if (ex.getSolutionParticipation() != null && ex.getSolutionParticipation().getSubmissions() != null) {
+                ex.getSolutionParticipation().getSubmissions().forEach(sub -> {
+                    Result r = latestSolutionResults.get(sub.getId());
+                    if (r != null) {
+                        sub.setResults(List.of(r));
+                    }
+                });
+            }
+            if (ex.getTemplateParticipation() != null && ex.getTemplateParticipation().getSubmissions() != null) {
+                ex.getTemplateParticipation().getSubmissions().forEach(sub -> {
+                    Result r = latestTemplateResults.get(sub.getId());
+                    if (r != null) {
+                        sub.setResults(List.of(r));
+                    }
+                });
+            }
+        });
+    }
+
+    /**
+     * Loads the latest {@link Result}s for the given set of participations and returns a map keyed by
+     * the corresponding submission id.
+     *
+     * @param participations the participations whose latest results should be loaded
+     * @return map of submission id -&gt; latest result
+     */
+    private Map<Long, Result> loadLatestResultsBySubmissionIdForParticipations(Set<? extends Participation> participations) {
+        if (participations == null || participations.isEmpty()) {
+            return Map.of();
+        }
+
+        Set<Long> participationIds = participations.stream().map(DomainObject::getId).collect(Collectors.toSet());
+
+        return resultRepository.findLatestResultsByParticipationIds(participationIds).stream().filter(r -> r.getSubmission() != null && r.getSubmission().getId() != null)
+                .collect(Collectors.toMap(r -> r.getSubmission().getId(), Function.identity(), (r1, r2) -> r1));
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamService.java
@@ -395,19 +395,23 @@ public class ExamService {
     private void attachParticipationsToExercises(Set<ProgrammingExercise> programmingExercises, Set<TemplateProgrammingExerciseParticipation> templateParticipations,
             Set<SolutionProgrammingExerciseParticipation> solutionParticipations) {
         Map<Long, TemplateProgrammingExerciseParticipation> templateByExerciseId = templateParticipations.stream()
-                .filter(p -> p.getProgrammingExercise() != null && p.getProgrammingExercise().getId() != null)
-                .collect(Collectors.toMap(p -> p.getProgrammingExercise().getId(), Function.identity(), (a, b) -> a));
+                .filter(templateProgrammingExerciseParticipation -> templateProgrammingExerciseParticipation.getProgrammingExercise() != null
+                        && templateProgrammingExerciseParticipation.getProgrammingExercise().getId() != null)
+                .collect(Collectors.toMap(templateProgrammingExerciseParticipation -> templateProgrammingExerciseParticipation.getProgrammingExercise().getId(),
+                        Function.identity(), (a, b) -> a));
 
         Map<Long, SolutionProgrammingExerciseParticipation> solutionByExerciseId = solutionParticipations.stream()
-                .filter(p -> p.getProgrammingExercise() != null && p.getProgrammingExercise().getId() != null)
-                .collect(Collectors.toMap(p -> p.getProgrammingExercise().getId(), Function.identity(), (a, b) -> a));
+                .filter(solutionProgrammingExerciseParticipation -> solutionProgrammingExerciseParticipation.getProgrammingExercise() != null
+                        && solutionProgrammingExerciseParticipation.getProgrammingExercise().getId() != null)
+                .collect(Collectors.toMap(solutionProgrammingExerciseParticipation -> solutionProgrammingExerciseParticipation.getProgrammingExercise().getId(),
+                        Function.identity(), (a, b) -> a));
 
-        programmingExercises.forEach(ex -> {
-            if (templateByExerciseId.containsKey(ex.getId())) {
-                ex.setTemplateParticipation(templateByExerciseId.get(ex.getId()));
+        programmingExercises.forEach(exercise -> {
+            if (templateByExerciseId.containsKey(exercise.getId())) {
+                exercise.setTemplateParticipation(templateByExerciseId.get(exercise.getId()));
             }
-            if (solutionByExerciseId.containsKey(ex.getId())) {
-                ex.setSolutionParticipation(solutionByExerciseId.get(ex.getId()));
+            if (solutionByExerciseId.containsKey(exercise.getId())) {
+                exercise.setSolutionParticipation(solutionByExerciseId.get(exercise.getId()));
             }
         });
     }
@@ -419,17 +423,17 @@ public class ExamService {
         programmingExercises.forEach(ex -> {
             if (ex.getSolutionParticipation() != null && ex.getSolutionParticipation().getSubmissions() != null) {
                 ex.getSolutionParticipation().getSubmissions().forEach(sub -> {
-                    Result r = latestSolutionResults.get(sub.getId());
-                    if (r != null) {
-                        sub.setResults(List.of(r));
+                    Result result = latestSolutionResults.get(sub.getId());
+                    if (result != null) {
+                        sub.setResults(List.of(result));
                     }
                 });
             }
             if (ex.getTemplateParticipation() != null && ex.getTemplateParticipation().getSubmissions() != null) {
                 ex.getTemplateParticipation().getSubmissions().forEach(sub -> {
-                    Result r = latestTemplateResults.get(sub.getId());
-                    if (r != null) {
-                        sub.setResults(List.of(r));
+                    Result result = latestTemplateResults.get(sub.getId());
+                    if (result != null) {
+                        sub.setResults(List.of(result));
                     }
                 });
             }
@@ -450,8 +454,9 @@ public class ExamService {
 
         Set<Long> participationIds = participations.stream().map(DomainObject::getId).collect(Collectors.toSet());
 
-        return resultRepository.findLatestResultsByParticipationIds(participationIds).stream().filter(r -> r.getSubmission() != null && r.getSubmission().getId() != null)
-                .collect(Collectors.toMap(r -> r.getSubmission().getId(), Function.identity(), (r1, r2) -> r1));
+        return resultRepository.findLatestResultsByParticipationIds(participationIds).stream()
+                .filter(result -> result.getSubmission() != null && result.getSubmission().getId() != null)
+                .collect(Collectors.toMap(result -> result.getSubmission().getId(), Function.identity(), (r1, r2) -> r1));
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.





### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Followup of #11375 to resolve the change request

### Description
<!-- Describe your changes in detail -->
Split `findWithExerciseGroupsAndExercisesAndDetailsByIdElseThrow` into multiple smaller methods


### Steps for Testing
Code Review


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exam details now consistently include all quiz questions for quiz exercises.
  * Programming exercises in exam details reliably show template/solution participations with their latest results attached.

* **Improvements**
  * More complete and dependable exam detail loading, reducing missing or out-of-date information.
  * Increased stability when viewing exams containing mixed exercise types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->