### PR TITLE
`Assessment`: Fix assessment note tooltip in student scores list

### DIFF
--- a/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.html
@@ -247,7 +247,7 @@
                                 @if (value?.submissions?.last()?.results?.last()?.assessmentNote?.note?.trim()) {
                                     <span class="w-100 text-center">
                                         <fa-icon
-                                            [ngbPopover]="value.results?.last()?.assessmentNote.note"
+                                            [ngbPopover]="value.submissions.last().results.last().assessmentNote.note"
                                             [triggers]="'hover'"
                                             [icon]="faComment"
                                             [container]="'body'"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

For manual assessments, an internal note can be added that is only visible to tutors/instructors. This note is shown as a column on the ‘Scores’ page for the exercise (see screenshot below). To not clutter the interface, the actual note is shown as a tooltip when hovering over the icon. This tooltip did not show up.


### Description
<!-- Describe your changes in detail -->
Fixes the tooltip display.

Note for reviewing: You can see the correct access to the note in the surrounding `if` condition. I only adapted the actual access to the note as part of this fix.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Programming exercise with manual assessment enabled, at least one submission that can be assessed, and after the due date
  - Should alternatively (probably) work with text or file upload exercises, too.

1. Go to the scores page for the exercise (exercise management, then button ‘Scores’ in the button cluster at the top.
2. Click on ‘Assess submission’.
3. At the bottom, you can add an internal tutor note. Write something in there and then submit/save the assessment.
4. Go back to the scores page. Now the icon for the internal note should be shown (see screenshot below) and on hovering your written text becomes visible.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

Note: we deployed this as a hotfix onto our production system at Uni Passau, so I know of at least four additional users that have tested it sucessfully there.

### Test Coverage

unchanged, only HTML template changes

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<img width="732" height="147" alt="image" src="https://github.com/user-attachments/assets/22ed9aca-7e2a-45c7-a20f-950c9f77773f" />

@coderabbitai ignore
