### PR TITLE
`Development`: Adjust broken client test for monaco code editor

### DIFF
--- a/src/main/webapp/app/programming/shared/code-editor/monaco/code-editor-monaco.component.spec.ts
+++ b/src/main/webapp/app/programming/shared/code-editor/monaco/code-editor-monaco.component.spec.ts
@@ -328,7 +328,7 @@ describe('CodeEditorMonacoComponent', () => {
         await new Promise((r) => setTimeout(r, 0));
 
         expect(addLineWidgetStub).toHaveBeenCalledTimes(8);
-        // 8=2x4 calls, as two feedbacks each trigger render three times
+        // 8=2x3+2 calls, as two feedbacks each trigger render three times
         // and the initial selectedFile=undefined and follow up selectedFile=file1.java
         // trigger the corresponding signal and effect twice.
         expect(addLineWidgetStub).toHaveBeenNthCalledWith(1, 2, `feedback-1-line-2`, document.createElement('div'));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Before the recent merges on Nov 7 2025, the test "" in `` was not asserting anything. The PR https://github.com/ls1intum/Artemis/pull/11474 fixed said issue. An independent PR https://github.com/ls1intum/Artemis/pull/11463 broke the test again, as they didn't know about the change yet.
The test is currently failing on develop.

### Description
<!-- Describe your changes in detail -->
In the constructor of `code-editor-monaco.component.ts` the lines
``
        effect(() => {
            this.renderFeedbackWidgets();
        });
``
were added. That causes each change to the input `selectedFile` to trigger the render function once. As there are two changes to that input, the initial set(undefined) and set(input1.java), the expected call count for a function inside `renderFeedbackWidgets` increases by 2, so it ends up at 8.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Verify the test now runs.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->
