### PR TITLE
`Development`: Increase the long feedback max length

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/Constants.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/Constants.java
@@ -150,7 +150,7 @@ public final class Constants {
      * Build logs are stored separately; this limit protects the database from
      * accidental storage explosions while keeping enough context for debugging.
      */
-    public static final int LONG_FEEDBACK_MAX_LENGTH = 20_000;
+    public static final int LONG_FEEDBACK_MAX_LENGTH = 50_000;
 
     // This value limits the amount of characters allowed for a complaint response text.
     // Set to 65535 as the db-column has type TEXT which can hold up to 65535 characters.


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

20.000 characters might be too short for our use-case of the blackbox tests. I agree that we also do not need 10_000_000 characters, but I guess up to 50_000 might occasionally happen for realistic non-infinite-looping submissions (e.g. pretty-printing the state of a chess or sudoku board in tasks that implement solvers or game AIs). The blackbox tests group a whole application usage scenario (i.e., integration test testing how a real user would use the developed application) into a single Artemis-test. Splitting this into smaller test cases is not reasonable.


### Description
<!-- Describe your changes in detail -->
Increases the maximum feedback length from 20000 to 50000. Was 10 million before 567c8ae57f564e010fface0aa0ccfe61ca546c13.

If the length is such a problem at TUM, future work could make this limit configurable per instance.


### Steps for Testing
None, code review is enough.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


### Test Coverage
unchanged


@coderabbitai ignore
