### PR TITLE
`Development`: Bump action-junit-report to v6.3.0

### DIFF
--- a/.github/actions/e2e-test-report/action.yml
+++ b/.github/actions/e2e-test-report/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: Generate Test Report
       id: test-report
-      uses: mikepenz/action-junit-report@v5.6.2
+      uses: mikepenz/action-junit-report@v6.3.0
       if: success() || failure()
       with:
         commit: ${{ inputs.commit-sha }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -292,7 +292,7 @@ jobs:
 
       - name: All Tests Report (PR)
         id: test-report
-        uses: mikepenz/action-junit-report@v5.6.2
+        uses: mikepenz/action-junit-report@v6.3.0
         if: success() || failure()
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
@@ -419,7 +419,7 @@ jobs:
           path: all-test-results
 
       - name: All Tests Report (Non-PR)
-        uses: mikepenz/action-junit-report@v5.6.2
+        uses: mikepenz/action-junit-report@v6.3.0
         if: success() || failure()
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
@@ -446,12 +446,12 @@ jobs:
           REMAINING_RESULT="${{ needs.run-e2e-remaining.result }}"
           ALL_PR_RESULT="${{ needs.run-e2e-all-pr.result }}"
           ALL_NON_PR_RESULT="${{ needs.run-e2e-all-non-pr.result }}"
-          
+
           echo "Phase 1 (relevant): $RELEVANT_RESULT"
           echo "Phase 2 (remaining): $REMAINING_RESULT"
           echo "All tests (PR): $ALL_PR_RESULT"
           echo "All tests (Non-PR): $ALL_NON_PR_RESULT"
-          
+
           # Determine the overall status
           if [ "$ALL_NON_PR_RESULT" = "success" ]; then
             echo "status=success" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Summary
Bump `mikepenz/action-junit-report` to `v6.3.0` in the shared e2e test report action and the e2e workflow.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
Our contribution to the action was merged and improves handling of `<error>` nodes in the report.

### Description
- Update the local e2e test report composite action to use `mikepenz/action-junit-report@v6.3.0`.
- Update the e2e workflow steps that invoke the junit report action to `v6.3.0`.

### Steps for Testing
Workflow-only change. Verification happens when the CI workflow runs for this PR.