### PR TITLE
`Development`: Fix flaky LectureIntegrationTest

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
@@ -118,7 +118,7 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         List<Course> courses = courseUtilService.createCoursesWithExercisesAndLectures(TEST_PREFIX, true, true, numberOfTutors);
         this.course1 = this.courseRepository.findByIdWithExercisesAndExerciseDetailsAndLecturesElseThrow(courses.getFirst().getId());
 
-        var lectures = this.course1.getLectures().stream().toList();
+        var lectures = this.course1.getLectures().stream().sorted(Comparator.comparing(Lecture::getStartDate)).toList();
         createChannelsForLectures(lectures);
 
         lecture2.setIsTutorialLecture(true);
@@ -544,12 +544,12 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         request.postWithoutResponseBody("/api/lecture/courses/" + course1.getId() + "/lectures", List.of(dto1, dto2), HttpStatus.NO_CONTENT);
 
-        List<Lecture> lectures = lectureRepository.findAllByCourseId(course1.getId()).stream().sorted(Comparator.comparing(Lecture::getStartDate)).toList();
-        assertThat(lectures).hasSize(4);
-        Lecture firstLecture = lectures.getFirst();
-        Lecture secondLecture = lectures.get(1);
-        Lecture thirdLecture = lectures.get(2);
-        Lecture fourthLecture = lectures.get(3);
+        List<Lecture> lecturesAfter = lectureRepository.findAllByCourseId(course1.getId()).stream().sorted(Comparator.comparing(Lecture::getStartDate)).toList();
+        assertThat(lecturesAfter).hasSize(4);
+        Lecture firstLecture = lecturesAfter.getFirst();
+        Lecture secondLecture = lecturesAfter.get(1);
+        Lecture thirdLecture = lecturesAfter.get(2);
+        Lecture fourthLecture = lecturesAfter.get(3);
 
         assertThat(firstLecture.getTitle()).isEqualTo(titleNewLecture1);
         assertThat(firstLecture.getStartDate().toInstant()).isEqualTo(startNewLecture1.toInstant());
@@ -564,7 +564,7 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         Set<Channel> channels = channelRepository.findLectureChannelsByCourseId(course1.getId());
 
-        assertThat(channels.stream().map(Channel::getLecture).collect(Collectors.toSet())).containsExactlyInAnyOrderElementsOf(lectures);
+        assertThat(channels.stream().map(Channel::getLecture).collect(Collectors.toSet())).containsExactlyInAnyOrderElementsOf(lecturesAfter);
 
         Map<Long, Channel> lectureIdToChannelMap = channels.stream().collect(Collectors.toMap(channel -> channel.getLecture().getId(), Function.identity()));
         Channel firstLectureChannel = lectureIdToChannelMap.get(firstLecture.getId());


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context

The test `testCreateLectureSeriesAndCorrectLectureAndChannelNames` in `LectureIntegrationTest` was flaky, failing approximately 50% of the time in CI/CD with:

```
org.opentest4j.AssertionFailedError: 
expected: "Requirements"
 but was: "Lecture 1"
```

### Description

**Root Cause:** In `initTestCase()`, `course1.getLectures()` returns a `Set<Lecture>` with non-deterministic iteration order. The test then called `getFirst()` and `getLast()` on this set converted to a list, causing `lecture1` and `lecture2` to be assigned to different physical lectures between test runs.

**Fix:** Sort lectures by `startDate` before assigning them to ensure `lecture1` is always the chronologically earlier lecture and `lecture2` is the later one.

```java
// Before:
var lectures = this.course1.getLectures().stream().toList();

// After:
var lectures = this.course1.getLectures().stream().sorted(Comparator.comparing(Lecture::getStartDate)).toList();
```

### Steps for Testing

1. Run the test multiple times locally:
   ```bash
   ./gradlew test --tests "de.tum.cit.aet.artemis.lecture.LectureIntegrationTest.testCreateLectureSeriesAndCorrectLectureAndChannelNames" --rerun-tasks
   ```
2. Verify it passes consistently (tested 5 consecutive runs successfully)

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1 (ran test 5 times locally, all passed)

### Test Coverage

| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------|------------------------------|
| LectureIntegrationTest.java | N/A (test file) | ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by enforcing deterministic ordering when preparing and retrieving lecture lists, ensuring consistent assertions and more stable test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->