### PR TITLE
`Development`: Move calendar event sorting from client to server

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/web/CalendarResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/CalendarResource.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -219,7 +220,8 @@ public class CalendarResource {
                 .collect(Collectors.toSet());
         Set<CalendarEventDTO> filteredDTOs = CalendarUtil.filterForEventsOverlappingMonths(calendarEventDTOs, months, clientTimeZone);
         Set<CalendarEventDTO> splitDTOs = CalendarUtil.splitEventsSpanningMultipleDaysIfNecessary(filteredDTOs, clientTimeZone);
-        Map<String, List<CalendarEventDTO>> calendarEventDTOsByDay = splitDTOs.stream()
+        List<CalendarEventDTO> sortedDTOs = splitDTOs.stream().sorted(Comparator.comparing(CalendarEventDTO::startDate)).toList();
+        Map<String, List<CalendarEventDTO>> calendarEventDTOsByDay = sortedDTOs.stream()
                 .collect(Collectors.groupingBy(dto -> dto.startDate().withZoneSameInstant(clientTimeZone).toLocalDate().toString()));
 
         return ResponseEntity.ok(calendarEventDTOsByDay);

--- a/src/main/webapp/app/core/calendar/mobile/month-presentation/calendar-mobile-month-presentation.component.ts
+++ b/src/main/webapp/app/core/calendar/mobile/month-presentation/calendar-mobile-month-presentation.component.ts
@@ -16,7 +16,7 @@ type Week = { days: Day[]; id: string };
     styleUrl: './calendar-mobile-month-presentation.component.scss',
 })
 export class CalendarMobileMonthPresentationComponent {
-    private dateToEventsMao = inject(CalendarService).eventMap;
+    private dateToEventsMap = inject(CalendarService).eventMap;
 
     readonly CalendarEventType = CalendarEventType;
 
@@ -33,7 +33,7 @@ export class CalendarMobileMonthPresentationComponent {
             const days: Day[] = [];
             for (let i = 0; i < 7; i++) {
                 const id = date.format('YYYY-MM-DD');
-                const events = this.dateToEventsMao().get(id) ?? [];
+                const events = this.dateToEventsMap().get(id) ?? [];
                 const firstTwoEvents = utils.limitToLengthTwo(events);
                 const isInDisplayedMonth = utils.areDatesInSameMonth(date, firstDateOfMonth);
                 days.push({ date: date, events, firstTwoEvents, isInDisplayedMonth, id });

--- a/src/main/webapp/app/core/calendar/shared/calendar-events-per-day-section/calendar-events-per-day-section.component.ts
+++ b/src/main/webapp/app/core/calendar/shared/calendar-events-per-day-section/calendar-events-per-day-section.component.ts
@@ -20,8 +20,8 @@ export class CalendarEventsPerDaySectionComponent {
     static readonly PIXELS_PER_REM = 16;
     static readonly HOUR_SEGMENT_HEIGHT_IN_PIXEL = 3.5 * CalendarEventsPerDaySectionComponent.PIXELS_PER_REM;
 
-    private eventService = inject(CalendarService);
-    private dateToEventAndPositionMap = computed(() => this.computeDateToEventAndPositionMap(this.eventService.eventMap(), this.dates()));
+    private calendarService = inject(CalendarService);
+    private dateToEventAndPositionMap = computed(() => this.computeDateToEventAndPositionMap(this.calendarService.eventMap(), this.dates()));
     private popover?: NgbPopover;
 
     readonly CalendarEventType = CalendarEventType;
@@ -88,12 +88,9 @@ export class CalendarEventsPerDaySectionComponent {
         if (calendarEvents.length === 0) {
             return [];
         }
-
-        const sorted = [...calendarEvents].sort((firstEvent, secondEvent) => firstEvent.startDate.diff(secondEvent.startDate));
-
         const eventsWithPositions: CalendarEventAndPosition[] = [];
         let currentGroup: CalendarEvent[] = [];
-        for (const event of sorted) {
+        for (const event of calendarEvents) {
             if (currentGroup.length === 0 || currentGroup.some((otherEvent) => this.doEventsOverlap(otherEvent, event))) {
                 currentGroup.push(event);
             } else {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Previously, events were sorted by start date in the week and day presentations, but not in the month presentations. While sorting is not strictly required in the month views—since its main purpose is to show which events occur on which day—we still want to guarantee a stable ordering within a day. Without this, the order of events on a single day might change in the month views after a refresh. To ensure consistent behavior, it would be preferable to move the sorting logic to the server and return events sorted by default.


### Description
<!-- Describe your changes in detail -->
This PR adds sorting to the endpoints that serves events to the Artemis client. Also it fixes a typo.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
- [x] laptop
- [x] mobile phone

1. Choose an unchecked option from the list above and check it.
2. Visit this calendar with the device you chose as an instructor.
3. Verify that events are sorted correctly (laptop: in month presentation and week presentation | mobile: in month presentation and day presentation)


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.


### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar events now appear in a consistent, predictable order across month and day views.
  * Improved grouping and positioning of overlapping events to reduce visual glitches and misalignment.

* **Refactor**
  * Cleaned up internal naming and streamlined data flow for calendar components to improve maintainability without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->