### PR TITLE
`Development`: Add tests for IrisExerciseSettingsUpdateComponent

### DIFF
--- a/src/main/webapp/app/iris/manage/settings/iris-exercise-settings-update/iris-exercise-settings-update.component.spec.ts
+++ b/src/main/webapp/app/iris/manage/settings/iris-exercise-settings-update/iris-exercise-settings-update.component.spec.ts
@@ -62,6 +62,12 @@ describe('IrisExerciseSettingsUpdateComponent Component', () => {
         jest.restoreAllMocks();
     });
 
+    it('Returns true when view child is not initialized yet', () => {
+        expect(comp.settingsUpdateComponent).toBeUndefined();
+        expect(comp.canDeactivate()).toBeTrue();
+        expect(comp.canDeactivateWarning).toBeUndefined();
+    });
+
     it('Setup works correctly', () => {
         fixture.detectChanges();
         expect(paramsSpy).toHaveBeenCalledOnce();
@@ -93,5 +99,45 @@ describe('IrisExerciseSettingsUpdateComponent Component', () => {
         comp.settingsUpdateComponent!.saveIrisSettings();
         expect(setSettingsSpy).toHaveBeenCalledWith(2, irisSettings);
         expect(comp.settingsUpdateComponent!.irisSettings).toEqual(irisSettingsSaved);
+    });
+});
+
+describe('IrisExerciseSettingsUpdateComponent without parent route params', () => {
+    let comp: IrisExerciseSettingsUpdateComponent;
+    let fixture: ComponentFixture<IrisExerciseSettingsUpdateComponent>;
+    let featureToggleService: FeatureToggleService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [IrisExerciseSettingsUpdateComponent, IrisSettingsUpdateComponent, MockComponent(IrisCommonSubSettingsUpdateComponent), MockComponent(ButtonComponent)],
+            providers: [
+                provideRouter([]),
+                MockProvider(IrisSettingsService),
+                MockProvider(FeatureToggleService),
+                { provide: ActivatedRoute, useValue: {} as ActivatedRoute },
+                { provide: TranslateService, useClass: MockTranslateService },
+                { provide: AccountService, useClass: MockAccountService },
+            ],
+        })
+            .compileComponents()
+            .then(() => {
+                featureToggleService = TestBed.inject(FeatureToggleService);
+                jest.spyOn(featureToggleService, 'getFeatureToggleActive').mockReturnValue(of(true));
+            });
+        fixture = TestBed.createComponent(IrisExerciseSettingsUpdateComponent);
+        comp = fixture.componentInstance;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('Skips rendering settings when no ids are provided and returns canDeactivate true', () => {
+        fixture.detectChanges();
+        expect(comp.courseId).toBeUndefined();
+        expect(comp.exerciseId).toBeUndefined();
+        expect(fixture.debugElement.query(By.directive(IrisSettingsUpdateComponent))).toBeNull();
+        expect(comp.canDeactivate()).toBeTrue();
+        expect(comp.canDeactivateWarning).toBeUndefined();
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR increases the test coverage for the `IrisExerciseSettingsUpdateComponent`.

### Description
<!-- Describe your changes in detail -->

- Added a test for the pre-initialized state to ensure `canDeactivate` defaults to true and no warning is exposed before the child settings component exists.

- Added a no-route-params scenario to confirm `courseId`/`exerciseId` remain undefined, the settings UI does not render under the `@if` guard, and `canDeactivate` still returns true.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Verify that all tests pass, including the newly added tests


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for exercise settings updates with additional scenarios validating component behavior when initialization state varies and route parameters are absent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->