### PR TITLE
`Development`: Fix time logging formatting for edge cases

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/util/TimeLogUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/TimeLogUtil.java
@@ -3,7 +3,7 @@ package de.tum.cit.aet.artemis.core.util;
 public class TimeLogUtil {
 
     /**
-     * calculate the difference to the given start time in nano seconds and format it in a readable way
+     * calculate the difference to the given start time in nanoseconds and format it in a readable way
      *
      * @param timeNanoStart the time of the first measurement in nanoseconds
      * @return formatted string of the duration between now and timeNanoStart

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/TimeLogUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/TimeLogUtil.java
@@ -1,7 +1,5 @@
 package de.tum.cit.aet.artemis.core.util;
 
-import org.apache.commons.lang3.time.DurationFormatUtils;
-
 public class TimeLogUtil {
 
     /**
@@ -32,21 +30,18 @@ public class TimeLogUtil {
          */
         int durationInMinutes = (int) (durationInSeconds / 60.0);
         if (durationInMinutes < 60) {
-            return durationInMinutes + ":" + ((int) durationInSeconds % 60) + "min";
+            return durationInMinutes + ":" + padTo2Digits((int) durationInSeconds % 60) + "min";
         }
 
         int durationInHours = durationInMinutes / 60;
-        return durationInHours + ":" + (durationInMinutes % 60) + "hours";
-    }
-
-    public static String formatDuration(long durationInSeconds) {
-        if (durationInSeconds < 60) {
-            return durationInSeconds + "s";
-        }
-        return DurationFormatUtils.formatDuration(durationInSeconds * 1000, "HH:mm:ss") + " (HH:mm:ss)";
+        return durationInHours + ":" + padTo2Digits(durationInMinutes % 60) + "hours";
     }
 
     private static String roundOffTo2DecPlaces(double val) {
         return String.format("%.2f", val);
+    }
+
+    private static String padTo2Digits(int val) {
+        return String.format("%02d", val);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
In https://github.com/ls1intum/Artemis/pull/11161 a feature was added but it unfortunately came with a small "bug". Namely when it showed `<minutes>:<seconds>`  or `<hours>:<minutes>`, and the part after the colon was `< 10`, then it didn't print a `0`, which leads to weird outputs like `1:5min` instead of `1:05min`.

### Description
Added padding to fix the issue explained in `Motivation and Context`. Also deleted an unused function from the `TimeLogUtil` class.


### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Time durations now consistently display two-digit minutes and seconds (e.g., 03:07), improving readability and uniformity across all views.

* **Documentation**
  * Minor wording correction in descriptions (“nanoseconds” terminology).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->