### PR TITLE
`Programming exercises`: Reduce the width of the dividers in online editor for programming exercises

### DIFF
--- a/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.scss
+++ b/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.scss
@@ -271,11 +271,11 @@
 .rg-sidebar-left,
 .rg-sidebar-right {
     cursor: col-resize;
-    margin-left: 4px;
-    margin-right: 4px;
+    margin-left: 1px;
+    margin-right: 1px;
 
     /* easier to grab + avoid selecting editor text while dragging */
-    padding: 6px 6px;
+    padding: 1px 1px;
     -webkit-user-select: none;
     user-select: none;
     touch-action: none;


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
The resizable dividers between panels in the code editor (file browser, editor, and problem statement) were taking up excessive horizontal space. This reduced the available area for actual content, especially on smaller screens or when multiple panels are open.

### Description
Reduced the width of the vertical resizable dividers in the code editor grid layout by adjusting the CSS properties in [code-editor-grid.scss](cci:7://file:///C:/Users/Admin/Desktop/TUM/7.Semester/Bachelor/Thesis/Artemis/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.scss:0:0-0:0):
- Decreased horizontal margins from `4px` to `1px`
- Reduced padding from `6px 6px` to `1px 1px`

This makes the dividers significantly more compact (from ~16px total width to ~4px) while maintaining their functionality for resizing panels. The dividers remain grabbable and functional but are now much less intrusive.

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Programming Exercise

1. Log in to Artemis as a student
2. Navigate to a programming exercise and start the exercise
3. Observe the vertical dividers between the file browser, code editor, and problem statement panels
4. Verify the dividers are much narrower and less intrusive than before
5. Test resizing functionality by dragging each divider left and right
6. Confirm that resizing still works smoothly and the cursor changes appropriately on hover
7. Test with both light and dark themes to ensure consistent appearance

#### Exam Mode Testing
Prerequisites:
- 1 Student
- 1 Exam with a Programming Exercise

1. Log in to Artemis as a student
2. Participate in the exam
3. Open the programming exercise
4. Verify the dividers are narrower and resizing still works correctly in exam mode

### Testserver States

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Test Coverage
No test coverage changes required - this is a pure CSS/styling change with no logic modifications.

### Screenshots
<!-- Before/After screenshots showing the narrower dividers -->
**Before:** Dividers were ~16px wide with significant margins and padding
<img width="2535" height="727" alt="image" src="https://github.com/user-attachments/assets/11a1e131-869c-4e30-94e9-7c45ce61082c" />

**After:** Dividers are now ~4px wide, providing more space for content
<img width="2544" height="786" alt="image" src="https://github.com/user-attachments/assets/a7c7195a-63e4-425b-bd69-7261d93f3194" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified the clickable area of resizable sidebar grips in the code editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->