### PR TITLE
`Lectures`: Remove redundant competencies popover from student view

### DIFF
--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.html
@@ -64,8 +64,8 @@
                         </div>
                     }
                     @for (lectureUnit of lectureUnits; track lectureUnit.id) {
-                        <div class="row m-0 mt-3 d-flex flex-nowrap">
-                            <div class="col-lg-11 p-0 col-10">
+                        <div class="row m-0 mt-3">
+                            <div class="col p-0">
                                 @switch (lectureUnit.type) {
                                     @case (LectureUnitType.EXERCISE) {
                                         <jhi-exercise-unit [exerciseUnit]="lectureUnit" [course]="lecture!.course!" />
@@ -80,14 +80,6 @@
                                         <jhi-online-unit [courseId]="courseId!" [lectureUnit]="lectureUnit" (onCompletion)="completeLectureUnit($event)" />
                                     }
                                 }
-                            </div>
-                            <div class="col-lg-1 col-2 my-auto mx-auto width-fit-content">
-                                <jhi-competencies-popover
-                                    [hidden]="!lectureUnit.competencyLinks?.length"
-                                    [courseId]="lecture!.course!.id!"
-                                    [competencyLinks]="lectureUnit.competencyLinks || []"
-                                    [navigateTo]="'courseCompetencies'"
-                                />
                             </div>
                         </div>
                     }

--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.spec.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.spec.ts
@@ -14,7 +14,6 @@ import { CourseLectureDetailsComponent } from 'app/lecture/overview/course-lectu
 import { AttachmentVideoUnitComponent } from 'app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component';
 import { ExerciseUnitComponent } from 'app/lecture/overview/course-lectures/exercise-unit/exercise-unit.component';
 import { TextUnitComponent } from 'app/lecture/overview/course-lectures/text-unit/text-unit.component';
-import { CompetenciesPopoverComponent } from 'app/atlas/shared/competencies-popover/competencies-popover.component';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisTimeAgoPipe } from 'app/shared/pipes/artemis-time-ago.pipe';
@@ -111,7 +110,6 @@ describe('CourseLectureDetailsComponent', () => {
                 MockComponent(ExerciseUnitComponent),
                 MockComponent(TextUnitComponent),
                 MockComponent(OnlineUnitComponent),
-                CompetenciesPopoverComponent,
                 NotReleasedTagComponent,
                 DifficultyBadgeComponent,
                 IncludedInScoreBadgeComponent,

--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.ts
@@ -27,7 +27,6 @@ import { ExerciseUnitComponent } from '../exercise-unit/exercise-unit.component'
 import { AttachmentVideoUnitComponent } from '../attachment-video-unit/attachment-video-unit.component';
 import { TextUnitComponent } from '../text-unit/text-unit.component';
 import { OnlineUnitComponent } from '../online-unit/online-unit.component';
-import { CompetenciesPopoverComponent } from 'app/atlas/shared/competencies-popover/competencies-popover.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { DiscussionSectionComponent } from 'app/communication/shared/discussion-section/discussion-section.component';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
@@ -53,7 +52,6 @@ export interface LectureUnitCompletionEvent {
         AttachmentVideoUnitComponent,
         TextUnitComponent,
         OnlineUnitComponent,
-        CompetenciesPopoverComponent,
         FaIconComponent,
         DiscussionSectionComponent,
         UpperCasePipe,


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] Following the [theming guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).


### Motivation and Context
The lecture details page displayed linked competencies in two places:
1. A flag button (`jhi-competencies-popover`) next to each lecture unit
2. The "Related Competencies" section inside expanded lecture units (via `jhi-competency-contribution`)

This duplication wastes horizontal space and provides no additional value since the same information is shown in both places.


### Description
This PR removes the redundant competencies popover from the student lecture details view. The competency information is still visible inside the lecture unit card when expanded.

**Changes:**
- Removed `jhi-competencies-popover` component from `course-lecture-details.component.html`
- Removed `CompetenciesPopoverComponent` import from the component
- Updated tests to remove the mocked component
- Simplified layout by using full-width column for lecture units

**Note:** The `CompetenciesPopoverComponent` is still used in the instructor's lecture unit management view where it serves a different purpose (quick reference without expanding units).


### Steps for Testing
Prerequisites:
- 1 Student account
- 1 Course with a lecture containing lecture units with linked competencies

1. Log in as student
2. Navigate to a course and open a lecture
3. Verify that lecture units no longer show the flag icon on the right
4. Expand a lecture unit and verify that "Related Competencies" section still shows the linked competencies
5. Verify that lecture units now use full width


### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Test Coverage
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| course-lecture-details.component.ts | 82.92% | ✅ |

### Screenshots
**Before:** Lecture units showed both the flag popover (right side) and "Related Competencies" section when expanded
<img width="1870" height="732" alt="CleanShot 2026-01-14 at 18 09 37" src="https://github.com/user-attachments/assets/5c75f529-8b57-4333-a101-3cbaf878730f" />


**After:** Only the "Related Competencies" section is shown when the lecture unit is expanded, and lecture units use full width
<img width="1892" height="748" alt="CleanShot 2026-01-14 at 18 47 00" src="https://github.com/user-attachments/assets/2db91adb-8c20-4744-9bad-bf4e197e7b19" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Simplified the lecture unit row layout to display in a single column format instead of the previous two-column layout.
  * Removed the competencies popover from the course lecture details view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->