### PR TITLE
`Quiz exercises`: Add isRated/isFree Mode Check to Quiz Training

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/QuizTrainingAnswerDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/QuizTrainingAnswerDTO.java
@@ -1,11 +1,11 @@
 package de.tum.cit.aet.artemis.quiz.dto;
 
-import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.quiz.domain.SubmittedAnswer;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record QuizTrainingAnswerDTO(@Nullable SubmittedAnswer submittedAnswer) {
+public record QuizTrainingAnswerDTO(@NotNull SubmittedAnswer submittedAnswer, boolean isRated) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/QuizQuestionTrainingDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/QuizQuestionTrainingDTO.java
@@ -1,0 +1,16 @@
+package de.tum.cit.aet.artemis.quiz.dto.question;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record QuizQuestionTrainingDTO(@JsonUnwrapped QuizQuestionWithSolutionDTO quizQuestionWithSolutionDTO, boolean isRated) {
+
+    public static QuizQuestionTrainingDTO of(QuizQuestionWithSolutionDTO quizQuestionWithSolutionDTO, boolean isRated) {
+        return new QuizQuestionTrainingDTO(quizQuestionWithSolutionDTO, isRated);
+    }
+
+    public long getId() {
+        return quizQuestionWithSolutionDTO().quizQuestionBaseDTO().id();
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/QuizQuestionTrainingDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/QuizQuestionTrainingDTO.java
@@ -1,10 +1,11 @@
 package de.tum.cit.aet.artemis.quiz.dto.question;
 
+import jakarta.validation.constraints.NotNull;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record QuizQuestionTrainingDTO(@JsonUnwrapped QuizQuestionWithSolutionDTO quizQuestionWithSolutionDTO, boolean isRated) {
+public record QuizQuestionTrainingDTO(@NotNull QuizQuestionWithSolutionDTO quizQuestionWithSolutionDTO, boolean isRated) {
 
     public static QuizQuestionTrainingDTO of(QuizQuestionWithSolutionDTO quizQuestionWithSolutionDTO, boolean isRated) {
         return new QuizQuestionTrainingDTO(quizQuestionWithSolutionDTO, isRated);

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizTrainingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizTrainingService.java
@@ -40,13 +40,16 @@ public class QuizTrainingService {
     public SubmittedAnswerAfterEvaluationDTO submitForTraining(long quizQuestionId, long userId, QuizTrainingAnswerDTO studentSubmittedAnswer, ZonedDateTime answeredAt) {
         QuizQuestion quizQuestion = quizQuestionRepository.findByIdElseThrow(quizQuestionId);
         SubmittedAnswer answer = studentSubmittedAnswer.submittedAnswer();
+        boolean isRated = studentSubmittedAnswer.isRated();
 
         double score = quizQuestion.scoreForAnswer(answer);
 
         answer.setScoreInPoints(score);
         answer.setQuizQuestion(quizQuestion);
 
-        quizQuestionProgressService.saveProgressFromTraining(quizQuestion, userId, answer, answeredAt);
+        if (isRated) {
+            quizQuestionProgressService.saveProgressFromTraining(quizQuestion, userId, answer, answeredAt);
+        }
 
         return SubmittedAnswerAfterEvaluationDTO.of(answer);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizTrainingResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizTrainingResource.java
@@ -26,9 +26,8 @@ import de.tum.cit.aet.artemis.core.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.security.Role;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
-import de.tum.cit.aet.artemis.quiz.domain.QuizQuestion;
 import de.tum.cit.aet.artemis.quiz.dto.QuizTrainingAnswerDTO;
-import de.tum.cit.aet.artemis.quiz.dto.question.QuizQuestionWithSolutionDTO;
+import de.tum.cit.aet.artemis.quiz.dto.question.QuizQuestionTrainingDTO;
 import de.tum.cit.aet.artemis.quiz.dto.submittedanswer.SubmittedAnswerAfterEvaluationDTO;
 import de.tum.cit.aet.artemis.quiz.service.QuizQuestionProgressService;
 import de.tum.cit.aet.artemis.quiz.service.QuizTrainingService;
@@ -68,15 +67,14 @@ public class QuizTrainingResource {
      */
     @GetMapping("courses/{courseId}/training-questions")
     @EnforceAtLeastStudent
-    public ResponseEntity<List<QuizQuestionWithSolutionDTO>> getQuizQuestionsForPractice(@PathVariable long courseId) {
+    public ResponseEntity<List<QuizQuestionTrainingDTO>> getQuizQuestionsForPractice(@PathVariable long courseId) {
         log.info("REST request to get quiz questions for course with id : {}", courseId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
         Course course = courseRepository.findByIdElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.STUDENT, course, user);
 
-        List<QuizQuestion> quizQuestions = quizQuestionProgressService.getQuestionsForSession(courseId, user.getId());
-        List<QuizQuestionWithSolutionDTO> quizQuestionsWithSolutions = quizQuestions.stream().map(QuizQuestionWithSolutionDTO::of).toList();
-        return ResponseEntity.ok(quizQuestionsWithSolutions);
+        List<QuizQuestionTrainingDTO> quizQuestions = quizQuestionProgressService.getQuestionsForSession(courseId, user.getId());
+        return ResponseEntity.ok(quizQuestions);
     }
 
     /**

--- a/src/main/webapp/app/quiz/overview/course-training-quiz/course-training-quiz.component.html
+++ b/src/main/webapp/app/quiz/overview/course-training-quiz/course-training-quiz.component.html
@@ -1,50 +1,66 @@
 <div>
+    @if (showUnratedConfirmation) {
+        <div class="modal-backdrop fade show"></div>
+        <div class="modal d-block" tabindex="-1" role="dialog">
+            <div class="modal-dialog modal-dialog-centered" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" jhiTranslate="artemisApp.quizQuestion.unratedConfirmationTitle"></h5>
+                    </div>
+                    <div class="modal-body">
+                        <p jhiTranslate="artemisApp.quizQuestion.unratedConfirmation"></p>
+                    </div>
+                    <div class="modal-footer">
+                        <jhi-button (onClick)="confirmUnratedPractice()" [title]="'global.generic.yes'" />
+                        <jhi-button (onClick)="cancelUnratedPractice()" [title]="'global.generic.no'" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+
     @if (questionsLoaded()) {
-        @if (questions().length > 0) {
-            @if (currentQuestion(); as question) {
-                @if (question.type === MULTIPLE_CHOICE) {
-                    <jhi-multiple-choice-question
-                        [question]="question"
-                        [selectedAnswerOptions]="selectedAnswerOptions"
-                        (selectedAnswerOptionsChange)="selectedAnswerOptions = $event"
-                        [questionIndex]="currentIndex() + 1"
-                        [showResult]="showingResult"
-                        [score]="questionScores"
-                    />
-                }
-                @if (question.type === SHORT_ANSWER) {
-                    <jhi-short-answer-question
-                        [question]="question"
-                        [submittedTexts]="shortAnswerSubmittedTexts"
-                        (submittedTextsChange)="shortAnswerSubmittedTexts = $event"
-                        [questionIndex]="currentIndex() + 1"
-                        [showResult]="showingResult"
-                        [score]="questionScores"
-                    />
-                }
-                @if (question.type === DRAG_AND_DROP) {
-                    <jhi-drag-and-drop-question
-                        [question]="question"
-                        [mappings]="dragAndDropMappings"
-                        (mappingsChange)="dragAndDropMappings = $event"
-                        [questionIndex]="currentIndex() + 1"
-                        [showResult]="showingResult"
-                        [score]="questionScores"
-                    />
-                }
+        @if (currentQuestion(); as question) {
+            @if (question.type === MULTIPLE_CHOICE) {
+                <jhi-multiple-choice-question
+                    [question]="question"
+                    [selectedAnswerOptions]="selectedAnswerOptions"
+                    (selectedAnswerOptionsChange)="selectedAnswerOptions = $event"
+                    [questionIndex]="currentIndex() + 1"
+                    [showResult]="showingResult"
+                    [score]="questionScores"
+                />
             }
-            @if (!submitted) {
-                <jhi-button id="submit-question" class="ms-2" (onClick)="onSubmit()" [title]="'artemisApp.exercise.submit'" />
+            @if (question.type === SHORT_ANSWER) {
+                <jhi-short-answer-question
+                    [question]="question"
+                    [submittedTexts]="shortAnswerSubmittedTexts"
+                    (submittedTextsChange)="shortAnswerSubmittedTexts = $event"
+                    [questionIndex]="currentIndex() + 1"
+                    [showResult]="showingResult"
+                    [score]="questionScores"
+                />
             }
-            @if (submitted) {
-                @if (isLastQuestion()) {
-                    <jhi-button class="ms-2" (onClick)="navigateToTraining()" [title]="'artemisApp.exercise.endTraining'" />
-                } @else {
-                    <jhi-button class="ms-2" (onClick)="nextQuestion()" [title]="'artemisApp.exercise.nextQuestion'" />
-                }
+            @if (question.type === DRAG_AND_DROP) {
+                <jhi-drag-and-drop-question
+                    [question]="question"
+                    [mappings]="dragAndDropMappings"
+                    (mappingsChange)="dragAndDropMappings = $event"
+                    [questionIndex]="currentIndex() + 1"
+                    [showResult]="showingResult"
+                    [score]="questionScores"
+                />
             }
-        } @else {
-            <span jhiTranslate="artemisApp.quizQuestion.noQuestionDue"></span>
+        }
+        @if (!submitted) {
+            <jhi-button id="submit-question" class="ms-2" (onClick)="onSubmit()" [title]="'artemisApp.exercise.submit'" />
+        }
+        @if (submitted) {
+            @if (isLastQuestion()) {
+                <jhi-button class="ms-2" (onClick)="navigateToTraining()" [title]="'artemisApp.exercise.endTraining'" />
+            } @else {
+                <jhi-button class="ms-2" (onClick)="nextQuestion()" [title]="'artemisApp.exercise.nextQuestion'" />
+            }
         }
     }
 </div>

--- a/src/main/webapp/app/quiz/overview/course-training-quiz/course-training-quiz.component.spec.ts
+++ b/src/main/webapp/app/quiz/overview/course-training-quiz/course-training-quiz.component.spec.ts
@@ -43,6 +43,12 @@ const question3: QuizQuestion = {
     exportQuiz: false,
 };
 
+const mockTrainingQuestions = [
+    { quizQuestion: question1, isRated: false },
+    { quizQuestion: question2, isRated: true },
+    { quizQuestion: question3, isRated: false },
+];
+
 const course = { id: 1, title: 'Test Course' };
 
 const answer: SubmittedAnswerAfterEvaluation = { selectedOptions: [{ scoreInPoints: 2 }] };
@@ -73,7 +79,7 @@ describe('CourseTrainingQuizComponent', () => {
                 },
             ]);
         quizService = TestBed.inject(CourseTrainingQuizService);
-        jest.spyOn(quizService, 'getQuizQuestions').mockReturnValue(of([question1, question2, question3]));
+        jest.spyOn(quizService, 'getQuizQuestions').mockReturnValue(of(mockTrainingQuestions));
         jest.spyOn(TestBed.inject(CourseManagementService), 'find').mockReturnValue(of(new HttpResponse({ body: course })));
 
         fixture = TestBed.createComponent(CourseTrainingQuizComponent);
@@ -94,8 +100,8 @@ describe('CourseTrainingQuizComponent', () => {
     });
 
     it('should load questions from service', () => {
-        expect(component.questionsSignal()).toEqual(mockQuestions);
-        expect(component.questions()).toEqual(mockQuestions);
+        expect(component.questionsSignal()).toEqual(mockTrainingQuestions);
+        expect(component.questions()).toEqual(mockTrainingQuestions);
     });
 
     it('should check for last question', () => {
@@ -114,7 +120,7 @@ describe('CourseTrainingQuizComponent', () => {
 
     it('should return the current question based on currentIndex', () => {
         component.currentIndex.set(0);
-        expect(component.currentQuestion()).toBe(question1);
+        expect(component.currentQuestion()).toBe(mockTrainingQuestions[0]);
     });
 
     it('should go to the next question and call initQuestion', () => {
@@ -142,7 +148,7 @@ describe('CourseTrainingQuizComponent', () => {
         const submitSpy = jest.spyOn(TestBed.inject(CourseTrainingQuizService), 'submitForTraining').mockReturnValue(of(new HttpResponse({ body: answer })));
         const showResultSpy = jest.spyOn(component, 'applyEvaluatedAnswer');
         // Drag and Drop
-        jest.spyOn(component, 'currentQuestion').mockReturnValue({ ...question1, exerciseId: 1 } as any);
+        jest.spyOn(component, 'currentQuestion').mockReturnValue({ quizQuestion: question1, isRated: false, exerciseId: 1 } as any);
         component.currentIndex.set(0);
         component.onSubmit();
         expect(submitSpy).toHaveBeenCalledOnce();
@@ -150,7 +156,7 @@ describe('CourseTrainingQuizComponent', () => {
         expect(showResultSpy).toHaveBeenCalledWith(answer);
         jest.clearAllMocks();
         // Multiple Choice
-        jest.spyOn(component, 'currentQuestion').mockReturnValue({ ...question2, exerciseId: 2 } as any);
+        jest.spyOn(component, 'currentQuestion').mockReturnValue({ quizQuestion: question1, isRated: false, exerciseId: 1 } as any);
         component.currentIndex.set(1);
         component.onSubmit();
         expect(submitSpy).toHaveBeenCalledOnce();
@@ -158,7 +164,7 @@ describe('CourseTrainingQuizComponent', () => {
         expect(showResultSpy).toHaveBeenCalledWith(answer);
         jest.clearAllMocks();
         // Short Answer
-        jest.spyOn(component, 'currentQuestion').mockReturnValue({ ...question3, exerciseId: 3 } as any);
+        jest.spyOn(component, 'currentQuestion').mockReturnValue({ quizQuestion: question3, isRated: false, exerciseId: 3 } as any);
         component.currentIndex.set(2);
         component.onSubmit();
         expect(submitSpy).toHaveBeenCalledOnce();

--- a/src/main/webapp/app/quiz/overview/course-training-quiz/course-training-quiz.component.spec.ts
+++ b/src/main/webapp/app/quiz/overview/course-training-quiz/course-training-quiz.component.spec.ts
@@ -43,12 +43,6 @@ const question3: QuizQuestion = {
     exportQuiz: false,
 };
 
-const mockTrainingQuestions = [
-    { quizQuestion: question1, isRated: false },
-    { quizQuestion: question2, isRated: true },
-    { quizQuestion: question3, isRated: false },
-];
-
 const course = { id: 1, title: 'Test Course' };
 
 const answer: SubmittedAnswerAfterEvaluation = { selectedOptions: [{ scoreInPoints: 2 }] };
@@ -59,7 +53,11 @@ describe('CourseTrainingQuizComponent', () => {
     let fixture: ComponentFixture<CourseTrainingQuizComponent>;
     let quizService: CourseTrainingQuizService;
 
-    const mockQuestions = [question1, question2, question3];
+    const mockQuestions = [
+        { quizQuestionWithSolutionDTO: question1, isRated: false },
+        { quizQuestionWithSolutionDTO: question2, isRated: true },
+        { quizQuestionWithSolutionDTO: question3, isRated: false },
+    ];
 
     beforeEach(async () => {
         await MockBuilder(CourseTrainingQuizComponent)
@@ -79,7 +77,7 @@ describe('CourseTrainingQuizComponent', () => {
                 },
             ]);
         quizService = TestBed.inject(CourseTrainingQuizService);
-        jest.spyOn(quizService, 'getQuizQuestions').mockReturnValue(of(mockTrainingQuestions));
+        jest.spyOn(quizService, 'getQuizQuestions').mockReturnValue(of(mockQuestions));
         jest.spyOn(TestBed.inject(CourseManagementService), 'find').mockReturnValue(of(new HttpResponse({ body: course })));
 
         fixture = TestBed.createComponent(CourseTrainingQuizComponent);
@@ -100,8 +98,8 @@ describe('CourseTrainingQuizComponent', () => {
     });
 
     it('should load questions from service', () => {
-        expect(component.questionsSignal()).toEqual(mockTrainingQuestions);
-        expect(component.questions()).toEqual(mockTrainingQuestions);
+        expect(component.questionsSignal()).toEqual(mockQuestions);
+        expect(component.questions()).toEqual(mockQuestions);
     });
 
     it('should check for last question', () => {
@@ -120,7 +118,7 @@ describe('CourseTrainingQuizComponent', () => {
 
     it('should return the current question based on currentIndex', () => {
         component.currentIndex.set(0);
-        expect(component.currentQuestion()).toBe(mockTrainingQuestions[0]);
+        expect(component.currentQuestion()).toBe(mockQuestions[0].quizQuestionWithSolutionDTO);
     });
 
     it('should go to the next question and call initQuestion', () => {
@@ -148,7 +146,7 @@ describe('CourseTrainingQuizComponent', () => {
         const submitSpy = jest.spyOn(TestBed.inject(CourseTrainingQuizService), 'submitForTraining').mockReturnValue(of(new HttpResponse({ body: answer })));
         const showResultSpy = jest.spyOn(component, 'applyEvaluatedAnswer');
         // Drag and Drop
-        jest.spyOn(component, 'currentQuestion').mockReturnValue({ quizQuestion: question1, isRated: false, exerciseId: 1 } as any);
+        jest.spyOn(component, 'currentQuestion').mockReturnValue(question1);
         component.currentIndex.set(0);
         component.onSubmit();
         expect(submitSpy).toHaveBeenCalledOnce();
@@ -156,7 +154,7 @@ describe('CourseTrainingQuizComponent', () => {
         expect(showResultSpy).toHaveBeenCalledWith(answer);
         jest.clearAllMocks();
         // Multiple Choice
-        jest.spyOn(component, 'currentQuestion').mockReturnValue({ quizQuestion: question1, isRated: false, exerciseId: 1 } as any);
+        jest.spyOn(component, 'currentQuestion').mockReturnValue(question2);
         component.currentIndex.set(1);
         component.onSubmit();
         expect(submitSpy).toHaveBeenCalledOnce();
@@ -164,7 +162,7 @@ describe('CourseTrainingQuizComponent', () => {
         expect(showResultSpy).toHaveBeenCalledWith(answer);
         jest.clearAllMocks();
         // Short Answer
-        jest.spyOn(component, 'currentQuestion').mockReturnValue({ quizQuestion: question3, isRated: false, exerciseId: 3 } as any);
+        jest.spyOn(component, 'currentQuestion').mockReturnValue(question3);
         component.currentIndex.set(2);
         component.onSubmit();
         expect(submitSpy).toHaveBeenCalledOnce();

--- a/src/main/webapp/app/quiz/overview/course-training-quiz/course-training-quiz.component.ts
+++ b/src/main/webapp/app/quiz/overview/course-training-quiz/course-training-quiz.component.ts
@@ -18,9 +18,10 @@ import { DragAndDropSubmittedAnswer } from 'app/quiz/shared/entities/drag-and-dr
 import { ShortAnswerSubmittedAnswer } from 'app/quiz/shared/entities/short-answer-submitted-answer.model';
 import { roundValueSpecifiedByCourseSettings } from 'app/shared/util/utils';
 import { CourseManagementService } from 'app/core/course/manage/services/course-management.service';
-import { QuizTrainingAnswer } from 'app/quiz/overview/course-training-quiz/QuizTrainingAnswer';
+import { QuizTrainingAnswer } from 'app/quiz/overview/course-training-quiz/quiz-training-answer.model';
 import { SubmittedAnswerAfterEvaluation } from 'app/quiz/overview/course-training-quiz/SubmittedAnswerAfterEvaluation';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { QuizQuestionTraining } from 'app/quiz/overview/course-training-quiz/quiz-question-training.model';
 
 @Component({
     selector: 'jhi-course-practice-quiz',
@@ -37,7 +38,7 @@ export class CourseTrainingQuizComponent {
     private router = inject(Router);
     private quizService = inject(CourseTrainingQuizService);
 
-    private static readonly INITIAL_QUESTIONS: QuizQuestion[] = [];
+    private static readonly INITIAL_QUESTIONS: QuizQuestionTraining[] = [];
 
     currentIndex = signal(0);
     private alertService = inject(AlertService);
@@ -101,7 +102,7 @@ export class CourseTrainingQuizComponent {
     nextQuestion(): void {
         if (this.currentIndex() < this.questions().length - 1) {
             this.currentIndex.set(this.currentIndex() + 1);
-            const question = this.currentQuestion();
+            const question = this.currentQuestion()?.quizQuestion;
             if (question) {
                 this.initQuestion(question);
             }
@@ -136,7 +137,7 @@ export class CourseTrainingQuizComponent {
      */
     applySelection() {
         this.trainingAnswer.submittedAnswer = undefined;
-        const question = this.currentQuestion();
+        const question = this.currentQuestion()?.quizQuestion;
         if (!question) {
             return;
         }
@@ -173,7 +174,7 @@ export class CourseTrainingQuizComponent {
      * Submits the quiz for practice
      */
     onSubmit() {
-        const questionId = this.currentQuestion()?.id;
+        const questionId = this.currentQuestion()?.quizQuestion?.id;
         if (!questionId) {
             this.alertService.addAlert({
                 type: AlertType.WARNING,
@@ -182,6 +183,7 @@ export class CourseTrainingQuizComponent {
             return;
         }
         this.applySelection();
+        this.trainingAnswer.isRated = this.currentQuestion()?.isRated;
         this.quizService.submitForTraining(this.trainingAnswer, questionId, this.courseId()).subscribe({
             next: (response: HttpResponse<SubmittedAnswerAfterEvaluation>) => {
                 if (response.body) {
@@ -218,7 +220,7 @@ export class CourseTrainingQuizComponent {
      * Applies the evaluated answer to the current question
      */
     applyEvaluatedAnswer(evaluatedAnswer: SubmittedAnswerAfterEvaluation) {
-        const question = this.currentQuestion();
+        const question = this.currentQuestion()?.quizQuestion;
         if (!question) return;
 
         switch (question.type) {

--- a/src/main/webapp/app/quiz/overview/course-training-quiz/quiz-question-training.model.ts
+++ b/src/main/webapp/app/quiz/overview/course-training-quiz/quiz-question-training.model.ts
@@ -1,0 +1,6 @@
+import { QuizQuestion } from 'app/quiz/shared/entities/quiz-question.model';
+
+export class QuizQuestionTraining {
+    public quizQuestion?: QuizQuestion;
+    public isRated?: boolean;
+}

--- a/src/main/webapp/app/quiz/overview/course-training-quiz/quiz-question-training.model.ts
+++ b/src/main/webapp/app/quiz/overview/course-training-quiz/quiz-question-training.model.ts
@@ -1,6 +1,6 @@
 import { QuizQuestion } from 'app/quiz/shared/entities/quiz-question.model';
 
 export class QuizQuestionTraining {
-    public quizQuestion?: QuizQuestion;
+    public quizQuestionWithSolutionDTO?: QuizQuestion;
     public isRated?: boolean;
 }

--- a/src/main/webapp/app/quiz/overview/course-training-quiz/quiz-training-answer.model.ts
+++ b/src/main/webapp/app/quiz/overview/course-training-quiz/quiz-training-answer.model.ts
@@ -2,6 +2,7 @@ import { SubmittedAnswer } from 'app/quiz/shared/entities/submitted-answer.model
 
 export class QuizTrainingAnswer {
     public submittedAnswer?: SubmittedAnswer;
+    public isRated?: boolean;
 
     constructor() {}
 }

--- a/src/main/webapp/app/quiz/overview/service/course-training-quiz.service.spec.ts
+++ b/src/main/webapp/app/quiz/overview/service/course-training-quiz.service.spec.ts
@@ -5,7 +5,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideHttpClient } from '@angular/common/http';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
-import { QuizTrainingAnswer } from '../course-training-quiz/QuizTrainingAnswer';
+import { QuizTrainingAnswer } from '../course-training-quiz/quiz-training-answer.model';
 import { SubmittedAnswerAfterEvaluation } from '../course-training-quiz/SubmittedAnswerAfterEvaluation';
 
 describe('CourseTrainingQuizService', () => {

--- a/src/main/webapp/app/quiz/overview/service/course-training-quiz.service.ts
+++ b/src/main/webapp/app/quiz/overview/service/course-training-quiz.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { QuizQuestion } from 'app/quiz/shared/entities/quiz-question.model';
-import { QuizTrainingAnswer } from 'app/quiz/overview/course-training-quiz/QuizTrainingAnswer';
+import { QuizTrainingAnswer } from 'app/quiz/overview/course-training-quiz/quiz-training-answer.model';
 import { SubmittedAnswerAfterEvaluation } from 'app/quiz/overview/course-training-quiz/SubmittedAnswerAfterEvaluation';
+import { QuizQuestionTraining } from 'app/quiz/overview/course-training-quiz/quiz-question-training.model';
 
 @Injectable({
     providedIn: 'root',
@@ -15,8 +15,8 @@ export class CourseTrainingQuizService {
      * Retrieves a set of quiz questions for a given course by course ID from the server and returns them as an Observable.
      * @param courseId
      */
-    getQuizQuestions(courseId: number): Observable<QuizQuestion[]> {
-        return this.http.get<QuizQuestion[]>(`api/quiz/courses/${courseId}/training-questions`);
+    getQuizQuestions(courseId: number): Observable<QuizQuestionTraining[]> {
+        return this.http.get<QuizQuestionTraining[]>(`api/quiz/courses/${courseId}/training-questions`);
     }
 
     submitForTraining(answer: QuizTrainingAnswer, questionId: number, courseId: number): Observable<HttpResponse<SubmittedAnswerAfterEvaluation>> {

--- a/src/main/webapp/i18n/de/quizQuestion.json
+++ b/src/main/webapp/i18n/de/quizQuestion.json
@@ -33,7 +33,8 @@
             "hideSampleSolution": "Blende die Musterlösung aus",
             "allOptions": "Wähle bitte alle richtigen Antwortmöglichkeiten aus.",
             "singleOption": "Wähle bitte die richtige Antwortmöglichkeit aus.",
-            "noQuestionDue": "Keine Fragen fällig, schaue morgen wieder vorbei."
+            "unratedConfirmation": "Es gibt keine fälligen Fragen. Möchtest du trotzdem im unbewerteten Modus trainieren?",
+            "unratedConfirmationTitle": "Keine fälligen Fragen"
         }
     }
 }

--- a/src/main/webapp/i18n/en/quizQuestion.json
+++ b/src/main/webapp/i18n/en/quizQuestion.json
@@ -33,7 +33,8 @@
             "hideSampleSolution": "Hide Sample Solution",
             "allOptions": "Please choose all correct answer options",
             "singleOption": "Please choose the correct answer option",
-            "noQuestionDue": "There are no questions due, come back tomorrow."
+            "unratedConfirmation": "There are no questions due. Do you still want to train in the unrated mode?",
+            "unratedConfirmationTitle": "No questions due"
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [ ] I **strictly** followed the principle of **data economy** for all database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.


#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ ] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [ ] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I translated all newly inserted strings into English and German.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


### Description
<!-- Describe your changes in detail -->


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
