### PR TITLE
`Integrated code lifecycle`: Fix build job queries for canceled jobs

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/BuildJobRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/BuildJobRepository.java
@@ -41,7 +41,7 @@ public interface BuildJobRepository extends ArtemisJpaRepository<BuildJob, Long>
     @Query("""
             SELECT b.id
             FROM BuildJob b
-            WHERE b.buildStatus not in (de.tum.cit.aet.artemis.programming.domain.build.BuildStatus.QUEUED, de.tum.cit.aet.artemis.programming.domain.build.BuildStatus.BUILDING )
+            WHERE b.buildStatus NOT IN (de.tum.cit.aet.artemis.programming.domain.build.BuildStatus.QUEUED, de.tum.cit.aet.artemis.programming.domain.build.BuildStatus.BUILDING)
             """)
     Slice<Long> findFinishedIds(Pageable pageable);
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/BuildJobRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/BuildJobRepository.java
@@ -50,8 +50,7 @@ public interface BuildJobRepository extends ArtemisJpaRepository<BuildJob, Long>
             SELECT b.id
             FROM BuildJob b
                 LEFT JOIN Course c ON b.courseId = c.id
-                WHERE b.buildStatus not in (de.tum.cit.aet.artemis.programming.domain.build.BuildStatus.QUEUED, de.tum.cit.aet.artemis.programming.domain.build.BuildStatus.BUILDING )
-                AND (:buildStatus IS NULL OR b.buildStatus = :buildStatus)
+                WHERE (:buildStatus IS NULL OR b.buildStatus = :buildStatus)
                 AND (:buildAgentAddress IS NULL OR b.buildAgentAddress = :buildAgentAddress)
                 AND (CAST(:startDate AS string) IS NULL OR b.buildSubmissionDate >= :startDate)
                 AND (CAST(:endDate AS string) IS NULL OR b.buildSubmissionDate <= :endDate)

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/BuildJobRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/BuildJobRepository.java
@@ -41,7 +41,7 @@ public interface BuildJobRepository extends ArtemisJpaRepository<BuildJob, Long>
     @Query("""
             SELECT b.id
             FROM BuildJob b
-            WHERE b.buildCompletionDate IS NOT NULL
+            WHERE b.buildStatus not in (de.tum.cit.aet.artemis.programming.domain.build.BuildStatus.QUEUED, de.tum.cit.aet.artemis.programming.domain.build.BuildStatus.BUILDING )
             """)
     Slice<Long> findFinishedIds(Pageable pageable);
 
@@ -50,7 +50,7 @@ public interface BuildJobRepository extends ArtemisJpaRepository<BuildJob, Long>
             SELECT b.id
             FROM BuildJob b
                 LEFT JOIN Course c ON b.courseId = c.id
-            WHERE b.buildCompletionDate IS NOT NULL
+                WHERE b.buildStatus not in (de.tum.cit.aet.artemis.programming.domain.build.BuildStatus.QUEUED, de.tum.cit.aet.artemis.programming.domain.build.BuildStatus.BUILDING )
                 AND (:buildStatus IS NULL OR b.buildStatus = :buildStatus)
                 AND (:buildAgentAddress IS NULL OR b.buildAgentAddress = :buildAgentAddress)
                 AND (CAST(:startDate AS string) IS NULL OR b.buildSubmissionDate >= :startDate)


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines]

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Cancelled jobs are not displayed in the build overview currently (see https://github.com/ls1intum/Artemis/pull/11145#pullrequestreview-3221966165)

### Description
- query jobs that are finished, i.e.  neither "Queued" or "Building"

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Use ts3 for ICL + admin account
Prerequisites:
- 1 Admin 
Steps:
1. go to Management->Build overview
2. check that the last build jobs are displayed correctly
3. Pause all build agents
4. Trigger a new build job (participate in one, or go the programming exercise -> manage -> retrigger the solution repository e.g. )
5. cancel the build job
6. check the build overview again and check if the canceled jobs shows up after refreshing 

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of “finished” build detection by using build status, ensuring completed builds appear consistently in lists and reports.
  * Fixed filtering so results reliably include builds that have completed even if a completion timestamp is missing.
  * Enhanced build filtering with explicit status-based criteria, working alongside existing filters (e.g., date range, course, agent, search term, duration) for more precise results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->