### PR TITLE
`Development`: Fix failing quiz exercise e2e tests

### DIFF
--- a/src/test/playwright/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { clearTextField, drag } from '../../../utils';
+import { clearTextField } from '../../../utils';
 import { QUIZ_EXERCISE_BASE } from '../../../constants';
 import { Fixtures } from '../../../../fixtures/fixtures';
 import { AbstractExerciseCreationPage } from '../AbstractExerciseCreationPage';
@@ -63,15 +63,32 @@ export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
         const boundingBox = await element?.boundingBox();
 
         expect(boundingBox, { message: 'Could not get bounding box of element' }).not.toBeNull();
-        await this.page.mouse.move(boundingBox!.x + 800, boundingBox!.y + 10);
+        await this.page.mouse.move(boundingBox!.x + 600, boundingBox!.y + 10);
         await this.page.mouse.down();
-        await this.page.mouse.move(boundingBox!.x + 1000, boundingBox!.y + 150);
+        await this.page.mouse.move(boundingBox!.x + 1000, boundingBox!.y + 250);
         await this.page.mouse.up();
 
         await this.createDragAndDropItem('Rick Astley');
         const dragLocator = this.page.locator('#drag-item-0');
         const dropLocator = this.page.locator('#drop-location');
-        await drag(this.page, dragLocator, dropLocator);
+
+        await dropLocator.scrollIntoViewIfNeeded();
+
+        const targetBox = await dropLocator.boundingBox();
+        const sourceBox = await dragLocator.boundingBox();
+        if (!targetBox || !sourceBox) {
+            throw new Error('Could not determine element bounding boxes for drag operation.');
+        }
+
+        const targetX = targetBox.x + targetBox.width / 2;
+        const targetY = targetBox.y + targetBox.height / 2;
+
+        // Move mouse to center of dragLocator
+        await dragLocator.hover();
+        await this.page.mouse.down();
+        // Move to center of dropLocator
+        await this.page.mouse.move(targetX, targetY, { steps: 8 });
+        await this.page.mouse.up();
 
         const fileContent = await Fixtures.get('exercise/quiz/drag_and_drop/question.txt');
         const textInputField = this.page.locator('.monaco-editor');
@@ -94,8 +111,10 @@ export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
     }
 
     async saveQuiz() {
+        const saveButton = this.page.locator('#quiz-save');
+        await saveButton.scrollIntoViewIfNeeded();
         const responsePromise = this.page.waitForResponse(QUIZ_EXERCISE_BASE);
-        await this.page.locator('#quiz-save').click();
+        await saveButton.click();
         return await responsePromise;
     }
 


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
Currently two E2E tests which are often failing are the `ts.Quiz Exercise Management › Quiz Exercise Creation › Creates a Quiz with Drag and Drop` & `ts.Quiz Exercise Participation › DnD Quiz participation › Student can participate in DnD Quiz`. This PR aims to fix the behavior of those two tests.

### Description
When a new quiz with a drag and drop question is being created, the old logic messed up when assigning a drag-and-drop element to a drop location. This issue was caused by the test calculating a wrong location to which to drag the element. I fixed the calculation and now the tests run successfully.

### Review Progress

#### Performance Review
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of end-to-end tests for quiz exercise creation by simulating drag-and-drop with precise mouse movements.
  * Ensured elements are scrolled into view and interacted with at their centers to reduce flakiness across viewports.
  * Adopted a dedicated locator for the save action to increase click reliability.
  * Added validations to fail fast when required elements are unavailable, aiding faster diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->