### PR TITLE
`Development`: Fix flaky exam archive test

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
@@ -1217,8 +1217,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         request.put("/api/core/courses/" + course.getId() + "/archive", null, HttpStatus.OK);
 
         final var courseId = course.getId();
-        await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100)).pollDelay(Duration.ofMillis(10))
-                .until(() -> courseRepository.findById(courseId).orElseThrow().getCourseArchivePath() != null);
+        await().atMost(Duration.ofSeconds(30)).until(() -> courseRepository.findById(courseId).orElseThrow().getCourseArchivePath() != null);
 
         var updatedCourse = courseRepository.findById(courseId).orElseThrow();
         assertThat(updatedCourse.getCourseArchivePath()).isNotEmpty();
@@ -1237,8 +1236,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         request.put("/api/exam/courses/" + course.getId() + "/exams/" + exam.getId() + "/archive", null, HttpStatus.OK);
 
         final var examId = exam.getId();
-        await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(100)).pollDelay(Duration.ofMillis(10))
-                .until(() -> examRepository.findById(examId).orElseThrow().getExamArchivePath() != null);
+        await().atMost(Duration.ofSeconds(30)).until(() -> examRepository.findById(examId).orElseThrow().getExamArchivePath() != null);
 
         var updatedExam = examRepository.findById(examId).orElseThrow();
         assertThat(updatedExam.getExamArchivePath()).isNotEmpty();


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
While working on https://github.com/ls1intum/Artemis/pull/12028 I noticed the flaky test https://bamboo.ase.in.tum.de/browse/ARTEMIS-TESTS9118-JAVATEST-11
<img width="915" height="236" alt="image" src="https://github.com/user-attachments/assets/c4f33e47-c1aa-4409-9c45-d05923f3dd6e" />


### Description
Fixes flaky test: ExamIntegrationTest.testArchiveExamAsInstructor() that was failing intermittently with ConditionTimeoutException after 10 seconds.

   Root Cause: Archive operations (exam and course archiving) can take longer than the default Awaitility timeout of 10 seconds, especially on slower databases like MySQL/Postgres compared to H2.

   Solution: Updated Awaitility configuration in both archiveExamAsInstructor() and archiveCourseAsInstructor() methods to use:

     - atMost(Duration.ofSeconds(30)) - Increased timeout for archive operations

#### Why this should fix the flakyness
Archive operations involve file system I/O and database updates that can vary in duration. The increased timeout accommodates legitimate processing time while maintaining test stability.


### Steps for Testing
💡 You can simply verify the test is passing in the pipeline

- Run the test multiple times to confirm flakiness is resolved:  ./gradlew test --tests ExamIntegrationTest.testArchiveExamAsInstructor -x webapp
- Verify related tests in ExamIntegrationTest still pass


### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-01-26 09:25:11 UTC_



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timing and wait configuration in exam integration tests to increase reliability of archive path validation checks. Extended timeouts, added short polling delays, and refined polling intervals to reduce flakiness and improve stability of test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->