### PR TITLE
`Development`: Fix Hazelcast cluster member detection with hostname/IP mismatch

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/HazelcastClusterManager.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/HazelcastClusterManager.java
@@ -130,8 +130,10 @@ public class HazelcastClusterManager {
             return;
         }
 
-        var hazelcastMemberAddresses = hazelcastInstance.getCluster().getMembers().stream()
-                .map(member -> eurekaInstanceHelper.formatAddressForHazelcast(member.getAddress().getHost(), String.valueOf(member.getAddress().getPort())))
+        // Resolve Hazelcast member hostnames to IPs for consistent comparison with Eureka addresses.
+        // Hazelcast may report hostnames (e.g., "artemis-app-node-1") while Eureka uses IPs.
+        var hazelcastMemberAddresses = hazelcastInstance.getCluster().getMembers().stream().map(member -> eurekaInstanceHelper
+                .formatAddressForHazelcast(eurekaInstanceHelper.resolveToIp(member.getAddress().getHost()), String.valueOf(member.getAddress().getPort())))
                 .collect(Collectors.toSet());
 
         var instances = eurekaInstanceHelper.getServiceInstances();

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/HazelcastConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/HazelcastConfiguration.java
@@ -702,11 +702,12 @@ public class HazelcastConfiguration {
      * @param config the Hazelcast configuration to modify
      */
     private void configurePortAndMetadata(Config config) {
-        // Use the configured Hazelcast interface if set, otherwise fall back to localhost.
-        // This ensures the registered address matches what Hazelcast actually binds to,
-        // which is critical for address comparison in HazelcastClusterManager.
-        // normalizeHost() strips brackets from IPv6 addresses for consistent comparison.
-        String hazelcastMetadataHost = (hazelcastInterface != null && !hazelcastInterface.isEmpty()) ? eurekaInstanceHelper.normalizeHost(hazelcastInterface) : "127.0.0.1";
+        // Resolve the configured Hazelcast interface to an IP address for consistent comparison.
+        // Hazelcast may be configured with a hostname (e.g., "artemis-app-node-1"), but Eureka
+        // returns IP addresses when EUREKA_INSTANCE_PREFERIPADDRESS=true. By resolving to IP here,
+        // we ensure the registered metadata matches what Eureka returns, avoiding comparison
+        // mismatches in HazelcastClusterManager during the metadata propagation window.
+        String hazelcastMetadataHost = (hazelcastInterface != null && !hazelcastInterface.isEmpty()) ? eurekaInstanceHelper.resolveToIp(hazelcastInterface) : "127.0.0.1";
         int effectivePort;
 
         if (hazelcastLocalInstances) {


### PR DESCRIPTION
### Summary 
Fixes a regression introduced in #12051 where Hazelcast cluster members are incorrectly flagged as "stale/zombie members" when `SPRING_HAZELCAST_INTERFACE` is set to a hostname but `EUREKA_INSTANCE_PREFERIPADDRESS=true`.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

After merging #12051 (Hazelcast build agent client mode), test servers running multi-node setups with LocalCI fail to start. The nodes enter an infinite loop logging:

```
WARN: Current instance not found in service registry; stale-member detection may be incomplete.
WARN: Hazelcast member artemis-app-node-1:5701 is not registered in service registry - may be a stale/zombie member.
```

This happens because of a hostname/IP address mismatch between what Hazelcast binds to and what gets registered in Eureka metadata.

### Description

**Root Cause:**

In `HazelcastConfiguration.configurePortAndMetadata()`, the Hazelcast address was registered using `registration.get().getHost()` which returns an **IP address** (due to `EUREKA_INSTANCE_PREFERIPADDRESS=true`), but Hazelcast actually binds to the configured `hazelcastInterface` which is a **hostname** (e.g., `artemis-app-node-1`).

```
Hazelcast binds to:     artemis-app-node-1:5701  (hostname)
Eureka metadata has:    192.168.1.5:5701         (IP address)
```

When `HazelcastClusterManager` compares cluster members with registry entries, they never match, causing the "stale member" warnings.

**The Fix:**

Use the configured `hazelcastInterface` value (normalized to strip IPv6 brackets) instead of `registration.get().getHost()` when registering the Hazelcast address in Eureka metadata:

```java
// Before (bug):
String hazelcastMetadataHost = registration.get().getHost();

// After (fix):
String hazelcastMetadataHost = (hazelcastInterface != null && !hazelcastInterface.isEmpty())
    ? eurekaInstanceHelper.normalizeHost(hazelcastInterface)
    : "127.0.0.1";
```

This ensures the registered address matches what Hazelcast actually uses, regardless of the `EUREKA_INSTANCE_PREFERIPADDRESS` setting.

### Steps for Testing

Prerequisites:
- Multi-node Artemis setup with LocalCI (e.g., test-server-multi-node-mysql-localci.yml)
- `SPRING_HAZELCAST_INTERFACE` set to hostname (e.g., `artemis-app-node-1`)
- `EUREKA_INSTANCE_PREFERIPADDRESS=true`

1. Start the multi-node setup
2. Check logs for node-1
3. Verify: `Registered Hazelcast address in service registry: host=artemis-app-node-1` (hostname, not IP)
4. Verify: No "stale/zombie member" warnings
5. Verify: Node becomes healthy and cluster forms correctly

### Testserver States
Tested locally with docker-compose multi-node setup.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| EurekaInstanceHelper.java | 20.00% | 152 |
| HazelcastClusterManager.java | 1.69% | 102 |
| HazelcastConfiguration.java | 63.03% | 360 |

_Last updated: 2026-02-04 16:56:48 UTC_

