### PR TITLE
`Development`: Regenerate package-lock.json to fix Docker builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -508,7 +508,6 @@
             "integrity": "sha512-vKz8aPA62W+e9+pF6ct4CRDG/MjlIH7sWFGYkxPPRst2g46ZQsRkrzfMZAWv/wnt6OZ1OwyRuO3RW83EMhag8g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@angular-devkit/core": "21.1.3",
                 "rxjs": "7.8.2"
@@ -528,7 +527,6 @@
             "integrity": "sha512-02mA04tz9UshwPTv8lBkLcMPpMFh7YnAMXM6u0fL558rU7UrBxsm3XfMmDao3f+jT8umA1mDHBx9OW9LIF4Ewg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "2.3.0",
                 "@angular-devkit/architect": "0.2101.3",
@@ -859,7 +857,6 @@
             "integrity": "sha512-TCb3qYOC/uXKZCo56cJ6N9sHeWdFhyVqrbbYfFjTi09081T6jllgHDZL5Ms7gOMNY8KywWGGbhxwvzeA0RwTgA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@angular-eslint/bundled-angular-compiler": "21.2.0",
                 "eslint-scope": "^9.0.0"
@@ -906,7 +903,6 @@
             "integrity": "sha512-RXVRuamfrSPwsFCLJgsO2ucp+dwWDbGbhXrQnMrGXm0qdgYpI8bAsBMd8wOeUA6vn4fRmjaRFQZbL/rcIVrkzw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "2.3.0",
                 "@angular-devkit/architect": "0.2101.3",
@@ -1057,7 +1053,6 @@
             "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.1.3.tgz",
             "integrity": "sha512-jMiEKCcZMIAnyx2jxrJHmw5c7JXAiN56ErZ4X+OuQ5yFvYRocRVEs25I0OMxntcXNdPTJQvpGwGlhWhS0yDorg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "parse5": "^8.0.0",
                 "tslib": "^2.3.0"
@@ -1075,7 +1070,6 @@
             "integrity": "sha512-UPtDcpKyrKZRPfym9gTovcibPzl2O/Woy7B8sm45sAnjDH+jDUCcCvuIak7GpH47shQkC2J4yvnHZbD4c6XxcQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@angular-devkit/architect": "0.2101.3",
                 "@angular-devkit/core": "21.1.3",
@@ -1111,7 +1105,6 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.1.3.tgz",
             "integrity": "sha512-Wdbln/UqZM5oVnpfIydRdhhL8A9x3bKZ9Zy1/mM0q+qFSftPvmFZIXhEpFqbDwNYbGUhGzx7t8iULC4sVVp/zA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1140,7 +1133,6 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.1.3.tgz",
             "integrity": "sha512-nKxoQ89W2B1WdonNQ9kgRnvLNS6DAxDrRHBslsKTlV+kbdv7h59M9PjT4ZZ2sp1M/M8LiofnUfa/s2jd/xYj5w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "7.28.5",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -1173,7 +1165,6 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.1.3.tgz",
             "integrity": "sha512-TbhQxRC7Lb/3WBdm1n8KRsktmVEuGBBp0WRF5mq0Ze4s1YewIM6cULrSw9ACtcL5jdcq7c74ms+uKQsaP/gdcQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1199,7 +1190,6 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.1.3.tgz",
             "integrity": "sha512-YW/YdjM9suZUeJam9agHFXIEE3qQIhGYXMjnnX7xGjOe+CuR2R0qsWn1AR0yrKrNmFspb0lKgM7kTTJyzt8gZg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "tslib": "^2.3.0"
@@ -1229,7 +1219,6 @@
             "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-21.1.3.tgz",
             "integrity": "sha512-o/zFe8t578OP1j9+7iYibkwcE19zVC8xRFl/+f8bLSwqxwqasMNu1/zCa1B2nq8Gd2xwbvX/7kDhAn25yM4FJg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "7.28.5",
                 "@types/babel__core": "7.20.5",
@@ -1271,7 +1260,6 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.1.3.tgz",
             "integrity": "sha512-W+ZMXAioaP7CsACafBCHsIxiiKrRTPOlQ+hcC7XNBwy+bn5mjGONoCgLreQs76M8HNWLtr/OAUAr6h26OguOuA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1294,7 +1282,6 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.1.3.tgz",
             "integrity": "sha512-wWEjrNtJfxzZmbDWdJSyRau7NWpQ6IFM9QAyn7xH3cQDGCj+Gy9lTU5sUIYQc+7sx3nKWztolc7h/M5meYCTAg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1313,7 +1300,6 @@
             "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.1.3.tgz",
             "integrity": "sha512-uAw4LAMHXAPCe4SywhlUEWjMYVbbLHwTxLyduSp1b+9aVwep0juy5O/Xttlxd/oigVe0NMnOyJG9y1Br/ubnrg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1332,7 +1318,6 @@
             "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-21.1.3.tgz",
             "integrity": "sha512-5qJD2JsFLn9H1BMQvEUzfKZhX7oMkgYRTfuPbQuyuxfR9U8M5EYifRqOtAY6xyIUDjnn0FOS6dqMPOq49DGAog==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1430,7 +1415,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -3232,7 +3216,6 @@
             "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@keyv/serialize": "^1.1.1"
             }
@@ -3370,7 +3353,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -3411,7 +3393,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -4738,7 +4719,6 @@
             "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.3.2",
                 "@inquirer/confirm": "^5.1.21",
@@ -5218,7 +5198,6 @@
             "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.2.0",
                 "@jest/expect": "30.2.0",
@@ -5496,9 +5475,9 @@
             }
         },
         "node_modules/@jsonjoy.com/buffers": {
-            "version": "17.65.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.65.0.tgz",
-            "integrity": "sha512-eBrIXd0/Ld3p9lpDDlMaMn6IEfWqtHMD+z61u0JrIiPzsV1r7m6xDZFRxJyvIFTEO+SWdYF9EiQbXZGd8BzPfA==",
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+            "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -5704,9 +5683,9 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
-            "version": "17.65.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.65.0.tgz",
-            "integrity": "sha512-Xrh7Fm/M0QAYpekSgmskdZYnFdSGnsxJ/tHaolA4bNwWdG9i65S8m83Meh7FOxyJyQAdo4d4J97NOomBLEfkDQ==",
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+            "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -5721,9 +5700,9 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
-            "version": "17.65.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.65.0.tgz",
-            "integrity": "sha512-7MXcRYe7n3BG+fo3jicvjB0+6ypl2Y/bQp79Sp7KeSiiCgLqw4Oled6chVv07/xLVTdo3qa1CD0VCCnPaw+RGA==",
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+            "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -5738,17 +5717,17 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
-            "version": "17.65.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.65.0.tgz",
-            "integrity": "sha512-e0SG/6qUCnVhHa0rjDJHgnXnbsacooHVqQHxspjvlYQSkHm+66wkHw6Gql+3u/WxI/b1VsOdUi0M+fOtkgKGdQ==",
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+            "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/base64": "17.65.0",
-                "@jsonjoy.com/buffers": "17.65.0",
-                "@jsonjoy.com/codegen": "17.65.0",
-                "@jsonjoy.com/json-pointer": "17.65.0",
-                "@jsonjoy.com/util": "17.65.0",
+                "@jsonjoy.com/base64": "17.67.0",
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0",
+                "@jsonjoy.com/json-pointer": "17.67.0",
+                "@jsonjoy.com/util": "17.67.0",
                 "hyperdyperid": "^1.2.0",
                 "thingies": "^2.5.0",
                 "tree-dump": "^1.1.0"
@@ -5765,13 +5744,13 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
-            "version": "17.65.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.65.0.tgz",
-            "integrity": "sha512-uhTe+XhlIZpWOxgPcnO+iSCDgKKBpwkDVTyYiXX9VayGV8HSFVJM67M6pUE71zdnXF1W0Da21AvnhlmdwYPpow==",
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+            "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/util": "17.65.0"
+                "@jsonjoy.com/util": "17.67.0"
             },
             "engines": {
                 "node": ">=10.0"
@@ -5785,14 +5764,14 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
-            "version": "17.65.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.65.0.tgz",
-            "integrity": "sha512-cWiEHZccQORf96q2y6zU3wDeIVPeidmGqd9cNKJRYoVHTV0S1eHPy5JTbHpMnGfDvtvujQwQozOqgO9ABu6h0w==",
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+            "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/buffers": "17.65.0",
-                "@jsonjoy.com/codegen": "17.65.0"
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0"
             },
             "engines": {
                 "node": ">=10.0"
@@ -6842,19 +6821,6 @@
             "peerDependencies": {
                 "@angular/common": ">=16",
                 "@angular/core": ">=16"
-            }
-        },
-        "node_modules/@noble/hashes": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -8077,7 +8043,6 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -9266,8 +9231,7 @@
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
             "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/@swimlane/ngx-charts": {
             "version": "23.1.0",
@@ -9815,7 +9779,8 @@
             "version": "15.7.15",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
             "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/qs": {
             "version": "6.14.0",
@@ -9975,7 +9940,6 @@
             "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
                 "@typescript-eslint/scope-manager": "8.54.0",
@@ -10005,7 +9969,6 @@
             "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.54.0",
                 "@typescript-eslint/types": "8.54.0",
@@ -10113,7 +10076,6 @@
             "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -10156,7 +10118,6 @@
             "integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
                 "@typescript-eslint/scope-manager": "8.54.0",
@@ -10903,7 +10864,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -10992,7 +10952,6 @@
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -11010,7 +10969,6 @@
             "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ajv": "^8.0.0"
             },
@@ -11030,7 +10988,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.1",
                 "schemes": "^1.4.0",
@@ -11744,7 +11701,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -12054,7 +12010,6 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "readdirp": "^5.0.0"
             },
@@ -12796,7 +12751,8 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/d3-array": {
             "version": "3.2.4",
@@ -12989,7 +12945,6 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -13721,7 +13676,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -14212,7 +14166,6 @@
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -15166,7 +15119,6 @@
             "integrity": "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -16056,7 +16008,6 @@
             "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -16387,7 +16338,6 @@
             "integrity": "sha512-zbBTiqr2Vl78pKp/laGBREYzbZx9ZtqPjOK4++lL4BNDhxRnahg51HtoDrk9/VjIy9IthNEWdKVd7H5bqBhiWQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.2.0",
                 "@jest/environment-jsdom-abstract": "30.2.0",
@@ -16971,7 +16921,6 @@
             "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@acemir/cssom": "^0.9.28",
                 "@asamuzakjp/dom-selector": "^6.7.6",
@@ -17235,7 +17184,6 @@
             "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "copy-anything": "^2.0.1",
                 "parse-node-version": "^1.0.1",
@@ -17342,7 +17290,6 @@
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "bindings": "~1.5.0",
                 "nan": "~2.22.2",
@@ -17427,7 +17374,6 @@
             "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cli-truncate": "^5.0.0",
                 "colorette": "^2.0.20",
@@ -17825,7 +17771,6 @@
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
             "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -20147,6 +20092,19 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/pkijs/node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.5.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -20167,7 +20125,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -20379,7 +20336,6 @@
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -20451,7 +20407,6 @@
             "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -20818,7 +20773,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -20849,7 +20803,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -20862,7 +20815,8 @@
             "version": "19.2.4",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
             "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-redux": {
             "version": "8.1.3",
@@ -20971,7 +20925,6 @@
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
             "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.9.2"
             }
@@ -21477,7 +21430,6 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
             "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -21501,7 +21453,6 @@
             "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "immutable": "^5.0.2",
@@ -22760,7 +22711,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@csstools/css-parser-algorithms": "^4.0.0",
                 "@csstools/css-syntax-patches-for-csstree": "^1.0.25",
@@ -23874,8 +23824,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "peer": true
+            "license": "0BSD"
         },
         "node_modules/tsyringe": {
             "version": "4.10.0",
@@ -24239,7 +24188,6 @@
             "integrity": "sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/eslint-plugin": "8.54.0",
                 "@typescript-eslint/parser": "8.54.0",
@@ -24596,7 +24544,6 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -24687,7 +24634,6 @@
             "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.0.18",
                 "@vitest/mocker": "4.0.18",
@@ -24886,7 +24832,6 @@
             "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -25604,7 +25549,6 @@
             "integrity": "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@oozcitak/dom": "^2.0.2",
                 "@oozcitak/infra": "^2.0.2",
@@ -25757,7 +25701,6 @@
             "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -25776,8 +25719,7 @@
             "version": "0.16.0",
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.0.tgz",
             "integrity": "sha512-LqLPpIQANebrlxY6jKcYKdgN5DTXyyHAKnnWWjE5pPfEQ4n7j5zn7mOEEpwNZVKGqx3kKKmvplEmoBrvpgROTA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         }
     }
 }


### PR DESCRIPTION
### Summary
Regenerates `package-lock.json` to fix Docker build failures caused by an incorrectly hoisted `@noble/hashes@1.4.0` dependency after commit 2fe22fa.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
Commit 2fe22fa ("Development: Update client dependencies") updated `package.json` and `package-lock.json`. The regenerated lockfile incorrectly hoisted `@noble/hashes@1.4.0` (required by `pkijs@3.3.3`) to the top level. This conflicted with `@exodus/bytes@1.11.0` (a new transitive dev dependency via `jsdom@27.4.0`), which declares an optional peer dependency on `@noble/hashes@"^1.8.0 || ^2.0.0"`. Since `1.4.0 < 1.8.0`, `npm ci` (used in Docker builds) rejected the lockfile as inconsistent.

### Description
Regenerated `package-lock.json` using the project's specified Node 24.7.0 / npm 11.5.1. The key change is that `@noble/hashes@1.4.0` moves from the top-level `node_modules/@noble/hashes` to `node_modules/pkijs/node_modules/@noble/hashes`, properly nesting it under the only package that needs it. Since the peer dependency from `@exodus/bytes` is optional, the absence of a top-level `@noble/hashes` is perfectly valid.

Verified locally that both `npm install` and `npm ci` succeed with the regenerated lockfile.

### Steps for Testing
Prerequisites:
- None (infrastructure-only change)

1. Verify that `npm ci` succeeds (checked by CI Docker build)
2. Verify that the application builds correctly (checked by CI .war build)
3. No functional changes — only the dependency resolution tree changed

### Testserver States
Not applicable — no functional changes.

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-02-06 13:43:13 UTC_


### Screenshots
No UI changes.