### PR TITLE
`Programming exercises`: Fix filter causing incorrect No Submissions

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationFilterService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationFilterService.java
@@ -74,10 +74,13 @@ public class ParticipationFilterService {
      */
     public void filterParticipationForCourseDashboard(StudentParticipation participation, boolean isStudent) {
         Optional<Submission> optionalSubmission = submissionFilterService.getLatestSubmissionWithResult(participation.getSubmissions(), true);
-        if (optionalSubmission.isPresent()) {
+        if (optionalSubmission.isPresent() && !ExerciseDateService.isAfterAssessmentDueDate(participation.getExercise())) {
             for (Result result : optionalSubmission.get().getResults()) {
-                if (result != null)
+                if (result != null) {
                     result.setScore(0.0);
+                    result.setAssessor(null);
+                    result.setRated(true);
+                }
             }
         }
 


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

On the course overview page for the student, there is a sidebar that lists the current enrolled exercises in a course.
In a specific scenario with Manually Graded exercises, the status e.g. "0% (preliminary)" would be wrongly set to "No Submission".
Closes https://github.com/ls1intum/Artemis/issues/11956.

### Description
If the programming exercise Due Date has passed, the Student has only one submission (i.e. only one push in git) and the instructor would grade the submission, faulty logic in `ParticipationFilterService::filterParticipationForCourseDashboard` would filter out the only valid submission and cause the `for-dashboard` endpoint to return an empty list of submissions in the student participation.
That filter logic is meant to filter out programming exercises with confidential data (e.g. graded exercises). This was achieved by simply filtering all Submissions that contained Results with e.g. applied grades to not show them to the user.
This would cause the Status of the Programming Exercise in the Sidebar to show "No Submission" instead of the correct "0% (preliminary)".
This PR simply deletes that confidential information from the latest Submission instead.


### Steps for Testing
1. Log in as Instructor
2. Create a new Programming Exercise with enabled Online Editor, Manual Grading, Due Date in 2min and Assessment Release Date in 1 day
3. Create a Submission in the Online Editor
4. Observe that the Status in the Sidebar says "0% (preliminary)"
5. Let the Due Date pass
6. Observe that the Status in the Sidebar says "0% (preliminary)"
7. Grade the Student Submission (but the results are not yet released)
8. Observe that the Status in the Sidebar says "0% (preliminary)" (in contrast to before not "No Submission")
9. Set the Assessment Release date to release the results now
10. Observe that the Status in the Sidebar now shows you the real result

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots

#### Exercise before Due Date, One Submission
<img width="217" height="74" alt="image" src="https://github.com/user-attachments/assets/df5b8ca7-567b-4018-9185-f33504532d5a" />

#### Exercise after Due Date, Already Manually Graded, Grades not released yet
<img width="217" height="74" alt="image" src="https://github.com/user-attachments/assets/0f19ea23-6722-4884-8686-e0fb8fb70835" />

#### Exercise Grades already released
<img width="217" height="74" alt="image" src="https://github.com/user-attachments/assets/5994f3a8-bf51-4f87-a339-0a43dbb3209c" />
