### PR TITLE
`Development`: Fix docker build by regenerating package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6800,19 +6800,6 @@
                 "@angular/core": ">=16"
             }
         },
-        "node_modules/@noble/hashes": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -20486,6 +20473,19 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/pkijs/node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/postcss": {


### PR DESCRIPTION
### Summary

Regenerate `package-lock.json` with the latest npm version (`11.5.1`) to fix test server deployment failures caused by lockfile inconsistencies.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

Test server deployments are currently broken due to `package-lock.json` being generated with an older npm version (`11.1.0`). When CI runs with Node 24 `.nvmrc` and `build.yml`, the lockfile mismatch causes build failures. 

Lastest docker image build run on develop branch is failing: https://github.com/ls1intum/Artemis/actions/runs/22067263270/job/63762270304

### Description

- Updated npm from `11.1.0` to `11.5.1` (that the Docker build uses)
- Deleted `node_modules` and `package-lock.json`, then ran `npm install` to regenerate a clean lockfile
- The diff only contains minor version bumps of transitive dependencies (`caniuse-lite`, `qs`, `tar`, `webpack-sources`, etc.) - no direct dependency changes

### Steps for Testing

1. Deploy this branch to a test server and verify the deployment succeeds
2. Verify the application starts and functions normally

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2