### PR TITLE
`Development`: Fix CourseLocalVCJenkinsIntegrationTest flakiness

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/service/course/CourseStatsService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/course/CourseStatsService.java
@@ -47,6 +47,7 @@ import de.tum.cit.aet.artemis.core.repository.CourseRepository;
 import de.tum.cit.aet.artemis.core.repository.LLMTokenUsageTraceRepository;
 import de.tum.cit.aet.artemis.core.repository.StatisticsRepository;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
+import de.tum.cit.aet.artemis.core.util.TimeUtil;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.IncludedInOverallScore;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
@@ -363,8 +364,8 @@ public class CourseStatsService {
      * @return end date of the time span
      */
     public ZonedDateTime determineEndDateForActiveStudents(Course course) {
-        var endDate = ZonedDateTime.now();
-        if (course.getEndDate() != null && ZonedDateTime.now().isAfter(course.getEndDate())) {
+        var endDate = TimeUtil.now();
+        if (course.getEndDate() != null && TimeUtil.now().isAfter(course.getEndDate())) {
             endDate = course.getEndDate();
         }
         return endDate;

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.core.util;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
@@ -91,7 +92,8 @@ public class TimeUtil {
      * @param newClock the new Clock instance to set
      */
     public static void setClock(Clock newClock) {
-        clock = newClock;
+        clock = Objects.requireNonNull(newClock, "Clock must not be null");
+
     }
 
     public static void resetClock() {

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
@@ -1,12 +1,16 @@
 package de.tum.cit.aet.artemis.core.util;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 
 public class TimeUtil {
+
+    private static volatile Clock clock = Clock.systemDefaultZone();
 
     /**
      * Private constructor to prevent instantiation.
@@ -62,5 +66,21 @@ public class TimeUtil {
             return null;
         }
         return zonedDateTime.toInstant();
+    }
+
+    public static ZonedDateTime now() {
+        return ZonedDateTime.now(clock);
+    }
+
+    public static ZonedDateTime now(ZoneId zone) {
+        return ZonedDateTime.now(clock.withZone(zone));
+    }
+
+    public static void setClock(Clock newClock) {
+        clock = newClock;
+    }
+
+    public static void resetClock() {
+        clock = Clock.systemDefaultZone();
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
@@ -83,6 +83,13 @@ public class TimeUtil {
         return ZonedDateTime.now(clock);
     }
 
+    /**
+     * Sets a new Clock instance.
+     * This is used for testing purposes to control the current time.
+     * When no longer needed, the clock should be reset to the system default using {@link #resetClock()}.
+     *
+     * @param newClock the new Clock instance to set
+     */
     public static void setClock(Clock newClock) {
         clock = newClock;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
@@ -91,7 +91,7 @@ public class TimeUtil {
      *
      * @param newClock the new Clock instance to set
      */
-    public static void setClock(Clock newClock) {
+    public static void setClock(@NotNull Clock newClock) {
         clock = Objects.requireNonNull(newClock, "Clock must not be null");
 
     }

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
@@ -2,12 +2,16 @@ package de.tum.cit.aet.artemis.core.util;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 
+/**
+ * Utility class for time-related operations.
+ * It provides methods to calculate relative time, convert between ZonedDateTime and Instant, and get the current time.
+ * It also allows setting a custom Clock for testing purposes.
+ */
 public class TimeUtil {
 
     private static volatile Clock clock = Clock.systemDefaultZone();
@@ -68,12 +72,15 @@ public class TimeUtil {
         return zonedDateTime.toInstant();
     }
 
+    /**
+     * Calculates the current ZonedDateTime based on the current clock.
+     * In production, this is the system default clock.
+     * In tests, the clock can be set to a fixed time for consistent results.
+     *
+     * @return the current ZonedDateTime
+     */
     public static ZonedDateTime now() {
         return ZonedDateTime.now(clock);
-    }
-
-    public static ZonedDateTime now(ZoneId zone) {
-        return ZonedDateTime.now(clock.withZone(zone));
     }
 
     public static void setClock(Clock newClock) {

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/CourseTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/CourseTestService.java
@@ -20,8 +20,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2686,6 +2688,8 @@ public class CourseTestService {
     public void testGetCourseManagementDetailData() throws Exception {
         adjustUserGroupsToCustomGroups();
         // we inject a fixed clock in our tests that TimeUtil uses, so the timestamp below is always the same in tests.
+        Clock fixedClock = Clock.fixed(Instant.parse("2025-09-10T10:25:00Z"), ZoneOffset.UTC);
+        TimeUtil.setClock(fixedClock);
         ZonedDateTime now = TimeUtil.now();
         // add courses with exercises
         var courses = courseUtilService.createCoursesWithExercisesAndLectures(userPrefix, true, 5);

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/CourseTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/CourseTestService.java
@@ -2685,8 +2685,8 @@ public class CourseTestService {
     // Test
     public void testGetCourseManagementDetailData() throws Exception {
         adjustUserGroupsToCustomGroups();
-        // TODO: we should use fixed dates here to avoid flakiness, e.g. mock the clock
-        ZonedDateTime now = ZonedDateTime.now();
+        // we inject a fixed clock in our tests that TimeUtil uses, so the timestamp below is always the same in tests.
+        ZonedDateTime now = TimeUtil.now();
         // add courses with exercises
         var courses = courseUtilService.createCoursesWithExercisesAndLectures(userPrefix, true, 5);
         var course1 = courses.getFirst();

--- a/src/test/java/de/tum/cit/aet/artemis/programming/CourseLocalVCJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/CourseLocalVCJenkinsIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,6 +19,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.util.CourseFactory;
+import de.tum.cit.aet.artemis.core.util.TimeUtil;
 
 class CourseLocalVCJenkinsIntegrationTest extends AbstractProgrammingIntegrationJenkinsLocalVCTest {
 
@@ -27,6 +29,11 @@ class CourseLocalVCJenkinsIntegrationTest extends AbstractProgrammingIntegration
     void setup() {
         courseTestService.setup(TEST_PREFIX, this);
         jenkinsRequestMockProvider.enableMockingOfRequests();
+    }
+
+    @AfterAll
+    static void resetClock() {
+        TimeUtil.resetClock();
     }
 
     @Test
@@ -777,6 +784,7 @@ class CourseLocalVCJenkinsIntegrationTest extends AbstractProgrammingIntegration
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testGetCourseManagementDetailData() throws Exception {
+        // This test uses a fixed clock to prevent flakiness related to weeks either included in the interval or not depending on the weekday.
         courseTestService.testGetCourseManagementDetailData();
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -7,12 +7,15 @@ import static org.mockito.Mockito.doReturn;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
 import jakarta.mail.internet.MimeMessage;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,6 +58,7 @@ import de.tum.cit.aet.artemis.core.util.HibernateQueryInterceptor;
 import de.tum.cit.aet.artemis.core.util.QueryCountAssert;
 import de.tum.cit.aet.artemis.core.util.RequestUtilService;
 import de.tum.cit.aet.artemis.core.util.ThrowingProducer;
+import de.tum.cit.aet.artemis.core.util.TimeUtil;
 import de.tum.cit.aet.artemis.exam.service.ExamAccessService;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseTestRepository;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
@@ -202,6 +206,8 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
         // Set the static file upload path for all tests
         // This makes it a simple unit test that doesn't require a server start.
         FilePathConverter.setFileUploadPath(rootPath);
+        Clock fixedClock = Clock.fixed(Instant.parse("2025-09-09T10:25:00Z"), ZoneOffset.UTC);
+        TimeUtil.setClock(fixedClock);
     }
 
     @BeforeEach
@@ -221,6 +227,11 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
     @AfterEach
     void stopQuizScheduler() {
         scheduleService.clearAllTasks();
+    }
+
+    @AfterAll
+    static void resetClock() {
+        TimeUtil.resetClock();
     }
 
     @AfterEach

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -206,7 +206,7 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
         // Set the static file upload path for all tests
         // This makes it a simple unit test that doesn't require a server start.
         FilePathConverter.setFileUploadPath(rootPath);
-        Clock fixedClock = Clock.fixed(Instant.parse("2025-09-09T10:25:00Z"), ZoneOffset.UTC);
+        Clock fixedClock = Clock.fixed(Instant.parse("2025-09-10T10:25:00Z"), ZoneOffset.UTC);
         TimeUtil.setClock(fixedClock);
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -7,9 +7,7 @@ import static org.mockito.Mockito.doReturn;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -206,8 +204,6 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
         // Set the static file upload path for all tests
         // This makes it a simple unit test that doesn't require a server start.
         FilePathConverter.setFileUploadPath(rootPath);
-        Clock fixedClock = Clock.fixed(Instant.parse("2025-09-10T10:25:00Z"), ZoneOffset.UTC);
-        TimeUtil.setClock(fixedClock);
     }
 
     @BeforeEach

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 
 import jakarta.mail.internet.MimeMessage;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +55,6 @@ import de.tum.cit.aet.artemis.core.util.HibernateQueryInterceptor;
 import de.tum.cit.aet.artemis.core.util.QueryCountAssert;
 import de.tum.cit.aet.artemis.core.util.RequestUtilService;
 import de.tum.cit.aet.artemis.core.util.ThrowingProducer;
-import de.tum.cit.aet.artemis.core.util.TimeUtil;
 import de.tum.cit.aet.artemis.exam.service.ExamAccessService;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseTestRepository;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
@@ -223,11 +221,6 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
     @AfterEach
     void stopQuizScheduler() {
         scheduleService.clearAllTasks();
-    }
-
-    @AfterAll
-    static void resetClock() {
-        TimeUtil.resetClock();
     }
 
     @AfterEach


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).




### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
CourseLocalVCJenkinsIntegrationTest:testGetCourseManagementDetailData is flaky. 

### Description
<!-- Describe your changes in detail -->
It's flaky because depending on the number of passed days in a week, a week is counted or not causing flakiness on certain weekdays.
We now use a fixed clock for tests to avoid that.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

- Code Review
- Make sure the mentioned test doesn't fail

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can use `supporting_script/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to automatically generate the coverage table from the corresponding artefacts of your branch (follow the ReadMe for setup details). -->
<!-- Alternatively you can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->
unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized current-time retrieval across course calculations to improve accuracy and reduce edge-case timing issues around course end dates.

* **Tests**
  * Stabilized time-dependent tests by using a controllable clock for deterministic timestamps.
  * Added test teardown to reset time configuration after runs to avoid cross-test side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->