### PR TITLE
`Development`: Add Hyperion to PR title validation workflow

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: Slashgear/action-check-pr-title@v5.0.1
         with:
-          regexp: '^`(Programming exercises|Integrated code lifecycle|Quiz exercises|Modeling exercises|Text exercises|File upload exercises|Exam mode|Grading|Assessment|Communication|Notifications|Team exercises|Lectures|Integrated markdown editor|Plagiarism checks|Learning analytics|Adaptive learning|Learning path|Tutorial groups|Iris|Scalability|Usability|Performance|Infrastructure|Mobile apps|Development|General)`:\s[A-Z].*$'
+          regexp: '^`(Programming exercises|Integrated code lifecycle|Quiz exercises|Modeling exercises|Text exercises|File upload exercises|Exam mode|Grading|Assessment|Communication|Notifications|Team exercises|Lectures|Integrated markdown editor|Plagiarism checks|Learning analytics|Adaptive learning|Learning path|Tutorial groups|Iris|Hyperion|Scalability|Usability|Performance|Infrastructure|Mobile apps|Development|General)`:\s[A-Z].*$'


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
The `Hyperion` feature tag was added to the [PR naming conventions documentation](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests), but the GitHub Actions workflow that validates PR titles was not updated to include it. This causes PRs with the `Hyperion` tag to fail the validation check.

### Description
This PR adds `Hyperion` to the list of valid feature tags in the PR title validation workflow (`.github/workflows/validate-pr-title.yml`).

### Steps for Testing
Not really needed

Prerequisites:
- 1 Developer

1. Create a new PR with a title like \`Hyperion\`: Test PR title
2. Verify that the PR title validation workflow passes

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2