### PR TITLE
`Communication`: Fix user and content mentions in messages starting on a new line

### DIFF
--- a/src/main/webapp/app/communication/posting-content/posting-content-part/posting-content-part.component.html
+++ b/src/main/webapp/app/communication/posting-content/posting-content-part/posting-content-part.component.html
@@ -1,5 +1,5 @@
 @if (postingContentPart()?.contentBeforeReference) {
-    <div class="markdown-preview" [innerHTML]="processedContentBeforeReference | htmlForPostingMarkdown: true : allowedHtmlTags : allowedHtmlAttributes"></div>
+    <span class="markdown-preview" [innerHTML]="processedContentBeforeReference | htmlForPostingMarkdown: true : allowedHtmlTags : allowedHtmlAttributes"></span>
 }
 @if (postingContentPart()?.linkToReference) {
     <a class="reference" [routerLink]="postingContentPart()?.linkToReference" [queryParams]="postingContentPart()?.queryParams">


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
When mentioning users, or content like exercises and lectures, markdown rendering would put the mention in a new line after the previous text. This is not desired behavior, as mentions often occur mid-sentence, and thus there should not be a new line.

### Description
Replaced the first part of the text rendering with  `<span>` instead of `<div>`, which caused the new line to start after it.

### Steps for Testing
Prerequisites:
- 1 User
- Course with communication enabled

1. Open any communication channel in any course.
2. Use markdown to type messages, in which you mention users, exercises, lectures, etc.
3. Ensure these mentions are not rendered on a new line in the markdown preview as well as in the sent message. Content like `Hello, [user]Anian(ge47xow)[/user], how are you?` should all be rendered in the same line, provided there is enough space.
4. Check that message markdown rendering for anything else didn't break.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2


### Screenshots
Before:
<img width="300" src="https://github.com/user-attachments/assets/6dd3921f-825e-48a6-80cf-2c18f25b9b32" />

After:
<img width="300" src="https://github.com/user-attachments/assets/678a055e-4bab-431e-b7aa-9ec59c389e6d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout rendering of content display in the posting area, changing from block-level to inline-level formatting while maintaining all existing functionality and styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->