### PR TITLE
`Iris`: Fix missing translation keys for module feature admin page

### DIFF
--- a/src/main/webapp/i18n/de/featureToggles.json
+++ b/src/main/webapp/i18n/de/featureToggles.json
@@ -27,10 +27,6 @@
                 "description": "Aktiviere oder deaktiviere Funktionen für alle Nutzer:innen. Änderungen werden sofort wirksam ohne Server-Neustart."
             },
             "profiles": {
-                "iris": {
-                    "name": "Iris (KI-Assistent)",
-                    "description": "Aktiviert den Iris-KI-Tutor, der von LLMs angetrieben wird, für personalisierte Studierendenunterstützung und Code-Hilfe."
-                },
                 "athena": {
                     "name": "Athena (KI-Bewertung)",
                     "description": "Aktiviert Athena ML-basierte automatisierte Feedback-Vorschläge für Text- und Programmieraufgaben."
@@ -69,6 +65,10 @@
                 }
             },
             "modules": {
+                "iris": {
+                    "name": "Iris (KI-Assistent)",
+                    "description": "Aktiviert den Iris-KI-Tutor, der von LLMs angetrieben wird, für personalisierte Studierendenunterstützung und Code-Hilfe."
+                },
                 "atlas": {
                     "name": "Atlas (Adaptives Lernen)",
                     "description": "Aktiviert kompetenzbasierte Lernfunktionen einschließlich Lernpfade, Kompetenz-Tracking und Analysen."

--- a/src/main/webapp/i18n/en/featureToggles.json
+++ b/src/main/webapp/i18n/en/featureToggles.json
@@ -27,10 +27,6 @@
                 "description": "Enable or disable features for all users. Changes take effect immediately without server restart."
             },
             "profiles": {
-                "iris": {
-                    "name": "Iris (AI Assistant)",
-                    "description": "Enables the Iris AI virtual tutor powered by LLMs for personalized student support and code assistance."
-                },
                 "athena": {
                     "name": "Athena (AI Assessment)",
                     "description": "Enables Athena ML-based automated feedback suggestions for text and programming exercises."
@@ -69,6 +65,10 @@
                 }
             },
             "modules": {
+                "iris": {
+                    "name": "Iris (AI Assistant)",
+                    "description": "Enables the Iris AI virtual tutor powered by LLMs for personalized student support and code assistance."
+                },
                 "atlas": {
                     "name": "Atlas (Adaptive Learning)",
                     "description": "Enables competency-based learning features including learning paths, competency tracking, and analytics."


### PR DESCRIPTION
### Summary 
After Iris was migrated from a Spring profile to a YAML module flag, the admin features page showed `translation-not-found[artemisApp.features.modules.iris.name]` and `translation-not-found[artemisApp.features.modules.iris.description]` because the i18n keys were only defined under `profiles`, not `modules`. This PR moves the Iris translation entries from `profiles` to `modules` in both EN and DE.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
When Iris was migrated from a Spring profile to a YAML module flag, the translation keys under `artemisApp.features.profiles.iris` became stale, and the new required keys under `artemisApp.features.modules.iris` were never added. This caused the admin features page to display raw translation key paths instead of human-readable names.

### Description
- Moved the `iris` translation entry (name + description) from `profiles` to `modules` in `src/main/webapp/i18n/en/featureToggles.json`
- Moved the `iris` translation entry (name + description) from `profiles` to `modules` in `src/main/webapp/i18n/de/featureToggles.json`
- The translation text itself is unchanged — only the location in the JSON hierarchy was corrected.

### Steps for Testing
Prerequisites:
- 1 Admin user
- Iris module enabled in application config

1. Log in to Artemis as admin
2. Navigate to Server Administration > Features
3. Scroll to "Module Features" section
4. Verify the Iris card shows "Iris (AI Assistant)" as name and a proper description instead of `translation-not-found[...]`
5. Switch language to German
6. Verify the Iris card shows "Iris (KI-Assistent)" as name and a proper description

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- No code changes requiring coverage — only JSON translation files modified. -->

### Screenshots
This PR only changes JSON translation files (no UI component code). The visual effect is that the admin "Module Features" page will show proper translated names instead of raw translation keys. No UI component changes were made.

**Before (current broken state):**
The Iris module card on the admin features page displays `translation-not-found[artemisApp.features.modules.iris.name]` and `translation-not-found[artemisApp.features.modules.iris.description]`.

**After:**
The Iris module card correctly shows "Iris (AI Assistant)" / "Iris (KI-Assistent)" with the corresponding description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized Iris AI Assistant feature configuration from profile-based to module-based categorization across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->