### PR TITLE
`Iris`: Support internal stages that are hidden in the client

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineService.java
@@ -122,8 +122,8 @@ public class PyrisPipelineService {
             Consumer<List<PyrisStageDTO>> statusUpdater) {
         // Define the preparation stages of pipeline execution with their initial states
         // There will be more stages added in Pyris later
-        var preparing = new PyrisStageDTO("Preparing", 10, null, null);
-        var executing = new PyrisStageDTO("Executing pipeline", 30, null, null);
+        var preparing = new PyrisStageDTO("Preparing", 10, null, null, false);
+        var executing = new PyrisStageDTO("Executing pipeline", 30, null, null, false);
 
         // Send initial status update indicating that the preparation stage is in progress
         statusUpdater.accept(List.of(preparing.inProgress(), executing.notStarted()));

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/dto/status/PyrisStageDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/dto/status/PyrisStageDTO.java
@@ -1,28 +1,29 @@
 package de.tum.cit.aet.artemis.iris.service.pyris.dto.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PyrisStageDTO(String name, int weight, PyrisStageState state, String message) {
+public record PyrisStageDTO(String name, int weight, PyrisStageState state, String message, @JsonProperty(defaultValue = "false") boolean internal) {
 
     public PyrisStageDTO notStarted() {
-        return new PyrisStageDTO(name, weight, PyrisStageState.NOT_STARTED, message);
+        return new PyrisStageDTO(name, weight, PyrisStageState.NOT_STARTED, message, internal);
     }
 
     public PyrisStageDTO inProgress() {
-        return new PyrisStageDTO(name, weight, PyrisStageState.IN_PROGRESS, message);
+        return new PyrisStageDTO(name, weight, PyrisStageState.IN_PROGRESS, message, internal);
     }
 
     public PyrisStageDTO error(String message) {
-        return new PyrisStageDTO(name, weight, PyrisStageState.ERROR, message);
+        return new PyrisStageDTO(name, weight, PyrisStageState.ERROR, message, internal);
     }
 
     public PyrisStageDTO done() {
-        return new PyrisStageDTO(name, weight, PyrisStageState.DONE, message);
+        return new PyrisStageDTO(name, weight, PyrisStageState.DONE, message, internal);
     }
 
     public PyrisStageDTO with(PyrisStageState state, String message) {
-        return new PyrisStageDTO(name, weight, state, message);
+        return new PyrisStageDTO(name, weight, state, message, internal);
     }
 
 }

--- a/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
+++ b/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
@@ -406,16 +406,20 @@ export class IrisChatService implements OnDestroy {
                     this.replaceOrAddMessage(payload.message);
                 }
                 if (payload.stages) {
-                    this.stages.next(payload.stages);
+                    this.stages.next(this.filterStages(payload.stages));
                 }
                 break;
             case IrisChatWebsocketPayloadType.STATUS:
-                this.stages.next(payload.stages || []);
+                this.stages.next(this.filterStages(payload.stages || []));
                 if (payload.suggestions) {
                     this.suggestions.next(payload.suggestions);
                 }
                 break;
         }
+    }
+
+    private filterStages(stages: IrisStageDTO[]): IrisStageDTO[] {
+        return stages.filter((stage) => !stage.internal);
     }
 
     protected close(): void {

--- a/src/main/webapp/app/iris/shared/entities/iris-stage-dto.model.ts
+++ b/src/main/webapp/app/iris/shared/entities/iris-stage-dto.model.ts
@@ -3,6 +3,8 @@ export class IrisStageDTO {
     weight: number;
     state: IrisStageStateDTO;
     message: string;
+    // Internal stages are not shown in the UI and are hidden from the user
+    internal: boolean;
 
     lowerCaseState?: string;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [ ] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [ ] I **strictly** followed the principle of **data economy** for all database calls.
- [ ] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.


#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ ] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [ ] I **strictly** followed the [client coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [ ] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We want to hide the long memory creation phase from the user and allow them to chat while it is running.

### Description
<!-- Describe your changes in detail -->
Soft-linked to https://github.com/ls1intum/edutelligence/pull/260.

I added an internal marker for stages. The UI filters out these stages and does not show them to the user, while still getting info from them.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Admin
- https://github.com/ls1intum/edutelligence/pull/260 deployed in the iris test server

1. Log in to Artemis
2. Go to the admin menu > Feature toggles
3. Enable Memiris
4. Go to User Settings > Learner Profile > Enable memory creation/usage
5. Go to a course dashboard
6. Chat with Iris
7. The Memory Creation stage will never show

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
