### PR TITLE
`Development`: Improve stale action to include more PRs and issues, prioritizing older ones

### DIFF
--- a/.github/workflows/pullrequest-stale.yml
+++ b/.github/workflows/pullrequest-stale.yml
@@ -11,6 +11,8 @@ jobs:
       - name: Check for stale PRs
         uses: actions/stale@v10
         with:
+          operations-per-run: 300
+          ascending: true
           days-before-stale: 7
           days-before-close: 14
           remove-stale-when-updated: true


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, the stale action only covers about 120-140 issues/PRs before it ends due to the operations-per-run value set to 30. This is to prevent being rate-limited by GitHub. However, with this setting, not all of the issues and PRs are getting checked for staleness and there are quite a few requests still remaining after running the action:
In addition, the stale action always starts checking the newest issues instead of starting with the oldest (which are most likely stale).

<img width="886" height="386" alt="image" src="https://github.com/user-attachments/assets/189d3202-df7b-495c-b294-f94498a8d141" />


### Description
<!-- Describe your changes in detail -->
This change increases the operations-per-run limit to 300 so that all issues/PRs are covered and also sets the order to ascending, so the action first checks the oldest issues.


### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2

