### PR TITLE
`Integrated code lifecycle`: Fix race condition in docker container setup commands

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -540,27 +540,27 @@ public class BuildJobContainerService {
         String defaultTestCheckoutPath = RepositoryCheckoutPath.TEST.forProgrammingLanguage(programmingLanguage);
         testCheckoutPath = (!StringUtils.isBlank(testCheckoutPath)) ? testCheckoutPath : defaultTestCheckoutPath;
 
-        // Make sure to create the working directory in case it does not exist.
-        // In case the test checkout path is the working directory, we only create up to the parent, as the working directory is created below.
-        addDirectory(buildJobContainerId, LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + (testCheckoutPath.isEmpty() ? "" : "/" + TESTING_DIR), true);
+        // Create the testing directory inside the container's working directory.
+        // This must always be created so that the subsequent chmod and repository copy operations have a valid target.
+        addDirectory(buildJobContainerId, LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/" + TESTING_DIR, true);
         // Make sure the working directory and all subdirectories are accessible
         executeDockerCommand(buildJobContainerId, null, true, "chmod", "-R", "777", LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/" + TESTING_DIR);
 
         // Copy the test repository to the container and move it to the test checkout path (may be the working directory)
-        addAndPrepareDirectoryAndReplaceContent(buildJobContainerId, testRepositoryPath, LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/testing-dir/" + testCheckoutPath,
+        addAndPrepareDirectoryAndReplaceContent(buildJobContainerId, testRepositoryPath, LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/" + TESTING_DIR + "/" + testCheckoutPath,
                 buildJobId);
         // Copy the assignment repository to the container and move it to the assignment checkout path
         addAndPrepareDirectoryAndReplaceContent(buildJobContainerId, assignmentRepositoryPath,
-                LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/testing-dir/" + assignmentCheckoutPath, buildJobId);
+                LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/" + TESTING_DIR + "/" + assignmentCheckoutPath, buildJobId);
         if (solutionRepositoryPath != null) {
             solutionCheckoutPath = (!StringUtils.isBlank(solutionCheckoutPath)) ? solutionCheckoutPath
                     : RepositoryCheckoutPath.SOLUTION.forProgrammingLanguage(programmingLanguage);
             addAndPrepareDirectoryAndReplaceContent(buildJobContainerId, solutionRepositoryPath,
-                    LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/testing-dir/" + solutionCheckoutPath, buildJobId);
+                    LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/" + TESTING_DIR + "/" + solutionCheckoutPath, buildJobId);
         }
         for (int i = 0; i < auxiliaryRepositoriesPaths.length; i++) {
             addAndPrepareDirectoryAndReplaceContent(buildJobContainerId, auxiliaryRepositoriesPaths[i],
-                    LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/testing-dir/" + auxiliaryRepositoryCheckoutDirectories[i], buildJobId);
+                    LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/" + TESTING_DIR + "/" + auxiliaryRepositoryCheckoutDirectories[i], buildJobId);
         }
 
         createScriptFile(buildJobContainerId);

--- a/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -180,14 +181,12 @@ class BuildJobContainerServiceTest extends AbstractArtemisBuildAgentTest {
     }
 
     @Test
-    void testCreateScriptFileExecutesSynchronously() {
+    void testSynchronousExecNeverUsesDetachedMode() {
         buildJobContainerService.runScriptInContainer(DUMMY_CONTAINER_ID, "build-job-1");
 
-        // All exec commands (including the script execution) must run synchronously
+        // Verify that withDetach(true) is never called for synchronous commands.
+        // This guards against regression: previously, setup commands accidentally used detached mode.
         verify(execStartCmd, atLeastOnce()).withDetach(false);
-
-        // All exec commands must attach stdout and stderr
-        verify(execCreateCmd, atLeastOnce()).withAttachStdout(true);
-        verify(execCreateCmd, atLeastOnce()).withAttachStderr(true);
+        verify(execStartCmd, never()).withDetach(true);
     }
 }


### PR DESCRIPTION
### Summary

Fix a race condition in the Local CI build agent where Docker `exec` commands for container setup (mkdir, chmod, cp) were running in detached mode, causing the build script to start before repository files were fully copied into the container. Under heavy concurrent load, this resulted in intermittent `chmod: cannot access './gradlew': No such file or directory` errors. Additionally fixes several other issues found during deep code review.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context

When multiple build jobs run concurrently on a build agent (e.g., during an exam with many submissions), the Docker daemon can become overloaded. The `BuildJobContainerService.executeDockerCommand` method previously determined whether to run in detached mode based on whether stdout/stderr were attached:

```java
boolean detach = !attachStdout && !attachStderr; // true for all setup commands
```

All container setup commands (mkdir, chmod, cp, script creation) passed `attachStdout=false, attachStderr=false`, which resulted in `detach=true`. In Docker's exec API, a detached command returns immediately without waiting for the process to finish inside the container.

Under heavy load with 5 concurrent builds, we observed the build script starting before `cp -r` had finished copying the test repository files, causing:
```
chmod: cannot access './gradlew': No such file or directory
```

The build would complete in ~1 second instead of the normal ~25 seconds.

### Description

**Race condition fix:**
- Simplified `executeDockerCommand` to always use `withDetach(false)`, ensuring each command completes inside the container before the next one starts
- Removed the now-unnecessary `attachStdout` and `attachStderr` parameters from the method signature
- Added a detailed comment explaining why `withDetach(false)` is critical

**Error handling improvements:**
- `onError` callback now propagates errors via `AtomicReference` instead of silently swallowing them
- Added 5-minute timeout to `latch.await()` to prevent permanently stuck build threads
- Restored interrupt flag when catching `InterruptedException`
- Added `checkPath()` validation for `destinationPath` in `moveResultsToSpecifiedDirectory`

**Bug fix:**
- Fixed `testCheckoutPath` logic that incorrectly required both the default and caller path to be non-blank (now matches `assignmentCheckoutPath` pattern — caller's override wins)

**Robustness improvements:**
- Fixed TOCTOU race in `stopContainer` by catching exceptions from exec (container may disappear between state check and stop signal)
- Added NPE defense in `getContainerForName` for containers with null/empty names

**Code quality:**
- Extracted `"testing-dir"` magic string to `TESTING_DIR` constant
- Updated stale comments and misleading Javadoc
- Removed redundant `executor.shutdown()` (try-with-resources handles it)
- Increased tar archive buffer from 1KB to 8KB for better IO performance
- Added 3 new tests verifying synchronous vs. detached execution behavior

### Steps for Testing

Prerequisites:
- 1 Build agent with multiple concurrent build slots (e.g., 5)
- Multiple programming exercises with student submissions

1. Trigger many concurrent builds on the same build agent (e.g., by having students submit simultaneously or re-triggering builds)
2. Verify that all builds complete successfully without `chmod: cannot access './gradlew'` errors
3. Verify that build times are normal (~25-30 seconds for Java/Gradle exercises, not ~1 second)

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Server tests failed. Coverage could not be fully measured. Please check the [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/22112676112).

_Last updated: 2026-02-17 19:36:50 UTC_

