### PR TITLE
`General`: Fix calendar events rendering edge cases

### DIFF
--- a/src/main/webapp/app/core/calendar/desktop/week-presentation/calendar-desktop-week-presentation.component.ts
+++ b/src/main/webapp/app/core/calendar/desktop/week-presentation/calendar-desktop-week-presentation.component.ts
@@ -14,7 +14,7 @@ import { CalendarEventsPerDaySectionComponent } from 'app/core/calendar/shared/c
 export class CalendarDesktopWeekPresentationComponent implements AfterViewInit {
     private static readonly INITIAL_SCROLL_HOURS_AFTER_MIDNIGHT = 7.5;
     private static readonly INITIAL_SCROLL_POSITION =
-        CalendarDesktopWeekPresentationComponent.INITIAL_SCROLL_HOURS_AFTER_MIDNIGHT * CalendarEventsPerDaySectionComponent.HOUR_SEGMENT_HEIGHT_IN_PIXEL;
+        CalendarDesktopWeekPresentationComponent.INITIAL_SCROLL_HOURS_AFTER_MIDNIGHT * CalendarEventsPerDaySectionComponent.HOUR_HEIGHT_IN_PIXEL;
     firstDayOfCurrentWeek = input.required<Dayjs>();
     isEventSelected = signal<boolean>(false);
     scrollContainer = viewChild<ElementRef>('scrollContainer');

--- a/src/main/webapp/app/core/calendar/mobile/day-presentation/calendar-mobile-day-presentation.component.ts
+++ b/src/main/webapp/app/core/calendar/mobile/day-presentation/calendar-mobile-day-presentation.component.ts
@@ -15,7 +15,7 @@ type Day = { date: Dayjs; isSelected: boolean; id: string };
 export class CalendarMobileDayPresentationComponent implements AfterViewInit {
     private static readonly INITIAL_SCROLL_HOURS_AFTER_MIDNIGHT = 7.5;
     private static readonly INITIAL_SCROLL_POSITION =
-        CalendarMobileDayPresentationComponent.INITIAL_SCROLL_HOURS_AFTER_MIDNIGHT * CalendarEventsPerDaySectionComponent.HOUR_SEGMENT_HEIGHT_IN_PIXEL;
+        CalendarMobileDayPresentationComponent.INITIAL_SCROLL_HOURS_AFTER_MIDNIGHT * CalendarEventsPerDaySectionComponent.HOUR_HEIGHT_IN_PIXEL;
     readonly utils = utils;
     private scrollContainer = viewChild<ElementRef>('scrollContainer');
 

--- a/src/main/webapp/app/core/calendar/shared/calendar-events-per-day-section/calendar-events-per-day-section.component.ts
+++ b/src/main/webapp/app/core/calendar/shared/calendar-events-per-day-section/calendar-events-per-day-section.component.ts
@@ -17,12 +17,19 @@ type Day = { date: Dayjs; eventsAndPositions: CalendarEventAndPosition[]; id: st
     styleUrl: './calendar-events-per-day-section.component.scss',
 })
 export class CalendarEventsPerDaySectionComponent {
+    // amount of pixels in 1rem
     static readonly PIXELS_PER_REM = 16;
+    // height of one hour in the grid that is part of the template (measured in rem)
     static readonly HOUR_HEIGHT_IN_REM = 3.5;
+    // height of one hour in the grid that is part of the template (measured in px)
     static readonly HOUR_HEIGHT_IN_PIXEL = CalendarEventsPerDaySectionComponent.HOUR_HEIGHT_IN_REM * CalendarEventsPerDaySectionComponent.PIXELS_PER_REM;
+    // amount of pixels that represent 1min in the grid that is part of the template
     static readonly PIXELS_PER_MINUTE = CalendarEventsPerDaySectionComponent.HOUR_HEIGHT_IN_PIXEL / 60;
+    // amount of minutes represented by 1px in the grid that is part of the template
     static readonly MINUTES_PER_PIXEL = 1 / CalendarEventsPerDaySectionComponent.PIXELS_PER_MINUTE;
+    // default height for events that are displayed in the template (equivalent to 1.5rem)
     static readonly DEFAULT_EVENT_HEIGHT_IN_PIXEL = 24;
+    // rounded amount of minutes that is equivalent to the default height of events
     static readonly DEFAULT_EVENT_LENGTH_IN_MINUTES = Math.ceil(
         CalendarEventsPerDaySectionComponent.DEFAULT_EVENT_HEIGHT_IN_PIXEL * CalendarEventsPerDaySectionComponent.MINUTES_PER_PIXEL,
     );


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When displaying events in the week view on desktop devices or in the day view on mobile devices, the client must determine whether events overlap in order to render them correctly. Some events only specify a start date but no end date. To ensure these events remain clickable and their titles remain readable, they are assigned a default minimal height. Consequently, during overlap calculation, events without an explicit end date should be given a default end date corresponding to this minimal height. Previously, this was not done. Additionally, it was possible for events to have a smaller height than the default height if the end date was set accordingly.


### Description
<!-- Describe your changes in detail -->
This PR fixes this by setting the endDate of events without endDate according to the default height. Events that have an end date but would be smaller than the default height also get default height.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Open [this](https://artemis-test2.artemis.cit.tum.de/courses/85/calendar) calendar.
2. Verify that the exercise start event is rendered next to the lecture event, even though the start event takes place a bit before the lecture start. Verify that because of this the events do not visually overlap.
3. Verify that the title of the lecture is not vertically clipped even though the event is only 5min long.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1261" height="610" alt="Bildschirmfoto 2025-09-22 um 19 32 50" src="https://github.com/user-attachments/assets/d8042768-b048-4ccc-bfae-ebe26b2d9235" />
(Test data for this PR before the changes were made. Shows 2 broken events: one without end date and one with end date that is smaller than the default height)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Very short or end-less events now display with a minimum height to remain visible.

- Bug Fixes
  - More accurate initial scroll position in desktop week and mobile day views.
  - Improved event overlap handling to prevent visual collisions.
  - Consistent event positioning and heights across the calendar.
  - Smoother minute-to-pixel scaling reduces layout glitches.

- Refactor
  - Standardized calendar sizing and time-to-pixel calculations to unify layout behavior across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->