### PR TITLE
`Development`: Increase operations-per-run for stale PR check

### DIFF
--- a/.github/workflows/pullrequest-stale.yml
+++ b/.github/workflows/pullrequest-stale.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check for stale PRs
         uses: actions/stale@v10
         with:
-          operations-per-run: 300
+          operations-per-run: 600
           ascending: true
           days-before-stale: 7
           days-before-close: 14


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We recently increased the operations-per-run to 300 and changed the processing order for issues/PRs to start with the oldest issues/PRs.
However, due to a bug in the stale action (https://github.com/actions/stale/issues/1136), the cache, which is normally used to save some state about already processed PRs/Issues is not accessible. Therefore, the action always starts with the same old issues over and over again and newer PRs and issues are not processed anymore.

### Description
<!-- Describe your changes in detail -->
There are two solutions to this problem:
1. Further increase the operations-per-run limit to 600, so hopefully all PRs/issues are processed in one run then.
2. Fork the stale action and implement the bug fix that is already available (https://github.com/actions/stale/pull/1152), but unfortunately, it has not been merged into the stale repo.

Currently, this PR implements the first solution and just increases the run operations.

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
