### PR TITLE
`Assessment`: Hide note input when no more submissions are assessable

### DIFF
--- a/src/main/webapp/app/assessment/manage/assessment-layout/assessment-layout.component.spec.ts
+++ b/src/main/webapp/app/assessment/manage/assessment-layout/assessment-layout.component.spec.ts
@@ -93,6 +93,20 @@ describe('AssessmentLayoutComponent', () => {
         expect(assessmentNoteComponent).toBeNull();
     });
 
+    it('should hide jhi-assessment-note when submission is cleared after navigating to next submission', () => {
+        fixture.componentRef.setInput('submission', { id: 1 } as Submission);
+        fixture.changeDetectorRef.detectChanges();
+
+        let assessmentNoteComponent = fixture.debugElement.query(By.directive(AssessmentNoteComponent));
+        expect(assessmentNoteComponent).not.toBeNull();
+
+        fixture.componentRef.setInput('submission', undefined);
+        fixture.changeDetectorRef.detectChanges();
+
+        assessmentNoteComponent = fixture.debugElement.query(By.directive(AssessmentNoteComponent));
+        expect(assessmentNoteComponent).toBeNull();
+    });
+
     it('should include jhi-complaints-for-tutor-form', () => {
         let complaintsForTutorComponent = fixture.debugElement.query(By.directive(ComplaintsForTutorComponent));
         expect(complaintsForTutorComponent).toBeFalsy();


### PR DESCRIPTION
### Summary

- Hide the internal assessment note input when no more submissions are available for assessment
- Add regression test verifying the note input disappears when navigating away from the last assessable submission

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

### Motivation and Context

Closes #9164

When a tutor finishes assessing the last available submission and clicks "Next Submission", an informational message is shown indicating no more submissions are available. However, the internal assessment note textarea remained visible below this message. Since there is no active submission to attach a note to, this input should be hidden.

### Description

The template fix (`@if (submission())` guard around `<jhi-assessment-note>`) was already applied in the assessment layout component during the signals migration (#11872). This PR adds a targeted regression test that verifies the specific bug scenario: when the submission input transitions from a value to `undefined` (simulating the "next submission" flow when no more submissions exist), the assessment note component is correctly removed from the DOM.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Tutor
- 1 Exercise with manual assessment enabled and a limited number of student submissions

1. Log in as the Tutor
2. Navigate to the exercise assessment dashboard
3. Assess all available submissions one by one
4. After completing the last assessment, click "Next Submission"
5. Verify that only the "not found" informational message is shown
6. Verify that the internal assessment note textarea is NOT visible at the bottom of the page

### Screenshots

No screenshots needed — this PR only adds a regression test (`.spec.ts` file). There are no visual or UI changes. The template fix was already applied in #11872.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for assessment note visibility behavior when submissions are cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->