### PR TITLE
`Programming exercises`: Add line breaks for long build job names

### DIFF
--- a/src/main/webapp/app/buildagent/build-agent-details/build-agent-details.component.html
+++ b/src/main/webapp/app/buildagent/build-agent-details/build-agent-details.component.html
@@ -401,6 +401,7 @@
                                     <td class="finish-jobs-column-strings">
                                         <span
                                             [ngClass]="{
+                                                'wrap-long-text': true,
                                                 'text-success': finishedBuildJob.status === 'SUCCESSFUL',
                                                 'text-warning': finishedBuildJob.status === 'CANCELLED',
                                                 'text-danger': finishedBuildJob.status === 'FAILED' || finishedBuildJob.status === 'ERROR',

--- a/src/main/webapp/app/buildagent/build-queue/build-overview.component.html
+++ b/src/main/webapp/app/buildagent/build-queue/build-overview.component.html
@@ -528,6 +528,7 @@
                                 <td class="finish-jobs-column-strings">
                                     <span
                                         [ngClass]="{
+                                            'wrap-long-text': true,
                                             'text-success': finishedBuildJob.status === 'SUCCESSFUL',
                                             'text-warning': finishedBuildJob.status === 'CANCELLED',
                                             'text-danger': finishedBuildJob.status === 'FAILED' || finishedBuildJob.status === 'ERROR',


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.



### Motivation and Context
Fixes an issue where long build job names in the build overview overlap with the status column instead of wrapping properly to a new line.

### Description
Applied the existing `wrap-long-text` CSS class to the build job name cell in the finished build jobs table. This ensures that long build job names break properly when the column width is too narrow, preventing overlap with adjacent columns.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with a very long name

1. Log in to Artemis as an instructor
2. Navigate to Course Administration → Build Management
3. Trigger some builds for the programming exercise with the long name
4. Wait for the builds to complete
5. Scroll down to the "Finished Build Jobs" table
6. Verify that long build job names now wrap to multiple lines instead of overflowing
7. Verify that the status column is no longer overlapped by the name


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2



### Screenshots

<img width="841" height="215" alt="Screenshot 2025-12-16 092821" src="https://github.com/user-attachments/assets/a4dbcce3-2f8b-4d38-a523-b28266a39a2d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text wrapping in finished builds tables to prevent overflow and improve readability for long build names and commit identifiers across the build agent details and build overview views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->