### PR TITLE
`Development`: Add server tests for IrisTextExerciseChatSession

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisTextExerciseChatSessionResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisTextExerciseChatSessionResourceTest.java
@@ -12,7 +12,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.domain.User;
-import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
 import de.tum.cit.aet.artemis.exam.util.ExamUtilService;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisTextExerciseChatSession;
 import de.tum.cit.aet.artemis.iris.repository.IrisTextExerciseChatSessionRepository;
@@ -63,8 +62,8 @@ class IrisTextExerciseChatSessionResourceTest extends AbstractIrisIntegrationTes
         var sessionsInDb = irisTextExerciseChatSessionRepository.findByExerciseIdAndUserIdElseThrow(textExercise.getId(),
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1").getId());
         assertThat(sessionsInDb).hasSize(1);
-        assertThat(sessionsInDb.get(0).getId()).isEqualTo(response.getId());
-        assertThat(sessionsInDb.get(0).getExerciseId()).isEqualTo(textExercise.getId());
+        assertThat(sessionsInDb.getFirst().getId()).isEqualTo(response.getId());
+        assertThat(sessionsInDb.getFirst().getExerciseId()).isEqualTo(textExercise.getId());
     }
 
     @Test
@@ -129,8 +128,8 @@ class IrisTextExerciseChatSessionResourceTest extends AbstractIrisIntegrationTes
 
         assertThat(student1Sessions).hasSize(1);
         assertThat(student2Sessions).hasSize(1);
-        assertThat(student1Sessions.get(0).getId()).isEqualTo(response1.getId());
-        assertThat(student2Sessions.get(0).getId()).isEqualTo(response2.getId());
+        assertThat(student1Sessions.getFirst().getId()).isEqualTo(response1.getId());
+        assertThat(student2Sessions.getFirst().getId()).isEqualTo(response2.getId());
     }
 
     @Test
@@ -144,8 +143,7 @@ class IrisTextExerciseChatSessionResourceTest extends AbstractIrisIntegrationTes
         activateIrisFor(otherExercise);
 
         // When/Then: Request should be forbidden (student1 with TEST_PREFIX is not in otherCourse)
-        request.postWithResponseBody("/api/iris/text-exercise-chat/" + otherExercise.getId() + "/sessions/current", null, IrisTextExerciseChatSession.class,
-                HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/iris/text-exercise-chat/" + otherExercise.getId() + "/sessions/current", null, IrisTextExerciseChatSession.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -159,8 +157,7 @@ class IrisTextExerciseChatSessionResourceTest extends AbstractIrisIntegrationTes
         activateIrisFor(examExercise);
 
         // When/Then: Request should fail with conflict
-        request.postWithResponseBody("/api/iris/text-exercise-chat/" + examExercise.getId() + "/sessions/current", null, IrisTextExerciseChatSession.class,
-                HttpStatus.CONFLICT);
+        request.postWithResponseBody("/api/iris/text-exercise-chat/" + examExercise.getId() + "/sessions/current", null, IrisTextExerciseChatSession.class, HttpStatus.CONFLICT);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This PR adds comprehensive unit tests for the `IrisTextExerciseChatSessionResource.getCurrentSessionOrCreateIfNotExists` endpoint to improve test coverage and ensure the reliability of the Iris text exercise chat feature.

### Description
<!-- Describe your changes in detail -->

- Created `IrisTextExerciseChatSessionResourceTest.java`
- Added 9 comprehensive tests covering:
  - Session creation when none exists (201 CREATED)
  - Returning existing session (200 OK)
  - Returning latest session when multiple exist
  - Session isolation between different users
  - Authorization checks (403 FORBIDDEN for non-enrolled users)
  - Exam exercise validation (409 CONFLICT)
  - Invalid exercise ID handling (403 FORBIDDEN - auth check happens first)
  - Role-based access for tutors and instructors

**Key improvements:**
- Used explicit date manipulation instead of `Thread.sleep()` for deterministic test behavior
- All tests follow best practices with proper setup, clear assertions, and comprehensive coverage
- Tests verify both success paths (200 OK, 201 CREATED) and error paths (403 FORBIDDEN, 409 CONFLICT)

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Run tests locally:
```bash
./gradlew test --tests IrisTextExerciseChatSessionResourceTest
```

All 9 tests should pass.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->

#### Code Review
- [x] Code Review 
#### Manual Tests
- [x] Test 1 - All tests pass locally
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. -->

| Class/File | Line Coverage | Instruction Coverage |
|------------|--------------:|---------------------:|
| IrisTextExerciseChatSessionResource.java | 79% (30/38 lines) | 66% (127/191 instructions) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for Iris text exercise chat session REST API, covering session creation, retrieval, user isolation, access control, and role-based authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->