### PR TITLE
`General`: Fix an issue with forwarding after passkey login

### DIFF
--- a/src/main/webapp/app/core/home/home.component.ts
+++ b/src/main/webapp/app/core/home/home.component.ts
@@ -132,10 +132,6 @@ export class HomeComponent implements OnInit, AfterViewChecked {
     async loginWithPasskey() {
         await this.webauthnService.loginWithPasskey();
         this.handleLoginSuccess();
-
-        this.accountService.identity(true).then((user) => {
-            this.currentUserCallback(user!);
-        });
     }
 
     /**

--- a/src/main/webapp/app/core/user/settings/passkey-settings/webauthn.service.ts
+++ b/src/main/webapp/app/core/user/settings/passkey-settings/webauthn.service.ts
@@ -114,12 +114,7 @@ export class WebauthnService {
             }
 
             await this.webauthnApiService.loginWithPasskey(credential);
-
-            this.accountService.userIdentity.set({
-                ...this.accountService.userIdentity(),
-                loggedInWithPasskey: true,
-                internal: this.accountService.userIdentity()?.internal ?? false,
-            });
+            await this.accountService.identity(true);
         } catch (error) {
             if (error instanceof InvalidCredentialError) {
                 this.alertService.addErrorAlert('artemisApp.userSettings.passkeySettingsPage.error.invalidCredential');


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
Fixes a bug that caused the `jhi-home` component to be displayed even after login.

### Description
Making a call to `/account` instead of locally setting respective values in `account.service.ts` as the changes do not seem to propagate properly to `jhi-home` component.

### Steps for Testing
1. Log out of Artemis
2. Login with a Passkey
3. See that you are forwarded to the course overview

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Screenshots
#### Before Bugfix
<img width="720" height="430" alt="image" src="https://github.com/user-attachments/assets/858a7a86-89f9-4ace-a72c-2ac3f5a94654" />

#### After Bugfix
<img width="1512" height="856" alt="image" src="https://github.com/user-attachments/assets/117dca29-2b5b-4ca2-b286-f257fb4a81e9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced passkey login state management for improved consistency and reliability in authentication state tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->