### PR TITLE
`Development`: Split text exercise resource

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -36,7 +36,7 @@ jobs:
 
           # TODO these values should become zero in the future
           max_large_classes=9
-          max_complex_beans=14
+          max_complex_beans=13
 
           echo "=========================================="
           echo "CODE QUALITY ANALYSIS SUMMARY"

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseCreationUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseCreationUpdateResource.java
@@ -1,0 +1,251 @@
+package de.tum.cit.aet.artemis.text.web;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.tum.cit.aet.artemis.athena.api.AthenaApi;
+import de.tum.cit.aet.artemis.atlas.api.CompetencyProgressApi;
+import de.tum.cit.aet.artemis.communication.repository.conversation.ChannelRepository;
+import de.tum.cit.aet.artemis.communication.service.conversation.ChannelService;
+import de.tum.cit.aet.artemis.communication.service.notifications.GroupNotificationScheduleService;
+import de.tum.cit.aet.artemis.core.domain.Course;
+import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
+import de.tum.cit.aet.artemis.core.exception.ConflictException;
+import de.tum.cit.aet.artemis.core.repository.UserRepository;
+import de.tum.cit.aet.artemis.core.security.Role;
+import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastEditor;
+import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
+import de.tum.cit.aet.artemis.core.service.course.CourseService;
+import de.tum.cit.aet.artemis.core.service.messaging.InstanceMessageSendService;
+import de.tum.cit.aet.artemis.exercise.repository.ParticipationRepository;
+import de.tum.cit.aet.artemis.exercise.service.ExerciseService;
+import de.tum.cit.aet.artemis.iris.api.IrisSettingsApi;
+import de.tum.cit.aet.artemis.lecture.api.SlideApi;
+import de.tum.cit.aet.artemis.text.config.TextEnabled;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
+import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
+
+/**
+ * REST controller for creating and updating text exercises.
+ */
+@Conditional(TextEnabled.class)
+@Lazy
+@RestController
+@RequestMapping("api/text/")
+public class TextExerciseCreationUpdateResource {
+
+    private static final Logger log = LoggerFactory.getLogger(TextExerciseCreationUpdateResource.class);
+
+    private static final String ENTITY_NAME = "textExercise";
+
+    private final ExerciseService exerciseService;
+
+    private final CourseService courseService;
+
+    private final AuthorizationCheckService authCheckService;
+
+    private final GroupNotificationScheduleService groupNotificationScheduleService;
+
+    private final InstanceMessageSendService instanceMessageSendService;
+
+    private final ChannelService channelService;
+
+    private final Optional<AthenaApi> athenaApi;
+
+    private final Optional<CompetencyProgressApi> competencyProgressApi;
+
+    private final Optional<IrisSettingsApi> irisSettingsApi;
+
+    private final Optional<SlideApi> slideApi;
+
+    private final TextExerciseRepository textExerciseRepository;
+
+    private final UserRepository userRepository;
+
+    private final ParticipationRepository participationRepository;
+
+    private final ChannelRepository channelRepository;
+
+    public TextExerciseCreationUpdateResource(TextExerciseRepository textExerciseRepository, UserRepository userRepository, AuthorizationCheckService authCheckService,
+            CourseService courseService, ParticipationRepository participationRepository, ExerciseService exerciseService,
+            GroupNotificationScheduleService groupNotificationScheduleService, InstanceMessageSendService instanceMessageSendService, ChannelService channelService,
+            ChannelRepository channelRepository, Optional<AthenaApi> athenaApi, Optional<CompetencyProgressApi> competencyProgressApi, Optional<IrisSettingsApi> irisSettingsApi,
+            Optional<SlideApi> slideApi) {
+        this.textExerciseRepository = textExerciseRepository;
+        this.userRepository = userRepository;
+        this.courseService = courseService;
+        this.authCheckService = authCheckService;
+        this.participationRepository = participationRepository;
+        this.groupNotificationScheduleService = groupNotificationScheduleService;
+        this.exerciseService = exerciseService;
+        this.instanceMessageSendService = instanceMessageSendService;
+        this.channelService = channelService;
+        this.channelRepository = channelRepository;
+        this.athenaApi = athenaApi;
+        this.competencyProgressApi = competencyProgressApi;
+        this.irisSettingsApi = irisSettingsApi;
+        this.slideApi = slideApi;
+    }
+
+    /**
+     * POST /text-exercises : Create a new textExercise.
+     *
+     * @param textExercise the textExercise to create
+     * @return the ResponseEntity with status 201 (Created) and with body the new textExercise, or
+     *         with status 400 (Bad Request) if the textExercise has already an ID
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @PostMapping("text-exercises")
+    @EnforceAtLeastEditor
+    public ResponseEntity<TextExercise> createTextExercise(@RequestBody TextExercise textExercise) throws URISyntaxException {
+        log.debug("REST request to save TextExercise : {}", textExercise);
+        if (textExercise.getId() != null) {
+            throw new BadRequestAlertException("A new textExercise cannot already have an ID", ENTITY_NAME, "idExists");
+        }
+
+        if (textExercise.getTitle() == null) {
+            throw new BadRequestAlertException("A new textExercise needs a title", ENTITY_NAME, "missingtitle");
+        }
+        // validates general settings: points, dates
+        textExercise.validateGeneralSettings();
+        // Valid exercises have set either a course or an exerciseGroup
+        textExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
+
+        // Retrieve the course over the exerciseGroup or the given courseId
+        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(textExercise);
+        // Check that the user is authorized to create the exercise
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, null);
+
+        // Check that only allowed athena modules are used
+        athenaApi.ifPresentOrElse(api -> api.checkHasAccessToAthenaModule(textExercise, course, ENTITY_NAME), () -> textExercise.setFeedbackSuggestionModule(null));
+
+        TextExercise result = exerciseService.saveWithCompetencyLinks(textExercise, textExerciseRepository::save);
+
+        channelService.createExerciseChannel(result, Optional.ofNullable(textExercise.getChannelName()));
+        instanceMessageSendService.sendTextExerciseSchedule(result.getId());
+        groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(textExercise);
+        competencyProgressApi.ifPresent(api -> api.updateProgressByLearningObjectAsync(result));
+
+        irisSettingsApi.ifPresent(api -> api.setEnabledForExerciseByCategories(result, new HashSet<>()));
+
+        return ResponseEntity.created(new URI("/api/text/text-exercises/" + result.getId())).body(result);
+    }
+
+    /**
+     * PUT /text-exercises : Updates an existing textExercise.
+     *
+     * @param textExercise     the textExercise to update
+     * @param notificationText about the text exercise update that should be displayed for the
+     *                             student group
+     * @return the ResponseEntity with status 200 (OK) and with body the updated textExercise, or
+     *         with status 400 (Bad Request) if the textExercise is not valid, or with status 500 (Internal
+     *         Server Error) if the textExercise couldn't be updated
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @PutMapping("text-exercises")
+    @EnforceAtLeastEditor
+    public ResponseEntity<TextExercise> updateTextExercise(@RequestBody TextExercise textExercise,
+            @RequestParam(value = "notificationText", required = false) String notificationText) throws URISyntaxException {
+        log.debug("REST request to update TextExercise : {}", textExercise);
+        if (textExercise.getId() == null) {
+            return createTextExercise(textExercise);
+        }
+        // validates general settings: points, dates
+        textExercise.validateGeneralSettings();
+        // Valid exercises have set either a course or an exerciseGroup
+        textExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
+
+        // Check that the user is authorized to update the exercise
+        var user = userRepository.getUserWithGroupsAndAuthorities();
+        // Important: use the original exercise for permission check
+        final TextExercise textExerciseBeforeUpdate = textExerciseRepository.findWithEagerCompetenciesAndCategoriesByIdElseThrow(textExercise.getId());
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, textExerciseBeforeUpdate, user);
+
+        // Forbid changing the course the exercise belongs to.
+        if (!Objects.equals(textExerciseBeforeUpdate.getCourseViaExerciseGroupOrCourseMember().getId(), textExercise.getCourseViaExerciseGroupOrCourseMember().getId())) {
+            throw new ConflictException("Exercise course id does not match the stored course id", ENTITY_NAME, "cannotChangeCourseId");
+        }
+
+        // Forbid conversion between normal course exercise and exam exercise
+        exerciseService.checkForConversionBetweenExamAndCourseExercise(textExercise, textExerciseBeforeUpdate, ENTITY_NAME);
+
+        // Check that only allowed athena modules are used
+        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(textExerciseBeforeUpdate);
+        athenaApi.ifPresentOrElse(api -> api.checkHasAccessToAthenaModule(textExercise, course, ENTITY_NAME), () -> textExercise.setFeedbackSuggestionModule(null));
+        // Changing Athena module after the due date has passed is not allowed
+        athenaApi.ifPresent(api -> api.checkValidAthenaModuleChange(textExerciseBeforeUpdate, textExercise, ENTITY_NAME));
+
+        channelService.updateExerciseChannel(textExerciseBeforeUpdate, textExercise);
+
+        TextExercise updatedTextExercise = exerciseService.saveWithCompetencyLinks(textExercise, textExerciseRepository::save);
+
+        exerciseService.logUpdate(updatedTextExercise, updatedTextExercise.getCourseViaExerciseGroupOrCourseMember(), user);
+        exerciseService.updatePointsInRelatedParticipantScores(textExerciseBeforeUpdate, updatedTextExercise);
+        participationRepository.removeIndividualDueDatesIfBeforeDueDate(updatedTextExercise, textExerciseBeforeUpdate.getDueDate());
+        instanceMessageSendService.sendTextExerciseSchedule(updatedTextExercise.getId());
+        exerciseService.checkExampleSubmissions(updatedTextExercise);
+        exerciseService.notifyAboutExerciseChanges(textExerciseBeforeUpdate, updatedTextExercise, notificationText);
+        slideApi.ifPresent(api -> api.handleDueDateChange(textExerciseBeforeUpdate, updatedTextExercise));
+
+        competencyProgressApi.ifPresent(api -> api.updateProgressForUpdatedLearningObjectAsync(textExerciseBeforeUpdate, Optional.of(textExercise)));
+
+        irisSettingsApi.ifPresent(api -> api.setEnabledForExerciseByCategories(textExercise, textExerciseBeforeUpdate.getCategories()));
+
+        return ResponseEntity.ok(updatedTextExercise);
+    }
+
+    /**
+     * PUT /text-exercises/{exerciseId}/re-evaluate : Re-evaluates and updates an existing textExercise.
+     *
+     * @param exerciseId                                  of the exercise
+     * @param textExercise                                the textExercise to re-evaluate and update
+     * @param deleteFeedbackAfterGradingInstructionUpdate boolean flag that indicates whether the associated feedback should be deleted or not
+     * @return the ResponseEntity with status 200 (OK) and with body the updated textExercise, or
+     *         with status 400 (Bad Request) if the textExercise is not valid, or with status 409 (Conflict)
+     *         if given exerciseId is not same as in the object of the request body, or with status 500
+     *         (Internal Server Error) if the textExercise couldn't be updated
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @PutMapping("text-exercises/{exerciseId}/re-evaluate")
+    @EnforceAtLeastEditor
+    public ResponseEntity<TextExercise> reEvaluateAndUpdateTextExercise(@PathVariable long exerciseId, @RequestBody TextExercise textExercise,
+            @RequestParam(value = "deleteFeedback", required = false) Boolean deleteFeedbackAfterGradingInstructionUpdate) throws URISyntaxException {
+        log.debug("REST request to re-evaluate TextExercise : {}", textExercise);
+
+        // check that the exercise exists for given id
+        textExerciseRepository.findByIdWithStudentParticipationsAndSubmissionsElseThrow(exerciseId);
+
+        authCheckService.checkGivenExerciseIdSameForExerciseInRequestBodyElseThrow(exerciseId, textExercise);
+
+        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(textExercise);
+
+        // Check that the user is authorized to update the exercise
+        User user = userRepository.getUserWithGroupsAndAuthorities();
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, user);
+
+        exerciseService.reEvaluateExercise(textExercise, deleteFeedbackAfterGradingInstructionUpdate);
+
+        return updateTextExercise(textExercise, null);
+    }
+
+    public ChannelRepository getChannelRepository() {
+        return channelRepository;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseCreationUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseCreationUpdateResource.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.artemis.athena.api.AthenaApi;
 import de.tum.cit.aet.artemis.atlas.api.CompetencyProgressApi;
-import de.tum.cit.aet.artemis.communication.repository.conversation.ChannelRepository;
 import de.tum.cit.aet.artemis.communication.service.conversation.ChannelService;
 import de.tum.cit.aet.artemis.communication.service.notifications.GroupNotificationScheduleService;
 import de.tum.cit.aet.artemis.core.domain.Course;
@@ -81,13 +80,10 @@ public class TextExerciseCreationUpdateResource {
 
     private final ParticipationRepository participationRepository;
 
-    private final ChannelRepository channelRepository;
-
     public TextExerciseCreationUpdateResource(TextExerciseRepository textExerciseRepository, UserRepository userRepository, AuthorizationCheckService authCheckService,
             CourseService courseService, ParticipationRepository participationRepository, ExerciseService exerciseService,
             GroupNotificationScheduleService groupNotificationScheduleService, InstanceMessageSendService instanceMessageSendService, ChannelService channelService,
-            ChannelRepository channelRepository, Optional<AthenaApi> athenaApi, Optional<CompetencyProgressApi> competencyProgressApi, Optional<IrisSettingsApi> irisSettingsApi,
-            Optional<SlideApi> slideApi) {
+            Optional<AthenaApi> athenaApi, Optional<CompetencyProgressApi> competencyProgressApi, Optional<IrisSettingsApi> irisSettingsApi, Optional<SlideApi> slideApi) {
         this.textExerciseRepository = textExerciseRepository;
         this.userRepository = userRepository;
         this.courseService = courseService;
@@ -97,7 +93,6 @@ public class TextExerciseCreationUpdateResource {
         this.exerciseService = exerciseService;
         this.instanceMessageSendService = instanceMessageSendService;
         this.channelService = channelService;
-        this.channelRepository = channelRepository;
         this.athenaApi = athenaApi;
         this.competencyProgressApi = competencyProgressApi;
         this.irisSettingsApi = irisSettingsApi;
@@ -243,9 +238,5 @@ public class TextExerciseCreationUpdateResource {
         exerciseService.reEvaluateExercise(textExercise, deleteFeedbackAfterGradingInstructionUpdate);
 
         return updateTextExercise(textExercise, null);
-    }
-
-    public ChannelRepository getChannelRepository() {
-        return channelRepository;
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseExportImportResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseExportImportResource.java
@@ -1,0 +1,138 @@
+package de.tum.cit.aet.artemis.text.web;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.tum.cit.aet.artemis.athena.api.AthenaApi;
+import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
+import de.tum.cit.aet.artemis.core.repository.UserRepository;
+import de.tum.cit.aet.artemis.core.security.Role;
+import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastEditor;
+import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastTutor;
+import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
+import de.tum.cit.aet.artemis.core.service.feature.Feature;
+import de.tum.cit.aet.artemis.core.service.feature.FeatureToggle;
+import de.tum.cit.aet.artemis.core.util.ResponseUtil;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionExportOptionsDTO;
+import de.tum.cit.aet.artemis.text.config.TextEnabled;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
+import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
+import de.tum.cit.aet.artemis.text.service.TextExerciseImportService;
+import de.tum.cit.aet.artemis.text.service.TextSubmissionExportService;
+
+/**
+ * REST controller for managing TextExercise.
+ */
+@Conditional(TextEnabled.class)
+@Lazy
+@RestController
+@RequestMapping("api/text/")
+public class TextExerciseExportImportResource {
+
+    private static final Logger log = LoggerFactory.getLogger(TextExerciseExportImportResource.class);
+
+    private static final String ENTITY_NAME = "textExercise";
+
+    private final TextExerciseImportService textExerciseImportService;
+
+    private final TextSubmissionExportService textSubmissionExportService;
+
+    private final AuthorizationCheckService authCheckService;
+
+    private final Optional<AthenaApi> athenaApi;
+
+    private final TextExerciseRepository textExerciseRepository;
+
+    private final UserRepository userRepository;
+
+    public TextExerciseExportImportResource(TextExerciseRepository textExerciseRepository, UserRepository userRepository, AuthorizationCheckService authCheckService,
+            TextExerciseImportService textExerciseImportService, TextSubmissionExportService textSubmissionExportService, Optional<AthenaApi> athenaApi) {
+        this.textExerciseRepository = textExerciseRepository;
+        this.userRepository = userRepository;
+        this.authCheckService = authCheckService;
+        this.textExerciseImportService = textExerciseImportService;
+        this.textSubmissionExportService = textSubmissionExportService;
+        this.athenaApi = athenaApi;
+    }
+
+    /**
+     * POST /text-exercises/import: Imports an existing text exercise into an existing course
+     * <p>
+     * This will import the whole exercise except for the participations and dates. Referenced
+     * entities will get cloned and assigned a new id.
+     *
+     * @param sourceExerciseId The ID of the original exercise which should get imported
+     * @param importedExercise The new exercise containing values that should get overwritten in the
+     *                             imported exercise, s.a. the title or difficulty
+     * @return The imported exercise (200), a not found error (404) if the template does not exist,
+     *         or a forbidden error (403) if the user is not at least an instructor in the target course.
+     * @throws URISyntaxException When the URI of the response entity is invalid
+     */
+    @PostMapping("text-exercises/import/{sourceExerciseId}")
+    @EnforceAtLeastEditor
+    public ResponseEntity<TextExercise> importExercise(@PathVariable long sourceExerciseId, @RequestBody TextExercise importedExercise) throws URISyntaxException {
+        if (sourceExerciseId <= 0 || (importedExercise.getCourseViaExerciseGroupOrCourseMember() == null && importedExercise.getExerciseGroup() == null)) {
+            log.debug("Either the courseId or exerciseGroupId must be set for an import");
+            throw new BadRequestAlertException("Either the courseId or exerciseGroupId must be set for an import", ENTITY_NAME, "noCourseIdOrExerciseGroupId");
+        }
+        importedExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
+        final var user = userRepository.getUserWithGroupsAndAuthorities();
+        final var originalTextExercise = textExerciseRepository.findByIdWithExampleSubmissionsAndResultsElseThrow(sourceExerciseId);
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, importedExercise, user);
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, originalTextExercise, user);
+        // validates general settings: points, dates
+        importedExercise.validateGeneralSettings();
+
+        // Athena: Check that only allowed athena modules are used, if not we catch the exception and disable feedback suggestions for the imported exercise
+        // If Athena is disabled and the service is not present, we also disable feedback suggestions
+        try {
+            athenaApi.ifPresentOrElse(api -> api.checkHasAccessToAthenaModule(importedExercise, importedExercise.getCourseViaExerciseGroupOrCourseMember(), ENTITY_NAME),
+                    () -> importedExercise.setFeedbackSuggestionModule(null));
+        }
+        catch (BadRequestAlertException e) {
+            importedExercise.setFeedbackSuggestionModule(null);
+        }
+
+        final var newTextExercise = textExerciseImportService.importTextExercise(originalTextExercise, importedExercise);
+        textExerciseRepository.save(newTextExercise);
+
+        return ResponseEntity.created(new URI("/api/text/text-exercises/" + newTextExercise.getId())).body(newTextExercise);
+    }
+
+    /**
+     * POST /text-exercises/:exerciseId/export-submissions : sends exercise submissions as zip
+     *
+     * @param exerciseId              the id of the exercise to get the repos from
+     * @param submissionExportOptions the options that should be used for the export
+     * @return ResponseEntity with status
+     */
+    @PostMapping("text-exercises/{exerciseId}/export-submissions")
+    @EnforceAtLeastTutor
+    @FeatureToggle(Feature.Exports)
+    public ResponseEntity<Resource> exportSubmissions(@PathVariable long exerciseId, @RequestBody SubmissionExportOptionsDTO submissionExportOptions) {
+        TextExercise textExercise = textExerciseRepository.findByIdElseThrow(exerciseId);
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, textExercise, null);
+
+        // TAs are not allowed to download all participations
+        if (submissionExportOptions.isExportAllParticipants()) {
+            authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, textExercise.getCourseViaExerciseGroupOrCourseMember(), null);
+        }
+
+        Path zipFilePath = textSubmissionExportService.exportStudentSubmissionsElseThrow(exerciseId, submissionExportOptions);
+        return ResponseUtil.ok(zipFilePath);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextExercisePlagiarismResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextExercisePlagiarismResource.java
@@ -1,0 +1,112 @@
+package de.tum.cit.aet.artemis.text.web;
+
+import static de.tum.cit.aet.artemis.plagiarism.web.PlagiarismResultResponseBuilder.buildPlagiarismResultResponse;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.jplag.exceptions.ExitException;
+import de.tum.cit.aet.artemis.core.security.Role;
+import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastEditor;
+import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
+import de.tum.cit.aet.artemis.core.service.feature.Feature;
+import de.tum.cit.aet.artemis.core.service.feature.FeatureToggle;
+import de.tum.cit.aet.artemis.core.util.TimeLogUtil;
+import de.tum.cit.aet.artemis.plagiarism.api.PlagiarismDetectionApi;
+import de.tum.cit.aet.artemis.plagiarism.api.PlagiarismResultApi;
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismDetectionConfigHelper;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismResultDTO;
+import de.tum.cit.aet.artemis.plagiarism.exception.PlagiarismApiNotPresentException;
+import de.tum.cit.aet.artemis.text.config.TextEnabled;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
+import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
+
+/**
+ * REST controller for handling plagiarism detection and results for Text Exercises.
+ */
+@Conditional(TextEnabled.class)
+@Lazy
+@RestController
+@RequestMapping("api/text/")
+public class TextExercisePlagiarismResource {
+
+    private static final Logger log = LoggerFactory.getLogger(TextExercisePlagiarismResource.class);
+
+    private final AuthorizationCheckService authCheckService;
+
+    private final Optional<PlagiarismResultApi> plagiarismResultApi;
+
+    private final Optional<PlagiarismDetectionApi> plagiarismDetectionApi;
+
+    private final TextExerciseRepository textExerciseRepository;
+
+    public TextExercisePlagiarismResource(TextExerciseRepository textExerciseRepository, Optional<PlagiarismResultApi> plagiarismResultApi,
+            AuthorizationCheckService authCheckService, Optional<PlagiarismDetectionApi> plagiarismDetectionApi) {
+        this.plagiarismResultApi = plagiarismResultApi;
+        this.textExerciseRepository = textExerciseRepository;
+        this.authCheckService = authCheckService;
+        this.plagiarismDetectionApi = plagiarismDetectionApi;
+    }
+
+    /**
+     * GET /text-exercises/{exerciseId}/plagiarism-result
+     * <p>
+     * Return the latest plagiarism result or null, if no plagiarism was detected for this exercise
+     * yet.
+     *
+     * @param exerciseId ID of the text exercise for which the plagiarism result should be returned
+     * @return The ResponseEntity with status 200 (Ok) or with status 400 (Bad Request) if the
+     *         parameters are invalid
+     */
+    @GetMapping("text-exercises/{exerciseId}/plagiarism-result")
+    @EnforceAtLeastEditor
+    public ResponseEntity<PlagiarismResultDTO> getPlagiarismResult(@PathVariable long exerciseId) {
+        log.debug("REST request to get the latest plagiarism result for the text exercise with id: {}", exerciseId);
+        PlagiarismResultApi api = plagiarismResultApi.orElseThrow(() -> new PlagiarismApiNotPresentException(PlagiarismResultApi.class));
+
+        TextExercise textExercise = textExerciseRepository.findByIdWithStudentParticipationsAndSubmissionsElseThrow(exerciseId);
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, textExercise, null);
+        var plagiarismResult = api.findFirstWithComparisonsByExerciseIdOrderByLastModifiedDateDescOrNull(textExercise.getId());
+        api.prepareResultForClient(plagiarismResult);
+        return buildPlagiarismResultResponse(plagiarismResult);
+    }
+
+    /**
+     * GET /text-exercises/{exerciseId}/check-plagiarism
+     * <p>
+     * Start the automated plagiarism detection for the given exercise and return its result.
+     *
+     * @param exerciseId          ID of the exercise for which to detect plagiarism
+     * @param similarityThreshold ignore comparisons whose similarity is below this threshold (in % between 0 and 100)
+     * @param minimumScore        consider only submissions whose score is greater or equal to this value
+     * @param minimumSize         consider only submissions whose size is greater or equal to this value
+     * @return the ResponseEntity with status 200 (OK) and the list of at most 500 pair-wise submissions with a similarity above the given threshold (e.g. 50%).
+     */
+    @GetMapping("text-exercises/{exerciseId}/check-plagiarism")
+    @FeatureToggle(Feature.PlagiarismChecks)
+    @EnforceAtLeastEditor
+    public ResponseEntity<PlagiarismResultDTO> checkPlagiarism(@PathVariable long exerciseId, @RequestParam int similarityThreshold, @RequestParam int minimumScore,
+            @RequestParam int minimumSize) throws ExitException {
+        PlagiarismDetectionApi api = plagiarismDetectionApi.orElseThrow(() -> new PlagiarismApiNotPresentException(PlagiarismDetectionApi.class));
+
+        TextExercise textExercise = textExerciseRepository.findByIdWithStudentParticipationsAndSubmissionsElseThrow(exerciseId);
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, textExercise, null);
+
+        long start = System.nanoTime();
+        log.info("Started manual plagiarism checks for text exercise: exerciseId={}.", exerciseId);
+        PlagiarismDetectionConfigHelper.updateWithTemporaryParameters(textExercise, similarityThreshold, minimumScore, minimumSize);
+        var plagiarismResult = api.checkTextExercise(textExercise);
+        log.info("Finished manual plagiarism checks for text exercise: exerciseId={}, elapsed={}.", exerciseId, TimeLogUtil.formatDurationFrom(start));
+        return buildPlagiarismResultResponse(plagiarismResult);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseResource.java
@@ -1,13 +1,7 @@
 package de.tum.cit.aet.artemis.text.web;
 
-import static de.tum.cit.aet.artemis.plagiarism.web.PlagiarismResultResponseBuilder.buildPlagiarismResultResponse;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -16,19 +10,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import de.jplag.exceptions.ExitException;
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.assessment.domain.ExampleSubmission;
 import de.tum.cit.aet.artemis.assessment.domain.Feedback;
@@ -37,21 +26,15 @@ import de.tum.cit.aet.artemis.assessment.domain.Result;
 import de.tum.cit.aet.artemis.assessment.repository.ExampleSubmissionRepository;
 import de.tum.cit.aet.artemis.assessment.repository.FeedbackRepository;
 import de.tum.cit.aet.artemis.assessment.repository.GradingCriterionRepository;
-import de.tum.cit.aet.artemis.assessment.repository.ResultRepository;
 import de.tum.cit.aet.artemis.assessment.repository.TextBlockRepository;
-import de.tum.cit.aet.artemis.athena.api.AthenaApi;
-import de.tum.cit.aet.artemis.atlas.api.CompetencyProgressApi;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Channel;
 import de.tum.cit.aet.artemis.communication.repository.conversation.ChannelRepository;
-import de.tum.cit.aet.artemis.communication.service.conversation.ChannelService;
-import de.tum.cit.aet.artemis.communication.service.notifications.GroupNotificationScheduleService;
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.dto.SearchResultPageDTO;
 import de.tum.cit.aet.artemis.core.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
-import de.tum.cit.aet.artemis.core.exception.ConflictException;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.core.repository.CourseRepository;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
@@ -61,38 +44,22 @@ import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastInstructor
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastTutor;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
-import de.tum.cit.aet.artemis.core.service.course.CourseService;
-import de.tum.cit.aet.artemis.core.service.feature.Feature;
-import de.tum.cit.aet.artemis.core.service.feature.FeatureToggle;
-import de.tum.cit.aet.artemis.core.service.messaging.InstanceMessageSendService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
-import de.tum.cit.aet.artemis.core.util.ResponseUtil;
-import de.tum.cit.aet.artemis.core.util.TimeLogUtil;
 import de.tum.cit.aet.artemis.exam.api.ExamAccessApi;
 import de.tum.cit.aet.artemis.exam.config.ExamApiNotPresentException;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
-import de.tum.cit.aet.artemis.exercise.dto.SubmissionExportOptionsDTO;
-import de.tum.cit.aet.artemis.exercise.repository.ParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseDateService;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseDeletionService;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseService;
-import de.tum.cit.aet.artemis.iris.api.IrisSettingsApi;
-import de.tum.cit.aet.artemis.lecture.api.SlideApi;
-import de.tum.cit.aet.artemis.plagiarism.api.PlagiarismDetectionApi;
-import de.tum.cit.aet.artemis.plagiarism.api.PlagiarismResultApi;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismDetectionConfigHelper;
-import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismResultDTO;
-import de.tum.cit.aet.artemis.plagiarism.exception.PlagiarismApiNotPresentException;
 import de.tum.cit.aet.artemis.text.config.TextEnabled;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
-import de.tum.cit.aet.artemis.text.service.TextExerciseImportService;
 import de.tum.cit.aet.artemis.text.service.TextExerciseService;
-import de.tum.cit.aet.artemis.text.service.TextSubmissionExportService;
 
 /**
  * REST controller for managing TextExercise.
@@ -110,206 +77,53 @@ public class TextExerciseResource {
     @Value("${jhipster.clientApp.name}")
     private String applicationName;
 
-    private final FeedbackRepository feedbackRepository;
-
-    private final TextBlockRepository textBlockRepository;
-
     private final TextExerciseService textExerciseService;
 
     private final ExerciseService exerciseService;
 
     private final ExerciseDeletionService exerciseDeletionService;
 
-    private final Optional<PlagiarismResultApi> plagiarismResultApi;
-
-    private final TextExerciseRepository textExerciseRepository;
-
-    private final TextExerciseImportService textExerciseImportService;
-
-    private final TextSubmissionExportService textSubmissionExportService;
-
-    private final UserRepository userRepository;
-
-    private final CourseService courseService;
-
     private final AuthorizationCheckService authCheckService;
-
-    private final StudentParticipationRepository studentParticipationRepository;
-
-    private final ParticipationRepository participationRepository;
-
-    private final ResultRepository resultRepository;
-
-    private final ExampleSubmissionRepository exampleSubmissionRepository;
-
-    private final GroupNotificationScheduleService groupNotificationScheduleService;
-
-    private final GradingCriterionRepository gradingCriterionRepository;
-
-    private final InstanceMessageSendService instanceMessageSendService;
-
-    private final Optional<PlagiarismDetectionApi> plagiarismDetectionApi;
-
-    private final CourseRepository courseRepository;
-
-    private final ChannelService channelService;
-
-    private final ChannelRepository channelRepository;
-
-    private final Optional<AthenaApi> athenaApi;
 
     private final Optional<ExamAccessApi> examAccessApi;
 
-    private final Optional<CompetencyProgressApi> competencyProgressApi;
+    private final FeedbackRepository feedbackRepository;
 
-    private final Optional<IrisSettingsApi> irisSettingsApi;
+    private final TextBlockRepository textBlockRepository;
 
-    private final Optional<SlideApi> slideApi;
+    private final TextExerciseRepository textExerciseRepository;
+
+    private final UserRepository userRepository;
+
+    private final StudentParticipationRepository studentParticipationRepository;
+
+    private final ExampleSubmissionRepository exampleSubmissionRepository;
+
+    private final GradingCriterionRepository gradingCriterionRepository;
+
+    private final CourseRepository courseRepository;
+
+    private final ChannelRepository channelRepository;
 
     public TextExerciseResource(TextExerciseRepository textExerciseRepository, TextExerciseService textExerciseService, FeedbackRepository feedbackRepository,
-            ExerciseDeletionService exerciseDeletionService, Optional<PlagiarismResultApi> plagiarismResultApi, UserRepository userRepository,
-            AuthorizationCheckService authCheckService, CourseService courseService, StudentParticipationRepository studentParticipationRepository,
-            ParticipationRepository participationRepository, ResultRepository resultRepository, TextExerciseImportService textExerciseImportService,
-            TextSubmissionExportService textSubmissionExportService, ExampleSubmissionRepository exampleSubmissionRepository, ExerciseService exerciseService,
-            GradingCriterionRepository gradingCriterionRepository, TextBlockRepository textBlockRepository, GroupNotificationScheduleService groupNotificationScheduleService,
-            InstanceMessageSendService instanceMessageSendService, Optional<PlagiarismDetectionApi> plagiarismDetectionApi, CourseRepository courseRepository,
-            ChannelService channelService, ChannelRepository channelRepository, Optional<AthenaApi> athenaApi, Optional<CompetencyProgressApi> competencyProgressApi,
-            Optional<IrisSettingsApi> irisSettingsApi, Optional<ExamAccessApi> examAccessApi, Optional<SlideApi> slideApi) {
+            ExerciseDeletionService exerciseDeletionService, UserRepository userRepository, AuthorizationCheckService authCheckService,
+            StudentParticipationRepository studentParticipationRepository, ExampleSubmissionRepository exampleSubmissionRepository, ExerciseService exerciseService,
+            GradingCriterionRepository gradingCriterionRepository, TextBlockRepository textBlockRepository, CourseRepository courseRepository, ChannelRepository channelRepository,
+            Optional<ExamAccessApi> examAccessApi) {
         this.feedbackRepository = feedbackRepository;
         this.exerciseDeletionService = exerciseDeletionService;
-        this.plagiarismResultApi = plagiarismResultApi;
         this.textBlockRepository = textBlockRepository;
         this.textExerciseService = textExerciseService;
         this.textExerciseRepository = textExerciseRepository;
         this.userRepository = userRepository;
-        this.courseService = courseService;
         this.authCheckService = authCheckService;
         this.studentParticipationRepository = studentParticipationRepository;
-        this.participationRepository = participationRepository;
-        this.resultRepository = resultRepository;
-        this.textExerciseImportService = textExerciseImportService;
-        this.textSubmissionExportService = textSubmissionExportService;
-        this.groupNotificationScheduleService = groupNotificationScheduleService;
         this.exampleSubmissionRepository = exampleSubmissionRepository;
         this.exerciseService = exerciseService;
         this.gradingCriterionRepository = gradingCriterionRepository;
-        this.instanceMessageSendService = instanceMessageSendService;
-        this.plagiarismDetectionApi = plagiarismDetectionApi;
         this.courseRepository = courseRepository;
-        this.channelService = channelService;
         this.channelRepository = channelRepository;
-        this.athenaApi = athenaApi;
         this.examAccessApi = examAccessApi;
-        this.competencyProgressApi = competencyProgressApi;
-        this.irisSettingsApi = irisSettingsApi;
-        this.slideApi = slideApi;
-    }
-
-    /**
-     * POST /text-exercises : Create a new textExercise.
-     *
-     * @param textExercise the textExercise to create
-     * @return the ResponseEntity with status 201 (Created) and with body the new textExercise, or
-     *         with status 400 (Bad Request) if the textExercise has already an ID
-     * @throws URISyntaxException if the Location URI syntax is incorrect
-     */
-    @PostMapping("text-exercises")
-    @EnforceAtLeastEditor
-    public ResponseEntity<TextExercise> createTextExercise(@RequestBody TextExercise textExercise) throws URISyntaxException {
-        log.debug("REST request to save TextExercise : {}", textExercise);
-        if (textExercise.getId() != null) {
-            throw new BadRequestAlertException("A new textExercise cannot already have an ID", ENTITY_NAME, "idExists");
-        }
-
-        if (textExercise.getTitle() == null) {
-            throw new BadRequestAlertException("A new textExercise needs a title", ENTITY_NAME, "missingtitle");
-        }
-        // validates general settings: points, dates
-        textExercise.validateGeneralSettings();
-        // Valid exercises have set either a course or an exerciseGroup
-        textExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
-
-        // Retrieve the course over the exerciseGroup or the given courseId
-        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(textExercise);
-        // Check that the user is authorized to create the exercise
-        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, null);
-
-        // Check that only allowed athena modules are used
-        athenaApi.ifPresentOrElse(api -> api.checkHasAccessToAthenaModule(textExercise, course, ENTITY_NAME), () -> textExercise.setFeedbackSuggestionModule(null));
-
-        TextExercise result = exerciseService.saveWithCompetencyLinks(textExercise, textExerciseRepository::save);
-
-        channelService.createExerciseChannel(result, Optional.ofNullable(textExercise.getChannelName()));
-        instanceMessageSendService.sendTextExerciseSchedule(result.getId());
-        groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(textExercise);
-        competencyProgressApi.ifPresent(api -> api.updateProgressByLearningObjectAsync(result));
-
-        irisSettingsApi.ifPresent(api -> api.setEnabledForExerciseByCategories(result, new HashSet<>()));
-
-        return ResponseEntity.created(new URI("/api/text/text-exercises/" + result.getId())).body(result);
-    }
-
-    /**
-     * PUT /text-exercises : Updates an existing textExercise.
-     *
-     * @param textExercise     the textExercise to update
-     * @param notificationText about the text exercise update that should be displayed for the
-     *                             student group
-     * @return the ResponseEntity with status 200 (OK) and with body the updated textExercise, or
-     *         with status 400 (Bad Request) if the textExercise is not valid, or with status 500 (Internal
-     *         Server Error) if the textExercise couldn't be updated
-     * @throws URISyntaxException if the Location URI syntax is incorrect
-     */
-    @PutMapping("text-exercises")
-    @EnforceAtLeastEditor
-    public ResponseEntity<TextExercise> updateTextExercise(@RequestBody TextExercise textExercise,
-            @RequestParam(value = "notificationText", required = false) String notificationText) throws URISyntaxException {
-        log.debug("REST request to update TextExercise : {}", textExercise);
-        if (textExercise.getId() == null) {
-            return createTextExercise(textExercise);
-        }
-        // validates general settings: points, dates
-        textExercise.validateGeneralSettings();
-        // Valid exercises have set either a course or an exerciseGroup
-        textExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
-
-        // Check that the user is authorized to update the exercise
-        var user = userRepository.getUserWithGroupsAndAuthorities();
-        // Important: use the original exercise for permission check
-        final TextExercise textExerciseBeforeUpdate = textExerciseRepository.findWithEagerCompetenciesAndCategoriesByIdElseThrow(textExercise.getId());
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, textExerciseBeforeUpdate, user);
-
-        // Forbid changing the course the exercise belongs to.
-        if (!Objects.equals(textExerciseBeforeUpdate.getCourseViaExerciseGroupOrCourseMember().getId(), textExercise.getCourseViaExerciseGroupOrCourseMember().getId())) {
-            throw new ConflictException("Exercise course id does not match the stored course id", ENTITY_NAME, "cannotChangeCourseId");
-        }
-
-        // Forbid conversion between normal course exercise and exam exercise
-        exerciseService.checkForConversionBetweenExamAndCourseExercise(textExercise, textExerciseBeforeUpdate, ENTITY_NAME);
-
-        // Check that only allowed athena modules are used
-        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(textExerciseBeforeUpdate);
-        athenaApi.ifPresentOrElse(api -> api.checkHasAccessToAthenaModule(textExercise, course, ENTITY_NAME), () -> textExercise.setFeedbackSuggestionModule(null));
-        // Changing Athena module after the due date has passed is not allowed
-        athenaApi.ifPresent(api -> api.checkValidAthenaModuleChange(textExerciseBeforeUpdate, textExercise, ENTITY_NAME));
-
-        channelService.updateExerciseChannel(textExerciseBeforeUpdate, textExercise);
-
-        TextExercise updatedTextExercise = exerciseService.saveWithCompetencyLinks(textExercise, textExerciseRepository::save);
-
-        exerciseService.logUpdate(updatedTextExercise, updatedTextExercise.getCourseViaExerciseGroupOrCourseMember(), user);
-        exerciseService.updatePointsInRelatedParticipantScores(textExerciseBeforeUpdate, updatedTextExercise);
-        participationRepository.removeIndividualDueDatesIfBeforeDueDate(updatedTextExercise, textExerciseBeforeUpdate.getDueDate());
-        instanceMessageSendService.sendTextExerciseSchedule(updatedTextExercise.getId());
-        exerciseService.checkExampleSubmissions(updatedTextExercise);
-        exerciseService.notifyAboutExerciseChanges(textExerciseBeforeUpdate, updatedTextExercise, notificationText);
-        slideApi.ifPresent(api -> api.handleDueDateChange(textExerciseBeforeUpdate, updatedTextExercise));
-
-        competencyProgressApi.ifPresent(api -> api.updateProgressForUpdatedLearningObjectAsync(textExerciseBeforeUpdate, Optional.of(textExercise)));
-
-        irisSettingsApi.ifPresent(api -> api.setEnabledForExerciseByCategories(textExercise, textExerciseBeforeUpdate.getCategories()));
-
-        return ResponseEntity.ok(updatedTextExercise);
     }
 
     /**
@@ -502,158 +316,5 @@ public class TextExerciseResource {
             @RequestParam(defaultValue = "true") boolean isCourseFilter, @RequestParam(defaultValue = "true") boolean isExamFilter) {
         final var user = userRepository.getUserWithGroupsAndAuthorities();
         return ResponseEntity.ok(textExerciseService.getAllOnPageWithSize(search, isCourseFilter, isExamFilter, user));
-    }
-
-    /**
-     * POST /text-exercises/import: Imports an existing text exercise into an existing course
-     * <p>
-     * This will import the whole exercise except for the participations and dates. Referenced
-     * entities will get cloned and assigned a new id.
-     *
-     * @param sourceExerciseId The ID of the original exercise which should get imported
-     * @param importedExercise The new exercise containing values that should get overwritten in the
-     *                             imported exercise, s.a. the title or difficulty
-     * @return The imported exercise (200), a not found error (404) if the template does not exist,
-     *         or a forbidden error (403) if the user is not at least an instructor in the target course.
-     * @throws URISyntaxException When the URI of the response entity is invalid
-     */
-    @PostMapping("text-exercises/import/{sourceExerciseId}")
-    @EnforceAtLeastEditor
-    public ResponseEntity<TextExercise> importExercise(@PathVariable long sourceExerciseId, @RequestBody TextExercise importedExercise) throws URISyntaxException {
-        if (sourceExerciseId <= 0 || (importedExercise.getCourseViaExerciseGroupOrCourseMember() == null && importedExercise.getExerciseGroup() == null)) {
-            log.debug("Either the courseId or exerciseGroupId must be set for an import");
-            throw new BadRequestAlertException("Either the courseId or exerciseGroupId must be set for an import", ENTITY_NAME, "noCourseIdOrExerciseGroupId");
-        }
-        importedExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
-        final var user = userRepository.getUserWithGroupsAndAuthorities();
-        final var originalTextExercise = textExerciseRepository.findByIdWithExampleSubmissionsAndResultsElseThrow(sourceExerciseId);
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, importedExercise, user);
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, originalTextExercise, user);
-        // validates general settings: points, dates
-        importedExercise.validateGeneralSettings();
-
-        // Athena: Check that only allowed athena modules are used, if not we catch the exception and disable feedback suggestions for the imported exercise
-        // If Athena is disabled and the service is not present, we also disable feedback suggestions
-        try {
-            athenaApi.ifPresentOrElse(api -> api.checkHasAccessToAthenaModule(importedExercise, importedExercise.getCourseViaExerciseGroupOrCourseMember(), ENTITY_NAME),
-                    () -> importedExercise.setFeedbackSuggestionModule(null));
-        }
-        catch (BadRequestAlertException e) {
-            importedExercise.setFeedbackSuggestionModule(null);
-        }
-
-        final var newTextExercise = textExerciseImportService.importTextExercise(originalTextExercise, importedExercise);
-        textExerciseRepository.save(newTextExercise);
-
-        return ResponseEntity.created(new URI("/api/text/text-exercises/" + newTextExercise.getId())).body(newTextExercise);
-    }
-
-    /**
-     * POST /text-exercises/:exerciseId/export-submissions : sends exercise submissions as zip
-     *
-     * @param exerciseId              the id of the exercise to get the repos from
-     * @param submissionExportOptions the options that should be used for the export
-     * @return ResponseEntity with status
-     */
-    @PostMapping("text-exercises/{exerciseId}/export-submissions")
-    @EnforceAtLeastTutor
-    @FeatureToggle(Feature.Exports)
-    public ResponseEntity<Resource> exportSubmissions(@PathVariable long exerciseId, @RequestBody SubmissionExportOptionsDTO submissionExportOptions) {
-        TextExercise textExercise = textExerciseRepository.findByIdElseThrow(exerciseId);
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, textExercise, null);
-
-        // TAs are not allowed to download all participations
-        if (submissionExportOptions.isExportAllParticipants()) {
-            authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, textExercise.getCourseViaExerciseGroupOrCourseMember(), null);
-        }
-
-        Path zipFilePath = textSubmissionExportService.exportStudentSubmissionsElseThrow(exerciseId, submissionExportOptions);
-        return ResponseUtil.ok(zipFilePath);
-    }
-
-    /**
-     * GET /text-exercises/{exerciseId}/plagiarism-result
-     * <p>
-     * Return the latest plagiarism result or null, if no plagiarism was detected for this exercise
-     * yet.
-     *
-     * @param exerciseId ID of the text exercise for which the plagiarism result should be returned
-     * @return The ResponseEntity with status 200 (Ok) or with status 400 (Bad Request) if the
-     *         parameters are invalid
-     */
-    @GetMapping("text-exercises/{exerciseId}/plagiarism-result")
-    @EnforceAtLeastEditor
-    public ResponseEntity<PlagiarismResultDTO> getPlagiarismResult(@PathVariable long exerciseId) {
-        log.debug("REST request to get the latest plagiarism result for the text exercise with id: {}", exerciseId);
-        PlagiarismResultApi api = plagiarismResultApi.orElseThrow(() -> new PlagiarismApiNotPresentException(PlagiarismResultApi.class));
-
-        TextExercise textExercise = textExerciseRepository.findByIdWithStudentParticipationsAndSubmissionsElseThrow(exerciseId);
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, textExercise, null);
-        var plagiarismResult = api.findFirstWithComparisonsByExerciseIdOrderByLastModifiedDateDescOrNull(textExercise.getId());
-        api.prepareResultForClient(plagiarismResult);
-        return buildPlagiarismResultResponse(plagiarismResult);
-    }
-
-    /**
-     * GET /text-exercises/{exerciseId}/check-plagiarism
-     * <p>
-     * Start the automated plagiarism detection for the given exercise and return its result.
-     *
-     * @param exerciseId          ID of the exercise for which to detect plagiarism
-     * @param similarityThreshold ignore comparisons whose similarity is below this threshold (in % between 0 and 100)
-     * @param minimumScore        consider only submissions whose score is greater or equal to this value
-     * @param minimumSize         consider only submissions whose size is greater or equal to this value
-     * @return the ResponseEntity with status 200 (OK) and the list of at most 500 pair-wise submissions with a similarity above the given threshold (e.g. 50%).
-     */
-    @GetMapping("text-exercises/{exerciseId}/check-plagiarism")
-    @FeatureToggle(Feature.PlagiarismChecks)
-    @EnforceAtLeastEditor
-    public ResponseEntity<PlagiarismResultDTO> checkPlagiarism(@PathVariable long exerciseId, @RequestParam int similarityThreshold, @RequestParam int minimumScore,
-            @RequestParam int minimumSize) throws ExitException {
-        PlagiarismDetectionApi api = plagiarismDetectionApi.orElseThrow(() -> new PlagiarismApiNotPresentException(PlagiarismDetectionApi.class));
-
-        TextExercise textExercise = textExerciseRepository.findByIdWithStudentParticipationsAndSubmissionsElseThrow(exerciseId);
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, textExercise, null);
-
-        long start = System.nanoTime();
-        log.info("Started manual plagiarism checks for text exercise: exerciseId={}.", exerciseId);
-        PlagiarismDetectionConfigHelper.updateWithTemporaryParameters(textExercise, similarityThreshold, minimumScore, minimumSize);
-        var plagiarismResult = api.checkTextExercise(textExercise);
-        log.info("Finished manual plagiarism checks for text exercise: exerciseId={}, elapsed={}.", exerciseId, TimeLogUtil.formatDurationFrom(start));
-        return buildPlagiarismResultResponse(plagiarismResult);
-    }
-
-    /**
-     * PUT /text-exercises/{exerciseId}/re-evaluate : Re-evaluates and updates an existing textExercise.
-     *
-     * @param exerciseId                                  of the exercise
-     * @param textExercise                                the textExercise to re-evaluate and update
-     * @param deleteFeedbackAfterGradingInstructionUpdate boolean flag that indicates whether the associated feedback should be deleted or not
-     * @return the ResponseEntity with status 200 (OK) and with body the updated textExercise, or
-     *         with status 400 (Bad Request) if the textExercise is not valid, or with status 409 (Conflict)
-     *         if given exerciseId is not same as in the object of the request body, or with status 500
-     *         (Internal Server Error) if the textExercise couldn't be updated
-     * @throws URISyntaxException if the Location URI syntax is incorrect
-     */
-    @PutMapping("text-exercises/{exerciseId}/re-evaluate")
-    @EnforceAtLeastEditor
-    public ResponseEntity<TextExercise> reEvaluateAndUpdateTextExercise(@PathVariable long exerciseId, @RequestBody TextExercise textExercise,
-            @RequestParam(value = "deleteFeedback", required = false) Boolean deleteFeedbackAfterGradingInstructionUpdate) throws URISyntaxException {
-        log.debug("REST request to re-evaluate TextExercise : {}", textExercise);
-
-        // check that the exercise exists for given id
-        textExerciseRepository.findByIdWithStudentParticipationsAndSubmissionsElseThrow(exerciseId);
-
-        authCheckService.checkGivenExerciseIdSameForExerciseInRequestBodyElseThrow(exerciseId, textExercise);
-
-        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(textExercise);
-
-        // Check that the user is authorized to update the exercise
-        User user = userRepository.getUserWithGroupsAndAuthorities();
-        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, user);
-
-        exerciseService.reEvaluateExercise(textExercise, deleteFeedbackAfterGradingInstructionUpdate);
-
-        return updateTextExercise(textExercise, null);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Text Resource is our rest controller with the third most dependencies.

### Description
<!-- Describe your changes in detail -->
Split Text Resource into Text Resource, TextExportImportResource, TextCreationUpdateResource and TextPlagiarismResource


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Code Review

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints for creating, updating, and re-evaluating text exercises.
  * Added import of text exercises and export of submissions.
  * Added viewing of latest plagiarism results and triggering plagiarism checks.

* **Refactor**
  * Moved creation/update/import/export/re-evaluation/plagiarism functionality into dedicated text API controllers and simplified the original text exercise resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->