### PR TITLE
`Development`: Increase Iris test coverage

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisCourseChatSessionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisCourseChatSessionServiceTest.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
-import de.tum.cit.aet.artemis.core.test_repository.UserTestRepository;
 import de.tum.cit.aet.artemis.core.user.util.UserUtilService;
 import de.tum.cit.aet.artemis.core.util.CourseUtilService;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisCourseChatSession;
@@ -32,9 +31,6 @@ class IrisCourseChatSessionServiceTest extends AbstractIrisIntegrationTest {
     @Autowired
     private UserUtilService userUtilService;
 
-    @Autowired
-    private UserTestRepository userTestRepository;
-
     private Course course;
 
     private User user;
@@ -50,7 +46,6 @@ class IrisCourseChatSessionServiceTest extends AbstractIrisIntegrationTest {
         user.setExternalLLMUsageAcceptedTimestamp(ZonedDateTime.now());
         // Ensure course membership for auth check
         user.setGroups(Set.of(course.getStudentGroupName()));
-        userTestRepository.save(user);
 
         session = new IrisCourseChatSession(course, user);
         session.setId(7L); // needed for exception message path


### PR DESCRIPTION
### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
This PR adds unit tests to improve test coverage of IrisCourseChatSessionService.

### Description
Added a test file called IrisCourseChatSessionServiceTest to the test structure.

### Steps for Testing
Run tests locally. 

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
IrisCourseChatSessionService:
Class: 100%
Method: 84%
Line: 85%
Branch: 61%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests for course chat session access covering three scenarios: session owners are granted access; other users are denied with an appropriate error; and access is denied if the user has not accepted the external LLM/privacy policy. These tests validate access-control behavior across typical and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->