### PR TITLE
`Programming exercises`: Fix code editor crash when viewing test repository

### DIFF
--- a/src/main/webapp/app/programming/manage/code-editor/container/code-editor-container.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/container/code-editor-container.component.ts
@@ -324,7 +324,7 @@ export class CodeEditorContainerComponent implements ComponentCanDeactivate {
      * Returns the feedbacks for the current submission or an empty array if no feedbacks are available.
      */
     feedbackForSubmission(): Feedback[] {
-        const submission = this.participation().submissions?.[0];
+        const submission = this.participation()?.submissions?.[0];
         const result = submission?.results?.[0];
         return this.showInlineFeedback() && result?.feedbacks ? result.feedbacks : [];
     }

--- a/src/test/javascript/spec/integration/code-editor/code-editor-container.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-container.integration.spec.ts
@@ -564,4 +564,19 @@ describe('CodeEditorContainerIntegration', () => {
             'src/Test3.java': [new FileBadge(FileBadgeType.FEEDBACK_SUGGESTION, 3)],
         });
     });
+
+    it('should return empty feedbacks when participation has no submissions (test repository)', () => {
+        const participation = { id: 1 } as Participation;
+        containerFixture.componentRef.setInput('participation', participation);
+        containerFixture.componentRef.setInput('showInlineFeedback', true);
+
+        expect(container.feedbackForSubmission()).toEqual([]);
+    });
+
+    it('should return empty feedbacks when participation is undefined (test repository via repository view)', () => {
+        containerFixture.componentRef.setInput('participation', undefined);
+        containerFixture.componentRef.setInput('showInlineFeedback', true);
+
+        expect(container.feedbackForSubmission()).toEqual([]);
+    });
 });


### PR DESCRIPTION
### Summary

Fixed a crash (`TypeError: Cannot read properties of undefined (reading 'submissions')`) in the code editor when instructors open the test repository. The test repository has no associated participation, so `feedbackForSubmission()` crashed when trying to access `submissions` on an undefined participation.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context

Closes #12065
Also related to #12100

When instructors try to view the test repository of a programming exercise in the code editor, the editor crashes and shows a broken view. This is because the test repository does not have an associated participation object. In `RepositoryViewComponent`, the `participation` field is never set when the test repository is selected, so `undefined` is passed to the code editor container. The `feedbackForSubmission()` method then crashes when it tries to access `.submissions` on `undefined`.

### Description

- Added optional chaining (`?.`) in `feedbackForSubmission()` to safely handle the case where `participation()` is `undefined` (test repositories have no participation)
- Added two integration tests verifying that `feedbackForSubmission()` returns an empty array when:
  - Participation has no submissions (test repository scenario)
  - Participation is undefined (repository view test repository scenario)

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Log in to Artemis as an instructor
2. Navigate to a programming exercise
3. Scroll to the repository section
4. Click on the "Code" button under "Test Repository Uri"
5. Click on the arrow icon to open the repository in the code editor
6. Verify the editor loads correctly and shows the test repository files
7. Also verify that switching between Template, Solution, and Test repositories in the full code editor works without errors

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| code-editor-container.component.ts | 98.50% | 241 | 46 | 19.1 |

_Last updated: 2026-02-07 12:28:23 UTC_

