### PR TITLE
`Development`: Add test for default case in Iris logo component

### DIFF
--- a/src/main/webapp/app/iris/overview/iris-logo/iris-logo.component.spec.ts
+++ b/src/main/webapp/app/iris/overview/iris-logo/iris-logo.component.spec.ts
@@ -52,4 +52,9 @@ describe('IrisLogoComponent', () => {
             expect(component.classList()).toBe(expectedClass);
         });
     });
+
+    it('should return empty string for custom numeric size', () => {
+        componentRef.setInput('size', 100);
+        expect(component.classList()).toBe('');
+    });
 });


### PR DESCRIPTION
### Motivation and Context
This PR adds test coverage for the default case in the `IrisLogoComponent.classList()` method that was previously uncovered (line 44). The default branch returns an empty string when a custom numeric size is provided.

### Description
- Added a test case that verifies the `classList()` computed property returns an empty string when given a custom numeric size (e.g., 100) instead of one of the predefined `IrisLogoSize` enum values
- This improves test coverage from 96% to 100% for the `iris-logo.component.ts` file

### Steps for Testing
1. Run the test suite for the IrisLogoComponent:
   ```bash
   npm run test:one -- iris-logo.component.spec
   ```
2. Verify that all tests pass, including the new test case "should return empty string for custom numeric size"

### Testserver States
Not applicable - this is a pure test addition with no functional changes.

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
Not applicable - test-only change
#### Exam Mode Test
Not applicable - test-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for edge-case input handling in the component, verifying behavior when receiving non-standard numeric values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->