### PR TITLE
`Iris`: Fix an issue when creating session for exercise without repositories

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisDTOService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisDTOService.java
@@ -133,12 +133,13 @@ public class PyrisDTOService {
     }
 
     /**
-     * Helper method to get & checkout the repository contents for a participation.
-     * This is an exception safe way to fetch the repository, as it will return an empty map if the repository could not be fetched.
+     * Helper method to get & checkout the repository contents for a given repository URI.
+     * This is an exception-safe way to fetch the repository contents: it returns an empty map
+     * if {@code repositoryUri} is null or if the repository could not be fetched.
      * This is useful, as the Pyris call should not fail if the repository is not available.
      *
      * @param repositoryUri the repositoryUri of the repository
-     * @return the repository or empty if it could not be fetched
+     * @return the repository contents, or an empty map if the URI is null or the fetch fails
      */
     private Map<String, String> getRepositoryContents(LocalVCRepositoryUri repositoryUri) {
         if (repositoryUri == null) {


### PR DESCRIPTION
### Summary
Fix a 500 Internal Server Error (NPE) that occurs when sending a message in an Iris session linked to a programming exercise that has no repositories set up (e.g., the student hasn't cloned the repo, or template/solution/test repositories don't exist yet).

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
When a user sends a message in an Iris session for a programming exercise that doesn't have repositories set up yet, `PyrisDTOService` attempts to call `LocalVCRepositoryUri.toString()` on a null reference, causing:

```
Cannot invoke "de.tum.cit.aet.artemis.programming.service.localvc.LocalVCRepositoryUri.toString()" because "repositoryUri" is null
```

at `/api/iris/sessions/{id}/messages`.

### Description
Added null guards in two private methods of `PyrisDTOService`:

1. **`getRepositoryContents(LocalVCRepositoryUri)`** — returns `Map.of()` when `repositoryUri` is null, consistent with the existing behavior of returning an empty map when the repository can't be fetched (IOException).

2. **`getFilteredRepositoryContents(ProgrammingExerciseParticipation)`** — returns `Map.of()` when `participation` is null.

This allows the Iris pipeline to proceed gracefully with empty repository contents instead of crashing. The AI tutor can still assist the student, just without code context.

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Programming Exercise with Iris enabled

1. Log in as the student
2. Navigate to the programming exercise
3. Open the Iris chat without having cloned/started the exercise repository
4. Send a message to Iris
5. Verify that no 500 error occurs and Iris responds (without code context)

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| PyrisDTOService.java | 75.61% | 94 |

_Last updated: 2026-02-23 17:44:36 UTC_

